### PR TITLE
Update/reflector net

### DIFF
--- a/McpPlugin.Common/McpPlugin.Common.csproj
+++ b/McpPlugin.Common/McpPlugin.Common.csproj
@@ -11,7 +11,7 @@
     <!-- NuGet Package Information -->
     <IsPackable>true</IsPackable>
     <PackageId>com.IvanMurzak.McpPlugin.Common</PackageId>
-    <Version>0.3.0</Version>
+    <Version>0.4.0</Version>
     <Authors>Ivan Murzak</Authors>
     <Company>Ivan Murzak</Company>
     <Copyright>Copyright © Ivan Murzak 2025</Copyright>

--- a/McpPlugin.Common/src/Utils/Consts.cs
+++ b/McpPlugin.Common/src/Utils/Consts.cs
@@ -12,7 +12,7 @@ namespace com.IvanMurzak.McpPlugin.Common
     public static partial class Consts
     {
         public const string ApiVersion = "2.0.0";
-        public const string PluginVersion = "0.3.0";
+        public const string PluginVersion = "0.4.0";
 
         public static class Guid
         {

--- a/McpPlugin.Server/McpPlugin.Server.csproj
+++ b/McpPlugin.Server/McpPlugin.Server.csproj
@@ -11,7 +11,7 @@
     <!-- NuGet Package Information -->
     <IsPackable>true</IsPackable>
     <PackageId>com.IvanMurzak.McpPlugin.Server</PackageId>
-    <Version>0.3.0</Version>
+    <Version>0.4.0</Version>
     <Authors>Ivan Murzak</Authors>
     <Company>Ivan Murzak</Company>
     <Copyright>Copyright © Ivan Murzak 2025</Copyright>

--- a/McpPlugin.Server/server.json
+++ b/McpPlugin.Server/server.json
@@ -8,13 +8,13 @@
     "source": "github",
     "subfolder": "McpPlugin.Server"
   },
-  "version": "0.3.0",
+  "version": "0.4.0",
   "packages": [
     {
       "registry_type": "oci",
       "registry_base_url": "https://docker.io",
       "identifier": "ivanmurzakdev/mcp-plugin-server",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "transport": {
         "type": "stdio"
       },

--- a/McpPlugin/McpPlugin.csproj
+++ b/McpPlugin/McpPlugin.csproj
@@ -11,7 +11,7 @@
     <!-- NuGet Package Information -->
     <IsPackable>true</IsPackable>
     <PackageId>com.IvanMurzak.McpPlugin</PackageId>
-    <Version>0.3.0</Version>
+    <Version>0.4.0</Version>
     <Authors>Ivan Murzak</Authors>
     <Company>Ivan Murzak</Company>
     <Copyright>Copyright © Ivan Murzak 2025</Copyright>


### PR DESCRIPTION
This pull request updates the plugin version to `0.4.0` across all relevant files and upgrades the dependency on `com.IvanMurzak.ReflectorNet` to version `2.4.0`. These changes ensure consistency in versioning and incorporate the latest improvements from the ReflectorNet package.

Version updates:

* Bumped the plugin version from `0.3.0` to `0.4.0` in `McpPlugin.Common.csproj`, `McpPlugin.Server.csproj`, `McpPlugin.csproj`, and `server.json`, as well as the `PluginVersion` constant in `Consts.cs`. [[1]](diffhunk://#diff-5d8853646ef83c17a4de3f81d744db80ec7092b91729f8b2aa534466e59c024aL14-R14) [[2]](diffhunk://#diff-865d35f4f7aeb53e8650abae861dae72dd3d46997561dae7d5ac9ce4aa97d688L14-R14) [[3]](diffhunk://#diff-2367df5186dce604f76f56cd4f04942cc2225e773f41a3643c61a57fd3d71113L14-R14) [[4]](diffhunk://#diff-4264f811092dda1460376036e9d0b1f2e4227828ef3df0119cf4664fa84c6283L11-R17) [[5]](diffhunk://#diff-924c9a5b5fa5605b0d8177f80ce49c24f81b66c1c45d6caf010f1ba8f4d914e3L15-R15)

Dependency upgrades:

* Updated the `com.IvanMurzak.ReflectorNet` package reference from version `2.3.2` to `2.4.0` in all project files. [[1]](diffhunk://#diff-5d8853646ef83c17a4de3f81d744db80ec7092b91729f8b2aa534466e59c024aL28-R28) [[2]](diffhunk://#diff-865d35f4f7aeb53e8650abae861dae72dd3d46997561dae7d5ac9ce4aa97d688L37-R37) [[3]](diffhunk://#diff-2367df5186dce604f76f56cd4f04942cc2225e773f41a3643c61a57fd3d71113L34-R34)
* Updated the Docker package version for `ivanmurzakdev/mcp-plugin-server` from `0.3.0` to `0.4.0` in `server.json`.