### PR TITLE
EDIT: Withdrawn and redrafted. Add image and audio content support to ResponseCallTool

### DIFF
--- a/McpPlugin.Common/src/Data/Response/Other/ContentBlock.cs
+++ b/McpPlugin.Common/src/Data/Response/Other/ContentBlock.cs
@@ -8,6 +8,8 @@
 └────────────────────────────────────────────────────────────────────────┘
 */
 
+using System;
+
 namespace com.IvanMurzak.McpPlugin.Common.Model
 {
     public class ContentBlock
@@ -23,12 +25,12 @@ namespace com.IvanMurzak.McpPlugin.Common.Model
         public string? Text { get; set; }
 
         /// <summary>
-        /// The base64-encoded image data.
+        /// The base64-encoded image or audio data.
         /// </summary>
         public string? Data { get; set; }
 
         /// <summary>
-        /// The MIME type of the image.
+        /// The MIME type of the content.
         /// </summary>
         public string? MimeType { get; set; }
 
@@ -38,5 +40,41 @@ namespace com.IvanMurzak.McpPlugin.Common.Model
         public ResponseResourceContent? Resource { get; set; }
 
         public ContentBlock() { }
+
+        /// <summary>
+        /// Creates a text content block.
+        /// </summary>
+        public static ContentBlock CreateText(string text, string mimeType = Consts.MimeType.TextPlain)
+            => new ContentBlock { Type = "text", Text = text, MimeType = mimeType };
+
+        /// <summary>
+        /// Creates an image content block from raw bytes.
+        /// </summary>
+        public static ContentBlock CreateImage(byte[] data, string mimeType)
+            => new ContentBlock { Type = "image", Data = Convert.ToBase64String(data), MimeType = mimeType };
+
+        /// <summary>
+        /// Creates an image content block from base64-encoded data.
+        /// </summary>
+        public static ContentBlock CreateImageBase64(string base64Data, string mimeType)
+            => new ContentBlock { Type = "image", Data = base64Data, MimeType = mimeType };
+
+        /// <summary>
+        /// Creates an audio content block from raw bytes.
+        /// </summary>
+        public static ContentBlock CreateAudio(byte[] data, string mimeType)
+            => new ContentBlock { Type = "audio", Data = Convert.ToBase64String(data), MimeType = mimeType };
+
+        /// <summary>
+        /// Creates an audio content block from base64-encoded data.
+        /// </summary>
+        public static ContentBlock CreateAudioBase64(string base64Data, string mimeType)
+            => new ContentBlock { Type = "audio", Data = base64Data, MimeType = mimeType };
+
+        /// <summary>
+        /// Creates a resource content block.
+        /// </summary>
+        public static ContentBlock CreateResource(ResponseResourceContent resource)
+            => new ContentBlock { Type = "resource", Resource = resource };
     }
 }

--- a/McpPlugin.Common/src/Data/Response/Tool/Call/ResponseCallTool.Static.cs
+++ b/McpPlugin.Common/src/Data/Response/Tool/Call/ResponseCallTool.Static.cs
@@ -10,6 +10,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json.Nodes;
 
 namespace com.IvanMurzak.McpPlugin.Common.Model
@@ -86,5 +87,91 @@ namespace com.IvanMurzak.McpPlugin.Common.Model
                         MimeType = Consts.MimeType.TextPlain
                     }
                 });
+
+        /// <summary>
+        /// Creates a successful response containing image content.
+        /// </summary>
+        /// <param name="data">Raw image bytes</param>
+        /// <param name="mimeType">MIME type (e.g., "image/png", "image/jpeg"). Use Consts.MimeType constants.</param>
+        /// <param name="message">Optional text message to include alongside the image</param>
+        public static ResponseCallTool Image(byte[] data, string mimeType, string? message = null)
+        {
+            var content = new List<ContentBlock>
+            {
+                new ContentBlock()
+                {
+                    Type = "image",
+                    Data = Convert.ToBase64String(data),
+                    MimeType = mimeType
+                }
+            };
+
+            if (!string.IsNullOrEmpty(message))
+            {
+                content.Insert(0, new ContentBlock()
+                {
+                    Type = "text",
+                    Text = message,
+                    MimeType = Consts.MimeType.TextPlain
+                });
+            }
+
+            return new ResponseCallTool(
+                status: ResponseStatus.Success,
+                content: content);
+        }
+
+        /// <summary>
+        /// Creates a successful response containing audio content.
+        /// </summary>
+        /// <param name="data">Raw audio bytes</param>
+        /// <param name="mimeType">MIME type (e.g., "audio/wav", "audio/mpeg"). Use Consts.MimeType constants.</param>
+        /// <param name="message">Optional text message to include alongside the audio</param>
+        public static ResponseCallTool Audio(byte[] data, string mimeType, string? message = null)
+        {
+            var content = new List<ContentBlock>
+            {
+                new ContentBlock()
+                {
+                    Type = "audio",
+                    Data = Convert.ToBase64String(data),
+                    MimeType = mimeType
+                }
+            };
+
+            if (!string.IsNullOrEmpty(message))
+            {
+                content.Insert(0, new ContentBlock()
+                {
+                    Type = "text",
+                    Text = message,
+                    MimeType = Consts.MimeType.TextPlain
+                });
+            }
+
+            return new ResponseCallTool(
+                status: ResponseStatus.Success,
+                content: content);
+        }
+
+        /// <summary>
+        /// Creates a successful response with multiple content blocks.
+        /// Use this when returning mixed content (e.g., text + images + audio).
+        /// </summary>
+        /// <param name="contentBlocks">Array of content blocks to include</param>
+        public static ResponseCallTool WithContent(params ContentBlock[] contentBlocks)
+            => new ResponseCallTool(
+                status: ResponseStatus.Success,
+                content: contentBlocks.ToList());
+
+        /// <summary>
+        /// Creates a response with specified status and multiple content blocks.
+        /// </summary>
+        /// <param name="status">Response status</param>
+        /// <param name="contentBlocks">Array of content blocks to include</param>
+        public static ResponseCallTool WithContent(ResponseStatus status, params ContentBlock[] contentBlocks)
+            => new ResponseCallTool(
+                status: status,
+                content: contentBlocks.ToList());
     }
 }

--- a/McpPlugin.Common/src/Utils/Consts.MimeType.cs
+++ b/McpPlugin.Common/src/Utils/Consts.MimeType.cs
@@ -13,6 +13,7 @@ namespace com.IvanMurzak.McpPlugin.Common
     {
         public static class MimeType
         {
+            // Text types
             public const string TextPlain = "text/plain";
             public const string TextHtml = "text/html";
             public const string TextJson = "application/json";
@@ -21,6 +22,19 @@ namespace com.IvanMurzak.McpPlugin.Common
             public const string TextCsv = "text/csv";
             public const string TextMarkdown = "text/markdown";
             public const string TextJavascript = "application/javascript";
+
+            // Image types
+            public const string ImagePng = "image/png";
+            public const string ImageJpeg = "image/jpeg";
+            public const string ImageGif = "image/gif";
+            public const string ImageWebp = "image/webp";
+            public const string ImageSvg = "image/svg+xml";
+
+            // Audio types
+            public const string AudioMpeg = "audio/mpeg";
+            public const string AudioWav = "audio/wav";
+            public const string AudioOgg = "audio/ogg";
+            public const string AudioWebm = "audio/webm";
         }
     }
 }

--- a/McpPlugin.Tests/Data/ContentBlockTests.cs
+++ b/McpPlugin.Tests/Data/ContentBlockTests.cs
@@ -1,0 +1,255 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+using System;
+using System.Linq;
+using com.IvanMurzak.McpPlugin.Common;
+using com.IvanMurzak.McpPlugin.Common.Model;
+using FluentAssertions;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.Tests.Data
+{
+    public class ContentBlockTests
+    {
+        private readonly byte[] _testImageData = new byte[] { 0x89, 0x50, 0x4E, 0x47 }; // PNG magic bytes
+        private readonly byte[] _testAudioData = new byte[] { 0x52, 0x49, 0x46, 0x46 }; // WAV RIFF header
+
+        [Fact]
+        public void CreateText_CreatesTextContentBlock()
+        {
+            // Arrange
+            var text = "Hello, World!";
+
+            // Act
+            var block = ContentBlock.CreateText(text);
+
+            // Assert
+            block.Type.Should().Be("text");
+            block.Text.Should().Be(text);
+            block.MimeType.Should().Be(Consts.MimeType.TextPlain);
+            block.Data.Should().BeNull();
+        }
+
+        [Fact]
+        public void CreateText_WithCustomMimeType_CreatesTextContentBlock()
+        {
+            // Arrange
+            var text = "{\"key\": \"value\"}";
+
+            // Act
+            var block = ContentBlock.CreateText(text, Consts.MimeType.TextJson);
+
+            // Assert
+            block.Type.Should().Be("text");
+            block.Text.Should().Be(text);
+            block.MimeType.Should().Be(Consts.MimeType.TextJson);
+        }
+
+        [Fact]
+        public void CreateImage_CreatesImageContentBlockWithBase64()
+        {
+            // Arrange
+            var expectedBase64 = Convert.ToBase64String(_testImageData);
+
+            // Act
+            var block = ContentBlock.CreateImage(_testImageData, Consts.MimeType.ImagePng);
+
+            // Assert
+            block.Type.Should().Be("image");
+            block.Data.Should().Be(expectedBase64);
+            block.MimeType.Should().Be(Consts.MimeType.ImagePng);
+            block.Text.Should().BeNull();
+        }
+
+        [Fact]
+        public void CreateImageBase64_CreatesImageContentBlockFromBase64()
+        {
+            // Arrange
+            var base64Data = "iVBORw0KGgo=";
+
+            // Act
+            var block = ContentBlock.CreateImageBase64(base64Data, Consts.MimeType.ImageJpeg);
+
+            // Assert
+            block.Type.Should().Be("image");
+            block.Data.Should().Be(base64Data);
+            block.MimeType.Should().Be(Consts.MimeType.ImageJpeg);
+        }
+
+        [Fact]
+        public void CreateAudio_CreatesAudioContentBlockWithBase64()
+        {
+            // Arrange
+            var expectedBase64 = Convert.ToBase64String(_testAudioData);
+
+            // Act
+            var block = ContentBlock.CreateAudio(_testAudioData, Consts.MimeType.AudioWav);
+
+            // Assert
+            block.Type.Should().Be("audio");
+            block.Data.Should().Be(expectedBase64);
+            block.MimeType.Should().Be(Consts.MimeType.AudioWav);
+            block.Text.Should().BeNull();
+        }
+
+        [Fact]
+        public void CreateAudioBase64_CreatesAudioContentBlockFromBase64()
+        {
+            // Arrange
+            var base64Data = "UklGRg==";
+
+            // Act
+            var block = ContentBlock.CreateAudioBase64(base64Data, Consts.MimeType.AudioMpeg);
+
+            // Assert
+            block.Type.Should().Be("audio");
+            block.Data.Should().Be(base64Data);
+            block.MimeType.Should().Be(Consts.MimeType.AudioMpeg);
+        }
+    }
+
+    public class ResponseCallToolImageAudioTests
+    {
+        private readonly byte[] _testImageData = new byte[] { 0x89, 0x50, 0x4E, 0x47 };
+        private readonly byte[] _testAudioData = new byte[] { 0x52, 0x49, 0x46, 0x46 };
+
+        [Fact]
+        public void Image_CreatesSuccessResponseWithImageContent()
+        {
+            // Arrange
+            var expectedBase64 = Convert.ToBase64String(_testImageData);
+
+            // Act
+            var response = ResponseCallTool.Image(_testImageData, Consts.MimeType.ImagePng);
+
+            // Assert
+            response.Status.Should().Be(ResponseStatus.Success);
+            response.Content.Should().HaveCount(1);
+            response.Content[0].Type.Should().Be("image");
+            response.Content[0].Data.Should().Be(expectedBase64);
+            response.Content[0].MimeType.Should().Be(Consts.MimeType.ImagePng);
+        }
+
+        [Fact]
+        public void Image_WithMessage_IncludesTextContentBeforeImage()
+        {
+            // Arrange
+            var message = "Screenshot captured";
+
+            // Act
+            var response = ResponseCallTool.Image(_testImageData, Consts.MimeType.ImagePng, message);
+
+            // Assert
+            response.Status.Should().Be(ResponseStatus.Success);
+            response.Content.Should().HaveCount(2);
+            response.Content[0].Type.Should().Be("text");
+            response.Content[0].Text.Should().Be(message);
+            response.Content[1].Type.Should().Be("image");
+        }
+
+        [Fact]
+        public void Audio_CreatesSuccessResponseWithAudioContent()
+        {
+            // Arrange
+            var expectedBase64 = Convert.ToBase64String(_testAudioData);
+
+            // Act
+            var response = ResponseCallTool.Audio(_testAudioData, Consts.MimeType.AudioWav);
+
+            // Assert
+            response.Status.Should().Be(ResponseStatus.Success);
+            response.Content.Should().HaveCount(1);
+            response.Content[0].Type.Should().Be("audio");
+            response.Content[0].Data.Should().Be(expectedBase64);
+            response.Content[0].MimeType.Should().Be(Consts.MimeType.AudioWav);
+        }
+
+        [Fact]
+        public void Audio_WithMessage_IncludesTextContentBeforeAudio()
+        {
+            // Arrange
+            var message = "Audio recorded";
+
+            // Act
+            var response = ResponseCallTool.Audio(_testAudioData, Consts.MimeType.AudioMpeg, message);
+
+            // Assert
+            response.Status.Should().Be(ResponseStatus.Success);
+            response.Content.Should().HaveCount(2);
+            response.Content[0].Type.Should().Be("text");
+            response.Content[0].Text.Should().Be(message);
+            response.Content[1].Type.Should().Be("audio");
+        }
+
+        [Fact]
+        public void WithContent_CreatesResponseWithMultipleBlocks()
+        {
+            // Arrange
+            var textBlock = ContentBlock.CreateText("Description");
+            var imageBlock = ContentBlock.CreateImage(_testImageData, Consts.MimeType.ImagePng);
+
+            // Act
+            var response = ResponseCallTool.WithContent(textBlock, imageBlock);
+
+            // Assert
+            response.Status.Should().Be(ResponseStatus.Success);
+            response.Content.Should().HaveCount(2);
+            response.Content[0].Should().BeSameAs(textBlock);
+            response.Content[1].Should().BeSameAs(imageBlock);
+        }
+
+        [Fact]
+        public void WithContent_WithStatus_CreatesResponseWithSpecifiedStatus()
+        {
+            // Arrange
+            var textBlock = ContentBlock.CreateText("Error details");
+
+            // Act
+            var response = ResponseCallTool.WithContent(ResponseStatus.Error, textBlock);
+
+            // Assert
+            response.Status.Should().Be(ResponseStatus.Error);
+            response.Content.Should().HaveCount(1);
+        }
+
+        [Fact]
+        public void Image_DataCanBeDecodedBackToOriginal()
+        {
+            // Act
+            var response = ResponseCallTool.Image(_testImageData, Consts.MimeType.ImagePng);
+            var decodedData = Convert.FromBase64String(response.Content[0].Data!);
+
+            // Assert
+            decodedData.Should().BeEquivalentTo(_testImageData);
+        }
+    }
+
+    public class MimeTypeConstantsTests
+    {
+        [Fact]
+        public void ImageMimeTypes_AreCorrectlyDefined()
+        {
+            Consts.MimeType.ImagePng.Should().Be("image/png");
+            Consts.MimeType.ImageJpeg.Should().Be("image/jpeg");
+            Consts.MimeType.ImageGif.Should().Be("image/gif");
+            Consts.MimeType.ImageWebp.Should().Be("image/webp");
+            Consts.MimeType.ImageSvg.Should().Be("image/svg+xml");
+        }
+
+        [Fact]
+        public void AudioMimeTypes_AreCorrectlyDefined()
+        {
+            Consts.MimeType.AudioMpeg.Should().Be("audio/mpeg");
+            Consts.MimeType.AudioWav.Should().Be("audio/wav");
+            Consts.MimeType.AudioOgg.Should().Be("audio/ogg");
+            Consts.MimeType.AudioWebm.Should().Be("audio/webm");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds support for returning image and audio content from MCP tools, implementing the multimodal content types defined in the MCP specification.

- Add `ResponseCallTool.Image(byte[], mimeType, message?)` factory method
- Add `ResponseCallTool.Audio(byte[], mimeType, message?)` factory method  
- Add `ResponseCallTool.WithContent(params ContentBlock[])` for mixed content
- Add `ContentBlock` factory methods: `CreateText`, `CreateImage`, `CreateImageBase64`, `CreateAudio`, `CreateAudioBase64`, `CreateResource`
- Add MIME type constants for images (png, jpeg, gif, webp, svg) and audio (mpeg, wav, ogg, webm)
- Add 15 unit tests covering all new functionality

Ref: #253

## Usage Example

```csharp
// Return image from a tool
[McpPluginTool("Camera_Screenshot")]
public ResponseCallTool Screenshot()
{
    var pngBytes = CaptureScreenshot();
    return ResponseCallTool.Image(pngBytes, Consts.MimeType.ImagePng, "Screenshot captured");
}

// Return mixed content
return ResponseCallTool.WithContent(
    ContentBlock.CreateText("Here is the result:"),
    ContentBlock.CreateImage(imageBytes, Consts.MimeType.ImagePng)
);
```

## Test plan

- [x] All 15 new unit tests pass
- [x] Existing tests unaffected
- [x] Build succeeds with no warnings