### PR TITLE
Update ReflectorNet package to version 3.2.0 and modify JsonOptions

### DIFF
--- a/McpPlugin.Common/McpPlugin.Common.csproj
+++ b/McpPlugin.Common/McpPlugin.Common.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="3.1.1" />
+    <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="3.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.1" />
     <PackageReference Include="ModelContextProtocol" Version="0.4.1-preview.1" />

--- a/McpPlugin.Common/src/Utils/JsonOptions.cs
+++ b/McpPlugin.Common/src/Utils/JsonOptions.cs
@@ -21,6 +21,7 @@ namespace com.IvanMurzak.McpPlugin.Common.Utils
             PropertyNameCaseInsensitive = true,
             WriteIndented = true,
             AllowTrailingCommas = false,
+            // ReferenceHandler = ReferenceHandler.IgnoreCycles,
             DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
             ReadCommentHandling = JsonCommentHandling.Skip,
             NumberHandling = JsonNumberHandling.AllowReadingFromString,

--- a/McpPlugin.Server/McpPlugin.Server.csproj
+++ b/McpPlugin.Server/McpPlugin.Server.csproj
@@ -34,7 +34,7 @@
 
   <ItemGroup>
     <ProjectReference Include="./../McpPlugin.Common/McpPlugin.Common.csproj" />
-    <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="3.1.1" />
+    <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="3.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.1" />
     <PackageReference Include="ModelContextProtocol" Version="0.4.1-preview.1" />

--- a/McpPlugin/McpPlugin.csproj
+++ b/McpPlugin/McpPlugin.csproj
@@ -31,7 +31,7 @@
 
   <ItemGroup>
     <ProjectReference Include="./../McpPlugin.Common/McpPlugin.Common.csproj" />
-    <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="3.1.1" />
+    <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="3.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.1" />
     <PackageReference Include="ModelContextProtocol" Version="0.4.1-preview.1" />


### PR DESCRIPTION
Update the ReflectorNet package reference to version 3.2.0 across all projects and comment out the ReferenceHandler in JsonOptions to prevent potential issues with reference cycles.