### PR TITLE
Fix Optional Enum input argument support without explicit value

### DIFF
--- a/McpPlugin.Tests/Mcp/McpBuilderTests_EnumDefaultValue.cs
+++ b/McpPlugin.Tests/Mcp/McpBuilderTests_EnumDefaultValue.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.Common.Model;
+using com.IvanMurzak.McpPlugin.Tests.Infrastructure;
+using com.IvanMurzak.McpPlugin.Utils;
+using com.IvanMurzak.ReflectorNet;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+using Version = com.IvanMurzak.McpPlugin.Common.Version;
+
+namespace com.IvanMurzak.McpPlugin.Tests.Mcp
+{
+    public enum TestEnum
+    {
+        Value1,
+        Value2
+    }
+
+    public class Method_EnumDefaultValue
+    {
+        public string Process(TestEnum? options = TestEnum.Value2)
+        {
+            return options?.ToString() ?? "null";
+        }
+    }
+
+    public class Method_MixedDefaultValue
+    {
+        public string Process(int count, TestEnum? options = TestEnum.Value2)
+        {
+            return $"{count}-{options?.ToString() ?? "null"}";
+        }
+    }
+
+    [Collection("McpPlugin")]
+    public class McpBuilderTests_EnumDefaultValue
+    {
+        private readonly ITestOutputHelper _output;
+        private readonly XunitTestOutputLoggerProvider _loggerProvider;
+        private readonly Version _version = new Version();
+
+        public McpBuilderTests_EnumDefaultValue(ITestOutputHelper output)
+        {
+            _output = output;
+            _loggerProvider = new XunitTestOutputLoggerProvider(output);
+        }
+
+        private IMcpPlugin BuildMcpPluginWithTool(Type classType, string methodName)
+        {
+            var method = classType.GetMethod(methodName)!;
+            var toolName = classType.GetTypeShortName();
+            var toolTitle = $"Title of {toolName}";
+
+            var reflector = new Reflector();
+            var mcpPluginBuilder = new McpPluginBuilder(_version, _loggerProvider)
+                .AddLogging(b => b.AddXunitTestOutput(_output));
+
+            mcpPluginBuilder.WithTool(
+                name: toolName,
+                title: toolTitle,
+                classType: classType,
+                method: method);
+
+            return mcpPluginBuilder.Build(reflector)!;
+        }
+
+        private static Dictionary<string, JsonElement> CreateArguments(params (string name, object value)[] args)
+        {
+            var dict = new Dictionary<string, JsonElement>();
+            foreach (var (name, value) in args)
+            {
+                var json = System.Text.Json.JsonSerializer.Serialize(value);
+                dict[name] = JsonDocument.Parse(json).RootElement.Clone();
+            }
+            return dict;
+        }
+
+        [Fact]
+        public async Task CallTool_WithEnumDefaultValue_ShouldSucceed()
+        {
+            // Arrange
+            var mcpPlugin = BuildMcpPluginWithTool(typeof(Method_EnumDefaultValue), nameof(Method_EnumDefaultValue.Process));
+            var toolName = typeof(Method_EnumDefaultValue).GetTypeShortName();
+
+            // Act - calling without arguments, expecting default value TestEnum.Value2
+            var request = new RequestCallTool(toolName, new Dictionary<string, JsonElement>());
+            var response = await mcpPlugin.McpManager.ToolManager!.RunCallTool(request);
+
+            // Assert
+            response.Should().NotBeNull();
+            if (response.Status != ResponseStatus.Success)
+            {
+                _output.WriteLine($"Error: {response.Message}");
+            }
+            response.Status.Should().Be(ResponseStatus.Success);
+            response.Value.Should().NotBeNull();
+            response.Value!.StructuredContent.Should().NotBeNull();
+            response.Value!.StructuredContent!["result"]!.GetValue<string>().Should().Be("Value2");
+        }
+
+        [Fact]
+        public async Task CallTool_WithMixedParameters_ShouldSucceed()
+        {
+            // Arrange
+            var mcpPlugin = BuildMcpPluginWithTool(typeof(Method_MixedDefaultValue), nameof(Method_MixedDefaultValue.Process));
+            var toolName = typeof(Method_MixedDefaultValue).GetTypeShortName();
+
+            // Act - calling with only 'count', expecting default value TestEnum.Value2 for 'options'
+            var request = new RequestCallTool(toolName, CreateArguments(("count", 42)));
+            var response = await mcpPlugin.McpManager.ToolManager!.RunCallTool(request);
+
+            // Assert
+            response.Should().NotBeNull();
+            if (response.Status != ResponseStatus.Success)
+            {
+                _output.WriteLine($"Error: {response.Message}");
+            }
+            response.Status.Should().Be(ResponseStatus.Success);
+            response.Value.Should().NotBeNull();
+            response.Value!.StructuredContent.Should().NotBeNull();
+            response.Value!.StructuredContent!["result"]!.GetValue<string>().Should().Be("42-Value2");
+        }
+    }
+}

--- a/McpPlugin.Tests/Mcp/McpBuilderTests_PromptEnumDefaultValue.cs
+++ b/McpPlugin.Tests/Mcp/McpBuilderTests_PromptEnumDefaultValue.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.Common.Model;
+using com.IvanMurzak.McpPlugin.Tests.Infrastructure;
+using com.IvanMurzak.McpPlugin.Utils;
+using com.IvanMurzak.ReflectorNet;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+using Version = com.IvanMurzak.McpPlugin.Common.Version;
+
+namespace com.IvanMurzak.McpPlugin.Tests.Mcp
+{
+    public enum PromptTestEnum
+    {
+        OptionA,
+        OptionB
+    }
+
+    public class PromptMethod_EnumDefaultValue
+    {
+        [McpPluginPrompt(Name = "test_prompt")]
+        public string GetPrompt(PromptTestEnum? options = PromptTestEnum.OptionB)
+        {
+            return options?.ToString() ?? "null";
+        }
+    }
+
+    [Collection("McpPlugin")]
+    public class McpBuilderTests_PromptEnumDefaultValue
+    {
+        private readonly ITestOutputHelper _output;
+        private readonly XunitTestOutputLoggerProvider _loggerProvider;
+        private readonly Version _version = new Version();
+
+        public McpBuilderTests_PromptEnumDefaultValue(ITestOutputHelper output)
+        {
+            _output = output;
+            _loggerProvider = new XunitTestOutputLoggerProvider(output);
+        }
+
+        private IMcpPlugin BuildMcpPluginWithPrompt(Type classType, string methodName)
+        {
+            var method = classType.GetMethod(methodName)!;
+            var promptName = "test_prompt";
+
+            var reflector = new Reflector();
+            var mcpPluginBuilder = new McpPluginBuilder(_version, _loggerProvider)
+                .AddLogging(b => b.AddXunitTestOutput(_output));
+
+            mcpPluginBuilder.WithPrompt(
+                name: promptName,
+                classType: classType,
+                method: method);
+
+            return mcpPluginBuilder.Build(reflector)!;
+        }
+
+        [Fact]
+        public async Task CallPrompt_WithEnumDefaultValue_ShouldSucceed()
+        {
+            // Arrange
+            var mcpPlugin = BuildMcpPluginWithPrompt(typeof(PromptMethod_EnumDefaultValue), nameof(PromptMethod_EnumDefaultValue.GetPrompt));
+            var promptName = "test_prompt";
+
+            // Act - calling without arguments, expecting default value PromptTestEnum.OptionB
+            var request = new RequestGetPrompt(promptName, new Dictionary<string, JsonElement>());
+            var response = await mcpPlugin.McpManager.PromptManager!.RunGetPrompt(request);
+
+            // Assert
+            response.Should().NotBeNull();
+            if (response.Status != ResponseStatus.Success)
+            {
+                _output.WriteLine($"Error: {response.Message}");
+            }
+            response.Status.Should().Be(ResponseStatus.Success);
+            response.Value.Should().NotBeNull();
+            response.Value!.Messages.Should().NotBeNull();
+            response.Value!.Messages.Should().HaveCount(1);
+            response.Value!.Messages![0].Content.Text.Should().Be("OptionB");
+        }
+    }
+}

--- a/McpPlugin/src/Mcp/Prompt/RunPrompt.cs
+++ b/McpPlugin/src/Mcp/Prompt/RunPrompt.cs
@@ -93,7 +93,7 @@ namespace com.IvanMurzak.McpPlugin
                 _logger?.LogTrace("Injecting RequestID parameter: {RequestID}", RequestID);
                 return RequestID;
             }
-            return base.GetParameterValue(reflector, paramInfo, value);
+            return FixEnumConversion(paramInfo, base.GetParameterValue(reflector, paramInfo, value));
         }
         protected override object? GetParameterValue(Reflector reflector, ParameterInfo paramInfo, IReadOnlyDictionary<string, object?>? namedParameters)
         {
@@ -102,7 +102,7 @@ namespace com.IvanMurzak.McpPlugin
                 _logger?.LogTrace("Injecting RequestID parameter: {RequestID}", RequestID);
                 return RequestID;
             }
-            return base.GetParameterValue(reflector, paramInfo, namedParameters);
+            return FixEnumConversion(paramInfo, base.GetParameterValue(reflector, paramInfo, namedParameters));
         }
         protected override object? GetDefaultParameterValue(Reflector reflector, ParameterInfo methodParameter)
         {
@@ -111,7 +111,22 @@ namespace com.IvanMurzak.McpPlugin
                 _logger?.LogTrace("Injecting RequestID parameter: {RequestID}", RequestID);
                 return RequestID;
             }
-            return base.GetDefaultParameterValue(reflector, methodParameter);
+            return FixEnumConversion(methodParameter, base.GetDefaultParameterValue(reflector, methodParameter));
+        }
+
+        private object? FixEnumConversion(ParameterInfo paramInfo, object? value)
+        {
+            if (value != null)
+            {
+                var paramType = paramInfo.ParameterType;
+                var underlyingType = Nullable.GetUnderlyingType(paramType) ?? paramType;
+
+                if (underlyingType.IsEnum && value.GetType() != underlyingType)
+                {
+                    return Enum.ToObject(underlyingType, value);
+                }
+            }
+            return value;
         }
 
         /// <summary>


### PR DESCRIPTION
This pull request improves support for enum default values in both tool and prompt execution within the MCP plugin. It introduces a utility to correctly handle enum parameter conversions, ensuring that default enum values (including nullable enums) are properly passed and invoked. Additionally, it adds comprehensive tests to verify this behavior and clarifies logging and error messages for prompt execution.

Parameter handling improvements:

* Added a `FixEnumConversion` method to both `RunTool` and `RunPrompt` classes, ensuring enum and nullable enum parameters are correctly converted when default values are used or when parameters are passed in. This prevents type mismatches and runtime errors when invoking methods with enum parameters. [[1]](diffhunk://#diff-b32a8c229a3922fcce6d59879dd718cda40cf290f9b7930714eb6ecd873e133eL68-R68) [[2]](diffhunk://#diff-b32a8c229a3922fcce6d59879dd718cda40cf290f9b7930714eb6ecd873e133eL77-R78) [[3]](diffhunk://#diff-b32a8c229a3922fcce6d59879dd718cda40cf290f9b7930714eb6ecd873e133eL86-R102) [[4]](diffhunk://#diff-e8cf7ee0e15fcc0f39964f111fee8e26d2d333883bc909f97974e2b3cf437587L96-R96) [[5]](diffhunk://#diff-e8cf7ee0e15fcc0f39964f111fee8e26d2d333883bc909f97974e2b3cf437587L105-R105) [[6]](diffhunk://#diff-e8cf7ee0e15fcc0f39964f111fee8e26d2d333883bc909f97974e2b3cf437587L114-R129)

Testing enhancements:

* Added new test classes `McpBuilderTests_EnumDefaultValue` and `McpBuilderTests_PromptEnumDefaultValue` to verify that tools and prompts with enum (and nullable enum) default parameters are correctly handled, both when arguments are omitted and when mixed with other parameters. [[1]](diffhunk://#diff-4a837af5839eb3bfff8b4577681873fa2b45544d2b7c655820c075fbe6a61a60R1-R127) [[2]](diffhunk://#diff-e8350c3ba50e109ddd1f58c6733517fc16644c34af1e6590517f68925af8215aR1-R85)

Logging and error message clarity:

* Updated error and log messages in `RunPrompt` to consistently refer to "prompt" instead of "tool", improving clarity in debugging and test output. [[1]](diffhunk://#diff-e8cf7ee0e15fcc0f39964f111fee8e26d2d333883bc909f97974e2b3cf437587L150-R177) [[2]](diffhunk://#diff-e8cf7ee0e15fcc0f39964f111fee8e26d2d333883bc909f97974e2b3cf437587L204-R238) [[3]](diffhunk://#diff-e8cf7ee0e15fcc0f39964f111fee8e26d2d333883bc909f97974e2b3cf437587L232-R262)