### PR TITLE
Update ModelContextProtocol package version to 0.7.0-preview.1 in all projects

### DIFF
--- a/McpPlugin.Common/McpPlugin.Common.csproj
+++ b/McpPlugin.Common/McpPlugin.Common.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="3.11.0" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.1" />
-    <PackageReference Include="ModelContextProtocol" Version="0.5.0-preview.1" />
+    <PackageReference Include="ModelContextProtocol" Version="0.7.0-preview.1" />
     <PackageReference Include="R3" Version="1.3.0" />
   </ItemGroup>
 

--- a/McpPlugin.Server/McpPlugin.Server.csproj
+++ b/McpPlugin.Server/McpPlugin.Server.csproj
@@ -37,8 +37,8 @@
     <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="3.11.0" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.1" />
-    <PackageReference Include="ModelContextProtocol" Version="0.5.0-preview.1" />
-    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.5.0-preview.1" />
+    <PackageReference Include="ModelContextProtocol" Version="0.7.0-preview.1" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.7.0-preview.1" />
     <PackageReference Include="NLog.Web.AspNetCore" Version="6.1.0" />
     <PackageReference Include="R3" Version="1.3.0" />
   </ItemGroup>

--- a/McpPlugin/McpPlugin.csproj
+++ b/McpPlugin/McpPlugin.csproj
@@ -38,7 +38,7 @@
     <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="3.11.0" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.1" />
-    <PackageReference Include="ModelContextProtocol" Version="0.5.0-preview.1" />
+    <PackageReference Include="ModelContextProtocol" Version="0.7.0-preview.1" />
     <PackageReference Include="R3" Version="1.3.0" />
   </ItemGroup>
 


### PR DESCRIPTION
This pull request updates the `ModelContextProtocol` and `ModelContextProtocol.AspNetCore` package dependencies to a newer preview version across multiple projects. The main goal is to ensure all components use the latest features and fixes provided by version `0.7.0-preview.1` of these packages.

Dependency version upgrades:

* Upgraded `ModelContextProtocol` from version `0.5.0-preview.1` to `0.7.0-preview.1` in `McpPlugin.Common.csproj` and `McpPlugin.csproj` to ensure compatibility with the latest protocol changes. [[1]](diffhunk://#diff-5d8853646ef83c17a4de3f81d744db80ec7092b91729f8b2aa534466e59c024aL31-R31) [[2]](diffhunk://#diff-2367df5186dce604f76f56cd4f04942cc2225e773f41a3643c61a57fd3d71113L41-R41)
* Upgraded both `ModelContextProtocol` and `ModelContextProtocol.AspNetCore` from version `0.5.0-preview.1` to `0.7.0-preview.1` in `McpPlugin.Server.csproj` for server-side improvements and consistency.