### PR TITLE
style: format JSON schema for clarity in McpToolManager

### DIFF
--- a/McpPlugin/src/Mcp/McpToolManager.cs
+++ b/McpPlugin/src/Mcp/McpToolManager.cs
@@ -10,8 +10,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Threading;
@@ -27,7 +27,7 @@ namespace com.IvanMurzak.McpPlugin
 {
     public class McpToolManager : IToolManager
     {
-        static readonly JsonElement EmptyInputSchema = JsonDocument.Parse("{\"type\":\"object\"}").RootElement;
+        static readonly JsonElement EmptyInputSchema = JsonDocument.Parse("{ \"type\": \"object\", \"additionalProperties\": false }").RootElement;
 
         protected readonly ILogger _logger;
         protected readonly Reflector _reflector;


### PR DESCRIPTION
This pull request makes a small adjustment to the `McpToolManager` class to ensure stricter input validation for tool schemas.

- The `EmptyInputSchema` definition was updated to explicitly disallow additional properties, improving input validation by setting `"additionalProperties": false`.

# Official MCP documentation

<img width="571" height="550" alt="image" src="https://github.com/user-attachments/assets/c9c15726-aa57-40b5-bc3a-7653ae3441b6" />