### PR TITLE
chore: update ModelContextProtocol to v0.9.0-preview.2

### DIFF
--- a/McpPlugin.Common/McpPlugin.Common.csproj
+++ b/McpPlugin.Common/McpPlugin.Common.csproj
@@ -27,7 +27,7 @@
   <ItemGroup>
     <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="3.12.1" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.3" />
-    <PackageReference Include="ModelContextProtocol" Version="0.9.0-preview.1" />
+    <PackageReference Include="ModelContextProtocol" Version="0.9.0-preview.2" />
     <PackageReference Include="R3" Version="1.3.0" />
   </ItemGroup>
 

--- a/McpPlugin.Server/McpPlugin.Server.csproj
+++ b/McpPlugin.Server/McpPlugin.Server.csproj
@@ -36,8 +36,8 @@
     <ProjectReference Include="./../McpPlugin.Common/McpPlugin.Common.csproj" />
     <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="3.12.1" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.3" />
-    <PackageReference Include="ModelContextProtocol" Version="0.9.0-preview.1" />
-    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.9.0-preview.1" />
+    <PackageReference Include="ModelContextProtocol" Version="0.9.0-preview.2" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.9.0-preview.2" />
     <PackageReference Include="NLog.Web.AspNetCore" Version="6.1.0" />
     <PackageReference Include="R3" Version="1.3.0" />
   </ItemGroup>

--- a/McpPlugin/McpPlugin.csproj
+++ b/McpPlugin/McpPlugin.csproj
@@ -37,7 +37,7 @@
     <ProjectReference Include="./../McpPlugin.Common/McpPlugin.Common.csproj" />
     <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="3.12.1" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.3" />
-    <PackageReference Include="ModelContextProtocol" Version="0.9.0-preview.1" />
+    <PackageReference Include="ModelContextProtocol" Version="0.9.0-preview.2" />
     <PackageReference Include="R3" Version="1.3.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Update `ModelContextProtocol` and `ModelContextProtocol.AspNetCore` from 0.9.0-preview.1 to 0.9.0-preview.2 across all three library projects.

Closes #56