### PR TITLE
Add OIDC permissions to deploy workflow job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,6 +152,9 @@ jobs:
   deploy:
     needs: release-at-github
     if: needs.release-at-github.outputs.success == 'true'
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/deploy.yml
     with:
       version: ${{ needs.release-at-github.outputs.version }}


### PR DESCRIPTION
## Description

Add explicit permissions to the `deploy` job in the release workflow to enable OpenID Connect (OIDC) token generation. This allows the deployment job to authenticate using OIDC instead of relying on static credentials.

The changes add:
- `id-token: write` - Required to generate and use OIDC tokens
- `contents: read` - Required to read repository contents during deployment

## Type of Change

- [x] CI/CD or build configuration change

## How Has This Been Tested?

N/A - Configuration change verified through GitHub Actions workflow validation.

## Checklist

- [x] My changes generate no new warnings

## Additional Context

This change improves security by enabling OIDC-based authentication for the deployment workflow, reducing reliance on long-lived credentials. The permissions are scoped to the minimum required for the deployment job to function.

https://claude.ai/code/session_01TREJxNHZXz9vWL8n4qxPzz