### PR TITLE
feat: update SkillFileGenerator to emit CLI syntax

### DIFF
--- a/McpPlugin.Server/src/Api/DirectToolCallEndpoints.cs
+++ b/McpPlugin.Server/src/Api/DirectToolCallEndpoints.cs
@@ -17,7 +17,6 @@ using com.IvanMurzak.McpPlugin.Common;
 using com.IvanMurzak.McpPlugin.Common.Hub.Client;
 using com.IvanMurzak.McpPlugin.Common.Model;
 using com.IvanMurzak.McpPlugin.Common.Utils;
-using com.IvanMurzak.McpPlugin.Server.Auth;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
@@ -72,10 +71,6 @@ namespace com.IvanMurzak.McpPlugin.Server.Api
         /// </summary>
         static async Task ListToolsHandler(HttpContext context)
         {
-            var authHeader = context.Request.Headers.Authorization.ToString();
-            if (authHeader.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
-                McpSessionTokenContext.CurrentToken = authHeader.Substring("Bearer ".Length).Trim();
-
             var toolHub = context.RequestServices.GetRequiredService<IClientToolHub>();
             var request = new RequestListTool();
             var response = await toolHub.RunListTool(request, context.RequestAborted);
@@ -129,13 +124,6 @@ namespace com.IvanMurzak.McpPlugin.Server.Api
         /// </summary>
         static async Task CallToolHandler(HttpContext context)
         {
-            // Propagate the bearer token into McpSessionTokenContext so that
-            // RemoteToolRunner can route the call to the correct Unity plugin
-            // via the token-based connection strategy.
-            var authHeader = context.Request.Headers.Authorization.ToString();
-            if (authHeader.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
-                McpSessionTokenContext.CurrentToken = authHeader.Substring("Bearer ".Length).Trim();
-
             var toolHub = context.RequestServices.GetRequiredService<IClientToolHub>();
             var name = context.Request.RouteValues["name"]?.ToString() ?? string.Empty;
 

--- a/McpPlugin.Server/src/Auth/McpSessionTokenMiddleware.cs
+++ b/McpPlugin.Server/src/Auth/McpSessionTokenMiddleware.cs
@@ -1,0 +1,37 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace com.IvanMurzak.McpPlugin.Server.Auth
+{
+    /// <summary>
+    /// Reads the <see cref="TokenAuthenticationHandler.TokenClaimType"/> claim
+    /// from <see cref="HttpContext.User"/> (set by <see cref="TokenAuthenticationHandler"/>)
+    /// and propagates it into <see cref="McpSessionTokenContext.CurrentToken"/>.
+    /// Must run after <c>UseAuthentication()</c> and before endpoint handlers.
+    /// </summary>
+    public class McpSessionTokenMiddleware
+    {
+        private readonly RequestDelegate _next;
+
+        public McpSessionTokenMiddleware(RequestDelegate next) => _next = next;
+
+        public async Task InvokeAsync(HttpContext context)
+        {
+            var tokenClaim = context.User?.FindFirst(TokenAuthenticationHandler.TokenClaimType);
+            if (tokenClaim != null)
+                McpSessionTokenContext.CurrentToken = tokenClaim.Value;
+
+            await _next(context);
+        }
+    }
+}

--- a/McpPlugin.Server/src/Extension/ExtensionsWebApplication.cs
+++ b/McpPlugin.Server/src/Extension/ExtensionsWebApplication.cs
@@ -12,6 +12,7 @@ using System;
 using com.IvanMurzak.McpPlugin.Common;
 using com.IvanMurzak.McpPlugin.Common.Utils;
 using com.IvanMurzak.McpPlugin.Server.Api;
+using com.IvanMurzak.McpPlugin.Server.Auth;
 using com.IvanMurzak.McpPlugin.Server.Transport;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http.Connections;
@@ -34,6 +35,7 @@ namespace com.IvanMurzak.McpPlugin.Server
 
             // Setup auth -------------------------------------------------------
             app.UseAuthentication();
+            app.UseMiddleware<McpSessionTokenMiddleware>();
             app.UseAuthorization();
 
             // Setup SignalR ----------------------------------------------------


### PR DESCRIPTION
## Summary
- Replace `curl` HTTP API examples in generated SKILL.md files with `unity-mcp-cli run-tool` CLI commands
- Authorization examples now use `--token YOUR_TOKEN` flag instead of `-H "Authorization: Bearer"` header
- Updated all XML doc comments to reference CLI syntax

## Changes
- **`SkillFileGenerator.cs`** — "How to Call" section generates `unity-mcp-cli run-tool {name} --url {host} --input '{...}'` instead of curl commands; authorization block uses `--token` flag; XML doc comments updated throughout
- **`SkillFileGeneratorTests.cs`** — Updated existing assertions from curl to CLI syntax; added 4 new tests: `Generate_CliCommand_ContainsToolName`, `Generate_CliCommand_ContainsInputFlag`, `Generate_CliCommand_DoesNotContainCurl`, `Generate_CliCommand_ContainsCliSection`

## Test plan
- [x] `dotnet test` — all 334 tests pass (net8.0 + net9.0)
- [ ] Generate SKILL.md files and verify they contain CLI syntax instead of curl
- [ ] Verify companion PR in Unity-MCP adds the `run-tool` CLI command

🤖 Generated with [Claude Code](https://claude.com/claude-code)