### PR TITLE
chore: upgrade GitHub Actions to Node.js 24

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,14 +26,14 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
             8.0.x
             9.0.x
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Extract version from tag
         id: version
@@ -32,7 +32,7 @@ jobs:
           echo "Extracted version: $version"
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
             8.0.x

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       tag_exists: ${{ steps.tag_exists.outputs.exists }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -28,11 +28,11 @@ jobs:
 
       - name: Find previous version tag
         id: prev_tag
-        uses: WyriHaximus/github-action-get-previous-tag@v1
+        uses: WyriHaximus/github-action-get-previous-tag@v2
 
       - name: Check if tag exists
         id: tag_exists
-        uses: mukunku/tag-exists-action@v1.6.0
+        uses: mukunku/tag-exists-action@v1.7.0
         with:
           tag: ${{ steps.get_version.outputs.current-version }}
 
@@ -45,10 +45,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
             8.0.x
@@ -74,7 +74,7 @@ jobs:
 
       - name: Upload Test Results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-results
           path: TestResults/**/*.trx
@@ -92,7 +92,7 @@ jobs:
       release_notes: ${{ steps.rel_desc.outputs.release_body }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -14,10 +14,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
             8.0.x
@@ -43,7 +43,7 @@ jobs:
 
       - name: Upload Test Results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-results
           path: TestResults/**/*.trx


### PR DESCRIPTION
## Summary
- Upgrade all GitHub Actions that have Node.js 24 versions to eliminate deprecation warnings
- Node.js 20 actions will be forced to Node.js 24 starting June 2nd, 2026

### Actions upgraded

| Action | Old | New | Node |
|--------|-----|-----|------|
| `actions/checkout` | v4 | v5 | 20 → 24 |
| `actions/setup-dotnet` | v4 | v5 | 20 → 24 |
| `actions/upload-artifact` | v4 | v7 | 20 → 24 |
| `mukunku/tag-exists-action` | v1.6.0 | v1.7.0 | 20 → 24 |
| `WyriHaximus/github-action-get-previous-tag` | v1 | v2 | 20 → 24 |

### Not yet upgradable
- `softprops/action-gh-release@v2` — still Node 20, no v3 available
- `NuGet/login@v1` — still Node 16, no newer version available

## Test plan
- [ ] Verify `release.yml` workflow runs without Node.js deprecation warnings
- [x] Verify `test-pull-request.yml` workflow runs without Node.js deprecation warnings
- [ ] Verify `deploy.yml` workflow runs without Node.js deprecation warnings
- [x] Verify `claude.yml` workflow runs without Node.js deprecation warnings