### PR TITLE
feat: add webhook instrumentation to SystemToolEndpoints

### DIFF
--- a/McpPlugin.Server/src/Api/SystemToolEndpoints.cs
+++ b/McpPlugin.Server/src/Api/SystemToolEndpoints.cs
@@ -210,14 +210,14 @@ namespace com.IvanMurzak.McpPlugin.Server.Api
 
                     if (isError)
                     {
-                        errorDetails = response?.Message;
+                        errorDetails = response?.Message ?? "System tool hub returned a null response.";
                     }
                     else if (response?.Value != null)
                     {
                         try
                         {
-                            responseSize = System.Text.Encoding.UTF8.GetByteCount(
-                                JsonSerializer.Serialize(response.Value));
+                            var responseBytes = JsonSerializer.SerializeToUtf8Bytes(response.Value);
+                            responseSize = responseBytes.LongLength;
                         }
                         catch (Exception) { /* measurement failure is non-fatal */ }
                     }


### PR DESCRIPTION
## Summary
- System tool HTTP API calls (`POST /api/system-tools/{name}`) were not emitting analytics webhooks, unlike the regular tool endpoints (`POST /api/tools/{name}`)
- Adds the same timing, size measurement, and `OnToolCall` webhook pattern used by `DirectToolCallEndpoints` so system tool usage is tracked in backend statistics

## Test plan
- [x] Call a system tool via `POST /api/system-tools/{name}` and verify a `tool.call.completed` webhook is sent to the backend
- [x] Confirm the event appears in the `mcp_event` table with `channel=http`
- [x] Verify existing `POST /api/tools/{name}` webhook behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)