### PR TITLE
fix: STJ v8 and SignalR v8 for Unity 6.5 compatibility

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,22 @@
+<Project>
+
+  <!-- Pin v8 packages only for Unity-targeted TFM (Unity 6.5 ships v8 of these,
+       disabling v10 copies in Editor). NU1605 is suppressed because ModelContextProtocol
+       1.2.0 transitively requires v10; the downgrade is intentional. net8.0/net9.0
+       targets are unaffected and still resolve v10. -->
+  <!-- NU1605 must be unconditional: NuGet restore evaluates NoWarn before
+       the per-TFM inner build sets $(TargetFramework), so a conditional
+       suppression is silently ignored during solution-level restore. -->
+  <PropertyGroup>
+    <NoWarn>$(NoWarn);NU1605</NoWarn>
+  </PropertyGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
+  </ItemGroup>
+
+</Project>

--- a/McpPlugin.Common/McpPlugin.Common.csproj
+++ b/McpPlugin.Common/McpPlugin.Common.csproj
@@ -31,15 +31,20 @@
     <PackageReference Include="R3" Version="1.3.0" />
   </ItemGroup>
 
-  <!-- Pin STJ 8 only for Unity-targeted TFM (Unity 6.6 ships STJ 8.0.5 alongside).
-       NU1605 is suppressed because ModelContextProtocol 1.2.0 transitively requires
-       STJ 10, but Unity can't load STJ 10 in Editor. The downgrade is intentional;
-       net8.0/net9.0 targets are unaffected and still resolve STJ 10. -->
+  <!-- Pin v8 packages only for Unity-targeted TFM (Unity 6.6 ships v8 of these,
+       disabling v10 copies in Editor). NU1605 is suppressed because ModelContextProtocol
+       1.2.0 transitively requires v10; the downgrade is intentional. net8.0/net9.0
+       targets are unaffected and still resolve v10. -->
   <PropertyGroup>
     <NoWarn>$(NoWarn);NU1605</NoWarn>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
   </ItemGroup>
 
   <!-- Include package files -->

--- a/McpPlugin.Common/McpPlugin.Common.csproj
+++ b/McpPlugin.Common/McpPlugin.Common.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="4.2.0" />
+    <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="4.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.15" />
     <PackageReference Include="ModelContextProtocol" Version="1.2.0" />
     <PackageReference Include="R3" Version="1.3.0" />

--- a/McpPlugin.Common/McpPlugin.Common.csproj
+++ b/McpPlugin.Common/McpPlugin.Common.csproj
@@ -31,22 +31,6 @@
     <PackageReference Include="R3" Version="1.3.0" />
   </ItemGroup>
 
-  <!-- Pin v8 packages only for Unity-targeted TFM (Unity 6.6 ships v8 of these,
-       disabling v10 copies in Editor). NU1605 is suppressed because ModelContextProtocol
-       1.2.0 transitively requires v10; the downgrade is intentional. net8.0/net9.0
-       targets are unaffected and still resolve v10. -->
-  <PropertyGroup>
-    <NoWarn>$(NoWarn);NU1605</NoWarn>
-  </PropertyGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
-    <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
-  </ItemGroup>
-
   <!-- Include package files -->
   <ItemGroup>
     <None Include="./../LICENSE" Pack="true" PackagePath="" />

--- a/McpPlugin.Common/McpPlugin.Common.csproj
+++ b/McpPlugin.Common/McpPlugin.Common.csproj
@@ -11,7 +11,7 @@
     <!-- NuGet Package Information -->
     <IsPackable>true</IsPackable>
     <PackageId>com.IvanMurzak.McpPlugin.Common</PackageId>
-    <Version>5.10.2</Version>
+    <Version>5.11.0</Version>
     <Authors>Ivan Murzak</Authors>
     <Company>Ivan Murzak</Company>
     <Copyright>Copyright © Ivan Murzak 2025</Copyright>
@@ -25,8 +25,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="4.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.3" />
+    <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="4.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.15" />
     <PackageReference Include="ModelContextProtocol" Version="1.2.0" />
     <PackageReference Include="R3" Version="1.3.0" />
   </ItemGroup>

--- a/McpPlugin.Common/McpPlugin.Common.csproj
+++ b/McpPlugin.Common/McpPlugin.Common.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="4.2.0" />
+    <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="5.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.15" />
     <PackageReference Include="ModelContextProtocol" Version="1.2.0" />
     <PackageReference Include="R3" Version="1.3.0" />

--- a/McpPlugin.Common/McpPlugin.Common.csproj
+++ b/McpPlugin.Common/McpPlugin.Common.csproj
@@ -25,10 +25,21 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="4.1.0" />
+    <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="4.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.15" />
     <PackageReference Include="ModelContextProtocol" Version="1.2.0" />
     <PackageReference Include="R3" Version="1.3.0" />
+  </ItemGroup>
+
+  <!-- Pin STJ 8 only for Unity-targeted TFM (Unity 6.6 ships STJ 8.0.5 alongside).
+       NU1605 is suppressed because ModelContextProtocol 1.2.0 transitively requires
+       STJ 10, but Unity can't load STJ 10 in Editor. The downgrade is intentional;
+       net8.0/net9.0 targets are unaffected and still resolve STJ 10. -->
+  <PropertyGroup>
+    <NoWarn>$(NoWarn);NU1605</NoWarn>
+  </PropertyGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
   <!-- Include package files -->

--- a/McpPlugin.Common/McpPlugin.Common.csproj
+++ b/McpPlugin.Common/McpPlugin.Common.csproj
@@ -11,7 +11,7 @@
     <!-- NuGet Package Information -->
     <IsPackable>true</IsPackable>
     <PackageId>com.IvanMurzak.McpPlugin.Common</PackageId>
-    <Version>5.11.0</Version>
+    <Version>6.0.0</Version>
     <Authors>Ivan Murzak</Authors>
     <Company>Ivan Murzak</Company>
     <Copyright>Copyright © Ivan Murzak 2025</Copyright>

--- a/McpPlugin.Common/src/Utils/Consts.cs
+++ b/McpPlugin.Common/src/Utils/Consts.cs
@@ -12,7 +12,7 @@ namespace com.IvanMurzak.McpPlugin.Common
     public static partial class Consts
     {
         public const string ApiVersion = "2.0.0";
-        public const string PluginVersion = "5.10.2";
+        public const string PluginVersion = "6.0.0";
 
         public static class Guid
         {

--- a/McpPlugin.Server/McpPlugin.Server.csproj
+++ b/McpPlugin.Server/McpPlugin.Server.csproj
@@ -34,7 +34,7 @@
 
   <ItemGroup>
     <ProjectReference Include="./../McpPlugin.Common/McpPlugin.Common.csproj" />
-    <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="4.1.0" />
+    <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="5.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.3" />
     <PackageReference Include="ModelContextProtocol" Version="1.2.0" />
     <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.2.0" />

--- a/McpPlugin.Server/McpPlugin.Server.csproj
+++ b/McpPlugin.Server/McpPlugin.Server.csproj
@@ -11,7 +11,7 @@
     <!-- NuGet Package Information -->
     <IsPackable>true</IsPackable>
     <PackageId>com.IvanMurzak.McpPlugin.Server</PackageId>
-    <Version>5.11.0</Version>
+    <Version>6.0.0</Version>
     <Authors>Ivan Murzak</Authors>
     <Company>Ivan Murzak</Company>
     <Copyright>Copyright © Ivan Murzak 2025</Copyright>

--- a/McpPlugin.Server/McpPlugin.Server.csproj
+++ b/McpPlugin.Server/McpPlugin.Server.csproj
@@ -11,7 +11,7 @@
     <!-- NuGet Package Information -->
     <IsPackable>true</IsPackable>
     <PackageId>com.IvanMurzak.McpPlugin.Server</PackageId>
-    <Version>5.10.2</Version>
+    <Version>5.11.0</Version>
     <Authors>Ivan Murzak</Authors>
     <Company>Ivan Murzak</Company>
     <Copyright>Copyright © Ivan Murzak 2025</Copyright>
@@ -34,7 +34,7 @@
 
   <ItemGroup>
     <ProjectReference Include="./../McpPlugin.Common/McpPlugin.Common.csproj" />
-    <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="4.1.0" />
+    <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="4.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.3" />
     <PackageReference Include="ModelContextProtocol" Version="1.2.0" />
     <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.2.0" />

--- a/McpPlugin.Server/McpPlugin.Server.csproj
+++ b/McpPlugin.Server/McpPlugin.Server.csproj
@@ -34,7 +34,7 @@
 
   <ItemGroup>
     <ProjectReference Include="./../McpPlugin.Common/McpPlugin.Common.csproj" />
-    <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="4.2.0" />
+    <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="4.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.3" />
     <PackageReference Include="ModelContextProtocol" Version="1.2.0" />
     <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.2.0" />

--- a/McpPlugin.Server/server.json
+++ b/McpPlugin.Server/server.json
@@ -8,13 +8,13 @@
     "source": "github",
     "subfolder": "McpPlugin.Server"
   },
-  "version": "5.10.2",
+  "version": "6.0.0",
   "packages": [
     {
       "registry_type": "oci",
       "registry_base_url": "https://docker.io",
       "identifier": "ivanmurzakdev/mcp-plugin-server",
-      "version": "5.10.2",
+      "version": "6.0.0",
       "transport": {
         "type": "stdio"
       },

--- a/McpPlugin.Tests/Extensions/ExtensionsJsonElementTests.cs
+++ b/McpPlugin.Tests/Extensions/ExtensionsJsonElementTests.cs
@@ -1,0 +1,222 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+using System.Text.Json;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.Tests.Extensions
+{
+    public class ExtensionsJsonElementTests
+    {
+        private static JsonElement? ParseElement(string json)
+        {
+            return JsonDocument.Parse(json).RootElement.Clone();
+        }
+
+        // ── int ──────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void SetProperty_Int_SetsValue()
+        {
+            JsonElement? element = null;
+            var result = element.SetProperty("count", 42);
+            result.GetProperty("count").GetInt32().ShouldBe(42);
+        }
+
+        [Fact]
+        public void SetProperty_Int_SkipsWhenUnchanged()
+        {
+            JsonElement? element = ParseElement("{\"count\":42}");
+            var original = element!.Value;
+            var result = element.SetProperty("count", 42);
+            result.GetRawText().ShouldBe(original.GetRawText());
+        }
+
+        // ── uint ─────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void SetProperty_UInt_SetsValue()
+        {
+            JsonElement? element = null;
+            var result = element.SetProperty("count", 42u);
+            result.GetProperty("count").GetUInt32().ShouldBe(42u);
+        }
+
+        [Fact]
+        public void SetProperty_UInt_SkipsWhenUnchanged()
+        {
+            JsonElement? element = ParseElement("{\"count\":42}");
+            var original = element!.Value;
+            var result = element.SetProperty("count", 42u);
+            result.GetRawText().ShouldBe(original.GetRawText());
+        }
+
+        [Fact]
+        public void SetProperty_UInt_ReplacesExistingValue()
+        {
+            JsonElement? element = ParseElement("{\"count\":10}");
+            var result = element.SetProperty("count", 99u);
+            result.GetProperty("count").GetUInt32().ShouldBe(99u);
+        }
+
+        // ── long ─────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void SetProperty_Long_SetsValue()
+        {
+            JsonElement? element = null;
+            var result = element.SetProperty("big", 9999999999L);
+            result.GetProperty("big").GetInt64().ShouldBe(9999999999L);
+        }
+
+        // ── ulong ────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void SetProperty_ULong_SetsValue()
+        {
+            JsonElement? element = null;
+            var result = element.SetProperty("big", 18446744073709551615UL);
+            result.GetProperty("big").GetUInt64().ShouldBe(18446744073709551615UL);
+        }
+
+        // ── float ────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void SetProperty_Float_SetsValue()
+        {
+            JsonElement? element = null;
+            var result = element.SetProperty("ratio", 3.14f);
+            result.GetProperty("ratio").GetSingle().ShouldBe(3.14f);
+        }
+
+        [Fact]
+        public void SetProperty_Float_SkipsWhenUnchanged()
+        {
+            JsonElement? element = ParseElement("{\"ratio\":3.14}");
+            var original = element!.Value;
+            var result = element.SetProperty("ratio", 3.14f);
+            result.GetRawText().ShouldBe(original.GetRawText());
+        }
+
+        // ── double ───────────────────────────────────────────────────────────
+
+        [Fact]
+        public void SetProperty_Double_SetsValue()
+        {
+            JsonElement? element = null;
+            var result = element.SetProperty("pi", 3.141592653589793);
+            result.GetProperty("pi").GetDouble().ShouldBe(3.141592653589793);
+        }
+
+        [Fact]
+        public void SetProperty_Double_SkipsWhenUnchanged()
+        {
+            JsonElement? element = ParseElement("{\"pi\":3.141592653589793}");
+            var original = element!.Value;
+            var result = element.SetProperty("pi", 3.141592653589793);
+            result.GetRawText().ShouldBe(original.GetRawText());
+        }
+
+        [Fact]
+        public void SetProperty_Double_ReplacesExistingValue()
+        {
+            JsonElement? element = ParseElement("{\"pi\":0.0}");
+            var result = element.SetProperty("pi", 3.14);
+            result.GetProperty("pi").GetDouble().ShouldBe(3.14);
+        }
+
+        // ── decimal ──────────────────────────────────────────────────────────
+
+        [Fact]
+        public void SetProperty_Decimal_SetsValue()
+        {
+            JsonElement? element = null;
+            var result = element.SetProperty("price", 19.99m);
+            result.GetProperty("price").GetDecimal().ShouldBe(19.99m);
+        }
+
+        [Fact]
+        public void SetProperty_Decimal_SkipsWhenUnchanged()
+        {
+            JsonElement? element = ParseElement("{\"price\":19.99}");
+            var original = element!.Value;
+            var result = element.SetProperty("price", 19.99m);
+            result.GetRawText().ShouldBe(original.GetRawText());
+        }
+
+        [Fact]
+        public void SetProperty_Decimal_ReplacesExistingValue()
+        {
+            JsonElement? element = ParseElement("{\"price\":10.00}");
+            var result = element.SetProperty("price", 29.99m);
+            result.GetProperty("price").GetDecimal().ShouldBe(29.99m);
+        }
+
+        // ── string ───────────────────────────────────────────────────────────
+
+        [Fact]
+        public void SetProperty_String_SetsValue()
+        {
+            JsonElement? element = null;
+            var result = element.SetProperty("name", "hello");
+            result.GetProperty("name").GetString().ShouldBe("hello");
+        }
+
+        [Fact]
+        public void SetProperty_String_SkipsWhenUnchanged()
+        {
+            JsonElement? element = ParseElement("{\"name\":\"hello\"}");
+            var original = element!.Value;
+            var result = element.SetProperty("name", "hello");
+            result.GetRawText().ShouldBe(original.GetRawText());
+        }
+
+        // ── bool ─────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void SetProperty_Bool_SetsValue()
+        {
+            JsonElement? element = null;
+            var result = element.SetProperty("active", true);
+            result.GetProperty("active").GetBoolean().ShouldBe(true);
+        }
+
+        [Fact]
+        public void SetProperty_Bool_SkipsWhenUnchanged()
+        {
+            JsonElement? element = ParseElement("{\"active\":true}");
+            var original = element!.Value;
+            var result = element.SetProperty("active", true);
+            result.GetRawText().ShouldBe(original.GetRawText());
+        }
+
+        // ── shared behavior ──────────────────────────────────────────────────
+
+        [Fact]
+        public void SetProperty_PreservesOtherProperties()
+        {
+            JsonElement? element = ParseElement("{\"a\":1,\"b\":\"two\",\"c\":true}");
+            var result = element.SetProperty("b", "updated");
+            result.GetProperty("a").GetInt32().ShouldBe(1);
+            result.GetProperty("b").GetString().ShouldBe("updated");
+            result.GetProperty("c").GetBoolean().ShouldBe(true);
+        }
+
+        [Fact]
+        public void SetProperty_AddsNewPropertyToExistingObject()
+        {
+            JsonElement? element = ParseElement("{\"existing\":1}");
+            var result = element.SetProperty("newProp", 42u);
+            result.GetProperty("existing").GetInt32().ShouldBe(1);
+            result.GetProperty("newProp").GetUInt32().ShouldBe(42u);
+        }
+    }
+}

--- a/McpPlugin/McpPlugin.csproj
+++ b/McpPlugin/McpPlugin.csproj
@@ -41,15 +41,20 @@
     <PackageReference Include="R3" Version="1.3.0" />
   </ItemGroup>
 
-  <!-- Pin STJ 8 only for Unity-targeted TFM (Unity 6.6 ships STJ 8.0.5 alongside).
-       NU1605 is suppressed because ModelContextProtocol 1.2.0 transitively requires
-       STJ 10, but Unity can't load STJ 10 in Editor. The downgrade is intentional;
-       net8.0/net9.0 targets are unaffected and still resolve STJ 10. -->
+  <!-- Pin v8 packages only for Unity-targeted TFM (Unity 6.6 ships v8 of these,
+       disabling v10 copies in Editor). NU1605 is suppressed because ModelContextProtocol
+       1.2.0 transitively requires v10; the downgrade is intentional. net8.0/net9.0
+       targets are unaffected and still resolve v10. -->
   <PropertyGroup>
     <NoWarn>$(NoWarn);NU1605</NoWarn>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
   </ItemGroup>
 
 </Project>

--- a/McpPlugin/McpPlugin.csproj
+++ b/McpPlugin/McpPlugin.csproj
@@ -35,7 +35,7 @@
 
   <ItemGroup>
     <ProjectReference Include="./../McpPlugin.Common/McpPlugin.Common.csproj" />
-    <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="4.2.0" />
+    <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="4.1.0" />
     <PackageReference Include="ModelContextProtocol" Version="1.2.0" />
     <PackageReference Include="R3" Version="1.3.0" />
   </ItemGroup>

--- a/McpPlugin/McpPlugin.csproj
+++ b/McpPlugin/McpPlugin.csproj
@@ -41,20 +41,4 @@
     <PackageReference Include="R3" Version="1.3.0" />
   </ItemGroup>
 
-  <!-- Pin v8 packages only for Unity-targeted TFM (Unity 6.6 ships v8 of these,
-       disabling v10 copies in Editor). NU1605 is suppressed because ModelContextProtocol
-       1.2.0 transitively requires v10; the downgrade is intentional. net8.0/net9.0
-       targets are unaffected and still resolve v10. -->
-  <PropertyGroup>
-    <NoWarn>$(NoWarn);NU1605</NoWarn>
-  </PropertyGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
-    <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
-  </ItemGroup>
-
 </Project>

--- a/McpPlugin/McpPlugin.csproj
+++ b/McpPlugin/McpPlugin.csproj
@@ -35,7 +35,7 @@
 
   <ItemGroup>
     <ProjectReference Include="./../McpPlugin.Common/McpPlugin.Common.csproj" />
-    <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="4.2.0" />
+    <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="5.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.15" />
     <PackageReference Include="ModelContextProtocol" Version="1.2.0" />
     <PackageReference Include="R3" Version="1.3.0" />

--- a/McpPlugin/McpPlugin.csproj
+++ b/McpPlugin/McpPlugin.csproj
@@ -15,7 +15,7 @@
     <!-- NuGet Package Information -->
     <IsPackable>true</IsPackable>
     <PackageId>com.IvanMurzak.McpPlugin</PackageId>
-    <Version>5.10.2</Version>
+    <Version>5.11.0</Version>
     <Authors>Ivan Murzak</Authors>
     <Company>Ivan Murzak</Company>
     <Copyright>Copyright © Ivan Murzak 2025</Copyright>
@@ -35,10 +35,19 @@
 
   <ItemGroup>
     <ProjectReference Include="./../McpPlugin.Common/McpPlugin.Common.csproj" />
-    <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="4.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.3" />
+    <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="4.2.0" />
     <PackageReference Include="ModelContextProtocol" Version="1.2.0" />
     <PackageReference Include="R3" Version="1.3.0" />
+  </ItemGroup>
+
+  <!-- v8 for netstandard2.1 and net8.0 (Unity + general compatibility) -->
+  <ItemGroup Condition="'$(TargetFramework)' != 'net9.0'">
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.15" />
+  </ItemGroup>
+
+  <!-- v10 for net9.0 (full features) -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.3" />
   </ItemGroup>
 
 </Project>

--- a/McpPlugin/McpPlugin.csproj
+++ b/McpPlugin/McpPlugin.csproj
@@ -36,18 +36,9 @@
   <ItemGroup>
     <ProjectReference Include="./../McpPlugin.Common/McpPlugin.Common.csproj" />
     <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="4.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.15" />
     <PackageReference Include="ModelContextProtocol" Version="1.2.0" />
     <PackageReference Include="R3" Version="1.3.0" />
-  </ItemGroup>
-
-  <!-- v8 for netstandard2.1 and net8.0 (Unity + general compatibility) -->
-  <ItemGroup Condition="'$(TargetFramework)' != 'net9.0'">
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.15" />
-  </ItemGroup>
-
-  <!-- v10 for net9.0 (full features) -->
-  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.3" />
   </ItemGroup>
 
 </Project>

--- a/McpPlugin/McpPlugin.csproj
+++ b/McpPlugin/McpPlugin.csproj
@@ -35,10 +35,21 @@
 
   <ItemGroup>
     <ProjectReference Include="./../McpPlugin.Common/McpPlugin.Common.csproj" />
-    <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="4.1.0" />
+    <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="4.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.15" />
     <PackageReference Include="ModelContextProtocol" Version="1.2.0" />
     <PackageReference Include="R3" Version="1.3.0" />
+  </ItemGroup>
+
+  <!-- Pin STJ 8 only for Unity-targeted TFM (Unity 6.6 ships STJ 8.0.5 alongside).
+       NU1605 is suppressed because ModelContextProtocol 1.2.0 transitively requires
+       STJ 10, but Unity can't load STJ 10 in Editor. The downgrade is intentional;
+       net8.0/net9.0 targets are unaffected and still resolve STJ 10. -->
+  <PropertyGroup>
+    <NoWarn>$(NoWarn);NU1605</NoWarn>
+  </PropertyGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
 </Project>

--- a/McpPlugin/McpPlugin.csproj
+++ b/McpPlugin/McpPlugin.csproj
@@ -15,7 +15,7 @@
     <!-- NuGet Package Information -->
     <IsPackable>true</IsPackable>
     <PackageId>com.IvanMurzak.McpPlugin</PackageId>
-    <Version>5.11.0</Version>
+    <Version>6.0.0</Version>
     <Authors>Ivan Murzak</Authors>
     <Company>Ivan Murzak</Company>
     <Copyright>Copyright © Ivan Murzak 2025</Copyright>

--- a/McpPlugin/src/Extension/ExtensionsJsonElement.cs
+++ b/McpPlugin/src/Extension/ExtensionsJsonElement.cs
@@ -9,7 +9,6 @@
 */
 
 using System;
-using System.Text;
 using System.Text.Json;
 
 namespace com.IvanMurzak.McpPlugin
@@ -74,8 +73,7 @@ namespace com.IvanMurzak.McpPlugin
         public static JsonElement SetProperty(this ref JsonElement? originalElement, string propertyName, float newValue)
         {
             if (originalElement != null && originalElement.Value.TryGetProperty(propertyName, out var prop)
-                && prop.ValueKind == JsonValueKind.Number
-                && prop.TryGetSingle(out var existing) && Math.Abs(existing - newValue) < float.Epsilon)
+                && prop.TryGetSingle(out var existing) && existing == newValue)
                 return originalElement.Value;
 
             return SetPropertyCore(ref originalElement, propertyName,
@@ -88,8 +86,7 @@ namespace com.IvanMurzak.McpPlugin
         public static JsonElement SetProperty(this ref JsonElement? originalElement, string propertyName, double newValue)
         {
             if (originalElement != null && originalElement.Value.TryGetProperty(propertyName, out var prop)
-                && prop.ValueKind == JsonValueKind.Number
-                && prop.TryGetDouble(out var existing) && Math.Abs(existing - newValue) < double.Epsilon)
+                && prop.TryGetDouble(out var existing) && existing == newValue)
                 return originalElement.Value;
 
             return SetPropertyCore(ref originalElement, propertyName,
@@ -169,8 +166,9 @@ namespace com.IvanMurzak.McpPlugin
             writer.WriteEndObject();
             writer.Flush();
 
-            var correctedJson = Encoding.UTF8.GetString(stream.ToArray());
-            originalElement = JsonDocument.Parse(correctedJson).RootElement;
+            var jsonBytes = new ReadOnlyMemory<byte>(stream.GetBuffer(), 0, (int)stream.Length);
+            using var doc = JsonDocument.Parse(jsonBytes);
+            originalElement = doc.RootElement.Clone();
             return originalElement.Value;
         }
     }

--- a/McpPlugin/src/Extension/ExtensionsJsonElement.cs
+++ b/McpPlugin/src/Extension/ExtensionsJsonElement.cs
@@ -8,6 +8,7 @@
 └────────────────────────────────────────────────────────────────────────┘
 */
 
+using System;
 using System.Text;
 using System.Text.Json;
 
@@ -16,197 +17,134 @@ namespace com.IvanMurzak.McpPlugin
     public static class ExtensionsJsonElement
     {
         /// <summary>
-        /// Updates a JsonElement by setting or replacing a specific property with a new value.
+        /// Updates a JsonElement by setting or replacing a specific property with a new int value.
         /// </summary>
-        /// <param name="originalElement">The original JsonElement to update</param>
-        /// <param name="propertyName">The name of the property to set/replace</param>
-        /// <param name="newValue">The new value for the property</param>
-        /// <returns>A new JsonElement with the updated property</returns>
-        public static JsonElement SetProperty(
-            this ref JsonElement? originalElement,
-            string propertyName,
-            int newValue)
+        public static JsonElement SetProperty(this ref JsonElement? originalElement, string propertyName, int newValue)
         {
-            // Check if need to set value
-            if (originalElement != null && originalElement.Value.TryGetProperty(propertyName, out var propertyElement))
-            {
-                if (propertyElement.TryGetInt32(out var existedValue))
-                {
-                    if (existedValue == newValue)
-                        return originalElement.Value; // no need to set value
-                }
-            }
+            if (originalElement != null && originalElement.Value.TryGetProperty(propertyName, out var prop)
+                && prop.TryGetInt32(out var existing) && existing == newValue)
+                return originalElement.Value;
 
-            using var stream = new System.IO.MemoryStream();
-            using var writer = new Utf8JsonWriter(stream);
-
-            writer.WriteStartObject();
-
-            if (originalElement == null)
-            {
-                // If originalElement is null, we just write the new property
-                writer.WriteNumber(propertyName, newValue);
-            }
-            else
-            {
-                // Copy all existing properties except the one we're updating
-                foreach (var property in originalElement.Value.EnumerateObject())
-                {
-                    if (property.Name != propertyName)
-                    {
-                        property.WriteTo(writer);
-                    }
-                }
-                // Write the new property value
-                writer.WriteNumber(propertyName, newValue);
-            }
-
-            writer.WriteEndObject();
-            writer.Flush();
-
-            // Parse and return the new JsonElement
-            var correctedJson = Encoding.UTF8.GetString(stream.ToArray());
-            originalElement = JsonDocument.Parse(correctedJson).RootElement;
-            return originalElement.Value;
+            return SetPropertyCore(ref originalElement, propertyName,
+                (w, name) => w.WriteNumber(name, newValue));
         }
 
         /// <summary>
-        /// Updates a JsonElement by setting or replacing a specific property with a new string value.
+        /// Updates a JsonElement by setting or replacing a specific property with a new uint value.
         /// </summary>
-        /// <param name="originalElement">The original JsonElement to update</param>
-        /// <param name="propertyName">The name of the property to set/replace</param>
-        /// <param name="newValue">The new string value for the property</param>
-        /// <returns>A new JsonElement with the updated property</returns>
-        public static JsonElement SetProperty(
-            this ref JsonElement? originalElement,
-            string propertyName,
-            string newValue)
+        public static JsonElement SetProperty(this ref JsonElement? originalElement, string propertyName, uint newValue)
         {
-            // Check if need to set value
-            if (originalElement != null && originalElement.Value.TryGetProperty(propertyName, out var propertyElement))
-            {
-                if (propertyElement.ValueKind == JsonValueKind.String)
-                {
-                    var existedValue = propertyElement.GetString();
-                    if (existedValue == newValue)
-                        return originalElement.Value; // no need to set value
-                }
-            }
+            if (originalElement != null && originalElement.Value.TryGetProperty(propertyName, out var prop)
+                && prop.TryGetUInt32(out var existing) && existing == newValue)
+                return originalElement.Value;
 
-            using var stream = new System.IO.MemoryStream();
-            using var writer = new Utf8JsonWriter(stream);
-
-            writer.WriteStartObject();
-
-            if (originalElement == null)
-            {
-                // If originalElement is null, we just write the new property
-                writer.WriteString(propertyName, newValue);
-            }
-            else
-            {
-                // Copy all existing properties except the one we're updating
-                foreach (var property in originalElement.Value.EnumerateObject())
-                {
-                    if (property.Name != propertyName)
-                    {
-                        property.WriteTo(writer);
-                    }
-                }
-                // Write the new property value
-                writer.WriteString(propertyName, newValue);
-            }
-
-            writer.WriteEndObject();
-            writer.Flush();
-
-            // Parse and return the new JsonElement
-            var correctedJson = Encoding.UTF8.GetString(stream.ToArray());
-            originalElement = JsonDocument.Parse(correctedJson).RootElement;
-            return originalElement.Value;
+            return SetPropertyCore(ref originalElement, propertyName,
+                (w, name) => w.WriteNumber(name, newValue));
         }
 
         /// <summary>
-        /// Updates a JsonElement by setting or replacing a specific property with a new boolean value.
+        /// Updates a JsonElement by setting or replacing a specific property with a new long value.
         /// </summary>
-        /// <param name="originalElement">The original JsonElement to update</param>
-        /// <param name="propertyName">The name of the property to set/replace</param>
-        /// <param name="newValue">The new boolean value for the property</param>
-        /// <returns>A new JsonElement with the updated property</returns>
-        public static JsonElement SetProperty(
-            this ref JsonElement? originalElement,
-            string propertyName,
-            bool newValue)
+        public static JsonElement SetProperty(this ref JsonElement? originalElement, string propertyName, long newValue)
         {
-            // Check if need to set value
-            if (originalElement != null && originalElement.Value.TryGetProperty(propertyName, out var propertyElement))
-            {
-                if (propertyElement.ValueKind == JsonValueKind.True || propertyElement.ValueKind == JsonValueKind.False)
-                {
-                    var existedValue = propertyElement.GetBoolean();
-                    if (existedValue == newValue)
-                        return originalElement.Value; // no need to set value
-                }
-            }
+            if (originalElement != null && originalElement.Value.TryGetProperty(propertyName, out var prop)
+                && prop.TryGetInt64(out var existing) && existing == newValue)
+                return originalElement.Value;
 
-            using var stream = new System.IO.MemoryStream();
-            using var writer = new Utf8JsonWriter(stream);
+            return SetPropertyCore(ref originalElement, propertyName,
+                (w, name) => w.WriteNumber(name, newValue));
+        }
 
-            writer.WriteStartObject();
+        /// <summary>
+        /// Updates a JsonElement by setting or replacing a specific property with a new ulong value.
+        /// </summary>
+        public static JsonElement SetProperty(this ref JsonElement? originalElement, string propertyName, ulong newValue)
+        {
+            if (originalElement != null && originalElement.Value.TryGetProperty(propertyName, out var prop)
+                && prop.TryGetUInt64(out var existing) && existing == newValue)
+                return originalElement.Value;
 
-            if (originalElement == null)
-            {
-                // If originalElement is null, we just write the new property
-                writer.WriteBoolean(propertyName, newValue);
-            }
-            else
-            {
-                // Copy all existing properties except the one we're updating
-                foreach (var property in originalElement.Value.EnumerateObject())
-                {
-                    if (property.Name != propertyName)
-                    {
-                        property.WriteTo(writer);
-                    }
-                }
-                // Write the new property value
-                writer.WriteBoolean(propertyName, newValue);
-            }
-
-            writer.WriteEndObject();
-            writer.Flush();
-
-            // Parse and return the new JsonElement
-            var correctedJson = Encoding.UTF8.GetString(stream.ToArray());
-            originalElement = JsonDocument.Parse(correctedJson).RootElement;
-            return originalElement.Value;
+            return SetPropertyCore(ref originalElement, propertyName,
+                (w, name) => w.WriteNumber(name, newValue));
         }
 
         /// <summary>
         /// Updates a JsonElement by setting or replacing a specific property with a new float value.
         /// </summary>
-        /// <param name="originalElement">The original JsonElement to update</param>
-        /// <param name="propertyName">The name of the property to set/replace</param>
-        /// <param name="newValue">The new float value for the property</param>
-        /// <returns>A new JsonElement with the updated property</returns>
-        public static JsonElement SetProperty(
-            this ref JsonElement? originalElement,
-            string propertyName,
-            float newValue)
+        public static JsonElement SetProperty(this ref JsonElement? originalElement, string propertyName, float newValue)
         {
-            // Check if need to set value
-            if (originalElement != null && originalElement.Value.TryGetProperty(propertyName, out var propertyElement))
-            {
-                if (propertyElement.ValueKind == JsonValueKind.Number)
-                {
-                    if (propertyElement.TryGetSingle(out var existedValue))
-                    {
-                        if (System.Math.Abs(existedValue - newValue) < float.Epsilon)
-                            return originalElement.Value; // no need to set value
-                    }
-                }
-            }
+            if (originalElement != null && originalElement.Value.TryGetProperty(propertyName, out var prop)
+                && prop.ValueKind == JsonValueKind.Number
+                && prop.TryGetSingle(out var existing) && Math.Abs(existing - newValue) < float.Epsilon)
+                return originalElement.Value;
 
+            return SetPropertyCore(ref originalElement, propertyName,
+                (w, name) => w.WriteNumber(name, newValue));
+        }
+
+        /// <summary>
+        /// Updates a JsonElement by setting or replacing a specific property with a new double value.
+        /// </summary>
+        public static JsonElement SetProperty(this ref JsonElement? originalElement, string propertyName, double newValue)
+        {
+            if (originalElement != null && originalElement.Value.TryGetProperty(propertyName, out var prop)
+                && prop.ValueKind == JsonValueKind.Number
+                && prop.TryGetDouble(out var existing) && Math.Abs(existing - newValue) < double.Epsilon)
+                return originalElement.Value;
+
+            return SetPropertyCore(ref originalElement, propertyName,
+                (w, name) => w.WriteNumber(name, newValue));
+        }
+
+        /// <summary>
+        /// Updates a JsonElement by setting or replacing a specific property with a new decimal value.
+        /// </summary>
+        public static JsonElement SetProperty(this ref JsonElement? originalElement, string propertyName, decimal newValue)
+        {
+            if (originalElement != null && originalElement.Value.TryGetProperty(propertyName, out var prop)
+                && prop.TryGetDecimal(out var existing) && existing == newValue)
+                return originalElement.Value;
+
+            return SetPropertyCore(ref originalElement, propertyName,
+                (w, name) => w.WriteNumber(name, newValue));
+        }
+
+        /// <summary>
+        /// Updates a JsonElement by setting or replacing a specific property with a new string value.
+        /// </summary>
+        public static JsonElement SetProperty(this ref JsonElement? originalElement, string propertyName, string newValue)
+        {
+            if (originalElement != null && originalElement.Value.TryGetProperty(propertyName, out var prop)
+                && prop.ValueKind == JsonValueKind.String && prop.GetString() == newValue)
+                return originalElement.Value;
+
+            return SetPropertyCore(ref originalElement, propertyName,
+                (w, name) => w.WriteString(name, newValue));
+        }
+
+        /// <summary>
+        /// Updates a JsonElement by setting or replacing a specific property with a new boolean value.
+        /// </summary>
+        public static JsonElement SetProperty(this ref JsonElement? originalElement, string propertyName, bool newValue)
+        {
+            if (originalElement != null && originalElement.Value.TryGetProperty(propertyName, out var prop)
+                && (prop.ValueKind == JsonValueKind.True || prop.ValueKind == JsonValueKind.False)
+                && prop.GetBoolean() == newValue)
+                return originalElement.Value;
+
+            return SetPropertyCore(ref originalElement, propertyName,
+                (w, name) => w.WriteBoolean(name, newValue));
+        }
+
+        /// <summary>
+        /// Shared implementation that copies all existing properties (except the target),
+        /// writes the new property via <paramref name="writeValue"/>, and parses the result back.
+        /// </summary>
+        private static JsonElement SetPropertyCore(
+            ref JsonElement? originalElement,
+            string propertyName,
+            Action<Utf8JsonWriter, string> writeValue)
+        {
             using var stream = new System.IO.MemoryStream();
             using var writer = new Utf8JsonWriter(stream);
 
@@ -214,12 +152,10 @@ namespace com.IvanMurzak.McpPlugin
 
             if (originalElement == null)
             {
-                // If originalElement is null, we just write the new property
-                writer.WriteNumber(propertyName, newValue);
+                writeValue(writer, propertyName);
             }
             else
             {
-                // Copy all existing properties except the one we're updating
                 foreach (var property in originalElement.Value.EnumerateObject())
                 {
                     if (property.Name != propertyName)
@@ -227,14 +163,12 @@ namespace com.IvanMurzak.McpPlugin
                         property.WriteTo(writer);
                     }
                 }
-                // Write the new property value
-                writer.WriteNumber(propertyName, newValue);
+                writeValue(writer, propertyName);
             }
 
             writer.WriteEndObject();
             writer.Flush();
 
-            // Parse and return the new JsonElement
             var correctedJson = Encoding.UTF8.GetString(stream.ToArray());
             originalElement = JsonDocument.Parse(correctedJson).RootElement;
             return originalElement.Value;

--- a/McpPlugin/src/McpPlugin/Skills/SkillFileGenerator.cs
+++ b/McpPlugin/src/McpPlugin/Skills/SkillFileGenerator.cs
@@ -15,6 +15,7 @@ using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using System.Text.Json.Serialization.Metadata;
 using Microsoft.Extensions.Logging;
 
 namespace com.IvanMurzak.McpPlugin.Skills
@@ -34,10 +35,13 @@ namespace com.IvanMurzak.McpPlugin.Skills
         readonly ILogger? _logger;
         static readonly UTF8Encoding _utf8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
 
+        // TypeInfoResolver is required on netstandard2.1/net8+: JsonNode.ToJsonString(options)
+        // calls options.MakeReadOnly(), which throws if no resolver is set.
         static readonly JsonSerializerOptions _prettyJsonOptions = new JsonSerializerOptions
         {
             WriteIndented = true,
-            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+            TypeInfoResolver = new DefaultJsonTypeInfoResolver()
         };
 
         public SkillFileGenerator(ILogger? logger = null)

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="local-reflectornet" value="../ReflectorNet/packages" />
+  </packageSources>
+</configuration>

--- a/nuget.config
+++ b/nuget.config
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="local-reflectornet" value="../ReflectorNet/packages" />
-  </packageSources>
-</configuration>


### PR DESCRIPTION
## Summary
- Pin v8 packages (STJ, SignalR, Microsoft.Extensions.*) for `netstandard2.1` via centralized `Directory.Build.props`
- Update ReflectorNet to 5.0.0
- Refactor `ExtensionsJsonElement`: extract shared `SetPropertyCore`, add `uint`/`double`/`decimal` overloads, fix `JsonDocument` leak
- Fix `SkillFileGenerator` crash on `netstandard2.1`/`net8+` by adding `TypeInfoResolver`
- Bump version to 6.0.0

## Context
Unity 6.5 ships System.Text.Json v8 as built-in BCL. All DLLs consumed by Unity must reference STJ v8 to avoid CS1705 errors. This ensures the netstandard2.1 DLLs (McpPlugin.dll, McpPlugin.Common.dll) are v8-compatible.

Depends on: IvanMurzak/ReflectorNet#75
Fixes IvanMurzak/Unity-MCP#625

## Test plan
- [x] `dotnet build McpPlugin.sln --configuration Release` — all projects build successfully
- [x] `dotnet test` — all 1240 tests pass on net8.0 and net9.0 (including 21 new ExtensionsJsonElement tests)
- [x] Zero warnings on restore and build
- [ ] Verify netstandard2.1 DLLs work in Unity 6.5