### PR TITLE
fix: remove unused ModelContextProtocol dependency from McpPlugin

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,22 +1,10 @@
 <Project>
 
-  <!-- Pin v8 packages only for Unity-targeted TFM (Unity 6.5 ships v8 of these,
-       disabling v10 copies in Editor). NU1605 is suppressed because ModelContextProtocol
-       1.2.0 transitively requires v10; the downgrade is intentional. net8.0/net9.0
-       targets are unaffected and still resolve v10. -->
-  <!-- NU1605 must be unconditional: NuGet restore evaluates NoWarn before
-       the per-TFM inner build sets $(TargetFramework), so a conditional
-       suppression is silently ignored during solution-level restore. -->
-  <PropertyGroup>
-    <NoWarn>$(NoWarn);NU1605</NoWarn>
-  </PropertyGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
-    <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
-  </ItemGroup>
+  <!-- Intentionally empty. Previously pinned v8 Microsoft.Extensions / System.Text.Json
+       packages to work around a v8/v10 conflict introduced by ModelContextProtocol 1.2.0.
+       The MCP dependency has been removed from McpPlugin and McpPlugin.Common (the
+       compiled DLLs never referenced MCP types), so transitive resolution is now
+       coherent: SignalR.Client 8.0.15 pulls the v8 stack naturally, and
+       McpPlugin.Server keeps its own v10 stack via SignalR.Client 10.0.3. -->
 
 </Project>

--- a/McpPlugin.Common/McpPlugin.Common.csproj
+++ b/McpPlugin.Common/McpPlugin.Common.csproj
@@ -11,7 +11,7 @@
     <!-- NuGet Package Information -->
     <IsPackable>true</IsPackable>
     <PackageId>com.IvanMurzak.McpPlugin.Common</PackageId>
-    <Version>6.0.0</Version>
+    <Version>6.1.0</Version>
     <Authors>Ivan Murzak</Authors>
     <Company>Ivan Murzak</Company>
     <Copyright>Copyright © Ivan Murzak 2025</Copyright>

--- a/McpPlugin.Common/McpPlugin.Common.csproj
+++ b/McpPlugin.Common/McpPlugin.Common.csproj
@@ -27,7 +27,6 @@
   <ItemGroup>
     <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="5.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.15" />
-    <PackageReference Include="ModelContextProtocol" Version="1.2.0" />
     <PackageReference Include="R3" Version="1.3.0" />
   </ItemGroup>
 

--- a/McpPlugin.Common/src/Utils/Consts.cs
+++ b/McpPlugin.Common/src/Utils/Consts.cs
@@ -12,7 +12,7 @@ namespace com.IvanMurzak.McpPlugin.Common
     public static partial class Consts
     {
         public const string ApiVersion = "2.0.0";
-        public const string PluginVersion = "6.0.0";
+        public const string PluginVersion = "6.1.0";
 
         public static class Guid
         {

--- a/McpPlugin.Server/McpPlugin.Server.csproj
+++ b/McpPlugin.Server/McpPlugin.Server.csproj
@@ -11,7 +11,7 @@
     <!-- NuGet Package Information -->
     <IsPackable>true</IsPackable>
     <PackageId>com.IvanMurzak.McpPlugin.Server</PackageId>
-    <Version>6.0.0</Version>
+    <Version>6.1.0</Version>
     <Authors>Ivan Murzak</Authors>
     <Company>Ivan Murzak</Company>
     <Copyright>Copyright © Ivan Murzak 2025</Copyright>

--- a/McpPlugin.Server/server.json
+++ b/McpPlugin.Server/server.json
@@ -8,13 +8,13 @@
     "source": "github",
     "subfolder": "McpPlugin.Server"
   },
-  "version": "6.0.0",
+  "version": "6.1.0",
   "packages": [
     {
       "registry_type": "oci",
       "registry_base_url": "https://docker.io",
       "identifier": "ivanmurzakdev/mcp-plugin-server",
-      "version": "6.0.0",
+      "version": "6.1.0",
       "transport": {
         "type": "stdio"
       },

--- a/McpPlugin/McpPlugin.csproj
+++ b/McpPlugin/McpPlugin.csproj
@@ -37,7 +37,6 @@
     <ProjectReference Include="./../McpPlugin.Common/McpPlugin.Common.csproj" />
     <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="5.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.15" />
-    <PackageReference Include="ModelContextProtocol" Version="1.2.0" />
     <PackageReference Include="R3" Version="1.3.0" />
   </ItemGroup>
 

--- a/McpPlugin/McpPlugin.csproj
+++ b/McpPlugin/McpPlugin.csproj
@@ -15,7 +15,7 @@
     <!-- NuGet Package Information -->
     <IsPackable>true</IsPackable>
     <PackageId>com.IvanMurzak.McpPlugin</PackageId>
-    <Version>6.0.0</Version>
+    <Version>6.1.0</Version>
     <Authors>Ivan Murzak</Authors>
     <Company>Ivan Murzak</Company>
     <Copyright>Copyright © Ivan Murzak 2025</Copyright>


### PR DESCRIPTION
## Summary

Removes the `ModelContextProtocol` 1.2.0 NuGet dependency from `McpPlugin` and `McpPlugin.Common`. Neither compiled DLL references any MCP types — the dependency was only in the nuspec, so no public API changes.

## Why

`ModelContextProtocol.Core` 1.2.0's `netstandard2.0` build pulls in v10 of the Microsoft.Extensions and System.Text.Json stack. McpPlugin itself is compiled against v8 (aligned with `Microsoft.AspNetCore.SignalR.Client` 8.0.15). When both are installed in a Unity project, the v8/v10 assembly-reference split makes Unity's TypeCache unable to resolve types inside MCP.Core:

```
TypeCache is unable to load info on field ModelContextProtocol.Protocol.ContextInclusion::None
Unloading broken assembly Assets/Plugins/NuGet/ModelContextProtocol.Core.1.2.0/ModelContextProtocol.Core.dll
```

Since McpPlugin never touches MCP types, dropping the dependency eliminates the clash at the source. `McpPlugin.Server` keeps its v10 stack and its MCP reference — it genuinely uses MCP protocol types for bridging and isn't affected.

## Changes

- `McpPlugin/McpPlugin.csproj` — drop `<PackageReference Include="ModelContextProtocol" Version="1.2.0" />`
- `McpPlugin.Common/McpPlugin.Common.csproj` — same
- `Directory.Build.props` — drop the netstandard2.1-only v8 pin block. With MCP gone, SignalR.Client 8.0.15 resolves the v8 Microsoft.Extensions stack cleanly for every TFM with no NU1605 conflict, so the pins (and the NU1605 suppression they required) are no longer needed.

## Verification

- `dotnet build McpPlugin.sln -c Release`: 0 warnings, 0 errors across `netstandard2.1`, `net8.0`, `net9.0`
- `dotnet test`: **1,240 / 1,240 pass** (`McpPlugin.Tests`: 394×2 TFMs, `McpPlugin.Server.Tests`: 226×2 TFMs)
- Built DLLs diff'd against pre-change build via `Assembly.GetReferencedAssemblies()` — identical reference set, confirming the DLLs never used MCP types
- Rebuilt nupkg installed into a Unity 2022.3 project that previously reproduced the broken-assembly error; Unity Editor now boots clean (0 TypeCache errors, 0 broken assemblies)

## Test plan

- [x] CI green on `net8.0` + `net9.0`
- [ ] Smoke-test `DemoConsoleApp` / `DemoWebApp` still run
- [x] Confirm no downstream package expects `ModelContextProtocol` types from `McpPlugin`'s public API (grep suggests none do)

## Risk

Low. Any consumer that implicitly relied on McpPlugin re-exporting MCP types would have been a latent bug (types weren't actually used by McpPlugin) — such a consumer should take a direct `ModelContextProtocol` reference instead.