### PR TITLE
refactor(auth): reduce auth-log noise on tokenless plugin probes

### DIFF
--- a/McpPlugin.Server.Tests/BaseHubAuthorizationTests.cs
+++ b/McpPlugin.Server.Tests/BaseHubAuthorizationTests.cs
@@ -11,6 +11,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.Common;
 using com.IvanMurzak.McpPlugin.Common.Hub.Client;
 using com.IvanMurzak.McpPlugin.Server;
 using com.IvanMurzak.McpPlugin.Server.Strategy;
@@ -243,6 +244,158 @@ namespace McpPlugin.Server.Tests
 
             hub.ConnectionRejectedFlag.ShouldBeFalse();
             mockContext.Verify(c => c.Abort(), Times.Never);
+        }
+
+        // --- auth=required + empty-token short-circuit tests (issue #99 commit 1) ---
+
+        /// <summary>
+        /// Helper: build hub fully wired for the empty-token short-circuit path —
+        /// strategy.AuthOption == required, mock IHubCallerClients with a settable Caller
+        /// so we can assert ForceDisconnect was invoked.
+        /// </summary>
+        static (TestHub Hub, Mock<IAuthorizationWebhookService> Webhook, Mock<IClientDisconnectable> Caller) CreateRequiredAuthTestHub(
+            Mock<HubCallerContext> mockContext)
+        {
+            var logger = new Mock<ILogger>().Object;
+
+            var strategy = new Mock<IMcpConnectionStrategy>();
+            strategy.SetupGet(s => s.AuthOption).Returns(Consts.MCP.Server.AuthOption.required);
+
+            var webhook = new Mock<IAuthorizationWebhookService>();
+            webhook.Setup(x => x.AuthorizePluginAsync(
+                    It.IsAny<string>(), It.IsAny<string?>(),
+                    It.IsAny<string?>(), It.IsAny<string?>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(true);
+
+            var caller = new Mock<IClientDisconnectable>();
+            var clients = new Mock<IHubCallerClients<IClientDisconnectable>>();
+            clients.SetupGet(c => c.Caller).Returns(caller.Object);
+
+            var hub = new TestHub(logger, strategy.Object, webhook.Object);
+            hub.Context = mockContext.Object;
+            hub.Clients = clients.Object;
+            return (hub, webhook, caller);
+        }
+
+        [Fact]
+        public async Task OnConnectedAsync_AuthRequired_EmptyToken_RejectsAndSkipsWebhook()
+        {
+            var mockContext = CreateMockHubCallerContext(bearerToken: null);
+            var (hub, webhook, caller) = CreateRequiredAuthTestHub(mockContext);
+
+            await hub.OnConnectedAsync();
+
+            // Connection rejected, Context.Abort() called.
+            hub.ConnectionRejectedFlag.ShouldBeTrue();
+            mockContext.Verify(c => c.Abort(), Times.Once);
+
+            // Webhook MUST NOT be invoked — that's the whole point of the short-circuit.
+            webhook.Verify(w => w.AuthorizePluginAsync(
+                    It.IsAny<string>(), It.IsAny<string?>(),
+                    It.IsAny<string?>(), It.IsAny<string?>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Never);
+
+            // Client was notified via ForceDisconnect with the auth=required reason.
+            caller.Verify(c => c.ForceDisconnect(
+                    "Authorization failed. A bearer token is required in auth=required mode."),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task OnConnectedAsync_AuthRequired_EmptyToken_DoesNotCallStrategyOnPluginConnected()
+        {
+            var mockContext = CreateMockHubCallerContext(bearerToken: null);
+            var logger = new Mock<ILogger>().Object;
+
+            var strategy = new Mock<IMcpConnectionStrategy>();
+            strategy.SetupGet(s => s.AuthOption).Returns(Consts.MCP.Server.AuthOption.required);
+
+            var webhook = new Mock<IAuthorizationWebhookService>();
+
+            var caller = new Mock<IClientDisconnectable>();
+            var clients = new Mock<IHubCallerClients<IClientDisconnectable>>();
+            clients.SetupGet(c => c.Caller).Returns(caller.Object);
+
+            var hub = new TestHub(logger, strategy.Object, webhook.Object);
+            hub.Context = mockContext.Object;
+            hub.Clients = clients.Object;
+
+            await hub.OnConnectedAsync();
+
+            // Strategy.OnPluginConnected MUST NOT be invoked when the empty-token
+            // short-circuit fires — connection is rejected before strategy registration.
+            strategy.Verify(
+                s => s.OnPluginConnected(
+                    It.IsAny<Type>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string?>(),
+                    It.IsAny<ILogger>(),
+                    It.IsAny<Action<string, string?>>()),
+                Times.Never);
+        }
+
+        [Fact]
+        public async Task OnConnectedAsync_AuthRequired_NonEmptyToken_StillCallsWebhook()
+        {
+            // Regression guard: the short-circuit triggers ONLY on empty tokens. With a
+            // present token, the existing webhook flow must still run unchanged.
+            var token = UniqueId();
+            var mockContext = CreateMockHubCallerContext(bearerToken: token);
+            var (hub, webhook, _) = CreateRequiredAuthTestHub(mockContext);
+
+            await hub.OnConnectedAsync();
+
+            hub.ConnectionRejectedFlag.ShouldBeFalse();
+            mockContext.Verify(c => c.Abort(), Times.Never);
+
+            webhook.Verify(w => w.AuthorizePluginAsync(
+                    It.IsAny<string>(),
+                    token,
+                    It.IsAny<string?>(),
+                    It.IsAny<string?>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task OnConnectedAsync_AuthNone_EmptyToken_DoesNotShortCircuit()
+        {
+            // Regression guard: the short-circuit must NOT fire in auth=none mode —
+            // empty-token connections are legitimate there.
+            var mockContext = CreateMockHubCallerContext(bearerToken: null);
+            var logger = new Mock<ILogger>().Object;
+
+            var strategy = new Mock<IMcpConnectionStrategy>();
+            strategy.SetupGet(s => s.AuthOption).Returns(Consts.MCP.Server.AuthOption.none);
+
+            var webhook = new Mock<IAuthorizationWebhookService>();
+            webhook.Setup(x => x.AuthorizePluginAsync(
+                    It.IsAny<string>(), It.IsAny<string?>(),
+                    It.IsAny<string?>(), It.IsAny<string?>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(true);
+
+            var caller = new Mock<IClientDisconnectable>();
+            var clients = new Mock<IHubCallerClients<IClientDisconnectable>>();
+            clients.SetupGet(c => c.Caller).Returns(caller.Object);
+
+            var hub = new TestHub(logger, strategy.Object, webhook.Object);
+            hub.Context = mockContext.Object;
+            hub.Clients = clients.Object;
+
+            await hub.OnConnectedAsync();
+
+            hub.ConnectionRejectedFlag.ShouldBeFalse();
+            mockContext.Verify(c => c.Abort(), Times.Never);
+
+            // Webhook IS invoked — auth=none keeps the existing behavior.
+            webhook.Verify(w => w.AuthorizePluginAsync(
+                    It.IsAny<string>(), It.IsAny<string?>(),
+                    It.IsAny<string?>(), It.IsAny<string?>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
         }
     }
 }

--- a/McpPlugin.Server.Tests/BaseHubAuthorizationTests.cs
+++ b/McpPlugin.Server.Tests/BaseHubAuthorizationTests.cs
@@ -249,24 +249,29 @@ namespace McpPlugin.Server.Tests
         // --- auth=required + empty-token short-circuit tests (issue #99 commit 1) ---
 
         /// <summary>
-        /// Helper: build hub fully wired for the empty-token short-circuit path —
-        /// strategy.AuthOption == required, mock IHubCallerClients with a settable Caller
-        /// so we can assert ForceDisconnect was invoked.
+        /// Helper: build a hub fully wired for the empty-token short-circuit / auth-mode tests —
+        /// configurable strategy.AuthOption and webhook stubbing, mock IHubCallerClients with a
+        /// settable Caller so tests can assert ForceDisconnect was invoked.
         /// </summary>
-        static (TestHub Hub, Mock<IAuthorizationWebhookService> Webhook, Mock<IClientDisconnectable> Caller) CreateRequiredAuthTestHub(
-            Mock<HubCallerContext> mockContext)
+        static (TestHub Hub, Mock<IMcpConnectionStrategy> Strategy, Mock<IAuthorizationWebhookService> Webhook, Mock<IClientDisconnectable> Caller) CreateAuthModeTestHub(
+            Mock<HubCallerContext> mockContext,
+            Consts.MCP.Server.AuthOption authOption = Consts.MCP.Server.AuthOption.required,
+            bool stubWebhookSuccess = true)
         {
             var logger = new Mock<ILogger>().Object;
 
             var strategy = new Mock<IMcpConnectionStrategy>();
-            strategy.SetupGet(s => s.AuthOption).Returns(Consts.MCP.Server.AuthOption.required);
+            strategy.SetupGet(s => s.AuthOption).Returns(authOption);
 
             var webhook = new Mock<IAuthorizationWebhookService>();
-            webhook.Setup(x => x.AuthorizePluginAsync(
-                    It.IsAny<string>(), It.IsAny<string?>(),
-                    It.IsAny<string?>(), It.IsAny<string?>(),
-                    It.IsAny<CancellationToken>()))
-                .ReturnsAsync(true);
+            if (stubWebhookSuccess)
+            {
+                webhook.Setup(x => x.AuthorizePluginAsync(
+                        It.IsAny<string>(), It.IsAny<string?>(),
+                        It.IsAny<string?>(), It.IsAny<string?>(),
+                        It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(true);
+            }
 
             var caller = new Mock<IClientDisconnectable>();
             var clients = new Mock<IHubCallerClients<IClientDisconnectable>>();
@@ -275,14 +280,14 @@ namespace McpPlugin.Server.Tests
             var hub = new TestHub(logger, strategy.Object, webhook.Object);
             hub.Context = mockContext.Object;
             hub.Clients = clients.Object;
-            return (hub, webhook, caller);
+            return (hub, strategy, webhook, caller);
         }
 
         [Fact]
         public async Task OnConnectedAsync_AuthRequired_EmptyToken_RejectsAndSkipsWebhook()
         {
             var mockContext = CreateMockHubCallerContext(bearerToken: null);
-            var (hub, webhook, caller) = CreateRequiredAuthTestHub(mockContext);
+            var (hub, _, webhook, caller) = CreateAuthModeTestHub(mockContext);
 
             await hub.OnConnectedAsync();
 
@@ -307,20 +312,9 @@ namespace McpPlugin.Server.Tests
         public async Task OnConnectedAsync_AuthRequired_EmptyToken_DoesNotCallStrategyOnPluginConnected()
         {
             var mockContext = CreateMockHubCallerContext(bearerToken: null);
-            var logger = new Mock<ILogger>().Object;
-
-            var strategy = new Mock<IMcpConnectionStrategy>();
-            strategy.SetupGet(s => s.AuthOption).Returns(Consts.MCP.Server.AuthOption.required);
-
-            var webhook = new Mock<IAuthorizationWebhookService>();
-
-            var caller = new Mock<IClientDisconnectable>();
-            var clients = new Mock<IHubCallerClients<IClientDisconnectable>>();
-            clients.SetupGet(c => c.Caller).Returns(caller.Object);
-
-            var hub = new TestHub(logger, strategy.Object, webhook.Object);
-            hub.Context = mockContext.Object;
-            hub.Clients = clients.Object;
+            // Don't stub the webhook — short-circuit must fire before any webhook call would happen,
+            // so unstubbed webhook (which would return default(false)) proves the short-circuit ran.
+            var (hub, strategy, _, _) = CreateAuthModeTestHub(mockContext, stubWebhookSuccess: false);
 
             await hub.OnConnectedAsync();
 
@@ -343,7 +337,7 @@ namespace McpPlugin.Server.Tests
             // present token, the existing webhook flow must still run unchanged.
             var token = UniqueId();
             var mockContext = CreateMockHubCallerContext(bearerToken: token);
-            var (hub, webhook, _) = CreateRequiredAuthTestHub(mockContext);
+            var (hub, _, webhook, _) = CreateAuthModeTestHub(mockContext);
 
             await hub.OnConnectedAsync();
 
@@ -365,25 +359,9 @@ namespace McpPlugin.Server.Tests
             // Regression guard: the short-circuit must NOT fire in auth=none mode —
             // empty-token connections are legitimate there.
             var mockContext = CreateMockHubCallerContext(bearerToken: null);
-            var logger = new Mock<ILogger>().Object;
-
-            var strategy = new Mock<IMcpConnectionStrategy>();
-            strategy.SetupGet(s => s.AuthOption).Returns(Consts.MCP.Server.AuthOption.none);
-
-            var webhook = new Mock<IAuthorizationWebhookService>();
-            webhook.Setup(x => x.AuthorizePluginAsync(
-                    It.IsAny<string>(), It.IsAny<string?>(),
-                    It.IsAny<string?>(), It.IsAny<string?>(),
-                    It.IsAny<CancellationToken>()))
-                .ReturnsAsync(true);
-
-            var caller = new Mock<IClientDisconnectable>();
-            var clients = new Mock<IHubCallerClients<IClientDisconnectable>>();
-            clients.SetupGet(c => c.Caller).Returns(caller.Object);
-
-            var hub = new TestHub(logger, strategy.Object, webhook.Object);
-            hub.Context = mockContext.Object;
-            hub.Clients = clients.Object;
+            var (hub, _, webhook, _) = CreateAuthModeTestHub(
+                mockContext,
+                authOption: Consts.MCP.Server.AuthOption.none);
 
             await hub.OnConnectedAsync();
 

--- a/McpPlugin.Server.Tests/TokenAuthenticationHandlerTests.cs
+++ b/McpPlugin.Server.Tests/TokenAuthenticationHandlerTests.cs
@@ -13,6 +13,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.Common;
 using com.IvanMurzak.McpPlugin.Server.Auth;
 using com.IvanMurzak.McpPlugin.Server.Webhooks.Services;
 using Microsoft.AspNetCore.Authentication;
@@ -35,7 +36,8 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
             bool requireToken = true,
             string? serverToken = null,
             string? registeredToken = null,
-            string? registeredConnectionId = null)
+            string? registeredConnectionId = null,
+            string? requestPath = null)
         {
             // Register token mapping if provided
             if (registeredToken != null && registeredConnectionId != null)
@@ -68,6 +70,8 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
                 var context = new DefaultHttpContext();
                 if (authorizationHeader != null)
                     context.Request.Headers["Authorization"] = authorizationHeader;
+                if (requestPath != null)
+                    context.Request.Path = new PathString(requestPath);
 
                 var scheme = new AuthenticationScheme(
                     TokenAuthenticationHandler.SchemeName,
@@ -154,6 +158,68 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
                 $"Bearer {UniqueId()}",
                 requireToken: true,
                 serverToken: "different-token");
+
+            result.Succeeded.ShouldBeFalse();
+            result.Failure!.Message.ShouldBe("Invalid or unrecognized token.");
+        }
+
+        // --- Hub-path scoped no-tier-match handling (issue #99 commit 2) ---
+
+        [Fact]
+        public async Task UnrecognizedToken_OnHubPath_ReturnsNoResult()
+        {
+            // On the SignalR hub path the plugin's bearer token is registered AFTER
+            // OnConnectedAsync runs (chicken-and-egg). Returning Fail here causes the
+            // framework to log "[7] McpPluginToken was not authenticated" on every probe.
+            // Returning NoResult lets the connection through silently; the hub endpoint is
+            // not RequireAuthorization()-gated so this is safe.
+            var result = await AuthenticateAsync(
+                $"Bearer {UniqueId()}",
+                requireToken: true,
+                serverToken: "different-token",
+                requestPath: Consts.Hub.RemoteApp);
+
+            result.None.ShouldBeTrue();
+        }
+
+        [Fact]
+        public async Task UnrecognizedToken_OnHubSubPath_ReturnsNoResult()
+        {
+            // SignalR appends sub-segments to the hub endpoint (e.g.
+            // /hub/mcp-server/negotiate, /hub/mcp-server?id=...). StartsWith covers them.
+            var result = await AuthenticateAsync(
+                $"Bearer {UniqueId()}",
+                requireToken: true,
+                serverToken: "different-token",
+                requestPath: Consts.Hub.RemoteApp + "/negotiate");
+
+            result.None.ShouldBeTrue();
+        }
+
+        [Fact]
+        public async Task UnrecognizedToken_OnHubPath_CaseInsensitive_ReturnsNoResult()
+        {
+            // PathString comparisons in ASP.NET Core are case-insensitive by convention.
+            // The match here uses StringComparison.OrdinalIgnoreCase explicitly.
+            var result = await AuthenticateAsync(
+                $"Bearer {UniqueId()}",
+                requireToken: true,
+                serverToken: "different-token",
+                requestPath: Consts.Hub.RemoteApp.ToUpperInvariant());
+
+            result.None.ShouldBeTrue();
+        }
+
+        [Fact]
+        public async Task UnrecognizedToken_OnNonHubPath_StillReturnsFail()
+        {
+            // Regression guard: non-hub paths (e.g. /mcp, /token) MUST still get Fail so
+            // the framework's RequireAuthorization() pipeline issues the 401 challenge.
+            var result = await AuthenticateAsync(
+                $"Bearer {UniqueId()}",
+                requireToken: true,
+                serverToken: "different-token",
+                requestPath: "/mcp");
 
             result.Succeeded.ShouldBeFalse();
             result.Failure!.Message.ShouldBe("Invalid or unrecognized token.");

--- a/McpPlugin.Server.Tests/TokenAuthenticationHandlerTests.cs
+++ b/McpPlugin.Server.Tests/TokenAuthenticationHandlerTests.cs
@@ -119,6 +119,20 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
         }
 
         [Fact]
+        public async Task EmptyBearerToken_OnHubPath_ReturnsNoResult()
+        {
+            // Same hub-path silencing rule as UnrecognizedToken_OnHubPath_ReturnsNoResult:
+            // an empty Bearer header on the hub path would otherwise trigger the
+            // "[7] McpPluginToken was not authenticated" info log on every probe.
+            var result = await AuthenticateAsync(
+                "Bearer ",
+                requireToken: true,
+                requestPath: Consts.Hub.RemoteApp);
+
+            result.None.ShouldBeTrue();
+        }
+
+        [Fact]
         public async Task ValidRegisteredToken_ReturnsSuccess()
         {
             var token = UniqueId();

--- a/McpPlugin.Server/src/Auth/TokenAuthenticationHandler.cs
+++ b/McpPlugin.Server/src/Auth/TokenAuthenticationHandler.cs
@@ -12,6 +12,7 @@ using System;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.Common;
 using com.IvanMurzak.McpPlugin.Server.Webhooks.Services;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
@@ -139,9 +140,28 @@ namespace com.IvanMurzak.McpPlugin.Server.Auth
                 ticket = new AuthenticationTicket(principal, SchemeName);
             }
 
-            // No tier matched — unrecognized token
+            // No tier matched — unrecognized token.
+            //
+            // On the SignalR hub path (Consts.Hub.RemoteApp == "/hub/mcp-server") this happens
+            // for EVERY new plugin connection: the plugin's bearer token is registered with
+            // ClientUtils.AddClient only AFTER OnConnectedAsync runs, but middleware-level
+            // authentication runs BEFORE OnConnectedAsync — chicken-and-egg. The hub endpoint
+            // is not RequireAuthorization()-gated, so the connection still proceeds; but
+            // returning Fail here causes the framework to auto-emit a "[7] McpPluginToken was
+            // not authenticated" info log on every probe — a documented production-log noise
+            // source (issue #99). Returning NoResult on the hub path lets the connection
+            // through silently while preserving the Fail+401 challenge on every other path
+            // (which IS RequireAuthorization()-gated).
             if (ticket == null)
+            {
+                var path = Request.Path.Value;
+                if (!string.IsNullOrEmpty(path)
+                    && path.StartsWith(Consts.Hub.RemoteApp, StringComparison.OrdinalIgnoreCase))
+                {
+                    return AuthenticateResult.NoResult();
+                }
                 return AuthenticateResult.Fail("Invalid or unrecognized token.");
+            }
 
             // Single authorization webhook check for whichever tier matched.
             // Note: AuthorizeAiAgentAsync returns false for both explicit denials

--- a/McpPlugin.Server/src/Auth/TokenAuthenticationHandler.cs
+++ b/McpPlugin.Server/src/Auth/TokenAuthenticationHandler.cs
@@ -73,7 +73,7 @@ namespace com.IvanMurzak.McpPlugin.Server.Auth
 
             var token = authHeader.Substring("Bearer ".Length).Trim();
             if (string.IsNullOrEmpty(token))
-                return AuthenticateResult.Fail("Empty Bearer token.");
+                return IsHubPath() ? AuthenticateResult.NoResult() : AuthenticateResult.Fail("Empty Bearer token.");
 
             // Token resolution — three additive sources, checked in priority order:
             //
@@ -151,17 +151,10 @@ namespace com.IvanMurzak.McpPlugin.Server.Auth
             // not authenticated" info log on every probe — a documented production-log noise
             // source (issue #99). Returning NoResult on the hub path lets the connection
             // through silently while preserving the Fail+401 challenge on every other path
-            // (which IS RequireAuthorization()-gated).
+            // (which IS RequireAuthorization()-gated). The same hub-path-silencing rule is
+            // also applied to the empty-Bearer case above (line 76).
             if (ticket == null)
-            {
-                var path = Request.Path.Value;
-                if (!string.IsNullOrEmpty(path)
-                    && path.StartsWith(Consts.Hub.RemoteApp, StringComparison.OrdinalIgnoreCase))
-                {
-                    return AuthenticateResult.NoResult();
-                }
-                return AuthenticateResult.Fail("Invalid or unrecognized token.");
-            }
+                return IsHubPath() ? AuthenticateResult.NoResult() : AuthenticateResult.Fail("Invalid or unrecognized token.");
 
             // Single authorization webhook check for whichever tier matched.
             // Note: AuthorizeAiAgentAsync returns false for both explicit denials
@@ -170,6 +163,16 @@ namespace com.IvanMurzak.McpPlugin.Server.Auth
                 return AuthenticateResult.Fail("Authorization webhook rejected the connection.");
 
             return AuthenticateResult.Success(ticket);
+        }
+
+        // True when the request targets the SignalR hub endpoint. Used to silence the
+        // "[7] McpPluginToken was not authenticated" info log noise on hub probes — see
+        // the comment on the no-tier-matched branch in HandleAuthenticateAsync.
+        bool IsHubPath()
+        {
+            var path = Request.Path.Value;
+            return !string.IsNullOrEmpty(path)
+                && path.StartsWith(Consts.Hub.RemoteApp, StringComparison.OrdinalIgnoreCase);
         }
 
         Task<bool> AuthorizeAiAgentAsync(string token)

--- a/McpPlugin.Server/src/Hub/BaseHub.cs
+++ b/McpPlugin.Server/src/Hub/BaseHub.cs
@@ -54,6 +54,34 @@ namespace com.IvanMurzak.McpPlugin.Server
                     token = authHeader.Substring("Bearer ".Length).Trim();
             }
 
+            // Short-circuit: in auth=required mode, an empty/missing token is always rejected
+            // by RequiredAuthMcpStrategy.OnPluginConnected anyway. Skip the AuthorizationWebhook
+            // round-trip — it would only return a "Missing bearerToken" denial and emit a Warning
+            // log line on the webhook side. Cuts a documented production-log noise source for
+            // tokenless connection probes (issue #99). Behavior in auth=none mode is unchanged.
+            if (string.IsNullOrEmpty(token)
+                && _strategy.AuthOption == Common.Consts.MCP.Server.AuthOption.required)
+            {
+                _connectionRejected = true;
+                _logger.LogDebug(
+                    "{guid} MCP Plugin connection rejected (auth=required, empty token) — webhook skipped. ConnectionId: {connectionId}.",
+                    _guid, Context.ConnectionId);
+
+                try
+                {
+                    await Clients.Caller.ForceDisconnect("Authorization failed. A bearer token is required in auth=required mode.");
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogDebug(ex,
+                        "{guid} Failed to send ForceDisconnect notification for rejected connection. ConnectionId: {connectionId}.",
+                        _guid, Context.ConnectionId);
+                }
+
+                Context.Abort();
+                return;
+            }
+
             // Check authorization webhook
             var allowed = await _authorizationWebhookService.AuthorizePluginAsync(
                 connectionId: Context.ConnectionId,

--- a/McpPlugin.Server/src/Hub/BaseHub.cs
+++ b/McpPlugin.Server/src/Hub/BaseHub.cs
@@ -11,6 +11,7 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.Common;
 using com.IvanMurzak.McpPlugin.Common.Hub.Client;
 using com.IvanMurzak.McpPlugin.Server.Strategy;
 using com.IvanMurzak.McpPlugin.Server.Webhooks.Services;
@@ -60,7 +61,7 @@ namespace com.IvanMurzak.McpPlugin.Server
             // log line on the webhook side. Cuts a documented production-log noise source for
             // tokenless connection probes (issue #99). Behavior in auth=none mode is unchanged.
             if (string.IsNullOrEmpty(token)
-                && _strategy.AuthOption == Common.Consts.MCP.Server.AuthOption.required)
+                && _strategy.AuthOption == Consts.MCP.Server.AuthOption.required)
             {
                 _connectionRejected = true;
                 _logger.LogDebug(


### PR DESCRIPTION
## Summary

Two surgical edits cut a documented production-log noise source (~1459 info-level lines/hour on the `mcp-server` deployment) where every tokenless plugin probe triggers (a) a wasted webhook round-trip and (b) a framework-emitted `[7] McpPluginToken was not authenticated` info log.

- **Commit 1 — `refactor(auth): skip webhook on empty token in auth=required mode`**
  In `BaseHub.OnConnectedAsync`, short-circuit BEFORE the `AuthorizationWebhookService.AuthorizePluginAsync(...)` call when the bearer token is empty AND the strategy is `auth=required`. `RequiredAuthMcpStrategy` would reject the connection anyway after the webhook returned; the round-trip is pure waste and was logging a `Warning` per probe. Behavior in `auth=none` mode is unchanged.
- **Commit 2 — `fix(auth): return NoResult on hub path when no token tier matches`**
  In `TokenAuthenticationHandler.HandleAuthenticateAsync`, the no-tier-matched branch now returns `NoResult` when the request path starts with `Consts.Hub.RemoteApp` (`/hub/mcp-server`, case-insensitive — also covers SignalR sub-paths like `/hub/mcp-server/negotiate`). Tier 1 misses by design on the hub path because the plugin's bearer token is registered via `ClientUtils.AddClient` only AFTER `OnConnectedAsync` runs (chicken-and-egg). The hub endpoint is not `RequireAuthorization()`-gated, so `NoResult` is safe — connection still proceeds. Non-hub paths still return `Fail` to preserve the 401 challenge.

Companion log-filter fix in AI-Game-Dev-Server's `appsettings.json` is a separate PR (out of scope here).

## Test plan

- [x] `dotnet restore` + `dotnet build --no-restore --configuration Release` clean (0 warnings, 0 errors)
- [x] `dotnet test --no-build --configuration Release` green on `net8.0` AND `net9.0` for both `McpPlugin.Tests` (394 + 394) and `McpPlugin.Server.Tests` (234 + 234) — 8 new tests added (4 per commit) covering the new branches plus regression guards (`auth=none` empty token still calls webhook; `auth=required` non-empty token still calls webhook; non-hub path still returns `Fail`; existing path-less `UnrecognizedToken_ReturnsFail` still passes).
- [x] No `<Version>` bump, no `com.IvanMurzak.ReflectorNet` `PackageReference Version` change.

Closes #99