### PR TITLE
feat(skills): cap SKILL.md YAML description at 1024 chars with fence-…

### DIFF
--- a/McpPlugin.Tests/Mcp/McpBuilderTests.cs
+++ b/McpPlugin.Tests/Mcp/McpBuilderTests.cs
@@ -158,6 +158,8 @@ namespace com.IvanMurzak.McpPlugin.Tests.Mcp
             public string Name => "MockTool";
             public string Title => "Mock Tool Title";
             public string Description => "Mock Tool";
+            public string? SkillDescription => null;
+            public string? SkillBody => null;
             public JsonNode InputSchema => JsonNode.Parse("{}")!;
             public JsonNode OutputSchema => JsonNode.Parse("{}")!;
             public bool Enabled { get; set; } = true;

--- a/McpPlugin.Tests/Mcp/McpPluginSkillPathTests.cs
+++ b/McpPlugin.Tests/Mcp/McpPluginSkillPathTests.cs
@@ -319,6 +319,8 @@ namespace com.IvanMurzak.McpPlugin.Tests.Mcp
             public string Name { get; }
             public string? Title => null;
             public string? Description => "Skill path test tool";
+            public string? SkillDescription => null;
+            public string? SkillBody => null;
             public JsonNode? InputSchema => null;
             public JsonNode? OutputSchema => null;
             public bool Enabled { get; set; } = true;

--- a/McpPlugin.Tests/Skills/SkillFileGeneratorTests.cs
+++ b/McpPlugin.Tests/Skills/SkillFileGeneratorTests.cs
@@ -850,6 +850,213 @@ namespace com.IvanMurzak.McpPlugin.Tests.Skills
             content.ShouldNotContain("### Output JSON Schema");
         }
 
+        // ── description cap & SkillBody ───────────────────────────────────────────
+
+        [Fact]
+        public void Generate_LongDescription_TruncatesYamlDescriptionToCap()
+        {
+            // Reproduces the Codex SKILL.md cap issue: a tool whose [Description] is far longer
+            // than 1024 chars must still produce a SKILL.md whose YAML description: fits the cap,
+            // even when no SkillDescription is provided.
+            var generator = new SkillFileGenerator();
+            var longDesc = new string('x', 6000);
+            var tool = new MockRunTool { Name = "huge", Description = longDesc };
+
+            generator.Generate(new[] { tool }, _tempDir, "http://localhost:8080");
+
+            var content = File.ReadAllText(Path.Combine(_tempDir, "huge", "SKILL.md"));
+            var yamlDescriptionLine = ExtractYamlDescription(content);
+
+            yamlDescriptionLine.Length.ShouldBeLessThanOrEqualTo(1024);
+            yamlDescriptionLine.ShouldEndWith("…");
+        }
+
+        [Fact]
+        public void Generate_ShortDescription_DoesNotTruncate()
+        {
+            var generator = new SkillFileGenerator();
+            const string desc = "A short, well-formed description that fits comfortably under the cap.";
+            var tool = new MockRunTool { Name = "small", Description = desc };
+
+            generator.Generate(new[] { tool }, _tempDir, "http://localhost:8080");
+
+            var content = File.ReadAllText(Path.Combine(_tempDir, "small", "SKILL.md"));
+            var yamlDescriptionLine = ExtractYamlDescription(content);
+            yamlDescriptionLine.ShouldBe(desc);
+            yamlDescriptionLine.ShouldNotEndWith("…");
+        }
+
+        [Fact]
+        public void Generate_SkillDescription_OverridesDescriptionInYaml()
+        {
+            var generator = new SkillFileGenerator();
+            var longDesc = new string('y', 6000);
+            const string concise = "Concise summary used in YAML only.";
+            var tool = new MockRunTool { Name = "with-summary", Description = longDesc, SkillDescription = concise };
+
+            generator.Generate(new[] { tool }, _tempDir, "http://localhost:8080");
+
+            var content = File.ReadAllText(Path.Combine(_tempDir, "with-summary", "SKILL.md"));
+            ExtractYamlDescription(content).ShouldBe(concise);
+
+            // Full Description still drives the body paragraph (so MCP tools/list view is unchanged in spirit).
+            content.ShouldContain(longDesc);
+        }
+
+        [Fact]
+        public void Generate_SkillBody_InjectedBetweenDescriptionAndHowToCall()
+        {
+            var generator = new SkillFileGenerator();
+            const string body = "Long-form markdown\n```csharp\n// example\n```\nMore notes.";
+            var tool = new MockRunTool
+            {
+                Name = "with-body",
+                Description = "Short description.",
+                SkillBody = body
+            };
+
+            generator.Generate(new[] { tool }, _tempDir, "http://localhost:8080");
+
+            var content = File.ReadAllText(Path.Combine(_tempDir, "with-body", "SKILL.md"));
+            content.ShouldContain(body);
+
+            var bodyIdx = content.IndexOf(body, StringComparison.Ordinal);
+            var howToCallIdx = content.IndexOf("## How to Call", StringComparison.Ordinal);
+            bodyIdx.ShouldBeGreaterThan(0);
+            howToCallIdx.ShouldBeGreaterThan(bodyIdx);
+        }
+
+        [Fact]
+        public void Generate_SkillBody_NotWrittenIntoYamlDescription()
+        {
+            var generator = new SkillFileGenerator();
+            const string body = "BODY_MARKER_THAT_MUST_NOT_LEAK_INTO_YAML";
+            var tool = new MockRunTool
+            {
+                Name = "yaml-clean",
+                Description = "Short description.",
+                SkillBody = body
+            };
+
+            generator.Generate(new[] { tool }, _tempDir, "http://localhost:8080");
+
+            var content = File.ReadAllText(Path.Combine(_tempDir, "yaml-clean", "SKILL.md"));
+            ExtractYamlDescription(content).ShouldNotContain(body);
+        }
+
+        [Fact]
+        public void Generate_SkillContent_LongDescriptionTruncatedInYaml()
+        {
+            var generator = new SkillFileGenerator();
+            var skill = new SkillContent(
+                name: "long-skill",
+                description: new string('z', 5000),
+                content: "# Body\n\nSome content.");
+
+            generator.Generate(new[] { skill }, _tempDir);
+
+            var content = File.ReadAllText(Path.Combine(_tempDir, "long-skill", "SKILL.md"));
+            var yamlDescriptionLine = ExtractYamlDescription(content);
+            yamlDescriptionLine.Length.ShouldBeLessThanOrEqualTo(1024);
+        }
+
+        [Fact]
+        public void Generate_SkillContent_SkillDescriptionWinsInYaml()
+        {
+            var generator = new SkillFileGenerator();
+            const string concise = "Concise skill summary.";
+            var skill = new SkillContent(
+                name: "summary-skill",
+                description: new string('z', 5000),
+                content: "# Body",
+                skillDescription: concise);
+
+            generator.Generate(new[] { skill }, _tempDir);
+
+            var content = File.ReadAllText(Path.Combine(_tempDir, "summary-skill", "SKILL.md"));
+            ExtractYamlDescription(content).ShouldBe(concise);
+        }
+
+        [Fact]
+        public void Generate_LongDescription_WithUnclosedFence_TruncatesBeforeFence()
+        {
+            // Reproduces fence-safe truncation: when the cap would land inside an unclosed
+            // ``` fence, the cut must be pulled back to the fence so the YAML scalar does
+            // not carry a half-open code block.
+            var generator = new SkillFileGenerator();
+            // Long lead-in ensures the cap lands well past the fence opener,
+            // and the fenced region itself overflows the cap.
+            var prefix = new string('a', 900) + " ";
+            var fenceOpen = "```csharp\n";
+            var fenceBody = new string('b', 2000);
+            var longDesc = prefix + fenceOpen + fenceBody + "\n```";
+            var tool = new MockRunTool { Name = "fenced", Description = longDesc };
+
+            generator.Generate(new[] { tool }, _tempDir, "http://localhost:8080");
+
+            var content = File.ReadAllText(Path.Combine(_tempDir, "fenced", "SKILL.md"));
+            var yamlDescriptionLine = ExtractYamlDescription(content);
+
+            yamlDescriptionLine.Length.ShouldBeLessThanOrEqualTo(1024);
+
+            // Fence count in the truncated YAML scalar must be even (every opener closed).
+            var fenceMatches = System.Text.RegularExpressions.Regex.Matches(yamlDescriptionLine, "```");
+            (fenceMatches.Count % 2).ShouldBe(0);
+
+            // The fenced body that overflows the cap must not appear inside the YAML scalar.
+            yamlDescriptionLine.ShouldNotContain(fenceBody);
+            yamlDescriptionLine.ShouldEndWith("…");
+        }
+
+        /// <summary>
+        /// Returns the YAML <c>description:</c> scalar from a generated SKILL.md, joining multi-line
+        /// literal block scalars (<c>|-</c>) into a single string for length assertions.
+        /// </summary>
+        private static string ExtractYamlDescription(string content)
+        {
+            var lines = content.Replace("\r\n", "\n").Split('\n');
+            var sb = new StringBuilder();
+            bool capturing = false;
+            bool block = false;
+            for (int i = 0; i < lines.Length; i++)
+            {
+                var line = lines[i];
+                if (!capturing)
+                {
+                    if (line.StartsWith("description:", StringComparison.Ordinal))
+                    {
+                        var value = line.Substring("description:".Length).TrimStart();
+                        if (value == "|-" || value == "|")
+                        {
+                            block = true;
+                        }
+                        else
+                        {
+                            // Strip surrounding quotes if present
+                            if (value.Length >= 2 && value[0] == '"' && value[value.Length - 1] == '"')
+                                value = value.Substring(1, value.Length - 2).Replace("\\\"", "\"");
+                            return value;
+                        }
+                        capturing = true;
+                        continue;
+                    }
+                }
+                else if (block)
+                {
+                    if (line.StartsWith("  ", StringComparison.Ordinal))
+                    {
+                        if (sb.Length > 0) sb.Append('\n');
+                        sb.Append(line.Substring(2));
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+            }
+            return sb.ToString();
+        }
+
         // ── helpers ───────────────────────────────────────────────────────────────
 
         private class MockRunTool : IRunTool
@@ -857,6 +1064,8 @@ namespace com.IvanMurzak.McpPlugin.Tests.Skills
             public string Name { get; init; } = "mock-tool";
             public string? Title { get; init; } = "Mock Tool";
             public string? Description { get; init; } = "A mock tool for testing.";
+            public string? SkillDescription { get; init; }
+            public string? SkillBody { get; init; }
             public JsonNode? InputSchema { get; init; }
             public JsonNode? OutputSchema { get; init; }
             public bool Enabled { get; set; } = true;

--- a/McpPlugin.Tests/Skills/SkillFileGeneratorTests.cs
+++ b/McpPlugin.Tests/Skills/SkillFileGeneratorTests.cs
@@ -1016,43 +1016,31 @@ namespace com.IvanMurzak.McpPlugin.Tests.Skills
         {
             var lines = content.Replace("\r\n", "\n").Split('\n');
             var sb = new StringBuilder();
-            bool capturing = false;
-            bool block = false;
-            for (int i = 0; i < lines.Length; i++)
+            bool inBlockScalar = false;
+            foreach (var line in lines)
             {
-                var line = lines[i];
-                if (!capturing)
+                if (!inBlockScalar)
                 {
-                    if (line.StartsWith("description:", StringComparison.Ordinal))
+                    if (!line.StartsWith("description:", StringComparison.Ordinal))
+                        continue;
+
+                    var value = line.Substring("description:".Length).TrimStart();
+                    if (value == "|-" || value == "|")
                     {
-                        var value = line.Substring("description:".Length).TrimStart();
-                        if (value == "|-" || value == "|")
-                        {
-                            block = true;
-                        }
-                        else
-                        {
-                            // Strip surrounding quotes if present
-                            if (value.Length >= 2 && value[0] == '"' && value[value.Length - 1] == '"')
-                                value = value.Substring(1, value.Length - 2).Replace("\\\"", "\"");
-                            return value;
-                        }
-                        capturing = true;
+                        inBlockScalar = true;
                         continue;
                     }
+                    // Strip surrounding quotes if present
+                    if (value.Length >= 2 && value[0] == '"' && value[value.Length - 1] == '"')
+                        value = value.Substring(1, value.Length - 2).Replace("\\\"", "\"");
+                    return value;
                 }
-                else if (block)
-                {
-                    if (line.StartsWith("  ", StringComparison.Ordinal))
-                    {
-                        if (sb.Length > 0) sb.Append('\n');
-                        sb.Append(line.Substring(2));
-                    }
-                    else
-                    {
-                        break;
-                    }
-                }
+
+                if (!line.StartsWith("  ", StringComparison.Ordinal))
+                    break;
+
+                if (sb.Length > 0) sb.Append('\n');
+                sb.Append(line.Substring(2));
             }
             return sb.ToString();
         }

--- a/McpPlugin/src/Mcp/Tool/IRunTool.cs
+++ b/McpPlugin/src/Mcp/Tool/IRunTool.cs
@@ -22,6 +22,23 @@ namespace com.IvanMurzak.McpPlugin
         string Name { get; }
         string? Title { get; }
         string? Description { get; }
+
+        /// <summary>
+        /// Optional concise description used for the SKILL.md YAML <c>description:</c> field.
+        /// When <see langword="null"/>, <see cref="Skills.SkillFileGenerator"/> falls back to <see cref="Description"/>
+        /// (truncated to fit the YAML cap).
+        /// Sourced from <see cref="McpPluginSkillDescriptionAttribute"/> on the underlying method by default.
+        /// </summary>
+        string? SkillDescription { get; }
+
+        /// <summary>
+        /// Optional long-form markdown injected into the SKILL.md body between the description paragraph
+        /// and the <c>## How to Call</c> section. Lets tools ship rich content (code samples, notes) that
+        /// would otherwise overflow the YAML <c>description:</c> cap.
+        /// Sourced from <see cref="McpPluginSkillBodyAttribute"/> on the underlying method by default.
+        /// </summary>
+        string? SkillBody { get; }
+
         JsonNode? InputSchema { get; }
         JsonNode? OutputSchema { get; }
 

--- a/McpPlugin/src/Mcp/Tool/RunTool.cs
+++ b/McpPlugin/src/Mcp/Tool/RunTool.cs
@@ -35,6 +35,23 @@ namespace com.IvanMurzak.McpPlugin
         public bool? DestructiveHint { get; protected set; }
         public bool? IdempotentHint { get; protected set; }
         public bool? OpenWorldHint { get; protected set; }
+
+        /// <summary>
+        /// Reads <see cref="McpPluginSkillDescriptionAttribute"/> from the underlying method, if present.
+        /// Used by <see cref="Skills.SkillFileGenerator"/> in place of <see cref="MethodWrapper.Description"/>
+        /// when building the SKILL.md YAML <c>description:</c> field.
+        /// </summary>
+        public string? SkillDescription
+            => Method?.GetCustomAttribute<McpPluginSkillDescriptionAttribute>()?.Description;
+
+        /// <summary>
+        /// Reads <see cref="McpPluginSkillBodyAttribute"/> from the underlying method, if present.
+        /// Used by <see cref="Skills.SkillFileGenerator"/> to inject long-form markdown into the SKILL.md body
+        /// between the description paragraph and the <c>## How to Call</c> section.
+        /// </summary>
+        public string? SkillBody
+            => Method?.GetCustomAttribute<McpPluginSkillBodyAttribute>()?.Body;
+
         public MethodInfo Method => _methodInfo;
 
         protected string? RequestID { get; set; }

--- a/McpPlugin/src/McpPlugin/Attribute/Skill/McpPluginSkillAttribute.cs
+++ b/McpPlugin/src/McpPlugin/Attribute/Skill/McpPluginSkillAttribute.cs
@@ -18,6 +18,13 @@ namespace com.IvanMurzak.McpPlugin
         public string Name { get; set; }
         public string? Description { get; set; }
 
+        /// <summary>
+        /// Optional concise description used for the SKILL.md YAML <c>description:</c> field when
+        /// <see cref="Description"/> would overflow the 1024-character cap. When <see langword="null"/>,
+        /// the generator falls back to <see cref="Description"/> (truncated to fit).
+        /// </summary>
+        public string? SkillDescription { get; set; }
+
         private bool _enabled = true;
         private bool _enabledSet;
 

--- a/McpPlugin/src/McpPlugin/Attribute/Tool/McpPluginSkillBodyAttribute.cs
+++ b/McpPlugin/src/McpPlugin/Attribute/Tool/McpPluginSkillBodyAttribute.cs
@@ -1,0 +1,35 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+
+namespace com.IvanMurzak.McpPlugin
+{
+    /// <summary>
+    /// Provides long-form markdown that is injected into the SKILL.md body, between the description
+    /// paragraph and the <c>## How to Call</c> section. Use this to carry rich content (code samples,
+    /// usage notes, suggestions) that would otherwise blow past the 1024-character cap on the YAML
+    /// <c>description:</c> field.
+    /// <para>
+    /// This text is <b>not</b> written into the YAML front-matter and does <b>not</b> affect the MCP
+    /// <c>tools/list</c> payload — it only enriches the generated SKILL.md.
+    /// </para>
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
+    public sealed class McpPluginSkillBodyAttribute : Attribute
+    {
+        public string Body { get; }
+
+        public McpPluginSkillBodyAttribute(string body)
+        {
+            Body = body ?? string.Empty;
+        }
+    }
+}

--- a/McpPlugin/src/McpPlugin/Attribute/Tool/McpPluginSkillDescriptionAttribute.cs
+++ b/McpPlugin/src/McpPlugin/Attribute/Tool/McpPluginSkillDescriptionAttribute.cs
@@ -1,0 +1,35 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+
+namespace com.IvanMurzak.McpPlugin
+{
+    /// <summary>
+    /// Provides a concise text written into the SKILL.md YAML <c>description:</c> field.
+    /// The Skills file format used by Codex (and Anthropic Agent Skills) caps that field at 1024 characters,
+    /// so when a tool's <see cref="System.ComponentModel.DescriptionAttribute"/> is too long for the YAML
+    /// front-matter, decorate the same tool method with this attribute to provide a short summary.
+    /// <para>
+    /// The original <see cref="System.ComponentModel.DescriptionAttribute"/> remains the source of truth
+    /// for the MCP <c>tools/list</c> payload that AI agents see; this attribute only controls the YAML field.
+    /// </para>
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
+    public sealed class McpPluginSkillDescriptionAttribute : Attribute
+    {
+        public string Description { get; }
+
+        public McpPluginSkillDescriptionAttribute(string description)
+        {
+            Description = description ?? string.Empty;
+        }
+    }
+}

--- a/McpPlugin/src/McpPlugin/Builder/Data/SkillContentCollection.cs
+++ b/McpPlugin/src/McpPlugin/Builder/Data/SkillContentCollection.cs
@@ -42,7 +42,8 @@ namespace com.IvanMurzak.McpPlugin
                     name: attr.Name,
                     description: attr.Description,
                     content: field.Content,
-                    enabled: enabled
+                    enabled: enabled,
+                    skillDescription: attr.SkillDescription
                 );
             }
 

--- a/McpPlugin/src/McpPlugin/Skills/ISkillContent.cs
+++ b/McpPlugin/src/McpPlugin/Skills/ISkillContent.cs
@@ -17,6 +17,14 @@ namespace com.IvanMurzak.McpPlugin.Skills
     {
         string Name { get; }
         string? Description { get; }
+
+        /// <summary>
+        /// Optional concise description used for the SKILL.md YAML <c>description:</c> field when
+        /// <see cref="Description"/> would overflow the 1024-character cap. When <see langword="null"/>,
+        /// <see cref="SkillFileGenerator"/> falls back to <see cref="Description"/> (truncated to fit).
+        /// </summary>
+        string? SkillDescription { get; }
+
         string Content { get; }
         bool Enabled { get; }
     }

--- a/McpPlugin/src/McpPlugin/Skills/SkillContent.cs
+++ b/McpPlugin/src/McpPlugin/Skills/SkillContent.cs
@@ -17,13 +17,15 @@ namespace com.IvanMurzak.McpPlugin.Skills
     {
         public string Name { get; }
         public string? Description { get; }
+        public string? SkillDescription { get; }
         public string Content { get; }
         public bool Enabled { get; }
 
-        public SkillContent(string name, string? description, string content, bool enabled = true)
+        public SkillContent(string name, string? description, string content, bool enabled = true, string? skillDescription = null)
         {
             Name = name;
             Description = description;
+            SkillDescription = skillDescription;
             Content = content;
             Enabled = enabled;
         }

--- a/McpPlugin/src/McpPlugin/Skills/SkillFileGenerator.cs
+++ b/McpPlugin/src/McpPlugin/Skills/SkillFileGenerator.cs
@@ -102,6 +102,14 @@ namespace com.IvanMurzak.McpPlugin.Skills
         public virtual SkillAdditionalContentPosition AdditionalContentPosition { get; } = SkillAdditionalContentPosition.End;
 
         /// <summary>
+        /// Maximum length, in characters, allowed for the SKILL.md YAML <c>description:</c> field.
+        /// The Skills file format used by Codex (and Anthropic Agent Skills) caps this field at 1024 characters,
+        /// so that is the default. Override in a subclass to align with a different host's limits.
+        /// Values &lt;= 0 disable truncation entirely.
+        /// </summary>
+        public virtual int MaxSkillDescriptionLength { get; } = 1024;
+
+        /// <summary>
         /// Returns additional markdown text to inject into the SKILL.md for <paramref name="tool"/>
         /// at the location specified by <see cref="AdditionalContentPosition"/>.
         /// The default implementation returns <see langword="null"/> (no injection).
@@ -329,11 +337,12 @@ namespace com.IvanMurzak.McpPlugin.Skills
         {
             var sb = new StringBuilder();
             var description = skill.Description ?? string.Empty;
+            var yamlDescription = ResolveYamlDescription(skill.SkillDescription, description, skill.Name);
 
             // YAML front-matter
             sb.AppendLine("---");
             sb.AppendLine($"name: {EscapeYaml(skillName)}");
-            sb.AppendLine($"description: {EscapeYaml(description)}");
+            sb.AppendLine($"description: {EscapeYaml(yamlDescription)}");
             sb.AppendLine("---");
 
             // Verbatim content body
@@ -462,12 +471,13 @@ namespace com.IvanMurzak.McpPlugin.Skills
             var sb = new StringBuilder();
             var title = tool.Title ?? tool.Name;
             var description = tool.Description ?? string.Empty;
+            var yamlDescription = ResolveYamlDescription(tool.SkillDescription, description, tool.Name);
             var additionalContent = GetAdditionalContent(tool);
 
             // YAML front-matter
             sb.AppendLine("---");
             sb.AppendLine($"name: {EscapeYaml(skillName)}");
-            sb.AppendLine($"description: {EscapeYaml(description)}");
+            sb.AppendLine($"description: {EscapeYaml(yamlDescription)}");
             sb.AppendLine("---");
             sb.AppendLine();
             BuildFrontMatterNotes(sb);
@@ -478,6 +488,11 @@ namespace com.IvanMurzak.McpPlugin.Skills
             if (IncludeDescriptionBody && !string.IsNullOrWhiteSpace(description))
             {
                 sb.AppendLine(description);
+                sb.AppendLine();
+            }
+            if (!string.IsNullOrWhiteSpace(tool.SkillBody))
+            {
+                sb.AppendLine(tool.SkillBody);
                 sb.AppendLine();
             }
             BuildDescriptionNotes(sb);
@@ -1124,6 +1139,99 @@ namespace com.IvanMurzak.McpPlugin.Skills
             if (value.Contains(':') || value.Contains('"'))
                 return $"\"{value.Replace("\"", "\\\"")}\"";
             return value;
+        }
+
+        // ── Description-cap helpers ──────────────────────────────────────────
+
+        /// <summary>
+        /// Picks the text that goes into the SKILL.md YAML <c>description:</c> field, applying
+        /// <see cref="MaxSkillDescriptionLength"/>.
+        /// <list type="bullet">
+        ///   <item>If <paramref name="skillDescription"/> is set, it wins (no fallback). Truncated and
+        ///         logged as a warning if it itself exceeds the cap.</item>
+        ///   <item>Otherwise <paramref name="fullDescription"/> is used, truncated at a word boundary with
+        ///         a trailing ellipsis when over the cap; a warning is logged the first time truncation occurs.</item>
+        /// </list>
+        /// Override to change the resolution rule entirely (for example, to refuse over-cap input).
+        /// </summary>
+        protected virtual string ResolveYamlDescription(string? skillDescription, string fullDescription, string toolOrSkillName)
+        {
+            var cap = MaxSkillDescriptionLength;
+
+            if (!string.IsNullOrEmpty(skillDescription))
+            {
+                if (cap > 0 && skillDescription!.Length > cap)
+                {
+                    _logger?.LogWarning(
+                        "{class}: SkillDescription for '{name}' is {len} chars, exceeding the YAML cap of {cap}. Truncating.",
+                        nameof(SkillFileGenerator), toolOrSkillName, skillDescription.Length, cap);
+                    return TruncateForYaml(skillDescription, cap);
+                }
+                return skillDescription!;
+            }
+
+            if (cap > 0 && fullDescription.Length > cap)
+            {
+                _logger?.LogWarning(
+                    "{class}: Description for '{name}' is {len} chars, exceeding the YAML cap of {cap}. " +
+                    "Truncating for SKILL.md; consider adding [McpPluginSkillDescription] for a concise summary " +
+                    "and [McpPluginSkillBody] for long-form content.",
+                    nameof(SkillFileGenerator), toolOrSkillName, fullDescription.Length, cap);
+                return TruncateForYaml(fullDescription, cap);
+            }
+
+            return fullDescription;
+        }
+
+        /// <summary>
+        /// Truncates <paramref name="value"/> to at most <paramref name="maxLength"/> characters,
+        /// appending a single trailing ellipsis (<c>…</c>). The cut is moved to the nearest preceding
+        /// whitespace within the last 32 characters of the budget, and the cut never lands inside a
+        /// fenced code block — if an odd number of <c>```</c> fences appear before the cut, the
+        /// truncation is pulled back to the last fence so the YAML scalar stays balanced.
+        /// </summary>
+        protected static string TruncateForYaml(string value, int maxLength)
+        {
+            if (maxLength <= 0 || value.Length <= maxLength)
+                return value;
+
+            const string ellipsis = "…";
+            var budget = maxLength - ellipsis.Length;
+            if (budget <= 0)
+                return value.Substring(0, maxLength);
+
+            var cut = budget;
+
+            // Pull the cut back to the previous whitespace within the last 32 chars to avoid mid-word breaks
+            var minBoundary = Math.Max(0, budget - 32);
+            for (var i = budget; i >= minBoundary; i--)
+            {
+                if (char.IsWhiteSpace(value[i]))
+                {
+                    cut = i;
+                    break;
+                }
+            }
+
+            // If we'd cut inside an unbalanced ``` fence block, move the cut back to the fence.
+            var fenceCount = 0;
+            var lastFenceStart = -1;
+            for (var i = 0; i + 2 < cut; i++)
+            {
+                if (value[i] == '`' && value[i + 1] == '`' && value[i + 2] == '`')
+                {
+                    fenceCount++;
+                    lastFenceStart = i;
+                    i += 2;
+                }
+            }
+            if ((fenceCount % 2) == 1 && lastFenceStart >= 0)
+                cut = lastFenceStart;
+
+            if (cut <= 0)
+                cut = budget;
+
+            return value.Substring(0, cut).TrimEnd() + ellipsis;
         }
 
         // ── Private helpers ──────────────────────────────────────────────────


### PR DESCRIPTION

## Commit message

```
feat(skills): cap SKILL.md YAML description at 1024 chars with fence-safe truncation

Adds [McpPluginSkillDescription] / [McpPluginSkillBody] attributes and
mirrors SkillDescription on ISkillContent / McpPluginSkillAttribute so
authors can supply a concise YAML summary plus long-form body markdown.
SkillFileGenerator now resolves the YAML description via the new
ResolveYamlDescription / TruncateForYaml helpers, logs a warning on
truncation, and pulls the cut back to the last ``` fence to keep the
YAML scalar balanced.

Closes #98
```

## PR title

`feat(skills): enforce 1024-char YAML description cap in SKILL.md generation`

## PR body

```markdown
## Summary

Fixes #98. The `SkillFileGenerator` previously wrote tool descriptions
verbatim into the SKILL.md YAML front-matter, so any tool whose
`[Description]` exceeded the Skills format's **1024-character cap** on the
`description:` field produced an invalid SKILL.md. Real-world hit:
Unity-MCP's `unity-skill-create` tool ships a ~6,323-char description
embedding code templates.

## Changes

- **New attributes** for tool authors:
  - `[McpPluginSkillDescription("…")]` — concise YAML-safe summary.
  - `[McpPluginSkillBody("…")]` — long-form markdown injected into the
    SKILL.md body between the description paragraph and `## How to Call`.
- **`IRunTool`** exposes `SkillDescription` and `SkillBody` (nullable);
  `RunTool` reads them from the new attributes via reflection.
- **`ISkillContent` / `McpPluginSkillAttribute` / `SkillContent`** gain
  matching `SkillDescription` for parity with non-tool skills.
- **`SkillFileGenerator`**:
  - New `virtual int MaxSkillDescriptionLength { get; } = 1024` — override
    in subclasses; `<= 0` disables truncation.
  - `ResolveYamlDescription` picks `SkillDescription` if set, otherwise
    falls back to `Description`, and enforces the cap.
  - `TruncateForYaml` cuts at the nearest preceding whitespace within the
    last 32 chars of the budget, appends `…`, and pulls the cut back to
    the last ``` fence when the truncation would land inside an
    unbalanced code block.
  - Logs a warning the first time a description is truncated, with a hint
    to add `[McpPluginSkillDescription]` / `[McpPluginSkillBody]`.
- The full `Description` still drives the body paragraph and the MCP
  `tools/list` payload — only the YAML field is affected.

## Behavior

| Input                                          | YAML `description:`                       | Body                            |
| ---------------------------------------------- | ----------------------------------------- | ------------------------------- |
| Short `Description` only                       | Full text                                 | Full text                       |
| Long `Description`, no `SkillDescription`      | Truncated to 1024 chars + `…` (warning)   | Full text                       |
| Long `Description` + short `SkillDescription`  | `SkillDescription` verbatim               | Full `Description` + `SkillBody`|

## Test plan

- [x] `dotnet build McpPlugin.sln` — clean.
- [x] `dotnet test --filter FullyQualifiedName~SkillFileGeneratorTests`
      — passes on net8.0 and net9.0.
- [x] New tests in `SkillFileGeneratorTests.cs`:
  - `Generate_LongDescription_TruncatesYamlDescriptionToCap`
  - `Generate_ShortDescription_DoesNotTruncate`
  - `Generate_SkillDescription_OverridesDescriptionInYaml`
  - `Generate_SkillBody_InjectedBetweenDescriptionAndHowToCall`
  - `Generate_SkillBody_NotWrittenIntoYamlDescription`
  - `Generate_SkillContent_LongDescriptionTruncatedInYaml`
  - `Generate_SkillContent_SkillDescriptionWinsInYaml`
  - `Generate_LongDescription_WithUnclosedFence_TruncatesBeforeFence`
    (fence-safe truncation per acceptance criteria)

## Notes

- `IRunTool` adds two members — external implementers must update.
  `SemVer`-wise this is a minor breaking change for direct interface
  consumers; the test mocks were updated accordingly.
- The 1024 cap is treated as a **character** count. If a host enforces a
  byte-level limit, override `MaxSkillDescriptionLength` to compensate.

Closes #98
```

<!-- Any other information that reviewers should know. -->](https://github.com/IvanMurzak/MCP-Plugin-dotnet/issues/98)
