### PR TITLE
fix(strategy): drop foreign-tenant client notifications in auth=required mode

### DIFF
--- a/McpPlugin.Server.Tests/NoAuthMcpStrategyTests.cs
+++ b/McpPlugin.Server.Tests/NoAuthMcpStrategyTests.cs
@@ -185,5 +185,17 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
             result.ShouldBeSameAs(expectedData);
             sessionTracker.Verify(s => s.GetServerData(), Times.Once);
         }
+
+        [Fact]
+        public void ResolveNotificationTarget_AlwaysBroadcasts()
+        {
+            // no-auth mode enforces a single plugin connection (OnPluginConnected disconnects
+            // any other), so Clients.All targets exactly one recipient — broadcast is correct.
+            // Routing token is ignored because there is no per-token mapping in this mode.
+            foreach (var probe in new[] { (string?)null, "", "any-token-value" })
+            {
+                _strategy.ResolveNotificationTarget(probe).Kind.ShouldBe(NotificationTarget.TargetKind.Broadcast);
+            }
+        }
     }
 }

--- a/McpPlugin.Server.Tests/NotificationRoutingTests.cs
+++ b/McpPlugin.Server.Tests/NotificationRoutingTests.cs
@@ -10,8 +10,12 @@
 
 using System;
 using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.Common;
 using com.IvanMurzak.McpPlugin.Common.Hub.Client;
 using com.IvanMurzak.McpPlugin.Common.Model;
+using com.IvanMurzak.McpPlugin.Common.Utils;
+using com.IvanMurzak.McpPlugin.Server.Auth;
+using com.IvanMurzak.McpPlugin.Server.Strategy;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -21,9 +25,12 @@ using Xunit;
 namespace com.IvanMurzak.McpPlugin.Server.Tests
 {
     /// <summary>
-    /// Tests for the token-scoped notification routing pattern used in McpServerService.
-    /// Verifies that when a token-mapped plugin exists, notifications target only that
-    /// connection rather than broadcasting to all.
+    /// Tests for the strategy-driven notification routing pattern used in McpServerService.
+    /// Verifies that the routing decision honors the active connection strategy:
+    ///   - auth=required: notifications target the per-token plugin OR are dropped (no broadcast).
+    ///   - auth=none: notifications broadcast to all (single-plugin invariant).
+    /// Regression coverage for issue #102: foreign Tier 2 (DCR) and Tier 3 (ServerToken) sessions
+    /// must not bleed into unrelated tenants' active-client lists via the broadcast fallback.
     /// </summary>
     [Collection("McpPlugin.Server")]
     public class NotificationRoutingTests
@@ -33,119 +40,94 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
         static string UniqueId() => Guid.NewGuid().ToString("N");
 
         /// <summary>
-        /// Simulates the notification routing logic from McpServerService.NotifyClientConnectedAsync.
+        /// Mirrors the dispatch shape of <see cref="McpServerService.NotifyClientConnectedAsync"/>:
+        /// resolve the notification target via the strategy, then dispatch to the hub or drop.
         /// </summary>
         async Task SimulateNotifyClientConnected(
-            string sessionId,
+            IMcpConnectionStrategy strategy,
+            string? routingToken,
             IHubContext<McpServerHub, IClientMcpRpc> hubContext,
             McpClientData connectedClient,
             McpClientData[] allActiveClients)
         {
-            var connectionId = ClientUtils.GetConnectionIdByToken(sessionId);
-            if (connectionId != null)
-                await hubContext.Clients.Client(connectionId).OnMcpClientConnected(connectedClient, allActiveClients);
-            else
-                await hubContext.Clients.All.OnMcpClientConnected(connectedClient, allActiveClients);
+            var target = strategy.ResolveNotificationTarget(routingToken);
+            switch (target.Kind)
+            {
+                case NotificationTarget.TargetKind.Specific:
+                    await hubContext.Clients.Client(target.ConnectionId!).OnMcpClientConnected(connectedClient, allActiveClients);
+                    break;
+                case NotificationTarget.TargetKind.Broadcast:
+                    await hubContext.Clients.All.OnMcpClientConnected(connectedClient, allActiveClients);
+                    break;
+                case NotificationTarget.TargetKind.Drop:
+                    // intentional: no addressable recipient
+                    break;
+            }
         }
 
-        /// <summary>
-        /// Simulates the notification routing logic from McpServerService.NotifyClientDisconnectedAsync.
-        /// </summary>
         async Task SimulateNotifyClientDisconnected(
-            string sessionId,
+            IMcpConnectionStrategy strategy,
+            string? routingToken,
             IHubContext<McpServerHub, IClientMcpRpc> hubContext,
             McpClientData disconnectedClient,
             McpClientData[] remainingClients)
         {
-            var connectionId = ClientUtils.GetConnectionIdByToken(sessionId);
-            if (connectionId != null)
-                await hubContext.Clients.Client(connectionId).OnMcpClientDisconnected(disconnectedClient, remainingClients);
-            else
-                await hubContext.Clients.All.OnMcpClientDisconnected(disconnectedClient, remainingClients);
+            var target = strategy.ResolveNotificationTarget(routingToken);
+            switch (target.Kind)
+            {
+                case NotificationTarget.TargetKind.Specific:
+                    await hubContext.Clients.Client(target.ConnectionId!).OnMcpClientDisconnected(disconnectedClient, remainingClients);
+                    break;
+                case NotificationTarget.TargetKind.Broadcast:
+                    await hubContext.Clients.All.OnMcpClientDisconnected(disconnectedClient, remainingClients);
+                    break;
+                case NotificationTarget.TargetKind.Drop:
+                    break;
+            }
         }
 
+        sealed class HubMocks
+        {
+            public Mock<IHubContext<McpServerHub, IClientMcpRpc>> HubContext { get; } = new();
+            public Mock<IHubClients<IClientMcpRpc>> HubClients { get; } = new();
+            public Mock<IClientMcpRpc> AllClients { get; } = new();
+
+            public HubMocks()
+            {
+                HubClients.Setup(c => c.All).Returns(AllClients.Object);
+                HubContext.Setup(c => c.Clients).Returns(HubClients.Object);
+            }
+
+            public Mock<IClientMcpRpc> RegisterClient(string connectionId)
+            {
+                var mock = new Mock<IClientMcpRpc>();
+                HubClients.Setup(c => c.Client(connectionId)).Returns(mock.Object);
+                return mock;
+            }
+        }
+
+        // ----- auth=required -----------------------------------------------------------------
+
         [Fact]
-        public async Task NotifyConnected_WithToken_TargetsSpecificPlugin()
+        public async Task RequiredAuth_WithMatchingPluginToken_TargetsThatPluginOnly()
         {
             // Arrange
+            var strategy = new RequiredAuthMcpStrategy();
             var token = UniqueId();
             var connId = UniqueId();
             ClientUtils.AddClient<McpServerHub>(connId, _logger, token);
 
+            var hub = new HubMocks();
+            var targetClient = hub.RegisterClient(connId);
             var clientData = new McpClientData { IsConnected = true, ClientName = "Claude" };
-            var targetClient = new Mock<IClientMcpRpc>();
-            var allClients = new Mock<IClientMcpRpc>();
-
-            var hubClients = new Mock<IHubClients<IClientMcpRpc>>();
-            hubClients.Setup(c => c.Client(connId)).Returns(targetClient.Object);
-            hubClients.Setup(c => c.All).Returns(allClients.Object);
-
-            var hubContext = new Mock<IHubContext<McpServerHub, IClientMcpRpc>>();
-            hubContext.Setup(c => c.Clients).Returns(hubClients.Object);
-
             try
             {
                 // Act
-                await SimulateNotifyClientConnected(token, hubContext.Object, clientData, new[] { clientData });
-
-                // Assert — targeted client was notified, not all
-                targetClient.Verify(c => c.OnMcpClientConnected(clientData, It.IsAny<McpClientData[]>()), Times.Once);
-                allClients.Verify(c => c.OnMcpClientConnected(It.IsAny<McpClientData>(), It.IsAny<McpClientData[]>()), Times.Never);
-            }
-            finally
-            {
-                ClientUtils.RemoveClient<McpServerHub>(connId, _logger);
-            }
-        }
-
-        [Fact]
-        public async Task NotifyConnected_WithoutToken_BroadcastsToAll()
-        {
-            // Arrange
-            var sessionId = "stdio"; // no token mapping exists for this
-            var clientData = new McpClientData { IsConnected = true, ClientName = "Claude" };
-            var allClients = new Mock<IClientMcpRpc>();
-
-            var hubClients = new Mock<IHubClients<IClientMcpRpc>>();
-            hubClients.Setup(c => c.All).Returns(allClients.Object);
-
-            var hubContext = new Mock<IHubContext<McpServerHub, IClientMcpRpc>>();
-            hubContext.Setup(c => c.Clients).Returns(hubClients.Object);
-
-            // Act
-            await SimulateNotifyClientConnected(sessionId, hubContext.Object, clientData, new[] { clientData });
-
-            // Assert — all clients were notified
-            allClients.Verify(c => c.OnMcpClientConnected(clientData, It.IsAny<McpClientData[]>()), Times.Once);
-        }
-
-        [Fact]
-        public async Task NotifyDisconnected_WithToken_TargetsSpecificPlugin()
-        {
-            // Arrange
-            var token = UniqueId();
-            var connId = UniqueId();
-            ClientUtils.AddClient<McpServerHub>(connId, _logger, token);
-
-            var targetClient = new Mock<IClientMcpRpc>();
-            var allClients = new Mock<IClientMcpRpc>();
-
-            var hubClients = new Mock<IHubClients<IClientMcpRpc>>();
-            hubClients.Setup(c => c.Client(connId)).Returns(targetClient.Object);
-            hubClients.Setup(c => c.All).Returns(allClients.Object);
-
-            var hubContext = new Mock<IHubContext<McpServerHub, IClientMcpRpc>>();
-            hubContext.Setup(c => c.Clients).Returns(hubClients.Object);
-
-            var disconnectedData = new McpClientData { IsConnected = false, ClientName = "Claude" };
-            try
-            {
-                // Act
-                await SimulateNotifyClientDisconnected(token, hubContext.Object, disconnectedData, Array.Empty<McpClientData>());
+                await SimulateNotifyClientConnected(strategy, token, hub.HubContext.Object, clientData, new[] { clientData });
 
                 // Assert
-                targetClient.Verify(c => c.OnMcpClientDisconnected(disconnectedData, It.IsAny<McpClientData[]>()), Times.Once);
-                allClients.Verify(c => c.OnMcpClientDisconnected(It.IsAny<McpClientData>(), It.IsAny<McpClientData[]>()), Times.Never);
+                targetClient.Verify(c => c.OnMcpClientConnected(clientData, It.IsAny<McpClientData[]>()), Times.Once);
+                hub.AllClients.Verify(c => c.OnMcpClientConnected(It.IsAny<McpClientData>(), It.IsAny<McpClientData[]>()), Times.Never);
             }
             finally
             {
@@ -154,30 +136,75 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
         }
 
         [Fact]
-        public async Task NotifyDisconnected_WithoutToken_BroadcastsToAll()
+        public async Task RequiredAuth_WithUnmappedToken_DropsNotification_DoesNotBroadcast()
         {
-            // Arrange
-            var sessionId = "stdio";
-            var allClients = new Mock<IClientMcpRpc>();
+            // Issue #102 reproduction: a Tier 2 (DCR) or Tier 3 (ServerToken) session's bearer
+            // token is valid for HTTP auth but is NOT mapped to a plugin in TokenToConnectionId.
+            // Pre-fix behavior: Clients.All received the notification, polluting every plugin's
+            // active-client list. Post-fix behavior: notification is dropped.
+            var strategy = new RequiredAuthMcpStrategy();
+            // No ConfigureAuthentication → dynamic-pairing mode (no _serverToken fallback).
 
-            var hubClients = new Mock<IHubClients<IClientMcpRpc>>();
-            hubClients.Setup(c => c.All).Returns(allClients.Object);
+            // A plugin from another tenant is connected (would be the wrong recipient pre-fix).
+            var unrelatedPluginConn = UniqueId();
+            var unrelatedPluginToken = UniqueId();
+            ClientUtils.AddClient<McpServerHub>(unrelatedPluginConn, _logger, unrelatedPluginToken);
 
-            var hubContext = new Mock<IHubContext<McpServerHub, IClientMcpRpc>>();
-            hubContext.Setup(c => c.Clients).Returns(hubClients.Object);
+            var hub = new HubMocks();
+            var unrelatedClient = hub.RegisterClient(unrelatedPluginConn);
+            var foreignClientData = new McpClientData { IsConnected = true, ClientName = "Claude (Tier 3 ServerToken)" };
+            try
+            {
+                // Act — the foreign session's routing token does NOT match any plugin.
+                var foreignSessionToken = UniqueId();
+                await SimulateNotifyClientConnected(strategy, foreignSessionToken, hub.HubContext.Object, foreignClientData, new[] { foreignClientData });
 
-            var disconnectedData = new McpClientData { IsConnected = false };
-            // Act
-            await SimulateNotifyClientDisconnected(sessionId, hubContext.Object, disconnectedData, Array.Empty<McpClientData>());
-
-            // Assert
-            allClients.Verify(c => c.OnMcpClientDisconnected(disconnectedData, It.IsAny<McpClientData[]>()), Times.Once);
+                // Assert — dropped: no plugin was notified, including the unrelated tenant's plugin.
+                hub.AllClients.Verify(c => c.OnMcpClientConnected(It.IsAny<McpClientData>(), It.IsAny<McpClientData[]>()), Times.Never);
+                unrelatedClient.Verify(c => c.OnMcpClientConnected(It.IsAny<McpClientData>(), It.IsAny<McpClientData[]>()), Times.Never);
+            }
+            finally
+            {
+                ClientUtils.RemoveClient<McpServerHub>(unrelatedPluginConn, _logger);
+            }
         }
 
         [Fact]
-        public async Task TwoPlugins_OnlyMatchingTokenReceivesNotification()
+        public async Task RequiredAuth_DisconnectWithUnmappedToken_DropsNotification_DoesNotBroadcast()
         {
-            // Arrange
+            // Disconnect-side mirror of the connect-side regression: a foreign Tier 2/Tier 3
+            // session ending must not broadcast OnMcpClientDisconnected to unrelated plugins.
+            var strategy = new RequiredAuthMcpStrategy();
+
+            var unrelatedPluginConn = UniqueId();
+            var unrelatedPluginToken = UniqueId();
+            ClientUtils.AddClient<McpServerHub>(unrelatedPluginConn, _logger, unrelatedPluginToken);
+
+            var hub = new HubMocks();
+            var unrelatedClient = hub.RegisterClient(unrelatedPluginConn);
+            var foreignClientData = new McpClientData { IsConnected = false };
+            try
+            {
+                // Act
+                var foreignSessionToken = UniqueId();
+                await SimulateNotifyClientDisconnected(strategy, foreignSessionToken, hub.HubContext.Object, foreignClientData, Array.Empty<McpClientData>());
+
+                // Assert — dropped: no broadcast, no targeted send to unrelated plugin.
+                hub.AllClients.Verify(c => c.OnMcpClientDisconnected(It.IsAny<McpClientData>(), It.IsAny<McpClientData[]>()), Times.Never);
+                unrelatedClient.Verify(c => c.OnMcpClientDisconnected(It.IsAny<McpClientData>(), It.IsAny<McpClientData[]>()), Times.Never);
+            }
+            finally
+            {
+                ClientUtils.RemoveClient<McpServerHub>(unrelatedPluginConn, _logger);
+            }
+        }
+
+        [Fact]
+        public async Task RequiredAuth_TwoPlugins_OnlyMatchingTokenReceivesNotification()
+        {
+            // Multi-tenant isolation check: two plugins with distinct tokens; only the one whose
+            // token matches the routing token of the notifying session receives the event.
+            var strategy = new RequiredAuthMcpStrategy();
             var tokenA = UniqueId();
             var tokenB = UniqueId();
             var connA = UniqueId();
@@ -185,34 +212,87 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
             ClientUtils.AddClient<McpServerHub>(connA, _logger, tokenA);
             ClientUtils.AddClient<McpServerHub>(connB, _logger, tokenB);
 
+            var hub = new HubMocks();
+            var clientA = hub.RegisterClient(connA);
+            var clientB = hub.RegisterClient(connB);
             var clientData = new McpClientData { IsConnected = true, ClientName = "Claude" };
-            var clientA = new Mock<IClientMcpRpc>();
-            var clientB = new Mock<IClientMcpRpc>();
-            var allClients = new Mock<IClientMcpRpc>();
-
-            var hubClients = new Mock<IHubClients<IClientMcpRpc>>();
-            hubClients.Setup(c => c.Client(connA)).Returns(clientA.Object);
-            hubClients.Setup(c => c.Client(connB)).Returns(clientB.Object);
-            hubClients.Setup(c => c.All).Returns(allClients.Object);
-
-            var hubContext = new Mock<IHubContext<McpServerHub, IClientMcpRpc>>();
-            hubContext.Setup(c => c.Clients).Returns(hubClients.Object);
-
             try
             {
-                // Act — notify for token A's session
-                await SimulateNotifyClientConnected(tokenA, hubContext.Object, clientData, new[] { clientData });
+                // Act
+                await SimulateNotifyClientConnected(strategy, tokenA, hub.HubContext.Object, clientData, new[] { clientData });
 
-                // Assert — only plugin A receives the notification
+                // Assert
                 clientA.Verify(c => c.OnMcpClientConnected(clientData, It.IsAny<McpClientData[]>()), Times.Once);
                 clientB.Verify(c => c.OnMcpClientConnected(It.IsAny<McpClientData>(), It.IsAny<McpClientData[]>()), Times.Never);
-                allClients.Verify(c => c.OnMcpClientConnected(It.IsAny<McpClientData>(), It.IsAny<McpClientData[]>()), Times.Never);
+                hub.AllClients.Verify(c => c.OnMcpClientConnected(It.IsAny<McpClientData>(), It.IsAny<McpClientData[]>()), Times.Never);
             }
             finally
             {
                 ClientUtils.RemoveClient<McpServerHub>(connA, _logger);
                 ClientUtils.RemoveClient<McpServerHub>(connB, _logger);
             }
+        }
+
+        [Fact]
+        public async Task RequiredAuth_StdioWithServerToken_FallsBackToServerTokenPlugin()
+        {
+            // Stdio transport never sets McpSessionTokenContext.CurrentToken, so the routing
+            // token reaching the notification path is null. When a server token is configured
+            // and a plugin registered with it, the notification must reach that plugin.
+            var strategy = new RequiredAuthMcpStrategy();
+            strategy.ConfigureAuthentication(new TokenAuthenticationOptions(), new DataArguments(new[] { "token=stdio-route-token" }));
+
+            var connId = UniqueId();
+            ClientUtils.AddClient<McpServerHub>(connId, _logger, "stdio-route-token");
+
+            var hub = new HubMocks();
+            var stdioPlugin = hub.RegisterClient(connId);
+            var clientData = new McpClientData { IsConnected = true, ClientName = "stdio" };
+            try
+            {
+                // Act — null routing token simulates stdio.
+                await SimulateNotifyClientConnected(strategy, null, hub.HubContext.Object, clientData, new[] { clientData });
+
+                // Assert
+                stdioPlugin.Verify(c => c.OnMcpClientConnected(clientData, It.IsAny<McpClientData[]>()), Times.Once);
+                hub.AllClients.Verify(c => c.OnMcpClientConnected(It.IsAny<McpClientData>(), It.IsAny<McpClientData[]>()), Times.Never);
+            }
+            finally
+            {
+                ClientUtils.RemoveClient<McpServerHub>(connId, _logger);
+            }
+        }
+
+        // ----- auth=none ---------------------------------------------------------------------
+
+        [Fact]
+        public async Task NoAuth_BroadcastsToAll()
+        {
+            // no-auth mode enforces a single plugin connection, so Clients.All targets exactly
+            // one recipient. Routing token is irrelevant in this mode.
+            var strategy = new NoAuthMcpStrategy();
+            var hub = new HubMocks();
+            var clientData = new McpClientData { IsConnected = true, ClientName = "Claude" };
+
+            // Act
+            await SimulateNotifyClientConnected(strategy, null, hub.HubContext.Object, clientData, new[] { clientData });
+
+            // Assert
+            hub.AllClients.Verify(c => c.OnMcpClientConnected(clientData, It.IsAny<McpClientData[]>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task NoAuth_DisconnectBroadcastsToAll()
+        {
+            var strategy = new NoAuthMcpStrategy();
+            var hub = new HubMocks();
+            var disconnectedData = new McpClientData { IsConnected = false };
+
+            // Act
+            await SimulateNotifyClientDisconnected(strategy, null, hub.HubContext.Object, disconnectedData, Array.Empty<McpClientData>());
+
+            // Assert
+            hub.AllClients.Verify(c => c.OnMcpClientDisconnected(disconnectedData, It.IsAny<McpClientData[]>()), Times.Once);
         }
     }
 }

--- a/McpPlugin.Server.Tests/RequiredAuthMcpStrategyTests.cs
+++ b/McpPlugin.Server.Tests/RequiredAuthMcpStrategyTests.cs
@@ -346,5 +346,100 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
             // Cleanup
             ClientUtils.RemoveClient(typeof(McpServerHub), connectionId, logger);
         }
+
+        [Fact]
+        public void ResolveNotificationTarget_WithMatchingPluginToken_TargetsThatPlugin()
+        {
+            // Arrange — register a plugin with token T; the routing token of an MCP session is T.
+            var logger = new Mock<ILogger>().Object;
+            var connectionId = "conn-required-notify-target";
+            var token = "notify-target-token";
+            ClientUtils.AddClient(typeof(McpServerHub), connectionId, logger, token);
+
+            try
+            {
+                // Act
+                var target = _strategy.ResolveNotificationTarget(token);
+
+                // Assert
+                target.Kind.ShouldBe(NotificationTarget.TargetKind.Specific);
+                target.ConnectionId.ShouldBe(connectionId);
+            }
+            finally
+            {
+                ClientUtils.RemoveClient(typeof(McpServerHub), connectionId, logger);
+            }
+        }
+
+        [Fact]
+        public void ResolveNotificationTarget_WithUnmappedToken_DropsNotification()
+        {
+            // Regression for issue #102: Tier 2 (DCR) and Tier 3 (ServerToken) sessions
+            // present a valid bearer token that is NOT in TokenToConnectionId. The notification
+            // must be dropped — broadcasting would leak foreign clients into every plugin.
+            var strategy = new RequiredAuthMcpStrategy();
+            // No ConfigureAuthentication call → _serverToken is null (dynamic-pairing mode).
+
+            var target = strategy.ResolveNotificationTarget("bearer-from-tier2-or-tier3-session");
+
+            target.Kind.ShouldBe(NotificationTarget.TargetKind.Drop);
+            target.ConnectionId.ShouldBeNull();
+        }
+
+        [Fact]
+        public void ResolveNotificationTarget_WithNullTokenAndNoServerToken_Drops()
+        {
+            // Dynamic mode (no _serverToken configured) and no per-session token: there is
+            // no addressable plugin. Broadcasting in this case is exactly the bug from #102.
+            var strategy = new RequiredAuthMcpStrategy();
+
+            var target = strategy.ResolveNotificationTarget(null);
+
+            target.Kind.ShouldBe(NotificationTarget.TargetKind.Drop);
+        }
+
+        [Fact]
+        public void ResolveNotificationTarget_WithNullTokenAndServerTokenConfigured_FallsBackToServerToken()
+        {
+            // Stdio transport never sets McpSessionTokenContext.CurrentToken, so the routing
+            // token reaching ResolveNotificationTarget can be null. When the server has a token
+            // configured (and a plugin has registered with it), notifications must still reach
+            // that plugin. Mirrors ResolveConnectionId's stdio fallback.
+            var strategy = new RequiredAuthMcpStrategy();
+            strategy.ConfigureAuthentication(new TokenAuthenticationOptions(), new DataArguments(new[] { "token=stdio-server-token" }));
+
+            var logger = new Mock<ILogger>().Object;
+            var connectionId = "conn-required-stdio-fallback";
+            ClientUtils.AddClient(typeof(McpServerHub), connectionId, logger, "stdio-server-token");
+
+            try
+            {
+                // Act
+                var target = strategy.ResolveNotificationTarget(null);
+
+                // Assert
+                target.Kind.ShouldBe(NotificationTarget.TargetKind.Specific);
+                target.ConnectionId.ShouldBe(connectionId);
+            }
+            finally
+            {
+                ClientUtils.RemoveClient(typeof(McpServerHub), connectionId, logger);
+            }
+        }
+
+        [Fact]
+        public void ResolveNotificationTarget_NeverBroadcasts()
+        {
+            // Invariant: auth-required must never resolve to a broadcast — that is the bug.
+            var strategy = new RequiredAuthMcpStrategy();
+            strategy.ConfigureAuthentication(new TokenAuthenticationOptions(), new DataArguments(new[] { "token=ignored-for-this-check" }));
+
+            foreach (var probe in new[] { (string?)null, "", "unknown", "another-unknown" })
+            {
+                var target = strategy.ResolveNotificationTarget(probe);
+                target.Kind.ShouldNotBe(NotificationTarget.TargetKind.Broadcast,
+                    customMessage: $"auth-required must never broadcast (probe='{probe ?? "<null>"}').");
+            }
+        }
     }
 }

--- a/McpPlugin.Server/src/McpServerService.cs
+++ b/McpPlugin.Server/src/McpServerService.cs
@@ -125,11 +125,20 @@ namespace com.IvanMurzak.McpPlugin.Server
             // Filter to clients visible to this plugin's routing token group.
             // Null token (no-auth) → returns all sessions; specific token → returns only matching.
             var allActiveClients = _sessionTracker.GetAllClientData(_routingToken).ToArray();
-            var connectionId = ClientUtils.GetConnectionIdByToken(_routingToken);
-            if (connectionId != null)
-                await _hubContext.Clients.Client(connectionId).OnMcpClientConnected(connectedClient, allActiveClients);
-            else
-                await _hubContext.Clients.All.OnMcpClientConnected(connectedClient, allActiveClients);
+            var target = _strategy.ResolveNotificationTarget(_routingToken);
+            switch (target.Kind)
+            {
+                case NotificationTarget.TargetKind.Specific:
+                    await _hubContext.Clients.Client(target.ConnectionId!).OnMcpClientConnected(connectedClient, allActiveClients);
+                    break;
+                case NotificationTarget.TargetKind.Broadcast:
+                    await _hubContext.Clients.All.OnMcpClientConnected(connectedClient, allActiveClients);
+                    break;
+                case NotificationTarget.TargetKind.Drop:
+                    _logger.LogDebug("{type} {method}: dropping notification — no addressable recipient for routing token.",
+                        GetType().GetTypeShortName(), nameof(NotifyClientConnectedAsync));
+                    break;
+            }
         }
 
         public async Task NotifyClientDisconnectedAsync()
@@ -139,11 +148,20 @@ namespace com.IvanMurzak.McpPlugin.Server
             // so GetAllClientData() returns the remaining clients (this session excluded).
             var disconnectedClient = GetClientData();
             var remainingClients = _sessionTracker.GetAllClientData(_routingToken).ToArray();
-            var connectionId = ClientUtils.GetConnectionIdByToken(_routingToken);
-            if (connectionId != null)
-                await _hubContext.Clients.Client(connectionId).OnMcpClientDisconnected(disconnectedClient, remainingClients);
-            else
-                await _hubContext.Clients.All.OnMcpClientDisconnected(disconnectedClient, remainingClients);
+            var target = _strategy.ResolveNotificationTarget(_routingToken);
+            switch (target.Kind)
+            {
+                case NotificationTarget.TargetKind.Specific:
+                    await _hubContext.Clients.Client(target.ConnectionId!).OnMcpClientDisconnected(disconnectedClient, remainingClients);
+                    break;
+                case NotificationTarget.TargetKind.Broadcast:
+                    await _hubContext.Clients.All.OnMcpClientDisconnected(disconnectedClient, remainingClients);
+                    break;
+                case NotificationTarget.TargetKind.Drop:
+                    _logger.LogDebug("{type} {method}: dropping notification — no addressable recipient for routing token.",
+                        GetType().GetTypeShortName(), nameof(NotifyClientDisconnectedAsync));
+                    break;
+            }
         }
 
         public Task StartAsync(CancellationToken cancellationToken)

--- a/McpPlugin.Server/src/Strategy/IMcpConnectionStrategy.cs
+++ b/McpPlugin.Server/src/Strategy/IMcpConnectionStrategy.cs
@@ -69,6 +69,17 @@ namespace com.IvanMurzak.McpPlugin.Server.Strategy
         bool ShouldNotifySession(string pluginConnectionId, string sessionId);
 
         /// <summary>
+        /// Resolves the destination of a client-lifecycle notification (connect/disconnect)
+        /// that originated from an MCP session carrying <paramref name="routingToken"/>.
+        /// For AuthOption.required: returns <see cref="NotificationTarget.Specific"/> when
+        /// the token maps to a registered plugin, otherwise <see cref="NotificationTarget.Drop"/>
+        /// — broadcasting would leak foreign clients into unrelated tenants' active-client lists.
+        /// For AuthOption.none: returns <see cref="NotificationTarget.Broadcast"/> because the
+        /// strategy enforces a single-plugin invariant, so the broadcast has at most one recipient.
+        /// </summary>
+        NotificationTarget ResolveNotificationTarget(string? routingToken);
+
+        /// <summary>
         /// Retrieves McpClientData scoped to the connection's token.
         /// For AuthOption.required: returns an empty <see cref="McpClientData"/> if the
         /// connection carries no token — unscoped access is denied.

--- a/McpPlugin.Server/src/Strategy/NoAuthMcpStrategy.cs
+++ b/McpPlugin.Server/src/Strategy/NoAuthMcpStrategy.cs
@@ -68,6 +68,13 @@ namespace com.IvanMurzak.McpPlugin.Server.Strategy
             return true;
         }
 
+        public NotificationTarget ResolveNotificationTarget(string? routingToken)
+        {
+            // no-auth mode: OnPluginConnected enforces a single plugin connection, so a
+            // broadcast targets at most one recipient. Routing token is ignored (always null).
+            return NotificationTarget.Broadcast();
+        }
+
         public McpClientData GetClientData(string? connectionId, IMcpSessionTracker sessionTracker)
         {
             return sessionTracker.GetClientData();

--- a/McpPlugin.Server/src/Strategy/NotificationTarget.cs
+++ b/McpPlugin.Server/src/Strategy/NotificationTarget.cs
@@ -1,0 +1,61 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+
+namespace com.IvanMurzak.McpPlugin.Server.Strategy
+{
+    /// <summary>
+    /// Routing decision for an MCP-client notification (connect/disconnect) emitted
+    /// by <see cref="McpServerService"/>. A connection strategy decides whether the
+    /// notification should target a specific plugin connection, broadcast to all
+    /// connected plugins, or be dropped entirely (no addressable recipient).
+    /// </summary>
+    public readonly struct NotificationTarget : IEquatable<NotificationTarget>
+    {
+        public enum TargetKind
+        {
+            /// <summary>No addressable recipient; the notification is suppressed.</summary>
+            Drop = 0,
+            /// <summary>Broadcast to every connected plugin (single-plugin invariant required).</summary>
+            Broadcast = 1,
+            /// <summary>Target the specific plugin connection identified by <see cref="ConnectionId"/>.</summary>
+            Specific = 2,
+        }
+
+        public TargetKind Kind { get; }
+        public string? ConnectionId { get; }
+
+        NotificationTarget(TargetKind kind, string? connectionId)
+        {
+            Kind = kind;
+            ConnectionId = connectionId;
+        }
+
+        public static NotificationTarget Drop() => new NotificationTarget(TargetKind.Drop, null);
+        public static NotificationTarget Broadcast() => new NotificationTarget(TargetKind.Broadcast, null);
+        public static NotificationTarget Specific(string connectionId)
+        {
+            if (string.IsNullOrEmpty(connectionId))
+                throw new ArgumentException("Connection id must be non-empty for a specific target.", nameof(connectionId));
+            return new NotificationTarget(TargetKind.Specific, connectionId);
+        }
+
+        public bool Equals(NotificationTarget other)
+            => Kind == other.Kind && string.Equals(ConnectionId, other.ConnectionId, StringComparison.Ordinal);
+
+        public override bool Equals(object? obj) => obj is NotificationTarget other && Equals(other);
+
+        public override int GetHashCode()
+            => unchecked(((int)Kind * 397) ^ (ConnectionId != null ? StringComparer.Ordinal.GetHashCode(ConnectionId) : 0));
+
+        public static bool operator ==(NotificationTarget left, NotificationTarget right) => left.Equals(right);
+        public static bool operator !=(NotificationTarget left, NotificationTarget right) => !left.Equals(right);
+    }
+}

--- a/McpPlugin.Server/src/Strategy/RequiredAuthMcpStrategy.cs
+++ b/McpPlugin.Server/src/Strategy/RequiredAuthMcpStrategy.cs
@@ -101,6 +101,36 @@ namespace com.IvanMurzak.McpPlugin.Server.Strategy
             return string.Equals(pluginToken, sessionId, StringComparison.Ordinal);
         }
 
+        public NotificationTarget ResolveNotificationTarget(string? routingToken)
+        {
+            // auth-required mode: a client-lifecycle notification only has a legitimate
+            // recipient when the routing token maps to a registered plugin. Broadcasting
+            // when the mapping is missing leaks foreign Tier 2 (DCR) and Tier 3 (ServerToken)
+            // sessions into every connected plugin's active-client list (issue #102).
+            if (!string.IsNullOrEmpty(routingToken))
+            {
+                var directMatch = ClientUtils.GetConnectionIdByToken(routingToken);
+                if (directMatch != null)
+                    return NotificationTarget.Specific(directMatch);
+            }
+
+            // Stdio transport never modifies McpSessionTokenContext.CurrentToken, so the
+            // session-level routing token may be null. Mirror ResolveConnectionId by falling
+            // back to the server-configured token so the plugin paired with that token still
+            // receives notifications produced over stdio.
+            if (!string.IsNullOrEmpty(_serverToken))
+            {
+                var serverMatch = ClientUtils.GetConnectionIdByToken(_serverToken);
+                if (serverMatch != null)
+                    return NotificationTarget.Specific(serverMatch);
+            }
+
+            // No addressable recipient: the notification belongs to a Tier 2 / Tier 3 session
+            // (or a plugin that has not yet (re)connected). Dropping is correct — broadcasting
+            // would pollute unrelated tenants.
+            return NotificationTarget.Drop();
+        }
+
         public McpClientData GetClientData(string? connectionId, IMcpSessionTracker sessionTracker)
         {
             var token = ClientUtils.GetTokenByConnectionId(connectionId);


### PR DESCRIPTION
## Summary

- Multi-tenant isolation fix for `McpServerService.NotifyClient{Connected,Disconnected}Async`: in `auth=required` mode the previous `Clients.All` fallback broadcast Tier 2 (DCR) and Tier 3 (ServerToken) MCP-client lifecycle events to every connected plugin, leaking foreign tenants' `McpClientData` into unrelated plugins' active-client lists (issue #102).
- Routing decision is now delegated to `IMcpConnectionStrategy` via a new `ResolveNotificationTarget(routingToken)` returning a `NotificationTarget` value (`Specific` / `Broadcast` / `Drop`). `RequiredAuthMcpStrategy` returns `Specific` for token-mapped plugins (with the existing stdio server-token fallback) and `Drop` otherwise. `NoAuthMcpStrategy` keeps `Broadcast` — its single-plugin invariant guarantees `Clients.All` targets exactly one recipient.
- `<Version>` and ReflectorNet `PackageReference` are intentionally untouched per the target profile.

## Test plan
- [x] `dotnet test --no-build --configuration Release` (CI-parity command) — 394/394 passing across `net8.0` + `net9.0`, both `McpPlugin.Tests` and `McpPlugin.Server.Tests`.
- [x] New tests in `RequiredAuthMcpStrategyTests` — `ResolveNotificationTarget` covers: matching plugin token (Specific), unmapped token (Drop, regression for #102), null token + no server token (Drop), null token + server token configured (Specific via fallback), and an invariant probe that the strategy never broadcasts.
- [x] New test in `NoAuthMcpStrategyTests` — `ResolveNotificationTarget` always broadcasts (token ignored).
- [x] `NotificationRoutingTests` rewritten to dispatch through the real strategy and to include explicit issue-#102 regression coverage on both connect and disconnect: when a Tier 2/Tier 3 session's token does not map to any plugin, no `Clients.All` broadcast and no targeted send to unrelated tenants' plugins are issued.

Closes #102