### PR TITLE
chore(deps): bump ModelContextProtocol packages to 1.3.0

### DIFF
--- a/McpPlugin.Server/McpPlugin.Server.csproj
+++ b/McpPlugin.Server/McpPlugin.Server.csproj
@@ -36,8 +36,8 @@
     <ProjectReference Include="./../McpPlugin.Common/McpPlugin.Common.csproj" />
     <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="5.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.3" />
-    <PackageReference Include="ModelContextProtocol" Version="1.2.0" />
-    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.2.0" />
+    <PackageReference Include="ModelContextProtocol" Version="1.3.0" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.3.0" />
     <PackageReference Include="NLog.Web.AspNetCore" Version="6.1.2" />
     <PackageReference Include="R3" Version="1.3.0" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- Bumps `ModelContextProtocol` and `ModelContextProtocol.AspNetCore` from `1.2.0` to `1.3.0` in `McpPlugin.Server/McpPlugin.Server.csproj` to track the upstream csharp-sdk v1.3.0 release.
- No source changes required: the only public-API behavior change in v1.3.0 (SSE/HTTP failures from `McpClient.CreateAsync(...)` now surface as `IOException` instead of `InvalidOperationException`, and `ClientTransportClosedException` becomes public) does not affect this codebase — neither symbol is referenced anywhere in the solution.
- `Directory.Build.props` is intentionally untouched: its comment about the v8/v10 conflict introduced by `ModelContextProtocol 1.2.0` remains factually correct as historical context.

## Upstream release notes
- https://github.com/modelcontextprotocol/csharp-sdk/releases/tag/v1.3.0

## Test plan
- [x] `dotnet restore` (worktree root) — succeeded.
- [x] `dotnet build --no-restore --configuration Release` — Build succeeded, 0 Warning(s), 0 Error(s).
- [x] `dotnet test --no-build --verbosity normal --configuration Release --logger "trx;LogFileName=test-results.trx" --results-directory ./TestResults` — Test Run Successful, **402/402 passed** across `net8.0` + `net9.0` for both `McpPlugin.Tests` and `McpPlugin.Server.Tests`.