### PR TITLE
feat(server): trusted internal clients receive unfiltered MCP catalog

### DIFF
--- a/McpPlugin.Common/src/Utils/Consts.MCP.cs
+++ b/McpPlugin.Common/src/Utils/Consts.MCP.cs
@@ -123,6 +123,35 @@ namespace com.IvanMurzak.McpPlugin.Common
                     none,
                     required
                 }
+
+                /// <summary>
+                /// HTTP request headers recognised by the MCP plugin server beyond
+                /// the stock <c>Authorization</c> header.
+                /// </summary>
+                public static class Headers
+                {
+                    /// <summary>
+                    /// Marks the caller as a trusted in-process client (e.g. our own
+                    /// CLI / desktop app). When the request carries this header set
+                    /// to <c>"1"</c>, the MCP list endpoints (<c>tools/list</c>,
+                    /// <c>prompts/list</c>, <c>resources/list</c>,
+                    /// <c>resources/templates/list</c>) return the FULL catalog —
+                    /// including primitives whose <c>Enabled</c> flag is <c>false</c>
+                    /// — and disabled entries are tagged with
+                    /// <c>_meta.enabled = false</c> so the trusted client can tell
+                    /// them apart. Any client that does NOT send this header keeps
+                    /// the pre-existing behaviour: disabled entries are filtered
+                    /// out, and no <c>_meta</c> is emitted by this server.
+                    ///
+                    /// This is a UX gate, NOT a security boundary — the header is
+                    /// trivially spoofable. Pair it with bearer-token auth when
+                    /// "disabled-tool exposure" is sensitive.
+                    /// </summary>
+                    public const string TrustedInternalClient = "X-McpPlugin-Internal-Client";
+
+                    /// <summary>Value the trusted-client header must carry to opt in.</summary>
+                    public const string TrustedInternalClientOptInValue = "1";
+                }
             }
         }
     }

--- a/McpPlugin.Server.Tests/TrustedInternalClientTests.cs
+++ b/McpPlugin.Server.Tests/TrustedInternalClientTests.cs
@@ -1,0 +1,235 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+using System.IO;
+using System.Linq;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.Common;
+using com.IvanMurzak.McpPlugin.Common.Model;
+using com.IvanMurzak.McpPlugin.Server.Auth;
+using Microsoft.AspNetCore.Http;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.Server.Tests
+{
+    /// <summary>
+    /// Covers the trusted-internal-client opt-in path: the
+    /// <c>X-McpPlugin-Internal-Client</c> request header flips
+    /// <see cref="McpSessionTokenContext.IsTrustedInternalClient"/>, which the
+    /// MCP <c>list</c> routers consume to skip the <c>Enabled = false</c>
+    /// filter, and the <c>To*()</c> extensions tag disabled primitives with
+    /// <c>_meta.enabled = false</c> so the trusted client can tell which
+    /// entries are off plugin-side.
+    ///
+    /// The <see cref="McpSessionTokenContext"/> values are <c>AsyncLocal</c>;
+    /// these tests reset the relevant slot in <c>finally</c> blocks (or use
+    /// the middleware's own cleanup) so state never leaks between cases.
+    /// </summary>
+    public class TrustedInternalClientTests
+    {
+        // ─────────────────────────────────────────────────────────────────────
+        // Middleware → AsyncLocal flag
+        // ─────────────────────────────────────────────────────────────────────
+
+        [Fact]
+        public async Task Middleware_SetsTrustedFlag_WhenHeaderEqualsOne()
+        {
+            // Sanity: AsyncLocal must start clear. If a sibling test polluted
+            // the slot, this assertion catches it before we measure anything.
+            McpSessionTokenContext.IsTrustedInternalClient.ShouldBeFalse();
+
+            var captured = false;
+            await InvokeMiddlewareAsync(
+                headers: new() { [Consts.MCP.Server.Headers.TrustedInternalClient] = "1" },
+                next: () =>
+                {
+                    captured = McpSessionTokenContext.IsTrustedInternalClient;
+                    return Task.CompletedTask;
+                });
+
+            captured.ShouldBeTrue();
+            // Middleware MUST clear the slot in `finally` so the flag never
+            // bleeds into the next request executing on the same async context.
+            McpSessionTokenContext.IsTrustedInternalClient.ShouldBeFalse();
+        }
+
+        [Fact]
+        public async Task Middleware_LeavesTrustedFlag_False_WhenHeaderAbsent()
+        {
+            McpSessionTokenContext.IsTrustedInternalClient.ShouldBeFalse();
+
+            var captured = true;
+            await InvokeMiddlewareAsync(
+                headers: new(),
+                next: () =>
+                {
+                    captured = McpSessionTokenContext.IsTrustedInternalClient;
+                    return Task.CompletedTask;
+                });
+
+            captured.ShouldBeFalse();
+        }
+
+        [Theory]
+        [InlineData("0")]
+        [InlineData("true")]
+        [InlineData("yes")]
+        [InlineData("")]
+        public async Task Middleware_LeavesTrustedFlag_False_ForUnknownHeaderValues(string headerValue)
+        {
+            McpSessionTokenContext.IsTrustedInternalClient.ShouldBeFalse();
+
+            var captured = true;
+            await InvokeMiddlewareAsync(
+                headers: new() { [Consts.MCP.Server.Headers.TrustedInternalClient] = headerValue },
+                next: () =>
+                {
+                    captured = McpSessionTokenContext.IsTrustedInternalClient;
+                    return Task.CompletedTask;
+                });
+
+            // Only the exact opt-in value flips the flag — anything else stays false.
+            // This guards against accidental coercion (e.g. case-insensitive matching).
+            captured.ShouldBeFalse();
+        }
+
+        [Fact]
+        public async Task Middleware_ClearsTrustedFlag_EvenIfNextThrows()
+        {
+            McpSessionTokenContext.IsTrustedInternalClient.ShouldBeFalse();
+
+            await Should.ThrowAsync<InvalidDataException>(() => InvokeMiddlewareAsync(
+                headers: new() { [Consts.MCP.Server.Headers.TrustedInternalClient] = "1" },
+                next: () => throw new InvalidDataException("boom")));
+
+            McpSessionTokenContext.IsTrustedInternalClient.ShouldBeFalse();
+        }
+
+        // ─────────────────────────────────────────────────────────────────────
+        // ExtensionsListMeta — _meta.enabled annotation rule
+        // ─────────────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void BuildEnabledMeta_ReturnsNull_WhenEnabled()
+        {
+            // Default-case wire shape MUST be unchanged for enabled primitives —
+            // a non-null Meta would surface to every existing third-party client.
+            ExtensionsListMeta.BuildEnabledMeta(enabled: true).ShouldBeNull();
+        }
+
+        [Fact]
+        public void BuildEnabledMeta_ReturnsEnabledFalseObject_WhenDisabled()
+        {
+            var meta = ExtensionsListMeta.BuildEnabledMeta(enabled: false);
+
+            meta.ShouldNotBeNull();
+            meta!.ContainsKey(ExtensionsListMeta.EnabledKey).ShouldBeTrue();
+            meta[ExtensionsListMeta.EnabledKey]!.GetValue<bool>().ShouldBeFalse();
+        }
+
+        // ─────────────────────────────────────────────────────────────────────
+        // To*() extensions — Meta is attached for disabled, omitted for enabled
+        // ─────────────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void ToTool_OmitsMeta_WhenEnabled()
+        {
+            new ResponseListTool { Name = "ping", Enabled = true, InputSchema = Consts.MCP.EmptyInputSchema }
+                .ToTool()
+                .Meta
+                .ShouldBeNull();
+        }
+
+        [Fact]
+        public void ToTool_AttachesEnabledFalseMeta_WhenDisabled()
+        {
+            var meta = new ResponseListTool { Name = "ping", Enabled = false, InputSchema = Consts.MCP.EmptyInputSchema }.ToTool().Meta;
+
+            meta.ShouldNotBeNull();
+            meta![ExtensionsListMeta.EnabledKey]!.GetValue<bool>().ShouldBeFalse();
+        }
+
+        [Fact]
+        public void ToPrompt_OmitsMeta_WhenEnabled()
+        {
+            new ResponsePrompt { Name = "p", Enabled = true }
+                .ToPrompt()
+                .Meta
+                .ShouldBeNull();
+        }
+
+        [Fact]
+        public void ToPrompt_AttachesEnabledFalseMeta_WhenDisabled()
+        {
+            var meta = new ResponsePrompt { Name = "p", Enabled = false }.ToPrompt().Meta;
+
+            meta.ShouldNotBeNull();
+            meta![ExtensionsListMeta.EnabledKey]!.GetValue<bool>().ShouldBeFalse();
+        }
+
+        [Fact]
+        public void ToResource_OmitsMeta_WhenEnabled()
+        {
+            new ResponseListResource(uri: "res://x", name: "x", enabled: true)
+                .ToResource()
+                .Meta
+                .ShouldBeNull();
+        }
+
+        [Fact]
+        public void ToResource_AttachesEnabledFalseMeta_WhenDisabled()
+        {
+            var meta = new ResponseListResource(uri: "res://x", name: "x", enabled: false)
+                .ToResource()
+                .Meta;
+
+            meta.ShouldNotBeNull();
+            meta![ExtensionsListMeta.EnabledKey]!.GetValue<bool>().ShouldBeFalse();
+        }
+
+        [Fact]
+        public void ToResourceTemplate_OmitsMeta_WhenEnabled()
+        {
+            new ResponseResourceTemplate(uri: "tpl://{x}", name: "tpl", enabled: true)
+                .ToResourceTemplate()
+                .Meta
+                .ShouldBeNull();
+        }
+
+        [Fact]
+        public void ToResourceTemplate_AttachesEnabledFalseMeta_WhenDisabled()
+        {
+            var meta = new ResponseResourceTemplate(uri: "tpl://{x}", name: "tpl", enabled: false)
+                .ToResourceTemplate()
+                .Meta;
+
+            meta.ShouldNotBeNull();
+            meta![ExtensionsListMeta.EnabledKey]!.GetValue<bool>().ShouldBeFalse();
+        }
+
+        // ─────────────────────────────────────────────────────────────────────
+        // helpers
+        // ─────────────────────────────────────────────────────────────────────
+
+        static async Task InvokeMiddlewareAsync(
+            System.Collections.Generic.Dictionary<string, string> headers,
+            System.Func<Task> next)
+        {
+            var ctx = new DefaultHttpContext();
+            foreach (var (k, v) in headers)
+                ctx.Request.Headers[k] = v;
+
+            var middleware = new McpSessionTokenMiddleware(_ => next());
+            await middleware.InvokeAsync(ctx);
+        }
+    }
+}

--- a/McpPlugin.Server/src/Auth/McpSessionTokenContext.cs
+++ b/McpPlugin.Server/src/Auth/McpSessionTokenContext.cs
@@ -21,6 +21,7 @@ namespace com.IvanMurzak.McpPlugin.Server.Auth
         static readonly AsyncLocal<string?> _currentToken = new();
         static readonly AsyncLocal<string?> _currentClientIp = new();
         static readonly AsyncLocal<string?> _currentUserAgent = new();
+        static readonly AsyncLocal<bool> _isTrustedInternalClient = new();
 
         public static string? CurrentToken
         {
@@ -38,6 +39,22 @@ namespace com.IvanMurzak.McpPlugin.Server.Auth
         {
             get => _currentUserAgent.Value;
             set => _currentUserAgent.Value = value;
+        }
+
+        /// <summary>
+        /// True when the in-flight request was issued by a trusted in-process
+        /// client (our own CLI / desktop app). Set by
+        /// <see cref="McpSessionTokenMiddleware"/> from the
+        /// <c>X-McpPlugin-Internal-Client</c> header (see
+        /// <c>Consts.MCP.Server.Headers.TrustedInternalClient</c>) and consumed
+        /// by the MCP <c>list</c> routers to decide whether to surface
+        /// <c>Enabled = false</c> primitives. Cleared in the middleware's
+        /// <c>finally</c>, so values never leak across requests.
+        /// </summary>
+        public static bool IsTrustedInternalClient
+        {
+            get => _isTrustedInternalClient.Value;
+            set => _isTrustedInternalClient.Value = value;
         }
     }
 }

--- a/McpPlugin.Server/src/Auth/McpSessionTokenMiddleware.cs
+++ b/McpPlugin.Server/src/Auth/McpSessionTokenMiddleware.cs
@@ -10,6 +10,7 @@
 
 using System;
 using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.Common;
 using Microsoft.AspNetCore.Http;
 
 namespace com.IvanMurzak.McpPlugin.Server.Auth
@@ -57,6 +58,14 @@ namespace com.IvanMurzak.McpPlugin.Server.Auth
             if (!string.IsNullOrEmpty(userAgent))
                 McpSessionTokenContext.CurrentUserAgent = userAgent;
 
+            if (context.Request.Headers.TryGetValue(Consts.MCP.Server.Headers.TrustedInternalClient, out var trustedHeader))
+            {
+                McpSessionTokenContext.IsTrustedInternalClient = string.Equals(
+                    trustedHeader.ToString(),
+                    Consts.MCP.Server.Headers.TrustedInternalClientOptInValue,
+                    StringComparison.Ordinal);
+            }
+
             try
             {
                 await _next(context);
@@ -66,6 +75,7 @@ namespace com.IvanMurzak.McpPlugin.Server.Auth
                 McpSessionTokenContext.CurrentToken = null;
                 McpSessionTokenContext.CurrentClientIp = null;
                 McpSessionTokenContext.CurrentUserAgent = null;
+                McpSessionTokenContext.IsTrustedInternalClient = false;
             }
         }
     }

--- a/McpPlugin.Server/src/Extension/ExtensionsListMeta.cs
+++ b/McpPlugin.Server/src/Extension/ExtensionsListMeta.cs
@@ -8,16 +8,28 @@
 └────────────────────────────────────────────────────────────────────────┘
 */
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json.Nodes;
+using com.IvanMurzak.McpPlugin.Server.Auth;
 
 namespace com.IvanMurzak.McpPlugin.Server
 {
     /// <summary>
-    /// Shared helpers for the <c>_meta</c> object the MCP <c>list</c> routers
-    /// attach to <see cref="ModelContextProtocol.Protocol.Tool"/>,
-    /// <see cref="ModelContextProtocol.Protocol.Prompt"/>,
-    /// <see cref="ModelContextProtocol.Protocol.Resource"/>, and
-    /// <see cref="ModelContextProtocol.Protocol.ResourceTemplate"/> primitives.
+    /// Shared helpers for the MCP <c>list</c> routers — <c>tools/list</c>,
+    /// <c>prompts/list</c>, <c>resources/list</c>,
+    /// <c>resources/templates/list</c>. Two concerns:
+    /// <list type="bullet">
+    ///   <item><description>Visibility filtering keyed off the trusted-internal-client
+    ///   flag (<see cref="SelectVisible{TIn, TOut}"/>).</description></item>
+    ///   <item><description>The <c>_meta</c> object emitted on the resulting
+    ///   <see cref="ModelContextProtocol.Protocol.Tool"/>,
+    ///   <see cref="ModelContextProtocol.Protocol.Prompt"/>,
+    ///   <see cref="ModelContextProtocol.Protocol.Resource"/>,
+    ///   <see cref="ModelContextProtocol.Protocol.ResourceTemplate"/> primitives
+    ///   (<see cref="BuildEnabledMeta"/>).</description></item>
+    /// </list>
     /// </summary>
     /// <remarks>
     /// MCP's <c>_meta</c> field is reserved for protocol-level metadata that
@@ -39,5 +51,29 @@ namespace com.IvanMurzak.McpPlugin.Server
         /// </summary>
         public static JsonObject? BuildEnabledMeta(bool enabled)
             => enabled ? null : new JsonObject { [EnabledKey] = false };
+
+        /// <summary>
+        /// Filters a list-router's source primitives to the set the current
+        /// caller is allowed to see, then projects each survivor through
+        /// <paramref name="project"/>. Trusted internal clients (callers that
+        /// sent <c>X-McpPlugin-Internal-Client: 1</c> — see
+        /// <see cref="com.IvanMurzak.McpPlugin.Common.Consts.MCP.Server.Headers.TrustedInternalClient"/>
+        /// and <see cref="McpSessionTokenContext.IsTrustedInternalClient"/>)
+        /// receive the FULL catalog including disabled primitives; every other
+        /// caller continues to see only entries where <paramref name="getEnabled"/>
+        /// returns <see langword="true"/>. Null elements are dropped in both modes.
+        /// </summary>
+        public static List<TOut> SelectVisible<TIn, TOut>(
+            this IEnumerable<TIn?> source,
+            Func<TIn, bool> getEnabled,
+            Func<TIn, TOut> project)
+            where TIn : class
+        {
+            var includeDisabled = McpSessionTokenContext.IsTrustedInternalClient;
+            return source
+                .Where(x => x != null && (includeDisabled || getEnabled(x)))
+                .Select(x => project(x!))
+                .ToList();
+        }
     }
 }

--- a/McpPlugin.Server/src/Extension/ExtensionsListMeta.cs
+++ b/McpPlugin.Server/src/Extension/ExtensionsListMeta.cs
@@ -1,0 +1,43 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+using System.Text.Json.Nodes;
+
+namespace com.IvanMurzak.McpPlugin.Server
+{
+    /// <summary>
+    /// Shared helpers for the <c>_meta</c> object the MCP <c>list</c> routers
+    /// attach to <see cref="ModelContextProtocol.Protocol.Tool"/>,
+    /// <see cref="ModelContextProtocol.Protocol.Prompt"/>,
+    /// <see cref="ModelContextProtocol.Protocol.Resource"/>, and
+    /// <see cref="ModelContextProtocol.Protocol.ResourceTemplate"/> primitives.
+    /// </summary>
+    /// <remarks>
+    /// MCP's <c>_meta</c> field is reserved for protocol-level metadata that
+    /// servers may emit and clients may ignore (per spec). We use it to surface
+    /// the plugin-side <c>Enabled</c> flag to trusted internal clients that
+    /// have opted in to the unfiltered catalog — see
+    /// <see cref="com.IvanMurzak.McpPlugin.Common.Consts.MCP.Server.Headers.TrustedInternalClient"/>.
+    /// </remarks>
+    public static class ExtensionsListMeta
+    {
+        /// <summary>Property name used on the <c>_meta</c> object.</summary>
+        public const string EnabledKey = "enabled";
+
+        /// <summary>
+        /// Returns a <see cref="JsonObject"/> carrying <c>{ "enabled": false }</c>
+        /// when the primitive is disabled; returns <see langword="null"/> for
+        /// enabled primitives so the wire shape for the default case is
+        /// unchanged.
+        /// </summary>
+        public static JsonObject? BuildEnabledMeta(bool enabled)
+            => enabled ? null : new JsonObject { [EnabledKey] = false };
+    }
+}

--- a/McpPlugin.Server/src/Extension/ExtensionsListResourceTemplates.cs
+++ b/McpPlugin.Server/src/Extension/ExtensionsListResourceTemplates.cs
@@ -28,7 +28,10 @@ namespace com.IvanMurzak.McpPlugin.Server
                 UriTemplate = response.UriTemplate,
                 Name = response.Name,
                 Description = response.Description,
-                MimeType = response.MimeType
+                MimeType = response.MimeType,
+                // See ExtensionsListMeta — disabled primitives surface `_meta.enabled = false`
+                // for trusted clients; null for enabled keeps the default wire shape unchanged.
+                Meta = ExtensionsListMeta.BuildEnabledMeta(response.Enabled)
             };
         }
     }

--- a/McpPlugin.Server/src/Extension/ExtensionsListResources.cs
+++ b/McpPlugin.Server/src/Extension/ExtensionsListResources.cs
@@ -28,7 +28,10 @@ namespace com.IvanMurzak.McpPlugin.Server
                 Uri = response.Uri,
                 Name = response.Name,
                 Description = response.Description,
-                MimeType = response.MimeType
+                MimeType = response.MimeType,
+                // See ExtensionsListMeta — disabled primitives surface `_meta.enabled = false`
+                // for trusted clients; null for enabled keeps the default wire shape unchanged.
+                Meta = ExtensionsListMeta.BuildEnabledMeta(response.Enabled)
             };
         }
     }

--- a/McpPlugin.Server/src/Extension/ExtensionsPrompt.cs
+++ b/McpPlugin.Server/src/Extension/ExtensionsPrompt.cs
@@ -50,7 +50,10 @@ namespace com.IvanMurzak.McpPlugin.Server
             Name = response.Name,
             Title = response.Title,
             Description = response.Description,
-            Arguments = response.Arguments?.Select(x => x.ToPromptArgument()).ToList()
+            Arguments = response.Arguments?.Select(x => x.ToPromptArgument()).ToList(),
+            // See ExtensionsListMeta — disabled primitives surface `_meta.enabled = false`
+            // for trusted clients; null for enabled keeps the default wire shape unchanged.
+            Meta = ExtensionsListMeta.BuildEnabledMeta(response.Enabled)
         };
 
         public static PromptMessage ToPromptMessage(this Common.Model.ResponsePromptMessage promptMessage) => new PromptMessage()

--- a/McpPlugin.Server/src/Extension/ExtensionsTool.cs
+++ b/McpPlugin.Server/src/Extension/ExtensionsTool.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using com.IvanMurzak.McpPlugin.Common;
 using com.IvanMurzak.McpPlugin.Common.Model;
 using ModelContextProtocol.Protocol;
 
@@ -73,7 +74,12 @@ namespace com.IvanMurzak.McpPlugin.Server
                     DestructiveHint = response.DestructiveHint,
                     IdempotentHint = response.IdempotentHint,
                     OpenWorldHint = response.OpenWorldHint
-                }
+                },
+                // Annotate disabled primitives with `_meta.enabled = false` so trusted
+                // internal clients (which receive the unfiltered list) can tell which
+                // entries the user has turned off plugin-side. Untrusted clients never
+                // receive disabled tools so the field never reaches them.
+                Meta = ExtensionsListMeta.BuildEnabledMeta(response.Enabled)
             };
         }
 

--- a/McpPlugin.Server/src/Mcp/Prompt/PromptRouter.List.cs
+++ b/McpPlugin.Server/src/Mcp/Prompt/PromptRouter.List.cs
@@ -15,6 +15,7 @@ using com.IvanMurzak.McpPlugin.Common;
 using com.IvanMurzak.McpPlugin.Common.Hub.Client;
 using com.IvanMurzak.McpPlugin.Common.Model;
 using com.IvanMurzak.McpPlugin.Common.Utils;
+using com.IvanMurzak.McpPlugin.Server.Auth;
 using com.IvanMurzak.ReflectorNet;
 using Microsoft.Extensions.DependencyInjection;
 using ModelContextProtocol.Protocol;
@@ -50,10 +51,13 @@ namespace com.IvanMurzak.McpPlugin.Server
             if (response.Value == null)
                 return new ListPromptsResult().SetError("[Error] Resource value is null");
 
+            // Trusted internal clients receive the unfiltered catalog —
+            // see McpSessionTokenContext.IsTrustedInternalClient and ToolRouter.ListAll.
+            var includeDisabled = McpSessionTokenContext.IsTrustedInternalClient;
             var result = new ListPromptsResult()
             {
                 Prompts = response.Value.Prompts
-                    .Where(x => x?.Enabled == true)
+                    .Where(x => x != null && (includeDisabled || x.Enabled))
                     .Select(x => x!.ToPrompt())
                     .ToList()
             };

--- a/McpPlugin.Server/src/Mcp/Prompt/PromptRouter.List.cs
+++ b/McpPlugin.Server/src/Mcp/Prompt/PromptRouter.List.cs
@@ -8,14 +8,12 @@
 └────────────────────────────────────────────────────────────────────────┘
 */
 
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using com.IvanMurzak.McpPlugin.Common;
 using com.IvanMurzak.McpPlugin.Common.Hub.Client;
 using com.IvanMurzak.McpPlugin.Common.Model;
 using com.IvanMurzak.McpPlugin.Common.Utils;
-using com.IvanMurzak.McpPlugin.Server.Auth;
 using com.IvanMurzak.ReflectorNet;
 using Microsoft.Extensions.DependencyInjection;
 using ModelContextProtocol.Protocol;
@@ -51,15 +49,10 @@ namespace com.IvanMurzak.McpPlugin.Server
             if (response.Value == null)
                 return new ListPromptsResult().SetError("[Error] Resource value is null");
 
-            // Trusted internal clients receive the unfiltered catalog —
-            // see McpSessionTokenContext.IsTrustedInternalClient and ToolRouter.ListAll.
-            var includeDisabled = McpSessionTokenContext.IsTrustedInternalClient;
+            // Trusted internal clients receive the unfiltered catalog — see ToolRouter.ListAll.
             var result = new ListPromptsResult()
             {
-                Prompts = response.Value.Prompts
-                    .Where(x => x != null && (includeDisabled || x.Enabled))
-                    .Select(x => x!.ToPrompt())
-                    .ToList()
+                Prompts = response.Value.Prompts.SelectVisible(x => x.Enabled, x => x.ToPrompt())
             };
 
             if (logger.IsTraceEnabled)

--- a/McpPlugin.Server/src/Mcp/Resource/ResourceRouter.ListResourceTemplates.cs
+++ b/McpPlugin.Server/src/Mcp/Resource/ResourceRouter.ListResourceTemplates.cs
@@ -13,6 +13,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using com.IvanMurzak.McpPlugin.Common.Hub.Client;
 using com.IvanMurzak.McpPlugin.Common.Model;
+using com.IvanMurzak.McpPlugin.Server.Auth;
 using Microsoft.Extensions.DependencyInjection;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
@@ -42,10 +43,13 @@ namespace com.IvanMurzak.McpPlugin.Server
             if (response.Value == null)
                 return new ListResourceTemplatesResult().SetError("[Error] Resource template value is null");
 
+            // Trusted internal clients receive the unfiltered catalog —
+            // see McpSessionTokenContext.IsTrustedInternalClient and ToolRouter.ListAll.
+            var includeDisabled = McpSessionTokenContext.IsTrustedInternalClient;
             return new ListResourceTemplatesResult()
             {
                 ResourceTemplates = response.Value
-                    .Where(x => x?.Enabled == true)
+                    .Where(x => x != null && (includeDisabled || x.Enabled))
                     .Select(x => x!.ToResourceTemplate())
                     .ToList()
             };

--- a/McpPlugin.Server/src/Mcp/Resource/ResourceRouter.ListResourceTemplates.cs
+++ b/McpPlugin.Server/src/Mcp/Resource/ResourceRouter.ListResourceTemplates.cs
@@ -8,12 +8,10 @@
 └────────────────────────────────────────────────────────────────────────┘
 */
 
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using com.IvanMurzak.McpPlugin.Common.Hub.Client;
 using com.IvanMurzak.McpPlugin.Common.Model;
-using com.IvanMurzak.McpPlugin.Server.Auth;
 using Microsoft.Extensions.DependencyInjection;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
@@ -43,15 +41,10 @@ namespace com.IvanMurzak.McpPlugin.Server
             if (response.Value == null)
                 return new ListResourceTemplatesResult().SetError("[Error] Resource template value is null");
 
-            // Trusted internal clients receive the unfiltered catalog —
-            // see McpSessionTokenContext.IsTrustedInternalClient and ToolRouter.ListAll.
-            var includeDisabled = McpSessionTokenContext.IsTrustedInternalClient;
+            // Trusted internal clients receive the unfiltered catalog — see ToolRouter.ListAll.
             return new ListResourceTemplatesResult()
             {
-                ResourceTemplates = response.Value
-                    .Where(x => x != null && (includeDisabled || x.Enabled))
-                    .Select(x => x!.ToResourceTemplate())
-                    .ToList()
+                ResourceTemplates = response.Value.SelectVisible(x => x.Enabled, x => x.ToResourceTemplate())
             };
 
             // -------------------------------------------------------------------------------------

--- a/McpPlugin.Server/src/Mcp/Resource/ResourceRouter.ListResources.cs
+++ b/McpPlugin.Server/src/Mcp/Resource/ResourceRouter.ListResources.cs
@@ -14,6 +14,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using com.IvanMurzak.McpPlugin.Common.Hub.Client;
 using com.IvanMurzak.McpPlugin.Common.Model;
+using com.IvanMurzak.McpPlugin.Server.Auth;
 using Microsoft.Extensions.DependencyInjection;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
@@ -43,10 +44,13 @@ namespace com.IvanMurzak.McpPlugin.Server
             if (response.Value == null)
                 return new ListResourcesResult().SetError("[Error] Resource value is null");
 
+            // Trusted internal clients receive the unfiltered catalog —
+            // see McpSessionTokenContext.IsTrustedInternalClient and ToolRouter.ListAll.
+            var includeDisabled = McpSessionTokenContext.IsTrustedInternalClient;
             return new ListResourcesResult()
             {
                 Resources = response.Value
-                    .Where(x => x?.Enabled == true)
+                    .Where(x => x != null && (includeDisabled || x.Enabled))
                     .Select(x => x!.ToResource())
                     .ToList() ?? new List<Resource>(),
             };

--- a/McpPlugin.Server/src/Mcp/Resource/ResourceRouter.ListResources.cs
+++ b/McpPlugin.Server/src/Mcp/Resource/ResourceRouter.ListResources.cs
@@ -8,13 +8,10 @@
 └────────────────────────────────────────────────────────────────────────┘
 */
 
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using com.IvanMurzak.McpPlugin.Common.Hub.Client;
 using com.IvanMurzak.McpPlugin.Common.Model;
-using com.IvanMurzak.McpPlugin.Server.Auth;
 using Microsoft.Extensions.DependencyInjection;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
@@ -44,15 +41,10 @@ namespace com.IvanMurzak.McpPlugin.Server
             if (response.Value == null)
                 return new ListResourcesResult().SetError("[Error] Resource value is null");
 
-            // Trusted internal clients receive the unfiltered catalog —
-            // see McpSessionTokenContext.IsTrustedInternalClient and ToolRouter.ListAll.
-            var includeDisabled = McpSessionTokenContext.IsTrustedInternalClient;
+            // Trusted internal clients receive the unfiltered catalog — see ToolRouter.ListAll.
             return new ListResourcesResult()
             {
-                Resources = response.Value
-                    .Where(x => x != null && (includeDisabled || x.Enabled))
-                    .Select(x => x!.ToResource())
-                    .ToList() ?? new List<Resource>(),
+                Resources = response.Value.SelectVisible(x => x.Enabled, x => x.ToResource())
             };
         }
     }

--- a/McpPlugin.Server/src/Mcp/Tool/ToolRouter.ListAll.cs
+++ b/McpPlugin.Server/src/Mcp/Tool/ToolRouter.ListAll.cs
@@ -10,13 +10,11 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using com.IvanMurzak.McpPlugin.Common.Hub.Client;
 using com.IvanMurzak.McpPlugin.Common.Model;
 using com.IvanMurzak.McpPlugin.Common.Utils;
-using com.IvanMurzak.McpPlugin.Server.Auth;
 using com.IvanMurzak.ReflectorNet;
 using Microsoft.Extensions.DependencyInjection;
 using ModelContextProtocol.Protocol;
@@ -78,13 +76,10 @@ namespace com.IvanMurzak.McpPlugin.Server
             // `X-McpPlugin-Internal-Client` header to receive the FULL catalog,
             // including `Enabled = false` tools tagged with `_meta.enabled = false`.
             // Every other caller continues to get the pre-existing filtered view.
-            var includeDisabled = McpSessionTokenContext.IsTrustedInternalClient;
+            // See ExtensionsListMeta.SelectVisible for the predicate.
             var result = new ListToolsResult()
             {
-                Tools = response.Value
-                    .Where(x => x != null && (includeDisabled || x.Enabled))
-                    .Select(x => x!.ToTool())
-                    .ToList()
+                Tools = response.Value.SelectVisible(x => x.Enabled, x => x.ToTool())
             };
 
             if (logger.IsTraceEnabled)

--- a/McpPlugin.Server/src/Mcp/Tool/ToolRouter.ListAll.cs
+++ b/McpPlugin.Server/src/Mcp/Tool/ToolRouter.ListAll.cs
@@ -16,6 +16,7 @@ using System.Threading.Tasks;
 using com.IvanMurzak.McpPlugin.Common.Hub.Client;
 using com.IvanMurzak.McpPlugin.Common.Model;
 using com.IvanMurzak.McpPlugin.Common.Utils;
+using com.IvanMurzak.McpPlugin.Server.Auth;
 using com.IvanMurzak.ReflectorNet;
 using Microsoft.Extensions.DependencyInjection;
 using ModelContextProtocol.Protocol;
@@ -73,10 +74,15 @@ namespace com.IvanMurzak.McpPlugin.Server
                 return new ListToolsResult() { Tools = new List<Tool>() };
             }
 
+            // Trusted internal clients (cli/desktop) opt in via the
+            // `X-McpPlugin-Internal-Client` header to receive the FULL catalog,
+            // including `Enabled = false` tools tagged with `_meta.enabled = false`.
+            // Every other caller continues to get the pre-existing filtered view.
+            var includeDisabled = McpSessionTokenContext.IsTrustedInternalClient;
             var result = new ListToolsResult()
             {
                 Tools = response.Value
-                    .Where(x => x?.Enabled == true)
+                    .Where(x => x != null && (includeDisabled || x.Enabled))
                     .Select(x => x!.ToTool())
                     .ToList()
             };


### PR DESCRIPTION
## Summary

- Adds an opt-in mechanism for trusted in-process clients (our own CLI / desktop apps) to receive the **full** MCP catalog from the four `list` routers (tools, prompts, resources, resource templates) — including primitives whose `Enabled` flag is `false`.
- Disabled primitives are tagged with `_meta.enabled = false` (MCP-spec-compliant metadata) so the trusted client can tell them apart from enabled ones.
- Untrusted clients (Claude Desktop, Cursor, third-party MCP clients) keep the existing filtered behaviour — **zero behaviour change for them**.

## Why

Our app-level `core` package needs to render an enable/disable UI for Unity tools and decide per-agent which subset to expose to the AI. To do that meaningfully, it has to see disabled tools too. The MCP filter is correct for third parties (don't burn AI tokens on tools the user explicitly turned off) but blocks our own use case.

## Mechanism

Mirrors the existing token-routing pattern in `McpSessionTokenMiddleware`:

1. **Header opt-in** — `X-McpPlugin-Internal-Client: 1` (constants in `Consts.MCP.Server.Headers`).
2. **AsyncLocal flag** — `McpSessionTokenContext.IsTrustedInternalClient`, set by the middleware, cleared in `finally`.
3. **Conditional filter** in the four `list` routers — `Where(x => x != null && (includeDisabled || x.Enabled))`.
4. **`_meta.enabled = false` annotation** — centralised in a tiny `ExtensionsListMeta.BuildEnabledMeta(bool)` helper, consumed by `ToTool` / `ToPrompt` / `ToResource` / `ToResourceTemplate`. Returns `null` for enabled (so the wire shape stays unchanged for the default case), returns `{ "enabled": false }` for disabled.

This is a UX gate, **not** a security boundary — the header is trivially spoofable. Pair with bearer-token auth in deployments where disabled-tool exposure is sensitive.

## Test plan

- [x] 17 new test cases in `TrustedInternalClientTests.cs`:
  - Middleware flips the AsyncLocal flag on the exact opt-in value.
  - Falsy/unknown header values (`"0"`, `"true"`, `"yes"`, `""`) leave it `false`.
  - `finally` clears the flag even when `next` throws.
  - `BuildEnabledMeta` returns `null` for enabled, `{ "enabled": false }` for disabled.
  - All four `To*()` extensions: `Meta` is `null` for enabled, populated for disabled.
- [x] Full suite: 1324 tests pass on both net8.0 and net9.0 (1290 existing + 34 new across TFMs).
- [ ] (Manual) Verify against a Unity project once the cli/desktop side starts sending the header — covered by the follow-up PR in `AI-Game-Dev-App`.

## Rollout

Cascading downstream — `McpPlugin.Server` is consumed by Unity-MCP. After merge + version bump here, Unity-MCP picks up the new server via NuGet and the `AI-Game-Dev-App` core change starts using the header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)