### PR TITLE
fix(plugin): inject project root for relative SkillsPath resolution

### DIFF
--- a/McpPlugin.Tests/Mcp/McpPluginSkillPathTests.cs
+++ b/McpPlugin.Tests/Mcp/McpPluginSkillPathTests.cs
@@ -4,7 +4,6 @@
 │  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
 │  Copyright (c) 2025 Ivan Murzak                                        │
 │  Licensed under the Apache License, Version 2.0.                       │
-│  See the LICENSE file in the project root for more information.        │
 └────────────────────────────────────────────────────────────────────────┘
 */
 
@@ -30,9 +29,6 @@ namespace com.IvanMurzak.McpPlugin.Tests.Mcp
         // Primary temp directory — cleaned up in Dispose.
         readonly string _tempDir;
 
-        // BaseDirectory paths created as side-effects — tracked for cleanup.
-        readonly List<string> _cleanupPaths = new();
-
         readonly Reflector _reflector = new Reflector();
         readonly Version _version = new Version();
 
@@ -49,10 +45,6 @@ namespace com.IvanMurzak.McpPlugin.Tests.Mcp
         {
             if (Directory.Exists(_tempDir))
                 Directory.Delete(_tempDir, recursive: true);
-
-            foreach (var path in _cleanupPaths)
-                if (Directory.Exists(path))
-                    Directory.Delete(path, recursive: true);
         }
 
         // ── helpers ────────────────────────────────────────────────────────────────
@@ -67,247 +59,176 @@ namespace com.IvanMurzak.McpPlugin.Tests.Mcp
         static string SkillFile(string resolvedSkillsDir) =>
             Path.Combine(resolvedSkillsDir, ToolName, "SKILL.md");
 
-        // Registers a path under AppDomain.BaseDirectory for cleanup after each test.
-        string TrackBaseDir(string relName)
-        {
-            var full = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, relName);
-            _cleanupPaths.Add(full);
-            return full;
-        }
-
-        // ── GenerateSkillFiles — path resolution ───────────────────────────────────
+        // ── Issue #107 — anchor resolution priority + loud-failure behaviour ──────
 
         [Fact]
-        public void GenerateSkillFiles_NullPath_RelativeSkillsPath_CreatesFilesInBaseDirectory()
+        public void ResolveSkillsPath_AbsoluteSkillsPath_UsedAsIs()
         {
-            // SkillsPath is relative; passing no path should fall back to AppDomain.BaseDirectory.
-            var relName = $"skills_{Guid.NewGuid():N}";
-            var expectedSkillsDir = TrackBaseDir(relName);
+            // Absolute SkillsPath bypasses every anchor — basePath / ProjectRootPath are
+            // ignored. Existing behaviour, asserted explicitly so the regression net is wide.
+            var absoluteSkillsDir = Path.Combine(_tempDir, "abs-skills");
+            var basePathThatMustBeIgnored = Path.Combine(_tempDir, "ignore-me-basepath");
 
-            var config = new ConnectionConfig { SkillsPath = relName, GenerateSkillFiles = false };
+            var config = new ConnectionConfig
+            {
+                SkillsPath = absoluteSkillsDir,
+                GenerateSkillFiles = false,
+                ProjectRootPath = Path.Combine(_tempDir, "ignore-me-projectroot")
+            };
             using var plugin = BuildPlugin(config);
 
-            var result = plugin.GenerateSkillFiles();
+            var result = plugin.GenerateSkillFiles(basePathThatMustBeIgnored);
 
             result.ShouldBeTrue();
-            File.Exists(SkillFile(expectedSkillsDir)).ShouldBeTrue(
-                $"path=null + relative SkillsPath → BaseDirectory/{relName}");
+            File.Exists(SkillFile(absoluteSkillsDir)).ShouldBeTrue(
+                "absolute SkillsPath must resolve to itself, regardless of basePath / ProjectRootPath");
+            Directory.Exists(basePathThatMustBeIgnored).ShouldBeFalse(
+                "basePath must not be touched when SkillsPath is absolute");
+            Directory.Exists(config.ProjectRootPath!).ShouldBeFalse(
+                "ProjectRootPath must not be touched when SkillsPath is absolute");
         }
 
         [Fact]
-        public void GenerateSkillFiles_WithCustomPath_RelativeSkillsPath_CreatesFilesUnderCustomPath()
+        public void ResolveSkillsPath_RelativeWithExplicitBasePath_AnchorsOnBasePath()
         {
-            // SkillsPath is relative; custom path should be prepended.
-            var customBase = Path.Combine(_tempDir, "custom-base");
+            // Relative SkillsPath + explicit basePath → files land at basePath/SkillsPath.
+            // basePath wins over ProjectRootPath (priority is documented on ConnectionConfig).
+            var customBase = Path.Combine(_tempDir, "base-from-arg");
+            var projectRootThatMustBeIgnored = Path.Combine(_tempDir, "project-root-loses");
             const string relName = "SKILLS";
 
-            var config = new ConnectionConfig { SkillsPath = relName, GenerateSkillFiles = false };
+            var config = new ConnectionConfig
+            {
+                SkillsPath = relName,
+                GenerateSkillFiles = false,
+                ProjectRootPath = projectRootThatMustBeIgnored
+            };
             using var plugin = BuildPlugin(config);
 
             var result = plugin.GenerateSkillFiles(customBase);
 
             result.ShouldBeTrue();
             File.Exists(SkillFile(Path.Combine(customBase, relName))).ShouldBeTrue(
-                $"custom path + relative SkillsPath → customBase/{relName}");
+                $"basePath + relative SkillsPath → basePath/{relName}");
+            Directory.Exists(projectRootThatMustBeIgnored).ShouldBeFalse(
+                "ProjectRootPath must not be touched when an explicit basePath was supplied");
         }
 
         [Fact]
-        public void GenerateSkillFiles_NullPath_AbsoluteSkillsPath_CreatesFilesInAbsolutePath()
+        public void ResolveSkillsPath_RelativeWithProjectRootInConfig_AnchorsOnProjectRoot()
         {
-            // SkillsPath is absolute; null path must not interfere.
-            var absoluteSkillsDir = Path.Combine(_tempDir, "abs-skills");
+            // Relative SkillsPath + no basePath + ProjectRootPath set → files land at
+            // ProjectRootPath/SkillsPath. This is the new behaviour introduced by issue #107.
+            var projectRoot = Path.Combine(_tempDir, "project-root");
+            const string relName = "SKILLS";
 
-            var config = new ConnectionConfig { SkillsPath = absoluteSkillsDir, GenerateSkillFiles = false };
+            var config = new ConnectionConfig
+            {
+                SkillsPath = relName,
+                GenerateSkillFiles = false,
+                ProjectRootPath = projectRoot
+            };
             using var plugin = BuildPlugin(config);
 
             var result = plugin.GenerateSkillFiles();
 
             result.ShouldBeTrue();
-            File.Exists(SkillFile(absoluteSkillsDir)).ShouldBeTrue(
-                "path=null + absolute SkillsPath → SkillsPath itself");
+            File.Exists(SkillFile(Path.Combine(projectRoot, relName))).ShouldBeTrue(
+                $"null basePath + ProjectRootPath + relative SkillsPath → ProjectRootPath/{relName}");
         }
 
         [Fact]
-        public void GenerateSkillFiles_WithCustomPath_AbsoluteSkillsPath_IgnoresCustomPath()
+        public void ResolveSkillsPath_RelativeBasePathOverridesProjectRoot()
         {
-            // SkillsPath is absolute; custom path must be completely ignored.
-            var absoluteSkillsDir = Path.Combine(_tempDir, "abs-skills");
-            var customBase = Path.Combine(_tempDir, "should-be-ignored");
+            // Priority check: explicit basePath beats ProjectRootPath even when both are set.
+            var customBase = Path.Combine(_tempDir, "wins-base");
+            var projectRoot = Path.Combine(_tempDir, "loses-projectroot");
+            const string relName = "SKILLS";
 
-            var config = new ConnectionConfig { SkillsPath = absoluteSkillsDir, GenerateSkillFiles = false };
+            var config = new ConnectionConfig
+            {
+                SkillsPath = relName,
+                GenerateSkillFiles = false,
+                ProjectRootPath = projectRoot
+            };
             using var plugin = BuildPlugin(config);
 
             var result = plugin.GenerateSkillFiles(customBase);
 
             result.ShouldBeTrue();
-            File.Exists(SkillFile(absoluteSkillsDir)).ShouldBeTrue(
-                "absolute SkillsPath takes precedence over custom path");
-            Directory.Exists(customBase).ShouldBeFalse(
-                "custom path must never be touched when SkillsPath is absolute");
-        }
-
-        // ── GenerateSkillFilesIfNeeded — flag + path ────────────────────────────────
-
-        [Fact]
-        public void GenerateSkillFilesIfNeeded_WhenDisabled_ReturnsFalse_NoFilesCreated()
-        {
-            // Even when a custom path is provided, the disabled flag must short-circuit everything.
-            var customBase = Path.Combine(_tempDir, "disabled-test");
-            const string relName = "SKILLS";
-
-            var config = new ConnectionConfig { SkillsPath = relName, GenerateSkillFiles = false };
-            using var plugin = BuildPlugin(config);
-
-            var result = plugin.GenerateSkillFilesIfNeeded(customBase);
-
-            result.ShouldBeFalse("generation is disabled via config");
-            Directory.Exists(customBase).ShouldBeFalse(
-                "no directory must be created when generation is disabled");
-        }
-
-        [Fact]
-        public void GenerateSkillFilesIfNeeded_WhenEnabled_NullPath_RelativeSkillsPath_CreatesFilesInBaseDirectory()
-        {
-            // When enabled and path=null, files must land in BaseDirectory/relName.
-            // The constructor also calls GenerateSkillFilesIfNeeded(), so we delete files first
-            // and then re-call to isolate the explicit invocation's behavior.
-            var relName = $"skills_{Guid.NewGuid():N}";
-            var expectedSkillsDir = TrackBaseDir(relName);
-
-            var config = new ConnectionConfig { SkillsPath = relName, GenerateSkillFiles = true };
-            using var plugin = BuildPlugin(config);
-
-            // Constructor already created files; delete them to make the next call non-trivially testable.
-            if (Directory.Exists(expectedSkillsDir))
-                Directory.Delete(expectedSkillsDir, recursive: true);
-
-            var result = plugin.GenerateSkillFilesIfNeeded();
-
-            result.ShouldBeTrue();
-            File.Exists(SkillFile(expectedSkillsDir)).ShouldBeTrue(
-                $"path=null + enabled + relative SkillsPath → BaseDirectory/{relName}");
-        }
-
-        [Fact]
-        public void GenerateSkillFilesIfNeeded_WhenEnabled_WithCustomPath_RelativeSkillsPath_CreatesFilesUnderCustomPath()
-        {
-            // When enabled and a custom path is supplied, files must land at customBase/relName.
-            var relName = $"skills_{Guid.NewGuid():N}";
-            TrackBaseDir(relName); // ctor creates files here with null path; register for cleanup
-
-            var customBase = Path.Combine(_tempDir, "custom-base");
-
-            var config = new ConnectionConfig { SkillsPath = relName, GenerateSkillFiles = true };
-            using var plugin = BuildPlugin(config);
-
-            var result = plugin.GenerateSkillFilesIfNeeded(customBase);
-
-            result.ShouldBeTrue();
             File.Exists(SkillFile(Path.Combine(customBase, relName))).ShouldBeTrue(
-                $"custom path + enabled + relative SkillsPath → customBase/{relName}");
+                "basePath must win over ProjectRootPath when both are supplied");
+            Directory.Exists(projectRoot).ShouldBeFalse(
+                "ProjectRootPath must not be touched when basePath wins");
         }
 
         [Fact]
-        public void GenerateSkillFilesIfNeeded_WhenEnabled_WithCustomPath_AbsoluteSkillsPath_IgnoresCustomPath()
+        public void ResolveSkillsPath_RelativeWithoutAnyAnchor_Throws()
         {
-            // Absolute SkillsPath must win over any supplied base path.
-            var absoluteSkillsDir = Path.Combine(_tempDir, "abs-skills");
-            var customBase = Path.Combine(_tempDir, "should-be-ignored");
-
-            var config = new ConnectionConfig { SkillsPath = absoluteSkillsDir, GenerateSkillFiles = true };
-            using var plugin = BuildPlugin(config); // ctor creates in absoluteSkillsDir
-
-            var result = plugin.GenerateSkillFilesIfNeeded(customBase);
-
-            result.ShouldBeTrue();
-            File.Exists(SkillFile(absoluteSkillsDir)).ShouldBeTrue(
-                "absolute SkillsPath takes precedence over custom path");
-            Directory.Exists(customBase).ShouldBeFalse(
-                "custom path must never be touched when SkillsPath is absolute");
-        }
-
-        // ── DeleteSkillFiles — path resolution ──────────────────────────────────────
-
-        [Fact]
-        public void DeleteSkillFiles_NullPath_RelativeSkillsPath_DeletesFromBaseDirectory()
-        {
-            var relName = $"skills_{Guid.NewGuid():N}";
-            var skillsDir = TrackBaseDir(relName);
-
-            var config = new ConnectionConfig { SkillsPath = relName, GenerateSkillFiles = false };
-            using var plugin = BuildPlugin(config);
-
-            plugin.GenerateSkillFiles(); // create files at BaseDirectory/relName
-
-            File.Exists(SkillFile(skillsDir)).ShouldBeTrue("setup: SKILL.md must exist before delete");
-
-            var result = plugin.DeleteSkillFiles();
-
-            result.ShouldBeTrue();
-            Directory.Exists(Path.Combine(skillsDir, ToolName)).ShouldBeFalse(
-                "path=null + relative SkillsPath → delete from BaseDirectory/relName");
-        }
-
-        [Fact]
-        public void DeleteSkillFiles_WithCustomPath_RelativeSkillsPath_DeletesFromCustomPath()
-        {
-            var customBase = Path.Combine(_tempDir, "custom-base");
+            // Loud-failure behaviour: no basePath + no ProjectRootPath + relative SkillsPath →
+            // InvalidOperationException. This replaces the old silent CWD fallback.
             const string relName = "SKILLS";
-            var skillsDir = Path.Combine(customBase, relName);
 
-            var config = new ConnectionConfig { SkillsPath = relName, GenerateSkillFiles = false };
+            var config = new ConnectionConfig
+            {
+                SkillsPath = relName,
+                GenerateSkillFiles = false,
+                ProjectRootPath = null
+            };
             using var plugin = BuildPlugin(config);
 
-            plugin.GenerateSkillFiles(customBase); // create files at customBase/SKILLS
-
-            File.Exists(SkillFile(skillsDir)).ShouldBeTrue("setup: SKILL.md must exist before delete");
-
-            var result = plugin.DeleteSkillFiles(customBase);
-
-            result.ShouldBeTrue();
-            Directory.Exists(Path.Combine(skillsDir, ToolName)).ShouldBeFalse(
-                "custom path + relative SkillsPath → delete from customBase/SKILLS");
+            var ex = Should.Throw<InvalidOperationException>(() => plugin.GenerateSkillFiles());
+            ex.Message.ShouldContain(nameof(ConnectionConfig.ProjectRootPath));
+            ex.Message.ShouldContain("SkillsPath");
         }
 
         [Fact]
-        public void DeleteSkillFiles_NullPath_AbsoluteSkillsPath_DeletesFromAbsolutePath()
+        public void ConnectionConfig_ProjectRootPath_IsNotSerialized()
         {
-            var absoluteSkillsDir = Path.Combine(_tempDir, "abs-skills");
+            // Persistence-side regression guard: ProjectRootPath MUST be carried as runtime-only
+            // state and MUST NOT round-trip to disk. Re-introducing it into the serialized form
+            // would resurrect Unity-MCP #761's path-portability bug.
+            var config = new ConnectionConfig
+            {
+                Host = "https://example.com",
+                SkillsPath = "SKILLS",
+                ProjectRootPath = "C:/Users/somebody/MyUnityProject"
+            };
 
-            var config = new ConnectionConfig { SkillsPath = absoluteSkillsDir, GenerateSkillFiles = false };
-            using var plugin = BuildPlugin(config);
+            var json = JsonSerializer.Serialize(config);
+            var node = JsonNode.Parse(json)!.AsObject();
 
-            plugin.GenerateSkillFiles(); // create files at absoluteSkillsDir
+            node.ContainsKey(nameof(ConnectionConfig.ProjectRootPath)).ShouldBeFalse(
+                $"{nameof(ConnectionConfig.ProjectRootPath)} must be marked [JsonIgnore] and never appear in serialized JSON");
 
-            File.Exists(SkillFile(absoluteSkillsDir)).ShouldBeTrue("setup: SKILL.md must exist before delete");
-
-            var result = plugin.DeleteSkillFiles();
-
-            result.ShouldBeTrue();
-            Directory.Exists(Path.Combine(absoluteSkillsDir, ToolName)).ShouldBeFalse(
-                "path=null + absolute SkillsPath → delete from absoluteSkillsDir");
+            // Sanity-check: the other properties DID serialize, so [JsonIgnore] is targeted.
+            node.ContainsKey(nameof(ConnectionConfig.Host)).ShouldBeTrue();
+            node.ContainsKey(nameof(ConnectionConfig.SkillsPath)).ShouldBeTrue();
         }
 
         [Fact]
-        public void DeleteSkillFiles_WithCustomPath_AbsoluteSkillsPath_IgnoresCustomPath()
+        public void OnToolsUpdated_WithMissingProjectRoot_LogsAndContinues()
         {
-            var absoluteSkillsDir = Path.Combine(_tempDir, "abs-skills");
-            var customBase = Path.Combine(_tempDir, "would-be-wrong");
+            // The two internal auto-fires (ctor + OnToolsUpdated subscription) MUST swallow the
+            // new InvalidOperationException via try/catch + LogError instead of letting it bubble
+            // into R3's fire-and-forget subscription context. Construction with a relative
+            // SkillsPath and no ProjectRootPath must therefore NOT crash — it must log and
+            // continue. This test asserts the no-crash contract; the matching LogError is
+            // observable in the xunit test output via the XunitTestOutputLoggerProvider.
+            var config = new ConnectionConfig
+            {
+                SkillsPath = "SKILLS",
+                GenerateSkillFiles = true,
+                ProjectRootPath = null
+            };
 
-            var config = new ConnectionConfig { SkillsPath = absoluteSkillsDir, GenerateSkillFiles = false };
-            using var plugin = BuildPlugin(config);
-
-            plugin.GenerateSkillFiles(); // create files at absoluteSkillsDir
-
-            File.Exists(SkillFile(absoluteSkillsDir)).ShouldBeTrue("setup: SKILL.md must exist before delete");
-
-            var result = plugin.DeleteSkillFiles(customBase);
-
-            result.ShouldBeTrue();
-            Directory.Exists(Path.Combine(absoluteSkillsDir, ToolName)).ShouldBeFalse(
-                "absolute SkillsPath takes precedence — deletes from absoluteSkillsDir");
-            Directory.Exists(customBase).ShouldBeFalse(
-                "custom path must never be created when SkillsPath is absolute");
+            Should.NotThrow(() =>
+            {
+                using var plugin = BuildPlugin(config);
+                // Construction triggers the initial GenerateSkillFilesIfNeeded() call.
+                // If the wrapper is missing, the InvalidOperationException would escape
+                // synchronously and fail the test.
+            });
         }
 
         // ── mock ───────────────────────────────────────────────────────────────────

--- a/McpPlugin/src/McpPlugin/McpPlugin.cs
+++ b/McpPlugin/src/McpPlugin/McpPlugin.cs
@@ -105,7 +105,17 @@ namespace com.IvanMurzak.McpPlugin
                     if (_cancellationTokenSource.Token.IsCancellationRequested)
                         return;
 
-                    GenerateSkillFilesIfNeeded();
+                    try
+                    {
+                        GenerateSkillFilesIfNeeded();
+                    }
+                    catch (InvalidOperationException ex)
+                    {
+                        _logger.LogError(ex,
+                            "{method}: skill auto-generation skipped — host did not provide a project root. " +
+                            "Set ConnectionConfig.ProjectRootPath or pass basePath to GenerateSkillFiles.",
+                            nameof(McpManager.ToolManager.OnToolsUpdated));
+                    }
 
                     if (_mcpManagerHub == null)
                     {
@@ -119,7 +129,17 @@ namespace com.IvanMurzak.McpPlugin
                 .AddTo(_disposables);
 
             // Generate skill files for the initial set of tools on build
-            GenerateSkillFilesIfNeeded();
+            try
+            {
+                GenerateSkillFilesIfNeeded();
+            }
+            catch (InvalidOperationException ex)
+            {
+                _logger.LogError(ex,
+                    "{ctor}: initial skill generation skipped — host did not provide a project root. " +
+                    "Set ConnectionConfig.ProjectRootPath or pass basePath to GenerateSkillFiles.",
+                    nameof(McpPlugin));
+            }
 
             McpManager.PromptManager?.OnPromptsUpdated
                 .ThrottleFirst(TimeSpan.FromMilliseconds(100))
@@ -233,7 +253,18 @@ namespace com.IvanMurzak.McpPlugin
             if (Path.IsPathRooted(skillsPath))
                 return Path.GetFullPath(skillsPath);
 
-            var resolvedBase = basePath ?? Environment.CurrentDirectory;
+            var resolvedBase = basePath ?? _connectionConfig.ProjectRootPath;
+            if (string.IsNullOrEmpty(resolvedBase))
+            {
+                throw new InvalidOperationException(
+                    $"Cannot resolve relative SkillsPath '{skillsPath}': no basePath was supplied " +
+                    $"and {nameof(ConnectionConfig)}.{nameof(ConnectionConfig.ProjectRootPath)} is not set. " +
+                    $"Host applications must either pass an explicit basePath to GenerateSkillFiles / " +
+                    $"DeleteSkillFiles, or set ConnectionConfig.ProjectRootPath at construction time. " +
+                    $"Silent fallback to Environment.CurrentDirectory has been removed to prevent " +
+                    $"skill files landing outside the host project (see GitHub issue #107).");
+            }
+
             return Path.GetFullPath(Path.Combine(resolvedBase, skillsPath));
         }
 

--- a/McpPlugin/src/McpPlugin/Network/Connection/ConnectionConfig.cs
+++ b/McpPlugin/src/McpPlugin/Network/Connection/ConnectionConfig.cs
@@ -9,6 +9,7 @@
 */
 using System;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 using com.IvanMurzak.McpPlugin.Common;
 using com.IvanMurzak.McpPlugin.Common.Utils;
 
@@ -37,10 +38,28 @@ namespace com.IvanMurzak.McpPlugin
         public virtual bool GenerateSkillFiles { get; set; } = true;
 
         /// <summary>
-        /// Path for generated skill markdown files. Can be absolute or relative to the current working directory (<see cref="System.Environment.CurrentDirectory"/>).
+        /// Path for generated skill markdown files. Can be absolute or relative.
+        /// When relative, it is anchored against (in priority order): the <c>basePath</c> argument
+        /// passed to <see cref="IMcpPlugin.GenerateSkillFiles(string?)"/> /
+        /// <see cref="IMcpPlugin.DeleteSkillFiles(string?)"/>; otherwise <see cref="ProjectRootPath"/>;
+        /// otherwise the resolver throws. There is no silent fallback to the host process's
+        /// current working directory — see GitHub issue #107.
         /// Default is 'SKILLS'. Set via command line arg 'mcp-skills-folder' or environment variable 'MCP_SKILLS_FOLDER'.
         /// </summary>
         public virtual string SkillsPath { get; set; } = "SKILLS";
+
+        /// <summary>
+        /// Absolute filesystem path to the host project root — the folder that relative
+        /// <see cref="SkillsPath"/> values are anchored against. Runtime-only; MUST NOT be
+        /// serialized to disk (see <see cref="JsonIgnoreAttribute"/>) so that the on-disk
+        /// connection config remains portable across machines (Unity-MCP issue #761).
+        /// Hosts SHOULD set this once at plugin construction — e.g. Unity sets it to the
+        /// parent of <c>Application.dataPath</c>. When null, callers MUST pass an explicit
+        /// <c>basePath</c> to any API that resolves a relative <see cref="SkillsPath"/>;
+        /// otherwise that API throws an <see cref="InvalidOperationException"/>.
+        /// </summary>
+        [JsonIgnore]
+        public string? ProjectRootPath { get; set; }
 
         public ConnectionConfig() { }
 


### PR DESCRIPTION
## Summary

- Adds `[JsonIgnore] string? ProjectRootPath` to `ConnectionConfig` as a runtime-only resolution anchor for relative `SkillsPath` values. `[JsonIgnore]` is mandatory so the field never round-trips into the persisted `AI-Game-Developer-Config.json` (avoiding the path-portability regression Unity-MCP #761 fixed).
- Rewrites `McpPlugin.ResolveSkillsPath` to resolve in priority order `basePath` → `ConnectionConfig.ProjectRootPath` → throw `InvalidOperationException`. The silent `Environment.CurrentDirectory` fallback is removed.
- Wraps the two internal auto-fires (`McpPlugin` ctor initial build + `OnToolsUpdated` R3 subscription) in `try/catch (InvalidOperationException)` that calls `_logger.LogError` with remediation guidance, so the new throw never gets swallowed by R3's fire-and-forget context.

Out of scope (deliberately): Unity-MCP's host-side cascade that will set `ConnectionConfig.ProjectRootPath = UnityMcpPluginEditor.ProjectRootPath` ships as a separate Unity-MCP PR once this version is released.

## Test plan

- [x] Target-specific local tests passed (see profile `test.md`): `dotnet test --no-build --configuration Release` → **397 / 397 passed** across `McpPlugin.Tests` and `McpPlugin.Server.Tests`, on both `net8.0` and `net9.0`.
- [x] 7 new tests in `McpPlugin.Tests/Mcp/McpPluginSkillPathTests.cs` cover the resolution priority matrix, the missing-anchor throw, the `[JsonIgnore]` serialization guard, and the ctor wrapper's no-crash contract.

Closes #107