### PR TITLE
test: encode $ref URI in test-helper to match ReflectorNet 5.1.2

### DIFF
--- a/McpPlugin.Tests/Utils/JsonObjectBuilder.cs
+++ b/McpPlugin.Tests/Utils/JsonObjectBuilder.cs
@@ -158,7 +158,7 @@ namespace com.IvanMurzak.McpPlugin.Common.Tests.Utils
 
             Result[JsonSchema.Properties]![name] = new JsonObject
             {
-                [JsonSchema.Ref] = JsonSchema.RefValue + typeId
+                [JsonSchema.Ref] = JsonSchema.RefValue + EncodeForJsonSchemaRef(typeId)
             };
 
             if (description != null)
@@ -204,11 +204,23 @@ namespace com.IvanMurzak.McpPlugin.Common.Tests.Utils
                 [JsonSchema.Type] = JsonSchema.Array,
                 [JsonSchema.Items] = new JsonObject
                 {
-                    [JsonSchema.Ref] = JsonSchema.RefValue + itemType
+                    [JsonSchema.Ref] = JsonSchema.RefValue + EncodeForJsonSchemaRef(itemType)
                 }
             };
 
             return AddDefinition(name, arrayDefinition);
+        }
+
+        // Mirrors ReflectorNet's $ref encoding (percent-encodes `[ ] < > +`). $defs keys stay raw;
+        // $ref values are URI references per RFC 6901 + RFC 3986. A consumer URI-decodes the
+        // fragment and looks up the raw $defs key directly.
+        static string EncodeForJsonSchemaRef(string typeId)
+        {
+            if (string.IsNullOrEmpty(typeId))
+                return typeId;
+            return typeId.Replace("[", "%5B").Replace("]", "%5D")
+                         .Replace("<", "%3C").Replace(">", "%3E")
+                         .Replace("+", "%2B");
         }
 
         public JsonObject? BuildJsonObject()


### PR DESCRIPTION
## Summary

`JsonObjectBuilder.AddRefProperty` / `AddArrayDefinitionRef` build the *expected* `$ref` as the raw concatenation `"#/$defs/" + typeId`. ReflectorNet 5.1.2 (just published) now percent-encodes `[ ] < > +` at the `$ref` construction site only (per RFC 6901 + RFC 3986: `$ref` is a URI reference, URI-decoding happens before JSON Pointer parsing, so `$defs` keys stay raw and `$ref` fragments get percent-encoded).

This mirror-encodes the test helper so expectations match the new (correct) schema output.

## Why this PR exists

`release.yml` run [26253229799](https://github.com/IvanMurzak/MCP-Plugin-dotnet/actions/runs/26253229799) for `6.3.2` failed at the test job because 3 tests in `McpBuilderTests_ListTool` asserted raw `<>` in `$ref` values. Once this PR merges and CI passes, `release.yml` re-fires on `main`, the 3 tests pass, and `6.3.2` ships to NuGet.

## Changes

- `McpPlugin.Tests/Utils/JsonObjectBuilder.cs` — added private `EncodeForJsonSchemaRef` helper; applied at the two `$ref` construction sites (`AddRefProperty` and `AddArrayDefinitionRef`). `$defs` keys (`AddDefinition`) unchanged.

## Test plan

- [x] `dotnet test` (full suite, net8.0 + net9.0): **1,314 / 1,314 pass** (McpPlugin.Tests 397 × 2, McpPlugin.Server.Tests 260 × 2)
- [x] `McpBuilderTests_ListTool` specifically: 9 / 9 pass (was 6 failing pre-fix)