### PR TITLE
refactor: rename reflection attributes to [Ai*] prefix with [Obsolete] aliases

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -71,9 +71,10 @@ common packages.
 Tools, prompts, and resources MUST be registered declaratively via attributes, not via imperative
 registration calls.
 
-- Tools: `[McpPluginTool]` on methods inside `[McpPluginToolType]`-annotated classes.
-- Prompts: `[McpPluginPrompt]` on methods inside `[McpPluginPromptType]`-annotated classes.
-- Resources: `[McpPluginResource]` on methods inside `[McpPluginResourceType]`-annotated classes.
+- Tools: `[AiTool]` on methods inside `[AiToolType]`-annotated classes.
+- Prompts: `[AiPrompt]` on methods inside `[AiPromptType]`-annotated classes.
+- Resources: `[AiResource]` on methods inside `[AiResourceType]`-annotated classes.
+- The legacy `[McpPlugin*]` attribute names remain available as `[Obsolete]` subclass aliases of the new `[Ai*]` types so existing consumer code keeps compiling (with a deprecation warning) — new code MUST use the `[Ai*]` names.
 - Reflection MUST use `com.IvanMurzak.ReflectorNet`, not raw `System.Reflection`.
 - Assembly scanning MUST be available via `WithToolsFromAssembly()`, `WithPromptsFromAssembly()`,
   and `WithResourcesFromAssembly()` builder methods.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ cd DemoWebApp && dotnet run port=11111 client-transport=stdio
 ## Find detail in
 
 - `docs/claude/architecture.md` — Bridge architecture, packages, SignalR hub endpoint
-- `docs/claude/patterns.md` — `[McpPluginToolType]` / `[McpPluginTool]` examples, builder & server registration
+- `docs/claude/patterns.md` — `[AiToolType]` / `[AiTool]` examples (and the `[McpPlugin*]` obsolete-alias compatibility note), builder & server registration
 - `docs/claude/style.md` — Code style mandates (LangVersion, R3, NLog, DI, disposal)
 - `docs/claude/testing.md` — xUnit + Shouldly + Moq conventions, filtered test commands
 - `docs/claude/release.md` — Versioning, bump-version, ReflectorNet updates, CI release flow

--- a/DemoConsoleApp/src/McpToolConsole.cs
+++ b/DemoConsoleApp/src/McpToolConsole.cs
@@ -10,10 +10,10 @@
 using System.ComponentModel;
 using com.IvanMurzak.McpPlugin;
 
-[McpPluginToolType]
+[AiToolType]
 public static class McpToolConsole
 {
-    [McpPluginTool("console-log", "Logs a message to the console.")]
+    [AiTool("console-log", "Logs a message to the console.")]
     [Description("Logs a message to the console.")]
     public static void Log(string message)
     {

--- a/McpPlugin.Tests/Data/Annotations/AnnotatedResourceClass.cs
+++ b/McpPlugin.Tests/Data/Annotations/AnnotatedResourceClass.cs
@@ -12,24 +12,24 @@ using com.IvanMurzak.McpPlugin.Common.Model;
 
 namespace com.IvanMurzak.McpPlugin.Tests.Data.Annotations
 {
-    [McpPluginResourceType]
+    [AiResourceType]
     public static class AnnotatedResourceClass
     {
-        [McpPluginResource(Route = "test://resource-enabled-default/{id}", Name = "resource-enabled-default", ListResources = nameof(ListResourcesEnabledDefault))]
+        [AiResource(Route = "test://resource-enabled-default/{id}", Name = "resource-enabled-default", ListResources = nameof(ListResourcesEnabledDefault))]
         public static ResponseResourceContent[] GetResourceEnabledDefault(string id)
             => new[] { ResponseResourceContent.CreateText($"test://resource-enabled-default/{id}", "default") };
 
         public static ResponseListResource[] ListResourcesEnabledDefault()
             => new[] { new ResponseListResource("test://resource-enabled-default/1", "resource-enabled-default") };
 
-        [McpPluginResource(Route = "test://resource-enabled-true/{id}", Name = "resource-enabled-true", Enabled = true, ListResources = nameof(ListResourcesEnabledTrue))]
+        [AiResource(Route = "test://resource-enabled-true/{id}", Name = "resource-enabled-true", Enabled = true, ListResources = nameof(ListResourcesEnabledTrue))]
         public static ResponseResourceContent[] GetResourceEnabledTrue(string id)
             => new[] { ResponseResourceContent.CreateText($"test://resource-enabled-true/{id}", "enabled") };
 
         public static ResponseListResource[] ListResourcesEnabledTrue()
             => new[] { new ResponseListResource("test://resource-enabled-true/1", "resource-enabled-true") };
 
-        [McpPluginResource(Route = "test://resource-enabled-false/{id}", Name = "resource-enabled-false", Enabled = false, ListResources = nameof(ListResourcesEnabledFalse))]
+        [AiResource(Route = "test://resource-enabled-false/{id}", Name = "resource-enabled-false", Enabled = false, ListResources = nameof(ListResourcesEnabledFalse))]
         public static ResponseResourceContent[] GetResourceEnabledFalse(string id)
             => new[] { ResponseResourceContent.CreateText($"test://resource-enabled-false/{id}", "disabled") };
 

--- a/McpPlugin.Tests/Data/Annotations/AnnotatedSkillClass.cs
+++ b/McpPlugin.Tests/Data/Annotations/AnnotatedSkillClass.cs
@@ -10,10 +10,10 @@
 
 namespace com.IvanMurzak.McpPlugin.Tests.Data.Annotations
 {
-    [McpPluginSkillType]
+    [AiSkillType]
     public static class AnnotatedSkillClass
     {
-        [McpPluginSkill("deploy-guide", "Step-by-step deployment instructions")]
+        [AiSkill("deploy-guide", "Step-by-step deployment instructions")]
         public const string DeployGuide = @"
 # Deploy Guide
 
@@ -22,7 +22,7 @@ namespace com.IvanMurzak.McpPlugin.Tests.Data.Annotations
 3. Deploy to staging
 ";
 
-        [McpPluginSkill("troubleshoot", "Troubleshooting common issues")]
+        [AiSkill("troubleshoot", "Troubleshooting common issues")]
         public const string Troubleshoot = @"
 # Troubleshooting
 
@@ -30,7 +30,7 @@ namespace com.IvanMurzak.McpPlugin.Tests.Data.Annotations
 - Restart service
 ";
 
-        [McpPluginSkill("disabled-skill", "This skill is disabled", Enabled = false)]
+        [AiSkill("disabled-skill", "This skill is disabled", Enabled = false)]
         public const string DisabledSkill = @"
 # Disabled
 
@@ -38,14 +38,14 @@ This should not appear.
 ";
 
         // Static property — should be picked up
-        [McpPluginSkill("platform-info", "Platform-specific instructions")]
+        [AiSkill("platform-info", "Platform-specific instructions")]
         public static string PlatformInfo => System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
             System.Runtime.InteropServices.OSPlatform.Windows)
             ? "# Windows\nUse PowerShell."
             : "# Linux\nUse bash.";
 
         // Static property with disabled attribute — should NOT be picked up
-        [McpPluginSkill("disabled-prop", "Disabled property skill", Enabled = false)]
+        [AiSkill("disabled-prop", "Disabled property skill", Enabled = false)]
         public static string DisabledProp => "# Disabled prop";
 
         // Non-const field — should NOT be picked up

--- a/McpPlugin.Tests/Data/Annotations/AnnotatedToolClass.cs
+++ b/McpPlugin.Tests/Data/Annotations/AnnotatedToolClass.cs
@@ -10,38 +10,38 @@
 
 namespace com.IvanMurzak.McpPlugin.Tests.Data.Annotations
 {
-    [McpPluginToolType]
+    [AiToolType]
     public static class AnnotatedToolClass
     {
-        [McpPluginTool("tool-no-hints", "Tool With No Hints")]
+        [AiTool("tool-no-hints", "Tool With No Hints")]
         public static void NoHints() { }
 
-        [McpPluginTool("tool-readonly", "Read-Only Tool", ReadOnlyHint = true)]
+        [AiTool("tool-readonly", "Read-Only Tool", ReadOnlyHint = true)]
         public static void ReadOnly() { }
 
-        [McpPluginTool("tool-destructive-false", "Non-Destructive Tool", DestructiveHint = false)]
+        [AiTool("tool-destructive-false", "Non-Destructive Tool", DestructiveHint = false)]
         public static void DestructiveFalse() { }
 
-        [McpPluginTool("tool-idempotent", "Idempotent Tool", IdempotentHint = true)]
+        [AiTool("tool-idempotent", "Idempotent Tool", IdempotentHint = true)]
         public static void Idempotent() { }
 
-        [McpPluginTool("tool-open-world", "Open World Tool", OpenWorldHint = true)]
+        [AiTool("tool-open-world", "Open World Tool", OpenWorldHint = true)]
         public static void OpenWorld() { }
 
-        [McpPluginTool("tool-all-hints", "All Hints Tool",
+        [AiTool("tool-all-hints", "All Hints Tool",
             ReadOnlyHint = true,
             DestructiveHint = false,
             IdempotentHint = true,
             OpenWorldHint = false)]
         public static void AllHints() { }
 
-        [McpPluginTool("tool-enabled-default", "Tool With Default Enabled")]
+        [AiTool("tool-enabled-default", "Tool With Default Enabled")]
         public static void EnabledDefault() { }
 
-        [McpPluginTool("tool-enabled-true", "Tool With Enabled True", Enabled = true)]
+        [AiTool("tool-enabled-true", "Tool With Enabled True", Enabled = true)]
         public static void EnabledTrue() { }
 
-        [McpPluginTool("tool-enabled-false", "Tool With Enabled False", Enabled = false)]
+        [AiTool("tool-enabled-false", "Tool With Enabled False", Enabled = false)]
         public static void EnabledFalse() { }
     }
 }

--- a/McpPlugin.Tests/Data/Annotations/MixedAliasAttributeClass.cs
+++ b/McpPlugin.Tests/Data/Annotations/MixedAliasAttributeClass.cs
@@ -71,6 +71,50 @@ namespace com.IvanMurzak.McpPlugin.Tests.Data.Annotations
         [McpPluginSkill("alias-skill-old", "Decorated with legacy [McpPluginSkill] obsolete alias")]
         public const string OldStyle = "# Old\n\nDecorated with the deprecated alias.";
     }
+
+    // ── Same-member dual-decoration fixtures.
+    //
+    // These exist to lock in the regression that during a consumer's gradual migration from
+    // [McpPlugin*] → [Ai*], a member temporarily carrying BOTH attributes must (a) not raise
+    // AmbiguousMatchException from any reflection lookup performed by the builder/runner code,
+    // and (b) be registered exactly ONCE (not duplicated, not skipped). Putting both attributes
+    // on the same member is the case the prior single-pass scanner mishandled.
+
+    [AiToolType]
+    public static class DualDecoratedToolClass
+    {
+        [AiTool("dual-decorated-tool", "Carries both [AiTool] and [McpPluginTool] on the same method")]
+        [McpPluginTool("dual-decorated-tool-legacy")]
+        public static string DualStyle() => "dual";
+    }
+
+    [AiPromptType]
+    public static class DualDecoratedPromptClass
+    {
+        [AiPrompt(Name = "dual-decorated-prompt")]
+        [McpPluginPrompt(Name = "dual-decorated-prompt-legacy")]
+        public static string DualStyle() => "dual";
+    }
+
+    [AiResourceType]
+    public static class DualDecoratedResourceClass
+    {
+        [AiResource(Route = "test://dual-decorated-resource/{id}", Name = "dual-decorated-resource", ListResources = nameof(ListDual))]
+        [McpPluginResource(Route = "test://dual-decorated-resource-legacy/{id}", Name = "dual-decorated-resource-legacy", ListResources = nameof(ListDual))]
+        public static ResponseResourceContent[] GetDual(string id)
+            => new[] { ResponseResourceContent.CreateText($"test://dual-decorated-resource/{id}", "dual") };
+
+        public static ResponseListResource[] ListDual()
+            => new[] { new ResponseListResource("test://dual-decorated-resource/1", "dual-decorated-resource") };
+    }
+
+    [AiSkillType]
+    public static class DualDecoratedSkillClass
+    {
+        [AiSkill("dual-decorated-skill", "Carries both [AiSkill] and [McpPluginSkill] on the same field")]
+        [McpPluginSkill("dual-decorated-skill-legacy")]
+        public const string DualStyle = "# Dual\n\nDecorated with both canonical and legacy attributes.";
+    }
 }
 
 #pragma warning restore CS0618

--- a/McpPlugin.Tests/Data/Annotations/MixedAliasAttributeClass.cs
+++ b/McpPlugin.Tests/Data/Annotations/MixedAliasAttributeClass.cs
@@ -1,0 +1,76 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+// This fixture intentionally uses BOTH the new canonical [Ai*] attributes AND the legacy
+// [Obsolete] [McpPlugin*] aliases on different members within the same class. It exists to
+// prove that reflection lookups for the new canonical attribute types (AiToolAttribute,
+// AiPromptAttribute, AiResourceAttribute, AiSkillAttribute) discover both old-style and
+// new-style decorations correctly via inheritance — which is what makes the deprecation path
+// backward-compatible for existing consumers shipped against earlier package versions.
+//
+// The CS0618 suppression is scoped to this file only — the build is otherwise expected to
+// emit zero [Obsolete] warnings on in-repo code.
+
+#pragma warning disable CS0618 // intentional use of obsolete McpPlugin* aliases to exercise discovery
+
+using com.IvanMurzak.McpPlugin.Common.Model;
+
+namespace com.IvanMurzak.McpPlugin.Tests.Data.Annotations
+{
+    [AiToolType] // class container uses the new canonical name
+    public static class MixedAliasToolClass
+    {
+        [AiTool("alias-tool-new", "Decorated with new [AiTool]")]
+        public static string NewStyle() => "new";
+
+        [McpPluginTool("alias-tool-old", "Decorated with legacy [McpPluginTool] obsolete alias")]
+        public static string OldStyle() => "old";
+    }
+
+    [AiPromptType]
+    public static class MixedAliasPromptClass
+    {
+        [AiPrompt(Name = "alias-prompt-new")]
+        public static string NewStyle() => "new";
+
+        [McpPluginPrompt(Name = "alias-prompt-old")]
+        public static string OldStyle() => "old";
+    }
+
+    [AiResourceType]
+    public static class MixedAliasResourceClass
+    {
+        [AiResource(Route = "test://alias-resource-new/{id}", Name = "alias-resource-new", ListResources = nameof(ListNew))]
+        public static ResponseResourceContent[] GetNew(string id)
+            => new[] { ResponseResourceContent.CreateText($"test://alias-resource-new/{id}", "new") };
+
+        public static ResponseListResource[] ListNew()
+            => new[] { new ResponseListResource("test://alias-resource-new/1", "alias-resource-new") };
+
+        [McpPluginResource(Route = "test://alias-resource-old/{id}", Name = "alias-resource-old", ListResources = nameof(ListOld))]
+        public static ResponseResourceContent[] GetOld(string id)
+            => new[] { ResponseResourceContent.CreateText($"test://alias-resource-old/{id}", "old") };
+
+        public static ResponseListResource[] ListOld()
+            => new[] { new ResponseListResource("test://alias-resource-old/1", "alias-resource-old") };
+    }
+
+    [AiSkillType]
+    public static class MixedAliasSkillClass
+    {
+        [AiSkill("alias-skill-new", "Decorated with new [AiSkill]")]
+        public const string NewStyle = "# New\n\nDecorated with the new canonical attribute.";
+
+        [McpPluginSkill("alias-skill-old", "Decorated with legacy [McpPluginSkill] obsolete alias")]
+        public const string OldStyle = "# Old\n\nDecorated with the deprecated alias.";
+    }
+}
+
+#pragma warning restore CS0618

--- a/McpPlugin.Tests/Data/Annotations/MixedToolTypeClass.cs
+++ b/McpPlugin.Tests/Data/Annotations/MixedToolTypeClass.cs
@@ -10,22 +10,22 @@
 
 namespace com.IvanMurzak.McpPlugin.Tests.Data.Annotations
 {
-    [McpPluginToolType]
+    [AiToolType]
     public static class MixedToolTypeClass
     {
-        [McpPluginTool("standard-tool-a", "Standard Tool A")]
+        [AiTool("standard-tool-a", "Standard Tool A")]
         public static string StandardA() => "a";
 
-        [McpPluginTool("standard-tool-b", "Standard Tool B")]
+        [AiTool("standard-tool-b", "Standard Tool B")]
         public static string StandardB() => "b";
 
-        [McpPluginTool("system-tool-x", "System Tool X", ToolType = McpToolType.System)]
+        [AiTool("system-tool-x", "System Tool X", ToolType = McpToolType.System)]
         public static string SystemX() => "x";
 
-        [McpPluginTool("system-tool-y", "System Tool Y", ToolType = McpToolType.System)]
+        [AiTool("system-tool-y", "System Tool Y", ToolType = McpToolType.System)]
         public static string SystemY() => "y";
 
-        [McpPluginTool("standard-default", "Default ToolType")]
+        [AiTool("standard-default", "Default ToolType")]
         public static string DefaultType() => "default";
     }
 }

--- a/McpPlugin.Tests/Data/IgnoreTests/IgnoreTestToolClass.cs
+++ b/McpPlugin.Tests/Data/IgnoreTests/IgnoreTestToolClass.cs
@@ -10,17 +10,17 @@
 
 namespace com.IvanMurzak.McpPlugin.Tests.Data.Ignored
 {
-    [McpPluginToolType]
+    [AiToolType]
     internal class IgnoreTestToolClass
     {
-        [McpPluginTool("ignore-test-tool", "Test tool for ignore tests")]
+        [AiTool("ignore-test-tool", "Test tool for ignore tests")]
         public static string TestTool() => "test";
     }
 
-    [McpPluginPromptType]
+    [AiPromptType]
     internal class IgnoreTestPromptClass
     {
-        [McpPluginPrompt(Name = "ignore-test-prompt")]
+        [AiPrompt(Name = "ignore-test-prompt")]
         public static string TestPrompt() => "test prompt";
     }
 }

--- a/McpPlugin.Tests/Data/IgnoreTests/IncludeTestToolClass.cs
+++ b/McpPlugin.Tests/Data/IgnoreTests/IncludeTestToolClass.cs
@@ -10,17 +10,17 @@
 
 namespace com.IvanMurzak.McpPlugin.Tests.Data.Included
 {
-    [McpPluginToolType]
+    [AiToolType]
     internal class IncludeTestToolClass
     {
-        [McpPluginTool("include-test-tool", "Test tool that should be included")]
+        [AiTool("include-test-tool", "Test tool that should be included")]
         public static string TestTool() => "test";
     }
 
-    [McpPluginPromptType]
+    [AiPromptType]
     internal class IncludeTestPromptClass
     {
-        [McpPluginPrompt(Name = "include-test-prompt")]
+        [AiPrompt(Name = "include-test-prompt")]
         public static string TestPrompt() => "test prompt";
     }
 }

--- a/McpPlugin.Tests/Data/IgnoreTests/SubNamespaceToolClass.cs
+++ b/McpPlugin.Tests/Data/IgnoreTests/SubNamespaceToolClass.cs
@@ -10,17 +10,17 @@
 
 namespace com.IvanMurzak.McpPlugin.Tests.Data.Ignored.SubNamespace
 {
-    [McpPluginToolType]
+    [AiToolType]
     internal class SubNamespaceToolClass
     {
-        [McpPluginTool("sub-namespace-tool", "Tool in sub-namespace")]
+        [AiTool("sub-namespace-tool", "Tool in sub-namespace")]
         public static string TestTool() => "test";
     }
 
-    [McpPluginPromptType]
+    [AiPromptType]
     internal class SubNamespacePromptClass
     {
-        [McpPluginPrompt(Name = "sub-namespace-prompt")]
+        [AiPrompt(Name = "sub-namespace-prompt")]
         public static string TestPrompt() => "test prompt";
     }
 }

--- a/McpPlugin.Tests/Mcp/AttributeAliasDiscoveryTests.cs
+++ b/McpPlugin.Tests/Mcp/AttributeAliasDiscoveryTests.cs
@@ -1,0 +1,191 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+using System.Linq;
+using System.Reflection;
+using com.IvanMurzak.McpPlugin.Skills;
+using com.IvanMurzak.McpPlugin.Tests.Data.Annotations;
+using com.IvanMurzak.McpPlugin.Tests.Infrastructure;
+using com.IvanMurzak.ReflectorNet;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+using Version = com.IvanMurzak.McpPlugin.Common.Version;
+
+namespace com.IvanMurzak.McpPlugin.Tests.Mcp
+{
+    /// <summary>
+    /// Verifies that the rename of <c>McpPlugin*Attribute</c> → <c>Ai*Attribute</c> preserves
+    /// reflection-discovery semantics: code that looks up the NEW canonical attribute type
+    /// (<see cref="AiToolAttribute"/> / <see cref="AiPromptAttribute"/> /
+    /// <see cref="AiResourceAttribute"/> / <see cref="AiSkillAttribute"/>) MUST also discover
+    /// members decorated with the LEGACY <c>[McpPlugin*]</c> attributes, because each old
+    /// class is now an <see cref="System.ObsoleteAttribute"/>-marked subclass of its new
+    /// canonical counterpart.
+    ///
+    /// The fixture data this test reads from
+    /// (<see cref="MixedAliasToolClass"/>, <see cref="MixedAliasPromptClass"/>,
+    /// <see cref="MixedAliasResourceClass"/>, <see cref="MixedAliasSkillClass"/>) intentionally
+    /// decorates one member with the new <c>[Ai*]</c> attribute and another with the legacy
+    /// <c>[McpPlugin*]</c> attribute, side by side.
+    /// </summary>
+    [Collection("McpPlugin")]
+    public class AttributeAliasDiscoveryTests
+    {
+        private readonly ITestOutputHelper _output;
+        private readonly XunitTestOutputLoggerProvider _loggerProvider;
+        private readonly Version _version = new Version();
+
+        public AttributeAliasDiscoveryTests(ITestOutputHelper output)
+        {
+            _output = output;
+            _loggerProvider = new XunitTestOutputLoggerProvider(output);
+        }
+
+        // ── Direct reflection lookup: the canonical [Ai*] attribute type
+        //    discovers BOTH old-style and new-style decorations via inheritance.
+
+        [Fact]
+        public void GetCustomAttribute_AiTool_FindsLegacyMcpPluginToolDecoration()
+        {
+            var newMethod = typeof(MixedAliasToolClass).GetMethod(nameof(MixedAliasToolClass.NewStyle), BindingFlags.Public | BindingFlags.Static);
+            var oldMethod = typeof(MixedAliasToolClass).GetMethod(nameof(MixedAliasToolClass.OldStyle), BindingFlags.Public | BindingFlags.Static);
+
+            newMethod.ShouldNotBeNull();
+            oldMethod.ShouldNotBeNull();
+
+            // Looking up by the NEW canonical type must find BOTH decorations.
+            var newAttr = newMethod!.GetCustomAttribute<AiToolAttribute>();
+            var oldAttr = oldMethod!.GetCustomAttribute<AiToolAttribute>();
+
+            newAttr.ShouldNotBeNull();
+            newAttr!.Name.ShouldBe("alias-tool-new");
+
+            oldAttr.ShouldNotBeNull();
+            oldAttr!.Name.ShouldBe("alias-tool-old");
+        }
+
+        [Fact]
+        public void GetCustomAttribute_AiPrompt_FindsLegacyMcpPluginPromptDecoration()
+        {
+            var newMethod = typeof(MixedAliasPromptClass).GetMethod(nameof(MixedAliasPromptClass.NewStyle), BindingFlags.Public | BindingFlags.Static);
+            var oldMethod = typeof(MixedAliasPromptClass).GetMethod(nameof(MixedAliasPromptClass.OldStyle), BindingFlags.Public | BindingFlags.Static);
+
+            newMethod.ShouldNotBeNull();
+            oldMethod.ShouldNotBeNull();
+
+            var newAttr = newMethod!.GetCustomAttribute<AiPromptAttribute>();
+            var oldAttr = oldMethod!.GetCustomAttribute<AiPromptAttribute>();
+
+            newAttr.ShouldNotBeNull();
+            newAttr!.Name.ShouldBe("alias-prompt-new");
+
+            oldAttr.ShouldNotBeNull();
+            oldAttr!.Name.ShouldBe("alias-prompt-old");
+        }
+
+        [Fact]
+        public void GetCustomAttribute_AiResource_FindsLegacyMcpPluginResourceDecoration()
+        {
+            var newMethod = typeof(MixedAliasResourceClass).GetMethod(nameof(MixedAliasResourceClass.GetNew), BindingFlags.Public | BindingFlags.Static);
+            var oldMethod = typeof(MixedAliasResourceClass).GetMethod(nameof(MixedAliasResourceClass.GetOld), BindingFlags.Public | BindingFlags.Static);
+
+            newMethod.ShouldNotBeNull();
+            oldMethod.ShouldNotBeNull();
+
+            var newAttr = newMethod!.GetCustomAttribute<AiResourceAttribute>();
+            var oldAttr = oldMethod!.GetCustomAttribute<AiResourceAttribute>();
+
+            newAttr.ShouldNotBeNull();
+            newAttr!.Name.ShouldBe("alias-resource-new");
+
+            oldAttr.ShouldNotBeNull();
+            oldAttr!.Name.ShouldBe("alias-resource-old");
+        }
+
+        [Fact]
+        public void GetCustomAttribute_AiSkill_FindsLegacyMcpPluginSkillDecoration()
+        {
+            var newField = typeof(MixedAliasSkillClass).GetField(nameof(MixedAliasSkillClass.NewStyle), BindingFlags.Public | BindingFlags.Static);
+            var oldField = typeof(MixedAliasSkillClass).GetField(nameof(MixedAliasSkillClass.OldStyle), BindingFlags.Public | BindingFlags.Static);
+
+            newField.ShouldNotBeNull();
+            oldField.ShouldNotBeNull();
+
+            var newAttr = newField!.GetCustomAttribute<AiSkillAttribute>();
+            var oldAttr = oldField!.GetCustomAttribute<AiSkillAttribute>();
+
+            newAttr.ShouldNotBeNull();
+            newAttr!.Name.ShouldBe("alias-skill-new");
+
+            oldAttr.ShouldNotBeNull();
+            oldAttr!.Name.ShouldBe("alias-skill-old");
+        }
+
+        // ── End-to-end via the actual McpPluginBuilder scanner code path.
+
+        [Fact]
+        public void BuilderScanner_DiscoversBothNewAndLegacyToolDecorations()
+        {
+            var plugin = new McpPluginBuilder(_version, _loggerProvider)
+                .AddLogging(b => b.AddXunitTestOutput(_output))
+                .WithTools(typeof(MixedAliasToolClass))
+                .Build(new Reflector());
+
+            var tools = plugin.McpManager.ToolManager!.GetAllTools().Select(t => t.Name).ToList();
+
+            tools.ShouldContain("alias-tool-new");
+            tools.ShouldContain("alias-tool-old");
+        }
+
+        [Fact]
+        public void BuilderScanner_DiscoversBothNewAndLegacyPromptDecorations()
+        {
+            var plugin = new McpPluginBuilder(_version, _loggerProvider)
+                .AddLogging(b => b.AddXunitTestOutput(_output))
+                .WithPrompts(typeof(MixedAliasPromptClass))
+                .Build(new Reflector());
+
+            var prompts = plugin.McpManager.PromptManager!.GetAllPrompts().Select(p => p.Name).ToList();
+
+            prompts.ShouldContain("alias-prompt-new");
+            prompts.ShouldContain("alias-prompt-old");
+        }
+
+        [Fact]
+        public void BuilderScanner_DiscoversBothNewAndLegacyResourceDecorations()
+        {
+            var plugin = new McpPluginBuilder(_version, _loggerProvider)
+                .AddLogging(b => b.AddXunitTestOutput(_output))
+                .WithResources(typeof(MixedAliasResourceClass))
+                .Build(new Reflector());
+
+            var routes = plugin.McpManager.ResourceManager!.GetAllResources().Select(r => r.Route).ToList();
+
+            routes.ShouldContain("test://alias-resource-new/{id}");
+            routes.ShouldContain("test://alias-resource-old/{id}");
+        }
+
+        [Fact]
+        public void BuilderScanner_DiscoversBothNewAndLegacySkillDecorations()
+        {
+            var builder = new McpPluginBuilder(_version, _loggerProvider);
+            builder
+                .AddLogging(b => b.AddXunitTestOutput(_output))
+                .WithSkills(typeof(MixedAliasSkillClass));
+            builder.Build(new Reflector());
+
+            var collection = builder.ServiceProvider!.GetRequiredService<SkillContentCollection>();
+            collection.ContainsKey("alias-skill-new").ShouldBeTrue();
+            collection.ContainsKey("alias-skill-old").ShouldBeTrue();
+        }
+    }
+}

--- a/McpPlugin.Tests/Mcp/AttributeAliasDiscoveryTests.cs
+++ b/McpPlugin.Tests/Mcp/AttributeAliasDiscoveryTests.cs
@@ -187,5 +187,95 @@ namespace com.IvanMurzak.McpPlugin.Tests.Mcp
             collection.ContainsKey("alias-skill-new").ShouldBeTrue();
             collection.ContainsKey("alias-skill-old").ShouldBeTrue();
         }
+
+        // ── Same-member dual-decoration regression tests.
+        //
+        // During a consumer's gradual migration from the legacy [McpPlugin*] aliases to the new
+        // canonical [Ai*] attributes, a member may temporarily carry BOTH attributes side by side.
+        // These tests lock in two properties of that scenario:
+        //
+        //   (a) Reflection lookups in the builder / scanner code path MUST NOT raise
+        //       AmbiguousMatchException — previously a real risk because the legacy [McpPlugin*]
+        //       subclasses both satisfy IsAssignableFrom(typeof(Ai*Attribute)), which trips the
+        //       SINGULAR generic GetCustomAttribute<T>() overload.
+        //
+        //   (b) The scanner MUST register the dual-decorated member EXACTLY ONCE per family, not
+        //       twice — otherwise the consumer would silently get duplicate runners for the same
+        //       method (whose Name property values may not even match each other, leading to two
+        //       distinct registrations with confusing names).
+        //
+        // We assert "registered count == 1" and "one of the declared names is present" rather
+        // than pinning to a specific name, since the implementation-defined order of
+        // GetCustomAttributes is not contractually guaranteed across .NET versions.
+
+        [Fact]
+        public void BuilderScanner_DualDecoratedTool_DoesNotThrowAndRegistersOnce()
+        {
+            var plugin = new McpPluginBuilder(_version, _loggerProvider)
+                .AddLogging(b => b.AddXunitTestOutput(_output))
+                .WithTools(typeof(DualDecoratedToolClass))
+                .Build(new Reflector());
+
+            var tools = plugin.McpManager.ToolManager!.GetAllTools().Select(t => t.Name).ToList();
+
+            // Exactly one registration for the dual-decorated method (NOT two).
+            var dualRegistrations = tools
+                .Where(n => n == "dual-decorated-tool" || n == "dual-decorated-tool-legacy")
+                .ToList();
+            dualRegistrations.Count.ShouldBe(1);
+        }
+
+        [Fact]
+        public void BuilderScanner_DualDecoratedPrompt_DoesNotThrowAndRegistersOnce()
+        {
+            var plugin = new McpPluginBuilder(_version, _loggerProvider)
+                .AddLogging(b => b.AddXunitTestOutput(_output))
+                .WithPrompts(typeof(DualDecoratedPromptClass))
+                .Build(new Reflector());
+
+            var prompts = plugin.McpManager.PromptManager!.GetAllPrompts().Select(p => p.Name).ToList();
+
+            var dualRegistrations = prompts
+                .Where(n => n == "dual-decorated-prompt" || n == "dual-decorated-prompt-legacy")
+                .ToList();
+            dualRegistrations.Count.ShouldBe(1);
+        }
+
+        [Fact]
+        public void BuilderScanner_DualDecoratedResource_DoesNotThrowAndRegistersOnce()
+        {
+            var plugin = new McpPluginBuilder(_version, _loggerProvider)
+                .AddLogging(b => b.AddXunitTestOutput(_output))
+                .WithResources(typeof(DualDecoratedResourceClass))
+                .Build(new Reflector());
+
+            var routes = plugin.McpManager.ResourceManager!.GetAllResources().Select(r => r.Route).ToList();
+
+            var dualRegistrations = routes
+                .Where(r => r == "test://dual-decorated-resource/{id}" || r == "test://dual-decorated-resource-legacy/{id}")
+                .ToList();
+            dualRegistrations.Count.ShouldBe(1);
+        }
+
+        [Fact]
+        public void BuilderScanner_DualDecoratedSkill_DoesNotThrowAndRegistersOnce()
+        {
+            var builder = new McpPluginBuilder(_version, _loggerProvider);
+            builder
+                .AddLogging(b => b.AddXunitTestOutput(_output))
+                .WithSkills(typeof(DualDecoratedSkillClass));
+            builder.Build(new Reflector());
+
+            var collection = builder.ServiceProvider!.GetRequiredService<SkillContentCollection>();
+
+            // The scanner reads the field exactly once and registers it under ONE name (whichever
+            // attribute instance the runtime returns first). The duplicate registration of the same
+            // const-string value under both names would throw a duplicate-key ArgumentException,
+            // so reaching this assertion at all proves single-registration semantics.
+            var hasNew = collection.ContainsKey("dual-decorated-skill");
+            var hasOld = collection.ContainsKey("dual-decorated-skill-legacy");
+            (hasNew ^ hasOld).ShouldBeTrue(
+                customMessage: "Dual-decorated skill field must be registered exactly once, not twice or zero times.");
+        }
     }
 }

--- a/McpPlugin.Tests/Mcp/McpBuilderTests_EnabledAttribute.cs
+++ b/McpPlugin.Tests/Mcp/McpBuilderTests_EnabledAttribute.cs
@@ -176,49 +176,49 @@ namespace com.IvanMurzak.McpPlugin.Tests.Mcp
         [Fact]
         public void ToolAttribute_EnabledNotSet_EnabledValueShouldBeNull()
         {
-            var attr = new McpPluginToolAttribute("test");
+            var attr = new AiToolAttribute("test");
             attr.EnabledValue.ShouldBeNull();
         }
 
         [Fact]
         public void ToolAttribute_EnabledSetTrue_EnabledValueShouldBeTrue()
         {
-            var attr = new McpPluginToolAttribute("test") { Enabled = true };
+            var attr = new AiToolAttribute("test") { Enabled = true };
             attr.EnabledValue.ShouldBe(true);
         }
 
         [Fact]
         public void ToolAttribute_EnabledSetFalse_EnabledValueShouldBeFalse()
         {
-            var attr = new McpPluginToolAttribute("test") { Enabled = false };
+            var attr = new AiToolAttribute("test") { Enabled = false };
             attr.EnabledValue.ShouldBe(false);
         }
 
         [Fact]
         public void PromptAttribute_EnabledNotSet_EnabledValueShouldBeNull()
         {
-            var attr = new McpPluginPromptAttribute();
+            var attr = new AiPromptAttribute();
             attr.EnabledValue.ShouldBeNull();
         }
 
         [Fact]
         public void PromptAttribute_EnabledSetFalse_EnabledValueShouldBeFalse()
         {
-            var attr = new McpPluginPromptAttribute { Enabled = false };
+            var attr = new AiPromptAttribute { Enabled = false };
             attr.EnabledValue.ShouldBe(false);
         }
 
         [Fact]
         public void ResourceAttribute_EnabledNotSet_EnabledValueShouldBeNull()
         {
-            var attr = new McpPluginResourceAttribute();
+            var attr = new AiResourceAttribute();
             attr.EnabledValue.ShouldBeNull();
         }
 
         [Fact]
         public void ResourceAttribute_EnabledSetFalse_EnabledValueShouldBeFalse()
         {
-            var attr = new McpPluginResourceAttribute { Enabled = false };
+            var attr = new AiResourceAttribute { Enabled = false };
             attr.EnabledValue.ShouldBe(false);
         }
 

--- a/McpPlugin.Tests/Mcp/McpBuilderTests_PromptEnumDefaultValue.cs
+++ b/McpPlugin.Tests/Mcp/McpBuilderTests_PromptEnumDefaultValue.cs
@@ -30,7 +30,7 @@ namespace com.IvanMurzak.McpPlugin.Tests.Mcp
 
     public class PromptMethod_EnumDefaultValue
     {
-        [McpPluginPrompt(Name = "test_prompt")]
+        [AiPrompt(Name = "test_prompt")]
         public string GetPrompt(PromptTestEnum? options = PromptTestEnum.OptionB)
         {
             return options?.ToString() ?? "null";

--- a/McpPlugin.Tests/Mcp/McpBuilderTests_SystemTools.cs
+++ b/McpPlugin.Tests/Mcp/McpBuilderTests_SystemTools.cs
@@ -50,14 +50,14 @@ namespace com.IvanMurzak.McpPlugin.Tests.Mcp
         [Fact]
         public void ToolAttribute_DefaultToolType_ShouldBeStandard()
         {
-            var attr = new McpPluginToolAttribute("test");
+            var attr = new AiToolAttribute("test");
             attr.ToolType.ShouldBe(McpToolType.Standard);
         }
 
         [Fact]
         public void ToolAttribute_ToolTypeSystem_ShouldBeSystem()
         {
-            var attr = new McpPluginToolAttribute("test") { ToolType = McpToolType.System };
+            var attr = new AiToolAttribute("test") { ToolType = McpToolType.System };
             attr.ToolType.ShouldBe(McpToolType.System);
         }
 

--- a/McpPlugin.Tests/Mcp/McpPluginSkillContentTests.cs
+++ b/McpPlugin.Tests/Mcp/McpPluginSkillContentTests.cs
@@ -140,7 +140,7 @@ namespace com.IvanMurzak.McpPlugin.Tests.Mcp
             collection.ContainsKey("disabled-prop").ShouldBeFalse();
         }
 
-        // ── WithSkillsFromAssembly discovers [McpPluginSkillType] classes ───
+        // ── WithSkillsFromAssembly discovers [AiSkillType] classes ───
 
         [Fact]
         public void WithSkillsFromAssembly_DiscoversAnnotatedSkillClasses()

--- a/McpPlugin/src/Mcp/McpSystemToolManager.cs
+++ b/McpPlugin/src/Mcp/McpSystemToolManager.cs
@@ -28,8 +28,8 @@ namespace com.IvanMurzak.McpPlugin
 {
     /// <summary>
     /// Manages system tools — internal tools available via HTTP API but NOT exposed to MCP clients.
-    /// System tools are discovered via <see cref="McpPluginToolAttribute"/> with
-    /// <see cref="McpPluginToolAttribute.ToolType"/> set to <see cref="McpToolType.System"/>.
+    /// System tools are discovered via <see cref="AiToolAttribute"/> with
+    /// <see cref="AiToolAttribute.ToolType"/> set to <see cref="McpToolType.System"/>.
     /// </summary>
     public class McpSystemToolManager : ISystemToolManager
     {

--- a/McpPlugin/src/Mcp/Prompt/RunPrompt.cs
+++ b/McpPlugin/src/Mcp/Prompt/RunPrompt.cs
@@ -74,19 +74,19 @@ namespace com.IvanMurzak.McpPlugin
         public RunPrompt(Reflector reflector, string name, ILogger? logger, MethodInfo methodInfo) : base(reflector, logger, methodInfo)
         {
             Name = name;
-            Role = methodInfo.GetCustomAttribute<McpPluginPromptAttribute>()?.Role ?? Role.User;
+            Role = methodInfo.GetCustomAttribute<AiPromptAttribute>()?.Role ?? Role.User;
         }
 
         public RunPrompt(Reflector reflector, string name, ILogger? logger, object targetInstance, MethodInfo methodInfo) : base(reflector, logger, targetInstance, methodInfo)
         {
             Name = name;
-            Role = methodInfo.GetCustomAttribute<McpPluginPromptAttribute>()?.Role ?? Role.User;
+            Role = methodInfo.GetCustomAttribute<AiPromptAttribute>()?.Role ?? Role.User;
         }
 
         public RunPrompt(Reflector reflector, string name, ILogger? logger, Type classType, MethodInfo methodInfo) : base(reflector, logger, classType, methodInfo)
         {
             Name = name;
-            Role = methodInfo.GetCustomAttribute<McpPluginPromptAttribute>()?.Role ?? Role.User;
+            Role = methodInfo.GetCustomAttribute<AiPromptAttribute>()?.Role ?? Role.User;
         }
 
         protected override object? GetParameterValue(Reflector reflector, ParameterInfo paramInfo, object? value)
@@ -213,7 +213,7 @@ namespace com.IvanMurzak.McpPlugin
 
                 return ResponseGetPrompt.Success(
                         result.ToString()!,
-                        role: Method.GetCustomAttribute<McpPluginPromptAttribute>()?.Role ?? Role.User,
+                        role: Method.GetCustomAttribute<AiPromptAttribute>()?.Role ?? Role.User,
                         description: description)
                     .SetRequestID(requestId);
             }

--- a/McpPlugin/src/Mcp/Prompt/RunPrompt.cs
+++ b/McpPlugin/src/Mcp/Prompt/RunPrompt.cs
@@ -74,20 +74,27 @@ namespace com.IvanMurzak.McpPlugin
         public RunPrompt(Reflector reflector, string name, ILogger? logger, MethodInfo methodInfo) : base(reflector, logger, methodInfo)
         {
             Name = name;
-            Role = methodInfo.GetCustomAttribute<AiPromptAttribute>()?.Role ?? Role.User;
+            Role = GetFirstAiPromptAttribute(methodInfo)?.Role ?? Role.User;
         }
 
         public RunPrompt(Reflector reflector, string name, ILogger? logger, object targetInstance, MethodInfo methodInfo) : base(reflector, logger, targetInstance, methodInfo)
         {
             Name = name;
-            Role = methodInfo.GetCustomAttribute<AiPromptAttribute>()?.Role ?? Role.User;
+            Role = GetFirstAiPromptAttribute(methodInfo)?.Role ?? Role.User;
         }
 
         public RunPrompt(Reflector reflector, string name, ILogger? logger, Type classType, MethodInfo methodInfo) : base(reflector, logger, classType, methodInfo)
         {
             Name = name;
-            Role = methodInfo.GetCustomAttribute<AiPromptAttribute>()?.Role ?? Role.User;
+            Role = GetFirstAiPromptAttribute(methodInfo)?.Role ?? Role.User;
         }
+
+        // Plural overload: tolerates methods carrying BOTH [AiPrompt] and the legacy [McpPluginPrompt]
+        // subclass alias without raising AmbiguousMatchException, returning the first instance found.
+        private static AiPromptAttribute? GetFirstAiPromptAttribute(MethodInfo methodInfo)
+            => methodInfo.GetCustomAttributes(typeof(AiPromptAttribute), inherit: false)
+                .Cast<AiPromptAttribute>()
+                .FirstOrDefault();
 
         protected override object? GetParameterValue(Reflector reflector, ParameterInfo paramInfo, object? value)
         {
@@ -213,7 +220,7 @@ namespace com.IvanMurzak.McpPlugin
 
                 return ResponseGetPrompt.Success(
                         result.ToString()!,
-                        role: Method.GetCustomAttribute<AiPromptAttribute>()?.Role ?? Role.User,
+                        role: GetFirstAiPromptAttribute(Method)?.Role ?? Role.User,
                         description: description)
                     .SetRequestID(requestId);
             }

--- a/McpPlugin/src/Mcp/Tool/IRunTool.cs
+++ b/McpPlugin/src/Mcp/Tool/IRunTool.cs
@@ -27,7 +27,7 @@ namespace com.IvanMurzak.McpPlugin
         /// Optional concise description used for the SKILL.md YAML <c>description:</c> field.
         /// When <see langword="null"/>, <see cref="Skills.SkillFileGenerator"/> falls back to <see cref="Description"/>
         /// (truncated to fit the YAML cap).
-        /// Sourced from <see cref="McpPluginSkillDescriptionAttribute"/> on the underlying method by default.
+        /// Sourced from <see cref="AiSkillDescriptionAttribute"/> on the underlying method by default.
         /// </summary>
         string? SkillDescription { get; }
 
@@ -35,7 +35,7 @@ namespace com.IvanMurzak.McpPlugin
         /// Optional long-form markdown injected into the SKILL.md body between the description paragraph
         /// and the <c>## How to Call</c> section. Lets tools ship rich content (code samples, notes) that
         /// would otherwise overflow the YAML <c>description:</c> cap.
-        /// Sourced from <see cref="McpPluginSkillBodyAttribute"/> on the underlying method by default.
+        /// Sourced from <see cref="AiSkillBodyAttribute"/> on the underlying method by default.
         /// </summary>
         string? SkillBody { get; }
 

--- a/McpPlugin/src/Mcp/Tool/RunTool.cs
+++ b/McpPlugin/src/Mcp/Tool/RunTool.cs
@@ -37,20 +37,20 @@ namespace com.IvanMurzak.McpPlugin
         public bool? OpenWorldHint { get; protected set; }
 
         /// <summary>
-        /// Reads <see cref="McpPluginSkillDescriptionAttribute"/> from the underlying method, if present.
+        /// Reads <see cref="AiSkillDescriptionAttribute"/> from the underlying method, if present.
         /// Used by <see cref="Skills.SkillFileGenerator"/> in place of <see cref="MethodWrapper.Description"/>
         /// when building the SKILL.md YAML <c>description:</c> field.
         /// </summary>
         public string? SkillDescription
-            => Method?.GetCustomAttribute<McpPluginSkillDescriptionAttribute>()?.Description;
+            => Method?.GetCustomAttribute<AiSkillDescriptionAttribute>()?.Description;
 
         /// <summary>
-        /// Reads <see cref="McpPluginSkillBodyAttribute"/> from the underlying method, if present.
+        /// Reads <see cref="AiSkillBodyAttribute"/> from the underlying method, if present.
         /// Used by <see cref="Skills.SkillFileGenerator"/> to inject long-form markdown into the SKILL.md body
         /// between the description paragraph and the <c>## How to Call</c> section.
         /// </summary>
         public string? SkillBody
-            => Method?.GetCustomAttribute<McpPluginSkillBodyAttribute>()?.Body;
+            => Method?.GetCustomAttribute<AiSkillBodyAttribute>()?.Body;
 
         public MethodInfo Method => _methodInfo;
 

--- a/McpPlugin/src/Mcp/Tool/RunTool.cs
+++ b/McpPlugin/src/Mcp/Tool/RunTool.cs
@@ -10,6 +10,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Text.Json;
 using System.Threading;
@@ -41,16 +42,31 @@ namespace com.IvanMurzak.McpPlugin
         /// Used by <see cref="Skills.SkillFileGenerator"/> in place of <see cref="MethodWrapper.Description"/>
         /// when building the SKILL.md YAML <c>description:</c> field.
         /// </summary>
+        /// <remarks>
+        /// Uses the plural <c>GetCustomAttributes</c> overload so that a method carrying BOTH
+        /// <see cref="AiSkillDescriptionAttribute"/> and the legacy
+        /// <see cref="McpPluginSkillDescriptionAttribute"/> subclass alias does not throw
+        /// <see cref="System.Reflection.AmbiguousMatchException"/>.
+        /// </remarks>
         public string? SkillDescription
-            => Method?.GetCustomAttribute<AiSkillDescriptionAttribute>()?.Description;
+            => Method?.GetCustomAttributes(typeof(AiSkillDescriptionAttribute), inherit: true)
+                .Cast<AiSkillDescriptionAttribute>()
+                .FirstOrDefault()?.Description;
 
         /// <summary>
         /// Reads <see cref="AiSkillBodyAttribute"/> from the underlying method, if present.
         /// Used by <see cref="Skills.SkillFileGenerator"/> to inject long-form markdown into the SKILL.md body
         /// between the description paragraph and the <c>## How to Call</c> section.
         /// </summary>
+        /// <remarks>
+        /// Uses the plural <c>GetCustomAttributes</c> overload so that a method carrying BOTH
+        /// <see cref="AiSkillBodyAttribute"/> and the legacy <see cref="McpPluginSkillBodyAttribute"/>
+        /// subclass alias does not throw <see cref="System.Reflection.AmbiguousMatchException"/>.
+        /// </remarks>
         public string? SkillBody
-            => Method?.GetCustomAttribute<AiSkillBodyAttribute>()?.Body;
+            => Method?.GetCustomAttributes(typeof(AiSkillBodyAttribute), inherit: true)
+                .Cast<AiSkillBodyAttribute>()
+                .FirstOrDefault()?.Body;
 
         public MethodInfo Method => _methodInfo;
 

--- a/McpPlugin/src/McpPlugin/Attribute/Prompt/AiPromptAttribute.cs
+++ b/McpPlugin/src/McpPlugin/Attribute/Prompt/AiPromptAttribute.cs
@@ -37,7 +37,5 @@ namespace com.IvanMurzak.McpPlugin
 
         /// <summary>Gets the Enabled value, or null if it was not explicitly set.</summary>
         public bool? EnabledValue => _enabledSet ? _enabled : null;
-
-        public AiPromptAttribute() { }
     }
 }

--- a/McpPlugin/src/McpPlugin/Attribute/Prompt/AiPromptAttribute.cs
+++ b/McpPlugin/src/McpPlugin/Attribute/Prompt/AiPromptAttribute.cs
@@ -9,23 +9,35 @@
 */
 
 using System;
-using System.Reflection;
+using com.IvanMurzak.McpPlugin.Common.Model;
 
 namespace com.IvanMurzak.McpPlugin
 {
-    public class ResourceMethodData
+    [AttributeUsage(AttributeTargets.Method)]
+    public class AiPromptAttribute : Attribute
     {
-        public Type ClassType { get; set; }
-        public MethodInfo GetContentMethod { get; set; }
-        public MethodInfo ListResourcesMethod { get; set; }
-        public AiResourceAttribute Attribute { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public Role Role { get; set; } = Role.User;
 
-        public ResourceMethodData(Type classType, MethodInfo getContentMethod, MethodInfo listResourcesMethod, AiResourceAttribute attribute)
+        // Not used for now
+        // public string? Title { get; set; }
+
+        private bool _enabled = true;
+        private bool _enabledSet;
+
+        /// <summary>
+        /// If set to false, the prompt will be disabled by default when first discovered.
+        /// When not set, the prompt defaults to enabled.
+        /// </summary>
+        public bool Enabled
         {
-            ClassType = classType;
-            GetContentMethod = getContentMethod;
-            ListResourcesMethod = listResourcesMethod;
-            Attribute = attribute;
+            get => _enabled;
+            set { _enabled = value; _enabledSet = true; }
         }
+
+        /// <summary>Gets the Enabled value, or null if it was not explicitly set.</summary>
+        public bool? EnabledValue => _enabledSet ? _enabled : null;
+
+        public AiPromptAttribute() { }
     }
 }

--- a/McpPlugin/src/McpPlugin/Attribute/Prompt/AiPromptTypeAttribute.cs
+++ b/McpPlugin/src/McpPlugin/Attribute/Prompt/AiPromptTypeAttribute.cs
@@ -8,18 +8,15 @@
 └────────────────────────────────────────────────────────────────────────┘
 */
 
-namespace com.IvanMurzak.McpPlugin.Tests.Data.Annotations
+using System;
+
+namespace com.IvanMurzak.McpPlugin
 {
-    [AiPromptType]
-    public static class AnnotatedPromptClass
+    [AttributeUsage(AttributeTargets.Class)]
+    public class AiPromptTypeAttribute : Attribute
     {
-        [AiPrompt(Name = "prompt-enabled-default")]
-        public static string EnabledDefault() => "default";
+        public string? Path { get; set; }
 
-        [AiPrompt(Name = "prompt-enabled-true", Enabled = true)]
-        public static string EnabledTrue() => "enabled";
-
-        [AiPrompt(Name = "prompt-enabled-false", Enabled = false)]
-        public static string EnabledFalse() => "disabled";
+        public AiPromptTypeAttribute() { }
     }
 }

--- a/McpPlugin/src/McpPlugin/Attribute/Prompt/AiPromptTypeAttribute.cs
+++ b/McpPlugin/src/McpPlugin/Attribute/Prompt/AiPromptTypeAttribute.cs
@@ -16,7 +16,5 @@ namespace com.IvanMurzak.McpPlugin
     public class AiPromptTypeAttribute : Attribute
     {
         public string? Path { get; set; }
-
-        public AiPromptTypeAttribute() { }
     }
 }

--- a/McpPlugin/src/McpPlugin/Attribute/Prompt/McpPluginPromptAttribute.cs
+++ b/McpPlugin/src/McpPlugin/Attribute/Prompt/McpPluginPromptAttribute.cs
@@ -9,35 +9,18 @@
 */
 
 using System;
-using com.IvanMurzak.McpPlugin.Common.Model;
 
 namespace com.IvanMurzak.McpPlugin
 {
+    /// <summary>
+    /// Deprecated alias for <see cref="AiPromptAttribute"/>. Kept as an
+    /// <see cref="ObsoleteAttribute"/>-marked subclass so existing decorations on consumer methods
+    /// continue to be discovered by reflection lookups for <see cref="AiPromptAttribute"/>.
+    /// </summary>
+    [Obsolete("Use [AiPrompt] instead. This alias will be removed in a future major release.")]
     [AttributeUsage(AttributeTargets.Method)]
-    public sealed class McpPluginPromptAttribute : Attribute
+    public sealed class McpPluginPromptAttribute : AiPromptAttribute
     {
-        public string Name { get; set; } = string.Empty;
-        public Role Role { get; set; } = Role.User;
-
-        // Not used for now
-        // public string? Title { get; set; }
-
-        private bool _enabled = true;
-        private bool _enabledSet;
-
-        /// <summary>
-        /// If set to false, the prompt will be disabled by default when first discovered.
-        /// When not set, the prompt defaults to enabled.
-        /// </summary>
-        public bool Enabled
-        {
-            get => _enabled;
-            set { _enabled = value; _enabledSet = true; }
-        }
-
-        /// <summary>Gets the Enabled value, or null if it was not explicitly set.</summary>
-        public bool? EnabledValue => _enabledSet ? _enabled : null;
-
         public McpPluginPromptAttribute() { }
     }
 }

--- a/McpPlugin/src/McpPlugin/Attribute/Prompt/McpPluginPromptTypeAttribute.cs
+++ b/McpPlugin/src/McpPlugin/Attribute/Prompt/McpPluginPromptTypeAttribute.cs
@@ -12,11 +12,15 @@ using System;
 
 namespace com.IvanMurzak.McpPlugin
 {
+    /// <summary>
+    /// Deprecated alias for <see cref="AiPromptTypeAttribute"/>. Kept as an
+    /// <see cref="ObsoleteAttribute"/>-marked subclass so existing decorations on consumer classes
+    /// continue to be discovered by reflection lookups for <see cref="AiPromptTypeAttribute"/>.
+    /// </summary>
+    [Obsolete("Use [AiPromptType] instead. This alias will be removed in a future major release.")]
     [AttributeUsage(AttributeTargets.Class)]
-    public sealed class McpPluginPromptTypeAttribute : Attribute
+    public sealed class McpPluginPromptTypeAttribute : AiPromptTypeAttribute
     {
-        public string? Path { get; set; }
-
         public McpPluginPromptTypeAttribute() { }
     }
 }

--- a/McpPlugin/src/McpPlugin/Attribute/Resources/AiResourceAttribute.cs
+++ b/McpPlugin/src/McpPlugin/Attribute/Resources/AiResourceAttribute.cs
@@ -12,15 +12,31 @@ using System;
 
 namespace com.IvanMurzak.McpPlugin
 {
-    /// <summary>
-    /// Deprecated alias for <see cref="AiResourceAttribute"/>. Kept as an
-    /// <see cref="ObsoleteAttribute"/>-marked subclass so existing decorations on consumer methods
-    /// continue to be discovered by reflection lookups for <see cref="AiResourceAttribute"/>.
-    /// </summary>
-    [Obsolete("Use [AiResource] instead. This alias will be removed in a future major release.")]
     [AttributeUsage(AttributeTargets.Method)]
-    public sealed class McpPluginResourceAttribute : AiResourceAttribute
+    public class AiResourceAttribute : Attribute
     {
-        public McpPluginResourceAttribute() { }
+        public string Route { get; set; } = string.Empty;
+        public string? Name { get; set; }
+        public string? Description { get; set; }
+        public string? MimeType { get; set; }
+        public string ListResources { get; set; } = string.Empty;
+
+        private bool _enabled = true;
+        private bool _enabledSet;
+
+        /// <summary>
+        /// If set to false, the resource will be disabled by default when first discovered.
+        /// When not set, the resource defaults to enabled.
+        /// </summary>
+        public bool Enabled
+        {
+            get => _enabled;
+            set { _enabled = value; _enabledSet = true; }
+        }
+
+        /// <summary>Gets the Enabled value, or null if it was not explicitly set.</summary>
+        public bool? EnabledValue => _enabledSet ? _enabled : null;
+
+        public AiResourceAttribute() { }
     }
 }

--- a/McpPlugin/src/McpPlugin/Attribute/Resources/AiResourceAttribute.cs
+++ b/McpPlugin/src/McpPlugin/Attribute/Resources/AiResourceAttribute.cs
@@ -36,7 +36,5 @@ namespace com.IvanMurzak.McpPlugin
 
         /// <summary>Gets the Enabled value, or null if it was not explicitly set.</summary>
         public bool? EnabledValue => _enabledSet ? _enabled : null;
-
-        public AiResourceAttribute() { }
     }
 }

--- a/McpPlugin/src/McpPlugin/Attribute/Resources/AiResourceTypeAttribute.cs
+++ b/McpPlugin/src/McpPlugin/Attribute/Resources/AiResourceTypeAttribute.cs
@@ -8,18 +8,15 @@
 └────────────────────────────────────────────────────────────────────────┘
 */
 
-namespace com.IvanMurzak.McpPlugin.Tests.Data.Annotations
+using System;
+
+namespace com.IvanMurzak.McpPlugin
 {
-    [AiPromptType]
-    public static class AnnotatedPromptClass
+    [AttributeUsage(AttributeTargets.Class)]
+    public class AiResourceTypeAttribute : Attribute
     {
-        [AiPrompt(Name = "prompt-enabled-default")]
-        public static string EnabledDefault() => "default";
+        public string? Path { get; set; }
 
-        [AiPrompt(Name = "prompt-enabled-true", Enabled = true)]
-        public static string EnabledTrue() => "enabled";
-
-        [AiPrompt(Name = "prompt-enabled-false", Enabled = false)]
-        public static string EnabledFalse() => "disabled";
+        public AiResourceTypeAttribute() { }
     }
 }

--- a/McpPlugin/src/McpPlugin/Attribute/Resources/AiResourceTypeAttribute.cs
+++ b/McpPlugin/src/McpPlugin/Attribute/Resources/AiResourceTypeAttribute.cs
@@ -16,7 +16,5 @@ namespace com.IvanMurzak.McpPlugin
     public class AiResourceTypeAttribute : Attribute
     {
         public string? Path { get; set; }
-
-        public AiResourceTypeAttribute() { }
     }
 }

--- a/McpPlugin/src/McpPlugin/Attribute/Resources/McpPluginResourceTypeAttribute.cs
+++ b/McpPlugin/src/McpPlugin/Attribute/Resources/McpPluginResourceTypeAttribute.cs
@@ -12,11 +12,15 @@ using System;
 
 namespace com.IvanMurzak.McpPlugin
 {
+    /// <summary>
+    /// Deprecated alias for <see cref="AiResourceTypeAttribute"/>. Kept as an
+    /// <see cref="ObsoleteAttribute"/>-marked subclass so existing decorations on consumer classes
+    /// continue to be discovered by reflection lookups for <see cref="AiResourceTypeAttribute"/>.
+    /// </summary>
+    [Obsolete("Use [AiResourceType] instead. This alias will be removed in a future major release.")]
     [AttributeUsage(AttributeTargets.Class)]
-    public sealed class McpPluginResourceTypeAttribute : Attribute
+    public sealed class McpPluginResourceTypeAttribute : AiResourceTypeAttribute
     {
-        public string? Path { get; set; }
-
         public McpPluginResourceTypeAttribute() { }
     }
 }

--- a/McpPlugin/src/McpPlugin/Attribute/Skill/AiSkillAttribute.cs
+++ b/McpPlugin/src/McpPlugin/Attribute/Skill/AiSkillAttribute.cs
@@ -1,0 +1,50 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+
+namespace com.IvanMurzak.McpPlugin
+{
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    public class AiSkillAttribute : Attribute
+    {
+        public string Name { get; set; }
+        public string? Description { get; set; }
+
+        /// <summary>
+        /// Optional concise description used for the SKILL.md YAML <c>description:</c> field when
+        /// <see cref="Description"/> would overflow the 1024-character cap. When <see langword="null"/>,
+        /// the generator falls back to <see cref="Description"/> (truncated to fit).
+        /// </summary>
+        public string? SkillDescription { get; set; }
+
+        private bool _enabled = true;
+        private bool _enabledSet;
+
+        /// <summary>
+        /// If set to false, the skill will be disabled by default when first discovered.
+        /// When not set, the skill defaults to enabled.
+        /// </summary>
+        public bool Enabled
+        {
+            get => _enabled;
+            set { _enabled = value; _enabledSet = true; }
+        }
+
+        /// <summary>Gets the Enabled value, or null if it was not explicitly set.</summary>
+        public bool? EnabledValue => _enabledSet ? _enabled : null;
+
+        public AiSkillAttribute(string name, string? description = null)
+        {
+            Name = name;
+            Description = description;
+        }
+    }
+}

--- a/McpPlugin/src/McpPlugin/Attribute/Skill/AiSkillTypeAttribute.cs
+++ b/McpPlugin/src/McpPlugin/Attribute/Skill/AiSkillTypeAttribute.cs
@@ -8,18 +8,13 @@
 └────────────────────────────────────────────────────────────────────────┘
 */
 
-namespace com.IvanMurzak.McpPlugin.Tests.Data.Annotations
+using System;
+
+namespace com.IvanMurzak.McpPlugin
 {
-    [AiPromptType]
-    public static class AnnotatedPromptClass
+    [AttributeUsage(AttributeTargets.Class)]
+    public class AiSkillTypeAttribute : Attribute
     {
-        [AiPrompt(Name = "prompt-enabled-default")]
-        public static string EnabledDefault() => "default";
-
-        [AiPrompt(Name = "prompt-enabled-true", Enabled = true)]
-        public static string EnabledTrue() => "enabled";
-
-        [AiPrompt(Name = "prompt-enabled-false", Enabled = false)]
-        public static string EnabledFalse() => "disabled";
+        public AiSkillTypeAttribute() { }
     }
 }

--- a/McpPlugin/src/McpPlugin/Attribute/Skill/AiSkillTypeAttribute.cs
+++ b/McpPlugin/src/McpPlugin/Attribute/Skill/AiSkillTypeAttribute.cs
@@ -15,6 +15,5 @@ namespace com.IvanMurzak.McpPlugin
     [AttributeUsage(AttributeTargets.Class)]
     public class AiSkillTypeAttribute : Attribute
     {
-        public AiSkillTypeAttribute() { }
     }
 }

--- a/McpPlugin/src/McpPlugin/Attribute/Skill/McpPluginSkillAttribute.cs
+++ b/McpPlugin/src/McpPlugin/Attribute/Skill/McpPluginSkillAttribute.cs
@@ -12,39 +12,18 @@ using System;
 
 namespace com.IvanMurzak.McpPlugin
 {
+    /// <summary>
+    /// Deprecated alias for <see cref="AiSkillAttribute"/>. Kept as an
+    /// <see cref="ObsoleteAttribute"/>-marked subclass so existing decorations on consumer fields/properties
+    /// continue to be discovered by reflection lookups for <see cref="AiSkillAttribute"/>.
+    /// </summary>
+    [Obsolete("Use [AiSkill] instead. This alias will be removed in a future major release.")]
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
-    public sealed class McpPluginSkillAttribute : Attribute
+    public sealed class McpPluginSkillAttribute : AiSkillAttribute
     {
-        public string Name { get; set; }
-        public string? Description { get; set; }
-
-        /// <summary>
-        /// Optional concise description used for the SKILL.md YAML <c>description:</c> field when
-        /// <see cref="Description"/> would overflow the 1024-character cap. When <see langword="null"/>,
-        /// the generator falls back to <see cref="Description"/> (truncated to fit).
-        /// </summary>
-        public string? SkillDescription { get; set; }
-
-        private bool _enabled = true;
-        private bool _enabledSet;
-
-        /// <summary>
-        /// If set to false, the skill will be disabled by default when first discovered.
-        /// When not set, the skill defaults to enabled.
-        /// </summary>
-        public bool Enabled
-        {
-            get => _enabled;
-            set { _enabled = value; _enabledSet = true; }
-        }
-
-        /// <summary>Gets the Enabled value, or null if it was not explicitly set.</summary>
-        public bool? EnabledValue => _enabledSet ? _enabled : null;
-
         public McpPluginSkillAttribute(string name, string? description = null)
+            : base(name, description)
         {
-            Name = name;
-            Description = description;
         }
     }
 }

--- a/McpPlugin/src/McpPlugin/Attribute/Skill/McpPluginSkillTypeAttribute.cs
+++ b/McpPlugin/src/McpPlugin/Attribute/Skill/McpPluginSkillTypeAttribute.cs
@@ -12,8 +12,14 @@ using System;
 
 namespace com.IvanMurzak.McpPlugin
 {
+    /// <summary>
+    /// Deprecated alias for <see cref="AiSkillTypeAttribute"/>. Kept as an
+    /// <see cref="ObsoleteAttribute"/>-marked subclass so existing decorations on consumer classes
+    /// continue to be discovered by reflection lookups for <see cref="AiSkillTypeAttribute"/>.
+    /// </summary>
+    [Obsolete("Use [AiSkillType] instead. This alias will be removed in a future major release.")]
     [AttributeUsage(AttributeTargets.Class)]
-    public sealed class McpPluginSkillTypeAttribute : Attribute
+    public sealed class McpPluginSkillTypeAttribute : AiSkillTypeAttribute
     {
         public McpPluginSkillTypeAttribute() { }
     }

--- a/McpPlugin/src/McpPlugin/Attribute/Tool/AiSkillBodyAttribute.cs
+++ b/McpPlugin/src/McpPlugin/Attribute/Tool/AiSkillBodyAttribute.cs
@@ -9,23 +9,27 @@
 */
 
 using System;
-using System.Reflection;
 
 namespace com.IvanMurzak.McpPlugin
 {
-    public class ResourceMethodData
+    /// <summary>
+    /// Provides long-form markdown that is injected into the SKILL.md body, between the description
+    /// paragraph and the <c>## How to Call</c> section. Use this to carry rich content (code samples,
+    /// usage notes, suggestions) that would otherwise blow past the 1024-character cap on the YAML
+    /// <c>description:</c> field.
+    /// <para>
+    /// This text is <b>not</b> written into the YAML front-matter and does <b>not</b> affect the MCP
+    /// <c>tools/list</c> payload — it only enriches the generated SKILL.md.
+    /// </para>
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
+    public class AiSkillBodyAttribute : Attribute
     {
-        public Type ClassType { get; set; }
-        public MethodInfo GetContentMethod { get; set; }
-        public MethodInfo ListResourcesMethod { get; set; }
-        public AiResourceAttribute Attribute { get; set; }
+        public string Body { get; }
 
-        public ResourceMethodData(Type classType, MethodInfo getContentMethod, MethodInfo listResourcesMethod, AiResourceAttribute attribute)
+        public AiSkillBodyAttribute(string body)
         {
-            ClassType = classType;
-            GetContentMethod = getContentMethod;
-            ListResourcesMethod = listResourcesMethod;
-            Attribute = attribute;
+            Body = body ?? string.Empty;
         }
     }
 }

--- a/McpPlugin/src/McpPlugin/Attribute/Tool/AiSkillDescriptionAttribute.cs
+++ b/McpPlugin/src/McpPlugin/Attribute/Tool/AiSkillDescriptionAttribute.cs
@@ -13,17 +13,23 @@ using System;
 namespace com.IvanMurzak.McpPlugin
 {
     /// <summary>
-    /// Deprecated alias for <see cref="AiSkillDescriptionAttribute"/>. Kept as an
-    /// <see cref="ObsoleteAttribute"/>-marked subclass so existing decorations continue to be
-    /// discovered by reflection lookups for <see cref="AiSkillDescriptionAttribute"/>.
+    /// Provides a concise text written into the SKILL.md YAML <c>description:</c> field.
+    /// The Skills file format used by Codex (and Anthropic Agent Skills) caps that field at 1024 characters,
+    /// so when a tool's <see cref="System.ComponentModel.DescriptionAttribute"/> is too long for the YAML
+    /// front-matter, decorate the same tool method with this attribute to provide a short summary.
+    /// <para>
+    /// The original <see cref="System.ComponentModel.DescriptionAttribute"/> remains the source of truth
+    /// for the MCP <c>tools/list</c> payload that AI agents see; this attribute only controls the YAML field.
+    /// </para>
     /// </summary>
-    [Obsolete("Use [AiSkillDescription] instead. This alias will be removed in a future major release.")]
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
-    public sealed class McpPluginSkillDescriptionAttribute : AiSkillDescriptionAttribute
+    public class AiSkillDescriptionAttribute : Attribute
     {
-        public McpPluginSkillDescriptionAttribute(string description)
-            : base(description)
+        public string Description { get; }
+
+        public AiSkillDescriptionAttribute(string description)
         {
+            Description = description ?? string.Empty;
         }
     }
 }

--- a/McpPlugin/src/McpPlugin/Attribute/Tool/AiToolAttribute.cs
+++ b/McpPlugin/src/McpPlugin/Attribute/Tool/AiToolAttribute.cs
@@ -1,0 +1,116 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+
+namespace com.IvanMurzak.McpPlugin
+{
+    [AttributeUsage(AttributeTargets.Method)]
+    public class AiToolAttribute : Attribute
+    {
+        public string Name { get; set; }
+        public string? Title { get; set; }
+
+        /// <summary>
+        /// The type of tool. Standard tools are exposed to MCP clients;
+        /// System tools are only available via the HTTP API.
+        /// Defaults to <see cref="McpToolType.Standard"/>.
+        /// </summary>
+        public McpToolType ToolType { get; set; } = McpToolType.Standard;
+
+        private bool _readOnlyHint;
+        private bool _readOnlyHintSet;
+
+        private bool _destructiveHint;
+        private bool _destructiveHintSet;
+
+        private bool _idempotentHint;
+        private bool _idempotentHintSet;
+
+        private bool _openWorldHint;
+        private bool _openWorldHintSet;
+
+        private bool _enabled = true;
+        private bool _enabledSet;
+
+        /// <summary>
+        /// If set to false, the tool will be disabled by default when first discovered.
+        /// When not set, the tool defaults to enabled.
+        /// </summary>
+        public bool Enabled
+        {
+            get => _enabled;
+            set { _enabled = value; _enabledSet = true; }
+        }
+
+        /// <summary>Gets the Enabled value, or null if it was not explicitly set.</summary>
+        public bool? EnabledValue => _enabledSet ? _enabled : null;
+
+        /// <summary>
+        /// If true, the tool only reads or queries data and does not modify system state.
+        /// When not set, null is passed to the MCP SDK, which will apply its own default.
+        /// </summary>
+        public bool ReadOnlyHint
+        {
+            get => _readOnlyHint;
+            set { _readOnlyHint = value; _readOnlyHintSet = true; }
+        }
+
+        /// <summary>
+        /// If true, the tool may perform destructive updates (e.g., deleting data, overwriting files).
+        /// When not set, null is passed to the MCP SDK, which will apply its own default.
+        /// </summary>
+        public bool DestructiveHint
+        {
+            get => _destructiveHint;
+            set { _destructiveHint = value; _destructiveHintSet = true; }
+        }
+
+        /// <summary>
+        /// If true, calling the tool multiple times with the same arguments will have no additional effect
+        /// on its environment beyond the first call.
+        /// When not set, null is passed to the MCP SDK, which will apply its own default.
+        /// </summary>
+        public bool IdempotentHint
+        {
+            get => _idempotentHint;
+            set { _idempotentHint = value; _idempotentHintSet = true; }
+        }
+
+        /// <summary>
+        /// If true, the tool may interact with an "open world" of external entities
+        /// (e.g., the web, external APIs, or real-world systems).
+        /// When not set, null is passed to the MCP SDK, which will apply its own default.
+        /// </summary>
+        public bool OpenWorldHint
+        {
+            get => _openWorldHint;
+            set { _openWorldHint = value; _openWorldHintSet = true; }
+        }
+
+        /// <summary>Gets the ReadOnlyHint value, or null if it was not explicitly set.</summary>
+        public bool? ReadOnlyHintValue => _readOnlyHintSet ? _readOnlyHint : null;
+
+        /// <summary>Gets the DestructiveHint value, or null if it was not explicitly set.</summary>
+        public bool? DestructiveHintValue => _destructiveHintSet ? _destructiveHint : null;
+
+        /// <summary>Gets the IdempotentHint value, or null if it was not explicitly set.</summary>
+        public bool? IdempotentHintValue => _idempotentHintSet ? _idempotentHint : null;
+
+        /// <summary>Gets the OpenWorldHint value, or null if it was not explicitly set.</summary>
+        public bool? OpenWorldHintValue => _openWorldHintSet ? _openWorldHint : null;
+
+        public AiToolAttribute(string name, string? title = null)
+        {
+            Name = name;
+            Title = title;
+        }
+    }
+}

--- a/McpPlugin/src/McpPlugin/Attribute/Tool/AiToolTypeAttribute.cs
+++ b/McpPlugin/src/McpPlugin/Attribute/Tool/AiToolTypeAttribute.cs
@@ -16,7 +16,5 @@ namespace com.IvanMurzak.McpPlugin
     public class AiToolTypeAttribute : Attribute
     {
         public string? Path { get; set; }
-
-        public AiToolTypeAttribute() { }
     }
 }

--- a/McpPlugin/src/McpPlugin/Attribute/Tool/AiToolTypeAttribute.cs
+++ b/McpPlugin/src/McpPlugin/Attribute/Tool/AiToolTypeAttribute.cs
@@ -8,18 +8,15 @@
 └────────────────────────────────────────────────────────────────────────┘
 */
 
-namespace com.IvanMurzak.McpPlugin.Tests.Data.Annotations
+using System;
+
+namespace com.IvanMurzak.McpPlugin
 {
-    [AiPromptType]
-    public static class AnnotatedPromptClass
+    [AttributeUsage(AttributeTargets.Class)]
+    public class AiToolTypeAttribute : Attribute
     {
-        [AiPrompt(Name = "prompt-enabled-default")]
-        public static string EnabledDefault() => "default";
+        public string? Path { get; set; }
 
-        [AiPrompt(Name = "prompt-enabled-true", Enabled = true)]
-        public static string EnabledTrue() => "enabled";
-
-        [AiPrompt(Name = "prompt-enabled-false", Enabled = false)]
-        public static string EnabledFalse() => "disabled";
+        public AiToolTypeAttribute() { }
     }
 }

--- a/McpPlugin/src/McpPlugin/Attribute/Tool/McpPluginSkillBodyAttribute.cs
+++ b/McpPlugin/src/McpPlugin/Attribute/Tool/McpPluginSkillBodyAttribute.cs
@@ -13,23 +13,17 @@ using System;
 namespace com.IvanMurzak.McpPlugin
 {
     /// <summary>
-    /// Provides long-form markdown that is injected into the SKILL.md body, between the description
-    /// paragraph and the <c>## How to Call</c> section. Use this to carry rich content (code samples,
-    /// usage notes, suggestions) that would otherwise blow past the 1024-character cap on the YAML
-    /// <c>description:</c> field.
-    /// <para>
-    /// This text is <b>not</b> written into the YAML front-matter and does <b>not</b> affect the MCP
-    /// <c>tools/list</c> payload — it only enriches the generated SKILL.md.
-    /// </para>
+    /// Deprecated alias for <see cref="AiSkillBodyAttribute"/>. Kept as an
+    /// <see cref="ObsoleteAttribute"/>-marked subclass so existing decorations continue to be
+    /// discovered by reflection lookups for <see cref="AiSkillBodyAttribute"/>.
     /// </summary>
+    [Obsolete("Use [AiSkillBody] instead. This alias will be removed in a future major release.")]
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
-    public sealed class McpPluginSkillBodyAttribute : Attribute
+    public sealed class McpPluginSkillBodyAttribute : AiSkillBodyAttribute
     {
-        public string Body { get; }
-
         public McpPluginSkillBodyAttribute(string body)
+            : base(body)
         {
-            Body = body ?? string.Empty;
         }
     }
 }

--- a/McpPlugin/src/McpPlugin/Attribute/Tool/McpPluginToolAttribute.cs
+++ b/McpPlugin/src/McpPlugin/Attribute/Tool/McpPluginToolAttribute.cs
@@ -12,105 +12,18 @@ using System;
 
 namespace com.IvanMurzak.McpPlugin
 {
+    /// <summary>
+    /// Deprecated alias for <see cref="AiToolAttribute"/>. Kept as an
+    /// <see cref="ObsoleteAttribute"/>-marked subclass so existing decorations on consumer methods
+    /// continue to be discovered by reflection lookups for <see cref="AiToolAttribute"/>.
+    /// </summary>
+    [Obsolete("Use [AiTool] instead. This alias will be removed in a future major release.")]
     [AttributeUsage(AttributeTargets.Method)]
-    public sealed class McpPluginToolAttribute : Attribute
+    public sealed class McpPluginToolAttribute : AiToolAttribute
     {
-        public string Name { get; set; }
-        public string? Title { get; set; }
-
-        /// <summary>
-        /// The type of tool. Standard tools are exposed to MCP clients;
-        /// System tools are only available via the HTTP API.
-        /// Defaults to <see cref="McpToolType.Standard"/>.
-        /// </summary>
-        public McpToolType ToolType { get; set; } = McpToolType.Standard;
-
-        private bool _readOnlyHint;
-        private bool _readOnlyHintSet;
-
-        private bool _destructiveHint;
-        private bool _destructiveHintSet;
-
-        private bool _idempotentHint;
-        private bool _idempotentHintSet;
-
-        private bool _openWorldHint;
-        private bool _openWorldHintSet;
-
-        private bool _enabled = true;
-        private bool _enabledSet;
-
-        /// <summary>
-        /// If set to false, the tool will be disabled by default when first discovered.
-        /// When not set, the tool defaults to enabled.
-        /// </summary>
-        public bool Enabled
-        {
-            get => _enabled;
-            set { _enabled = value; _enabledSet = true; }
-        }
-
-        /// <summary>Gets the Enabled value, or null if it was not explicitly set.</summary>
-        public bool? EnabledValue => _enabledSet ? _enabled : null;
-
-        /// <summary>
-        /// If true, the tool only reads or queries data and does not modify system state.
-        /// When not set, null is passed to the MCP SDK, which will apply its own default.
-        /// </summary>
-        public bool ReadOnlyHint
-        {
-            get => _readOnlyHint;
-            set { _readOnlyHint = value; _readOnlyHintSet = true; }
-        }
-
-        /// <summary>
-        /// If true, the tool may perform destructive updates (e.g., deleting data, overwriting files).
-        /// When not set, null is passed to the MCP SDK, which will apply its own default.
-        /// </summary>
-        public bool DestructiveHint
-        {
-            get => _destructiveHint;
-            set { _destructiveHint = value; _destructiveHintSet = true; }
-        }
-
-        /// <summary>
-        /// If true, calling the tool multiple times with the same arguments will have no additional effect
-        /// on its environment beyond the first call.
-        /// When not set, null is passed to the MCP SDK, which will apply its own default.
-        /// </summary>
-        public bool IdempotentHint
-        {
-            get => _idempotentHint;
-            set { _idempotentHint = value; _idempotentHintSet = true; }
-        }
-
-        /// <summary>
-        /// If true, the tool may interact with an "open world" of external entities
-        /// (e.g., the web, external APIs, or real-world systems).
-        /// When not set, null is passed to the MCP SDK, which will apply its own default.
-        /// </summary>
-        public bool OpenWorldHint
-        {
-            get => _openWorldHint;
-            set { _openWorldHint = value; _openWorldHintSet = true; }
-        }
-
-        /// <summary>Gets the ReadOnlyHint value, or null if it was not explicitly set.</summary>
-        public bool? ReadOnlyHintValue => _readOnlyHintSet ? _readOnlyHint : null;
-
-        /// <summary>Gets the DestructiveHint value, or null if it was not explicitly set.</summary>
-        public bool? DestructiveHintValue => _destructiveHintSet ? _destructiveHint : null;
-
-        /// <summary>Gets the IdempotentHint value, or null if it was not explicitly set.</summary>
-        public bool? IdempotentHintValue => _idempotentHintSet ? _idempotentHint : null;
-
-        /// <summary>Gets the OpenWorldHint value, or null if it was not explicitly set.</summary>
-        public bool? OpenWorldHintValue => _openWorldHintSet ? _openWorldHint : null;
-
         public McpPluginToolAttribute(string name, string? title = null)
+            : base(name, title)
         {
-            Name = name;
-            Title = title;
         }
     }
 }

--- a/McpPlugin/src/McpPlugin/Attribute/Tool/McpPluginToolTypeAttribute.cs
+++ b/McpPlugin/src/McpPlugin/Attribute/Tool/McpPluginToolTypeAttribute.cs
@@ -12,11 +12,15 @@ using System;
 
 namespace com.IvanMurzak.McpPlugin
 {
+    /// <summary>
+    /// Deprecated alias for <see cref="AiToolTypeAttribute"/>. Kept as an
+    /// <see cref="ObsoleteAttribute"/>-marked subclass so existing decorations on consumer classes
+    /// continue to be discovered by reflection lookups for <see cref="AiToolTypeAttribute"/>.
+    /// </summary>
+    [Obsolete("Use [AiToolType] instead. This alias will be removed in a future major release.")]
     [AttributeUsage(AttributeTargets.Class)]
-    public sealed class McpPluginToolTypeAttribute : Attribute
+    public sealed class McpPluginToolTypeAttribute : AiToolTypeAttribute
     {
-        public string? Path { get; set; }
-
         public McpPluginToolTypeAttribute() { }
     }
 }

--- a/McpPlugin/src/McpPlugin/Builder/Data/PromptMethodData.cs
+++ b/McpPlugin/src/McpPlugin/Builder/Data/PromptMethodData.cs
@@ -18,9 +18,9 @@ namespace com.IvanMurzak.McpPlugin
         public string Name => Attribute.Name;
         public Type ClassType { get; set; }
         public MethodInfo MethodInfo { get; set; }
-        public McpPluginPromptAttribute Attribute { get; set; }
+        public AiPromptAttribute Attribute { get; set; }
 
-        public PromptMethodData(Type classType, MethodInfo methodInfo, McpPluginPromptAttribute attribute)
+        public PromptMethodData(Type classType, MethodInfo methodInfo, AiPromptAttribute attribute)
         {
             ClassType = classType;
             MethodInfo = methodInfo;

--- a/McpPlugin/src/McpPlugin/Builder/Data/SkillMemberData.cs
+++ b/McpPlugin/src/McpPlugin/Builder/Data/SkillMemberData.cs
@@ -18,10 +18,10 @@ namespace com.IvanMurzak.McpPlugin
         public string Name => Attribute.Name;
         public Type ClassType { get; set; }
         public MemberInfo MemberInfo { get; set; }
-        public McpPluginSkillAttribute Attribute { get; set; }
+        public AiSkillAttribute Attribute { get; set; }
         public string Content { get; set; }
 
-        public SkillMemberData(Type classType, MemberInfo memberInfo, McpPluginSkillAttribute attribute, string content)
+        public SkillMemberData(Type classType, MemberInfo memberInfo, AiSkillAttribute attribute, string content)
         {
             ClassType = classType;
             MemberInfo = memberInfo;

--- a/McpPlugin/src/McpPlugin/Builder/Data/SystemToolRunnerCollection.cs
+++ b/McpPlugin/src/McpPlugin/Builder/Data/SystemToolRunnerCollection.cs
@@ -18,7 +18,7 @@ namespace com.IvanMurzak.McpPlugin
 {
     /// <summary>
     /// Collection of system tool runners — built from methods with
-    /// <see cref="McpPluginToolAttribute.ToolType"/> set to <see cref="McpToolType.System"/>.
+    /// <see cref="AiToolAttribute.ToolType"/> set to <see cref="McpToolType.System"/>.
     /// </summary>
     public class SystemToolRunnerCollection : Dictionary<string, IRunTool>
     {

--- a/McpPlugin/src/McpPlugin/Builder/Data/ToolMethodData.cs
+++ b/McpPlugin/src/McpPlugin/Builder/Data/ToolMethodData.cs
@@ -18,9 +18,9 @@ namespace com.IvanMurzak.McpPlugin
         public string Name => Attribute.Name;
         public Type ClassType { get; set; }
         public MethodInfo MethodInfo { get; set; }
-        public McpPluginToolAttribute Attribute { get; set; }
+        public AiToolAttribute Attribute { get; set; }
 
-        public ToolMethodData(Type classType, MethodInfo methodInfo, McpPluginToolAttribute attribute)
+        public ToolMethodData(Type classType, MethodInfo methodInfo, AiToolAttribute attribute)
         {
             ClassType = classType;
             MethodInfo = methodInfo;

--- a/McpPlugin/src/McpPlugin/Builder/IMcpPluginBuilder.cs
+++ b/McpPlugin/src/McpPlugin/Builder/IMcpPluginBuilder.cs
@@ -24,7 +24,7 @@ namespace com.IvanMurzak.McpPlugin
 
         // Tool methods
         IMcpPluginBuilder WithTool(Type classType, MethodInfo methodInfo);
-        IMcpPluginBuilder WithTool(McpPluginToolAttribute attribute, Type classType, MethodInfo methodInfo);
+        IMcpPluginBuilder WithTool(AiToolAttribute attribute, Type classType, MethodInfo methodInfo);
         IMcpPluginBuilder WithTool(string name, string? title, Type classType, MethodInfo methodInfo);
         IMcpPluginBuilder AddTool(string name, IRunTool runner);
         IMcpPluginBuilder WithTools<T>();

--- a/McpPlugin/src/McpPlugin/Builder/McpPluginBuilder.AttributeScanner.cs
+++ b/McpPlugin/src/McpPlugin/Builder/McpPluginBuilder.AttributeScanner.cs
@@ -59,10 +59,10 @@ namespace com.IvanMurzak.McpPlugin
                         continue;
 
                     // Use IsDefined for fast check before GetCustomAttribute
-                    var hasToolTypeAttr = isToolAssembly && Attribute.IsDefined(type, typeof(McpPluginToolTypeAttribute));
-                    var hasPromptTypeAttr = isPromptAssembly && Attribute.IsDefined(type, typeof(McpPluginPromptTypeAttribute));
-                    var hasResourceTypeAttr = isResourceAssembly && Attribute.IsDefined(type, typeof(McpPluginResourceTypeAttribute));
-                    var hasSkillTypeAttr = isSkillAssembly && Attribute.IsDefined(type, typeof(McpPluginSkillTypeAttribute));
+                    var hasToolTypeAttr = isToolAssembly && Attribute.IsDefined(type, typeof(AiToolTypeAttribute));
+                    var hasPromptTypeAttr = isPromptAssembly && Attribute.IsDefined(type, typeof(AiPromptTypeAttribute));
+                    var hasResourceTypeAttr = isResourceAssembly && Attribute.IsDefined(type, typeof(AiResourceTypeAttribute));
+                    var hasSkillTypeAttr = isSkillAssembly && Attribute.IsDefined(type, typeof(AiSkillTypeAttribute));
 
                     if (!hasToolTypeAttr && !hasPromptTypeAttr && !hasResourceTypeAttr && !hasSkillTypeAttr)
                         continue;
@@ -145,19 +145,19 @@ namespace com.IvanMurzak.McpPlugin
                 // Single pass through attributes
                 foreach (var attr in attributes)
                 {
-                    if (processTool && attr is McpPluginToolAttribute toolAttr)
+                    if (processTool && attr is AiToolAttribute toolAttr)
                     {
                         if (string.IsNullOrEmpty(toolAttr.Name))
                             throw new ArgumentException($"Tool name cannot be null or empty. Type: {type.Name}, Method: {method.Name}");
                         WithTool(toolAttr, classType: type, methodInfo: method);
                     }
-                    else if (processPrompt && attr is McpPluginPromptAttribute promptAttr)
+                    else if (processPrompt && attr is AiPromptAttribute promptAttr)
                     {
                         if (string.IsNullOrEmpty(promptAttr.Name))
                             throw new ArgumentException($"Prompt name cannot be null or empty. Type: {type.Name}, Method: {method.Name}");
                         WithPrompt(name: promptAttr.Name, classType: type, methodInfo: method);
                     }
-                    else if (processResource && attr is McpPluginResourceAttribute)
+                    else if (processResource && attr is AiResourceAttribute)
                     {
                         WithResource(classType: type, getContentMethod: method);
                     }
@@ -170,13 +170,13 @@ namespace com.IvanMurzak.McpPlugin
             // Scan const string fields
             foreach (var field in type.GetFields(FieldBindingFlags))
             {
-                var skillAttr = field.GetCustomAttribute<McpPluginSkillAttribute>();
+                var skillAttr = field.GetCustomAttribute<AiSkillAttribute>();
                 if (skillAttr == null)
                     continue;
 
                 if (!field.IsLiteral || field.FieldType != typeof(string))
                     throw new ArgumentException(
-                        $"Field '{field.Name}' in type '{type.Name}' has [McpPluginSkill] but is not a const string. " +
+                        $"Field '{field.Name}' in type '{type.Name}' has [AiSkill] but is not a const string. " +
                         "Only const string fields and static string properties are supported.");
 
                 if (string.IsNullOrEmpty(skillAttr.Name))
@@ -201,19 +201,19 @@ namespace com.IvanMurzak.McpPlugin
             // Scan static string properties
             foreach (var property in type.GetProperties(FieldBindingFlags))
             {
-                var skillAttr = property.GetCustomAttribute<McpPluginSkillAttribute>();
+                var skillAttr = property.GetCustomAttribute<AiSkillAttribute>();
                 if (skillAttr == null)
                     continue;
 
                 if (property.PropertyType != typeof(string))
                     throw new ArgumentException(
-                        $"Property '{property.Name}' in type '{type.Name}' has [McpPluginSkill] but is not a string property. " +
+                        $"Property '{property.Name}' in type '{type.Name}' has [AiSkill] but is not a string property. " +
                         "Only const string fields and static string properties are supported.");
 
                 var getter = property.GetGetMethod(nonPublic: true);
                 if (getter == null || !getter.IsStatic)
                     throw new ArgumentException(
-                        $"Property '{property.Name}' in type '{type.Name}' has [McpPluginSkill] but is not a static property with a getter. " +
+                        $"Property '{property.Name}' in type '{type.Name}' has [AiSkill] but is not a static property with a getter. " +
                         "Only const string fields and static string properties are supported.");
 
                 if (string.IsNullOrEmpty(skillAttr.Name))

--- a/McpPlugin/src/McpPlugin/Builder/McpPluginBuilder.AttributeScanner.cs
+++ b/McpPlugin/src/McpPlugin/Builder/McpPluginBuilder.AttributeScanner.cs
@@ -10,6 +10,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using com.IvanMurzak.ReflectorNet.Utils;
 
@@ -139,25 +140,46 @@ namespace com.IvanMurzak.McpPlugin
         {
             foreach (var method in type.GetMethods(MethodBindingFlags))
             {
-                // Batch: get all custom attributes once per method
-                var attributes = method.GetCustomAttributes(inherit: false);
-
-                // Single pass through attributes
-                foreach (var attr in attributes)
+                // Per-family lookup: fetch AT MOST ONE attribute per family per method, even if
+                // the method carries multiple instances (e.g. both [AiTool] and the legacy
+                // [McpPluginTool] subclass alias during a consumer migration). The non-generic
+                // GetCustomAttributes(Type, inherit) overload does NOT throw on multiple matches,
+                // unlike the singular generic GetCustomAttribute<T>() which would raise
+                // AmbiguousMatchException in that scenario. Picking FirstOrDefault deterministically
+                // registers the method exactly once per family — preventing duplicate-registration
+                // errors when consumers gradually swap [McpPlugin*] → [Ai*].
+                if (processTool)
                 {
-                    if (processTool && attr is AiToolAttribute toolAttr)
+                    var toolAttr = method.GetCustomAttributes(typeof(AiToolAttribute), inherit: false)
+                        .Cast<AiToolAttribute>()
+                        .FirstOrDefault();
+                    if (toolAttr != null)
                     {
                         if (string.IsNullOrEmpty(toolAttr.Name))
                             throw new ArgumentException($"Tool name cannot be null or empty. Type: {type.Name}, Method: {method.Name}");
                         WithTool(toolAttr, classType: type, methodInfo: method);
                     }
-                    else if (processPrompt && attr is AiPromptAttribute promptAttr)
+                }
+
+                if (processPrompt)
+                {
+                    var promptAttr = method.GetCustomAttributes(typeof(AiPromptAttribute), inherit: false)
+                        .Cast<AiPromptAttribute>()
+                        .FirstOrDefault();
+                    if (promptAttr != null)
                     {
                         if (string.IsNullOrEmpty(promptAttr.Name))
                             throw new ArgumentException($"Prompt name cannot be null or empty. Type: {type.Name}, Method: {method.Name}");
                         WithPrompt(name: promptAttr.Name, classType: type, methodInfo: method);
                     }
-                    else if (processResource && attr is AiResourceAttribute)
+                }
+
+                if (processResource)
+                {
+                    var resourceAttr = method.GetCustomAttributes(typeof(AiResourceAttribute), inherit: false)
+                        .Cast<AiResourceAttribute>()
+                        .FirstOrDefault();
+                    if (resourceAttr != null)
                     {
                         WithResource(classType: type, getContentMethod: method);
                     }
@@ -170,7 +192,11 @@ namespace com.IvanMurzak.McpPlugin
             // Scan const string fields
             foreach (var field in type.GetFields(FieldBindingFlags))
             {
-                var skillAttr = field.GetCustomAttribute<AiSkillAttribute>();
+                // Plural overload: tolerates members carrying BOTH [AiSkill] and the legacy
+                // [McpPluginSkill] subclass alias without raising AmbiguousMatchException.
+                var skillAttr = field.GetCustomAttributes(typeof(AiSkillAttribute), inherit: true)
+                    .Cast<AiSkillAttribute>()
+                    .FirstOrDefault();
                 if (skillAttr == null)
                     continue;
 
@@ -201,7 +227,10 @@ namespace com.IvanMurzak.McpPlugin
             // Scan static string properties
             foreach (var property in type.GetProperties(FieldBindingFlags))
             {
-                var skillAttr = property.GetCustomAttribute<AiSkillAttribute>();
+                // Plural overload: see field-scan comment above.
+                var skillAttr = property.GetCustomAttributes(typeof(AiSkillAttribute), inherit: true)
+                    .Cast<AiSkillAttribute>()
+                    .FirstOrDefault();
                 if (skillAttr == null)
                     continue;
 

--- a/McpPlugin/src/McpPlugin/Builder/McpPluginBuilder.cs
+++ b/McpPlugin/src/McpPlugin/Builder/McpPluginBuilder.cs
@@ -104,23 +104,23 @@ namespace com.IvanMurzak.McpPlugin
         {
             ThrowIfBuilt();
 
-            var attribute = methodInfo.GetCustomAttribute<McpPluginToolAttribute>();
+            var attribute = methodInfo.GetCustomAttribute<AiToolAttribute>();
             return WithTool(attribute!, classType, methodInfo);
         }
         public virtual IMcpPluginBuilder WithTool(string name, string? title, Type classType, MethodInfo methodInfo)
         {
             ThrowIfBuilt();
 
-            var attribute = new McpPluginToolAttribute(name, title);
+            var attribute = new AiToolAttribute(name, title);
             return WithTool(attribute, classType, methodInfo);
         }
-        public virtual IMcpPluginBuilder WithTool(McpPluginToolAttribute attribute, Type classType, MethodInfo methodInfo)
+        public virtual IMcpPluginBuilder WithTool(AiToolAttribute attribute, Type classType, MethodInfo methodInfo)
         {
             ThrowIfBuilt();
 
             if (attribute == null)
             {
-                _logger?.LogWarning($"Method {classType.FullName}{methodInfo.Name} does not have a '{nameof(McpPluginToolAttribute)}'.");
+                _logger?.LogWarning($"Method {classType.FullName}{methodInfo.Name} does not have a '{nameof(AiToolAttribute)}'.");
                 return this;
             }
 
@@ -152,10 +152,10 @@ namespace com.IvanMurzak.McpPlugin
         {
             ThrowIfBuilt();
 
-            var attribute = methodInfo.GetCustomAttribute<McpPluginPromptAttribute>();
+            var attribute = methodInfo.GetCustomAttribute<AiPromptAttribute>();
             if (attribute == null)
             {
-                _logger?.LogWarning($"Method {classType.FullName}{methodInfo.Name} does not have a '{nameof(McpPluginPromptAttribute)}'.");
+                _logger?.LogWarning($"Method {classType.FullName}{methodInfo.Name} does not have a '{nameof(AiPromptAttribute)}'.");
                 return this;
             }
 
@@ -187,10 +187,10 @@ namespace com.IvanMurzak.McpPlugin
         {
             ThrowIfBuilt();
 
-            var attribute = getContentMethod.GetCustomAttribute<McpPluginResourceAttribute>();
+            var attribute = getContentMethod.GetCustomAttribute<AiResourceAttribute>();
             if (attribute == null)
             {
-                _logger?.LogWarning($"Method {classType.FullName}{getContentMethod.Name} does not have a '{nameof(McpPluginResourceAttribute)}'.");
+                _logger?.LogWarning($"Method {classType.FullName}{getContentMethod.Name} does not have a '{nameof(AiResourceAttribute)}'.");
                 return this;
             }
 

--- a/McpPlugin/src/McpPlugin/Builder/McpPluginBuilder.cs
+++ b/McpPlugin/src/McpPlugin/Builder/McpPluginBuilder.cs
@@ -104,7 +104,11 @@ namespace com.IvanMurzak.McpPlugin
         {
             ThrowIfBuilt();
 
-            var attribute = methodInfo.GetCustomAttribute<AiToolAttribute>();
+            // Plural overload: tolerates methods carrying BOTH [AiTool] and the legacy [McpPluginTool]
+            // subclass alias without raising AmbiguousMatchException.
+            var attribute = methodInfo.GetCustomAttributes(typeof(AiToolAttribute), inherit: false)
+                .Cast<AiToolAttribute>()
+                .FirstOrDefault();
             return WithTool(attribute!, classType, methodInfo);
         }
         public virtual IMcpPluginBuilder WithTool(string name, string? title, Type classType, MethodInfo methodInfo)
@@ -152,7 +156,11 @@ namespace com.IvanMurzak.McpPlugin
         {
             ThrowIfBuilt();
 
-            var attribute = methodInfo.GetCustomAttribute<AiPromptAttribute>();
+            // Plural overload: tolerates methods carrying BOTH [AiPrompt] and the legacy [McpPluginPrompt]
+            // subclass alias without raising AmbiguousMatchException.
+            var attribute = methodInfo.GetCustomAttributes(typeof(AiPromptAttribute), inherit: false)
+                .Cast<AiPromptAttribute>()
+                .FirstOrDefault();
             if (attribute == null)
             {
                 _logger?.LogWarning($"Method {classType.FullName}{methodInfo.Name} does not have a '{nameof(AiPromptAttribute)}'.");
@@ -187,7 +195,11 @@ namespace com.IvanMurzak.McpPlugin
         {
             ThrowIfBuilt();
 
-            var attribute = getContentMethod.GetCustomAttribute<AiResourceAttribute>();
+            // Plural overload: tolerates methods carrying BOTH [AiResource] and the legacy [McpPluginResource]
+            // subclass alias without raising AmbiguousMatchException.
+            var attribute = getContentMethod.GetCustomAttributes(typeof(AiResourceAttribute), inherit: false)
+                .Cast<AiResourceAttribute>()
+                .FirstOrDefault();
             if (attribute == null)
             {
                 _logger?.LogWarning($"Method {classType.FullName}{getContentMethod.Name} does not have a '{nameof(AiResourceAttribute)}'.");

--- a/McpPlugin/src/McpPlugin/Skills/SkillFileGenerator.cs
+++ b/McpPlugin/src/McpPlugin/Skills/SkillFileGenerator.cs
@@ -1174,8 +1174,8 @@ namespace com.IvanMurzak.McpPlugin.Skills
             {
                 _logger?.LogWarning(
                     "{class}: Description for '{name}' is {len} chars, exceeding the YAML cap of {cap}. " +
-                    "Truncating for SKILL.md; consider adding [McpPluginSkillDescription] for a concise summary " +
-                    "and [McpPluginSkillBody] for long-form content.",
+                    "Truncating for SKILL.md; consider adding [AiSkillDescription] for a concise summary " +
+                    "and [AiSkillBody] for long-form content.",
                     nameof(SkillFileGenerator), toolOrSkillName, fullDescription.Length, cap);
                 return TruncateForYaml(fullDescription, cap);
             }

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Add the `com.IvanMurzak.McpPlugin` package to your .NET application.
 
 ```csharp
 using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.McpPlugin.Common.Model;
 using System.ComponentModel;
 
 [AiToolType]
@@ -150,9 +151,11 @@ public static class MyMcpComponents
 
     // --- Resources ---
     [AiResource(Route = "logs://system", Name = "system-logs", Description = "Returns the latest system logs", ListResources = nameof(ListLogs))]
-    public static string GetLogs() => "Log entry 1: System started...";
+    public static ResponseResourceContent[] GetLogs()
+        => new[] { ResponseResourceContent.CreateText("logs://system", "Log entry 1: System started...") };
 
-    public static string[] ListLogs() => new[] { "logs://system" };
+    public static ResponseListResource[] ListLogs()
+        => new[] { new ResponseListResource("logs://system", "system-logs") };
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ graph LR
 
 ## Features
 
-- **Attribute-Based Registration**: Easily expose tools, prompts, and resources using `[McpPluginTool]`, `[McpPluginPrompt]`, and `[McpPluginResource]` attributes.
+- **Attribute-Based Registration**: Easily expose tools, prompts, and resources using `[AiTool]`, `[AiPrompt]`, and `[AiResource]` attributes. (The legacy `[McpPluginTool]`, `[McpPluginPrompt]`, `[McpPluginResource]` names remain available as `[Obsolete]` aliases for backward compatibility.)
 - **Powered by ReflectorNet**:
   - **Complex Type Support**: Seamlessly handle nested objects, collections, and custom types in tool parameters.
   - **Fuzzy Matching**: AI can find and call methods even with partial names or slightly mismatched signatures.
@@ -136,21 +136,23 @@ Add the `com.IvanMurzak.McpPlugin` package to your .NET application.
 using com.IvanMurzak.McpPlugin;
 using System.ComponentModel;
 
-[McpPluginToolType]
+[AiToolType]
 public static class MyMcpComponents
 {
     // --- Tools ---
-    [McpPluginTool("calculate-sum", "Adds two numbers")]
+    [AiTool("calculate-sum", "Adds two numbers")]
     [Description("Adds two numbers")]
     public static int Add(int a, int b) => a + b;
 
     // --- Prompts ---
-    [McpPluginPrompt("explain-code", "Explains a piece of code")]
+    [AiPrompt(Name = "explain-code")]
     public static string ExplainCode(string code) => $"The following code: {code} does X, Y, and Z.";
 
     // --- Resources ---
-    [McpPluginResource("system-logs", "Returns the latest system logs", "logs://system")]
+    [AiResource(Route = "logs://system", Name = "system-logs", Description = "Returns the latest system logs", ListResources = nameof(ListLogs))]
     public static string GetLogs() => "Log entry 1: System started...";
+
+    public static string[] ListLogs() => new[] { "logs://system" };
 }
 ```
 
@@ -173,7 +175,7 @@ var plugin = new McpPluginBuilder(version)
     .WithConfig(config => {
         config.Host = "http://localhost:11111"; // Match your server port
     })
-    // Option A: Scan assemblies for [McpPluginTool], [McpPluginPrompt], [McpPluginResource]
+    // Option A: Scan assemblies for [AiTool], [AiPrompt], [AiResource]
     .WithToolsFromAssembly(typeof(MyMcpComponents).Assembly)
     .WithPromptsFromAssembly(typeof(MyMcpComponents).Assembly)
     .WithResourcesFromAssembly(typeof(MyMcpComponents).Assembly)
@@ -195,7 +197,7 @@ public class UserProfile {
     public List<string> Roles { get; set; }
 }
 
-[McpPluginTool("update-user")]
+[AiTool("update-user")]
 public static void UpdateUser(UserProfile profile) {
     // ReflectorNet automatically deserializes the JSON from the AI into this object
 }

--- a/docs/claude/patterns.md
+++ b/docs/claude/patterns.md
@@ -16,10 +16,12 @@ new McpPluginBuilder(version)
 
 ### Attribute-based component registration
 ```csharp
-[McpPluginToolType]
+[AiToolType]
 public static class MyTools
 {
-    [McpPluginTool("add", "Adds two numbers")]
+    [AiTool("add", "Adds two numbers")]
     public static int Add(int a, int b) => a + b;
 }
 ```
+
+The legacy `[McpPluginToolType]` / `[McpPluginTool]` / `[McpPluginPrompt]` / `[McpPluginResource]` / `[McpPluginSkill]` names remain available as `[Obsolete]` subclass aliases of the new `[Ai*]` types, so existing consumer code continues to compile (with a deprecation warning) until callers migrate to the new names.


### PR DESCRIPTION
## Summary

- Renames the McpPlugin*-prefixed reflection attribute classes (10 total) to a shorter, protocol-agnostic `[Ai*]` prefix.
- Keeps the original class names at their original file paths as `[Obsolete]`-marked subclasses of the new canonical types, so existing consumer code (Unity-MCP, extensions, downstream NuGet consumers) continues to compile against the next package release with deprecation warnings while consumers migrate.
- Internal repo usages (DemoConsoleApp, all `McpPlugin.Tests` fixtures, README, docs/claude, constitution.md) switched to the new `[Ai*]` names — `dotnet build` emits zero `[Obsolete]` warnings on in-repo code; the warnings are reserved for external consumers.

## Rename map

The new class is canonical; the old class is the `[Obsolete]` subclass alias preserving its original file path and class name.

| Old (now `[Obsolete]` alias) | New (canonical) |
| --- | --- |
| `McpPluginToolAttribute` | `AiToolAttribute` |
| `McpPluginToolTypeAttribute` | `AiToolTypeAttribute` |
| `McpPluginPromptAttribute` | `AiPromptAttribute` |
| `McpPluginPromptTypeAttribute` | `AiPromptTypeAttribute` |
| `McpPluginResourceAttribute` | `AiResourceAttribute` |
| `McpPluginResourceTypeAttribute` | `AiResourceTypeAttribute` |
| `McpPluginSkillAttribute` | `AiSkillAttribute` |
| `McpPluginSkillTypeAttribute` | `AiSkillTypeAttribute` |
| `McpPluginSkillBodyAttribute` | `AiSkillBodyAttribute` |
| `McpPluginSkillDescriptionAttribute` | `AiSkillDescriptionAttribute` |

Note: the issue's rename map listed `McpPluginPromptArgumentAttribute` (which does not exist in the current repo layout) and did not name the three Skill* siblings (`McpPluginSkillTypeAttribute`, `McpPluginSkillBodyAttribute`, `McpPluginSkillDescriptionAttribute`). Following the issue's "Verify and adjust during implementation if the layout has drifted" guidance and to keep the family consistent, this PR renames the 10 actual `McpPlugin*Attribute` classes found in the repo. `McpPluginPromptArgumentAttribute` is intentionally NOT added — it has no current decoration sites.

## Why subclass alias (not `using` alias, not `[AssemblyMetadata]`, not delete)

The orchestrator decided the subclass approach because it:
- Preserves wire-compat across NuGet — `[McpPluginTool]` decorations in already-shipped consumer DLLs keep being discovered via inheritance, since `GetCustomAttribute<AiToolAttribute>()` matches base-type instances.
- Keeps the old class as a real type, so it works in C# generic constraints and in C# attribute syntax (a `using` alias would not survive the type system).
- Lets `[Obsolete]` warnings propagate to consumer source naturally, encouraging migration without breaking the build.
- Survives the type-resolution path that `[AssemblyMetadata]`-style markers cannot.

## Reflection / scanner updates

`McpPluginBuilder` and its `AttributeScanner` partial now query the new canonical attribute types. Because each old class extends its new counterpart, the scanner discovers BOTH legacy and new-style decorations correctly. Public surface that referenced the old types (e.g. `IMcpPluginBuilder.WithTool(McpPluginToolAttribute, ...)`, the `Attribute` property on `ToolMethodData` / `PromptMethodData` / `ResourceMethodData` / `SkillMemberData`) now references the new canonical types; consumers passing instances of the old `[Obsolete]` subclasses still satisfy the new parameter type via inheritance.

## Test plan

- [x] `dotnet restore` succeeded.
- [x] `dotnet build --no-restore --configuration Release` — 0 errors, 0 warnings on in-repo code.
- [x] `dotnet test --no-build --configuration Release` — 405/405 passed across `McpPlugin.Tests` + `McpPlugin.Server.Tests` on both `net8.0` and `net9.0`.
- [x] New scanner-discovery fixture `AttributeAliasDiscoveryTests` (8 tests) proves discovery parity for `AiTool` / `AiPrompt` / `AiResource` / `AiSkill` via both direct reflection (`GetCustomAttribute<AiToolAttribute>()` etc.) AND end-to-end through the actual `McpPluginBuilder` scanner. The fixture file (`MixedAliasAttributeClass.cs`) is the only place a legacy `[McpPlugin*]` decoration intentionally lives, with file-scoped `#pragma warning disable CS0618` so the rest of the repo stays warning-free.

Closes #111