### PR TITLE
fix: raise SignalR transport limits so large tool results aren't dropped

### DIFF
--- a/McpPlugin.Server/src/Extension/ExtensionsMcpServerBuilder.cs
+++ b/McpPlugin.Server/src/Extension/ExtensionsMcpServerBuilder.cs
@@ -49,7 +49,12 @@ namespace com.IvanMurzak.McpPlugin.Server
             signalRConfigure ??= configure =>
             {
                 configure.EnableDetailedErrors = false;
-                configure.MaximumReceiveMessageSize = 1024 * 1024 * 4; // 4 MB
+                // 128 MB per-message cap. This is an upper bound, not a pre-allocation, so it is
+                // cheap to keep generous; it must comfortably exceed a screenshot tool result
+                // (image base64 inside a JSON envelope), which a 4 MB cap silently dropped for
+                // high-resolution Game View captures. Plugin-side capture tools clamp their own
+                // resolution to keep real payloads far below this ceiling.
+                configure.MaximumReceiveMessageSize = 1024 * 1024 * 128; // 128 MB
                 configure.ClientTimeoutInterval = TimeSpan.FromMinutes(5);
                 configure.KeepAliveInterval = TimeSpan.FromSeconds(30);
                 configure.HandshakeTimeout = TimeSpan.FromMinutes(2);

--- a/McpPlugin.Server/src/Extension/ExtensionsWebApplication.cs
+++ b/McpPlugin.Server/src/Extension/ExtensionsWebApplication.cs
@@ -51,8 +51,12 @@ namespace com.IvanMurzak.McpPlugin.Server
             app.MapHub<McpServerHub>(Consts.Hub.RemoteApp, options =>
             {
                 options.Transports = HttpTransports.All;
-                options.ApplicationMaxBufferSize = 1024 * 1024 * 4; // 4 MB
-                options.TransportMaxBufferSize = 1024 * 1024 * 4; // 4 MB
+                // 16 MB pipe buffers — large enough to carry a screenshot tool result
+                // (image base64 inside a JSON envelope) without dropping it in transit, while
+                // staying well below the previous 256 MB ceiling. Plugin-side capture tools cap
+                // their own resolution so payloads stay within this bound.
+                options.ApplicationMaxBufferSize = 1024 * 1024 * 16; // 16 MB
+                options.TransportMaxBufferSize = 1024 * 1024 * 16; // 16 MB
             });
 
             // Delegate MCP endpoint mapping to transport layer

--- a/McpPlugin.Server/src/Extension/ExtensionsWebApplication.cs
+++ b/McpPlugin.Server/src/Extension/ExtensionsWebApplication.cs
@@ -52,9 +52,9 @@ namespace com.IvanMurzak.McpPlugin.Server
             {
                 options.Transports = HttpTransports.All;
                 // 16 MB pipe buffers — large enough to carry a screenshot tool result
-                // (image base64 inside a JSON envelope) without dropping it in transit, while
-                // staying well below the previous 256 MB ceiling. Plugin-side capture tools cap
-                // their own resolution so payloads stay within this bound.
+                // (image base64 inside a JSON envelope) without dropping it in transit, raised
+                // from the previous 4 MB which silently truncated high-resolution captures.
+                // Plugin-side capture tools cap their own resolution so payloads stay within this bound.
                 options.ApplicationMaxBufferSize = 1024 * 1024 * 16; // 16 MB
                 options.TransportMaxBufferSize = 1024 * 1024 * 16; // 16 MB
             });


### PR DESCRIPTION
## Problem

Commit `b436278` ("reduce maximum buffer sizes for SignalR and transport to 4 MB") lowered:

- `MaximumReceiveMessageSize`: 256 MB → 4 MB (`ExtensionsMcpServerBuilder.cs`)
- `ApplicationMaxBufferSize` / `TransportMaxBufferSize`: 10 MB → 4 MB (`ExtensionsWebApplication.cs`)

The plugin (SignalR client) sends tool results *up* to the server, which is the receiver — so the 4 MB `MaximumReceiveMessageSize` caps them. Any result larger than 4 MB is rejected/dropped in transit with no surfaced error. This regressed high-resolution screenshot tool results: a base64 PNG inside a JSON envelope easily exceeds 4 MB (e.g. a native 4K Game View capture), so the image never reaches the AI client.

## Fix

- `MaximumReceiveMessageSize` → **128 MB** (an upper bound, not a pre-allocation, so cheap to keep generous)
- `ApplicationMaxBufferSize` / `TransportMaxBufferSize` → **16 MB** (flow-control buffers)

This restores the screenshot transport path. The companion Unity-MCP change caps capture resolution to 3840 px (≈59 MB worst case) so real payloads stay well within this ceiling — the generous bound is the safety net, not the primary guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)