### PR TITLE
fix(server): raise default idle-timeout to 6h (fix "Session not found" after idle)

### DIFF
--- a/McpPlugin.Common/McpPlugin.Common.csproj
+++ b/McpPlugin.Common/McpPlugin.Common.csproj
@@ -11,7 +11,7 @@
     <!-- NuGet Package Information -->
     <IsPackable>true</IsPackable>
     <PackageId>com.IvanMurzak.McpPlugin.Common</PackageId>
-    <Version>6.5.4</Version>
+    <Version>6.5.5</Version>
     <Authors>Ivan Murzak</Authors>
     <Company>Ivan Murzak</Company>
     <Copyright>Copyright © Ivan Murzak 2025</Copyright>

--- a/McpPlugin.Common/src/Utils/Consts.MCP.cs
+++ b/McpPlugin.Common/src/Utils/Consts.MCP.cs
@@ -72,13 +72,15 @@ namespace com.IvanMurzak.McpPlugin.Common
                 /// Default idle-timeout (seconds) for the streamableHttp transport's
                 /// <c>HttpServerTransportOptions.IdleTimeout</c>. An idle MCP session is evicted
                 /// from the server's in-memory session tracker after this much time without
-                /// activity. The SDK's own default is 2 hours; we use 10 minutes as a middle
-                /// ground that survives typical client reconnect latencies while keeping the
-                /// tracker footprint bounded by <c>MaxIdleSessionCount</c>. Override via the
-                /// <see cref="Args.IdleTimeoutSeconds"/> CLI argument or
+                /// activity; the next request on an evicted session fails with
+                /// <c>HTTP 404</c> / JSON-RPC <c>-32001 "Session not found"</c>. We set 6 hours
+                /// (21600 seconds) — well above the SDK's own 2-hour default — so the long idle
+                /// gaps between an AI agent's tool calls don't evict an otherwise-live session.
+                /// The tracker footprint stays bounded by <c>MaxIdleSessionCount</c>. Override via
+                /// the <see cref="Args.IdleTimeoutSeconds"/> CLI argument or
                 /// <see cref="Env.IdleTimeoutSeconds"/> environment variable.
                 /// </summary>
-                public const int DefaultIdleTimeoutSeconds = 600;
+                public const int DefaultIdleTimeoutSeconds = 21600;
 
                 public const string DefaultBodyPath = "mcpServers";
                 public const string DefaultServerName = "McpPlugin";

--- a/McpPlugin.Common/src/Utils/Consts.cs
+++ b/McpPlugin.Common/src/Utils/Consts.cs
@@ -12,7 +12,7 @@ namespace com.IvanMurzak.McpPlugin.Common
     public static partial class Consts
     {
         public const string ApiVersion = "2.0.0";
-        public const string PluginVersion = "6.5.4";
+        public const string PluginVersion = "6.5.5";
 
         public static class Guid
         {

--- a/McpPlugin.Server/McpPlugin.Server.csproj
+++ b/McpPlugin.Server/McpPlugin.Server.csproj
@@ -11,7 +11,7 @@
     <!-- NuGet Package Information -->
     <IsPackable>true</IsPackable>
     <PackageId>com.IvanMurzak.McpPlugin.Server</PackageId>
-    <Version>6.5.4</Version>
+    <Version>6.5.5</Version>
     <Authors>Ivan Murzak</Authors>
     <Company>Ivan Murzak</Company>
     <Copyright>Copyright © Ivan Murzak 2025</Copyright>

--- a/McpPlugin.Server/server.json
+++ b/McpPlugin.Server/server.json
@@ -8,13 +8,13 @@
     "source": "github",
     "subfolder": "McpPlugin.Server"
   },
-  "version": "6.5.4",
+  "version": "6.5.5",
   "packages": [
     {
       "registry_type": "oci",
       "registry_base_url": "https://docker.io",
       "identifier": "ivanmurzakdev/mcp-plugin-server",
-      "version": "6.5.4",
+      "version": "6.5.5",
       "transport": {
         "type": "stdio"
       },

--- a/McpPlugin/McpPlugin.csproj
+++ b/McpPlugin/McpPlugin.csproj
@@ -15,7 +15,7 @@
     <!-- NuGet Package Information -->
     <IsPackable>true</IsPackable>
     <PackageId>com.IvanMurzak.McpPlugin</PackageId>
-    <Version>6.5.4</Version>
+    <Version>6.5.5</Version>
     <Authors>Ivan Murzak</Authors>
     <Company>Ivan Murzak</Company>
     <Copyright>Copyright © Ivan Murzak 2025</Copyright>


### PR DESCRIPTION
## Root cause

On the streamableHttp MCP transport, an idle session is evicted from the server's in-memory tracker once `HttpServerTransportOptions.IdleTimeout` elapses. With the previous **600s (10 min)** default, a short idle gap between an AI agent's tool calls would evict an otherwise-live session, and the next request would fail with `HTTP 404` / JSON-RPC `-32001 "Session not found"`.

## Fix

Raise `DefaultIdleTimeoutSeconds` from `600` to **`21600` (6 hours)** — well above the SDK's own 2-hour default — so realistic idle gaps between tool calls no longer evict sessions. The tracker footprint stays bounded by `MaxIdleSessionCount`, and the value remains overridable via:

- CLI arg: `idle-timeout-seconds`
- env var: `MCP_PLUGIN_IDLE_TIMEOUT_SECONDS`

The XML doc comment above the constant was rewritten to reflect the new rationale.

## Version

Bump `6.5.4` -> `6.5.5` (single-sourced via `commands/bump-version.ps1`; touches the three `.csproj` files, `McpPlugin.Server/server.json`, and `Consts.cs` `PluginVersion`).

## Validation

- `dotnet build McpPlugin.sln -c Release` — succeeded, 0 warnings / 0 errors.
- `dotnet test McpPlugin.sln -c Release` — all pass (McpPlugin.Tests 409/409, McpPlugin.Server.Tests 268/268, per TFM net8.0 + net9.0).

> Note: merging to `main` triggers the NuGet release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)