### PR TITLE
feat: add IReflectorModule assembly-scanned converter + prune registration for extensions

### DIFF
--- a/McpPlugin.Tests/Data/ReflectorModules/ReflectorModuleFixtures.cs
+++ b/McpPlugin.Tests/Data/ReflectorModules/ReflectorModuleFixtures.cs
@@ -190,6 +190,38 @@ namespace com.IvanMurzak.McpPlugin.Tests.Data.ReflectorModules.Throwing
     }
 }
 
+namespace com.IvanMurzak.McpPlugin.Tests.Data.ReflectorModules.CtorFailure
+{
+    using com.IvanMurzak.McpPlugin.Tests.Data.ReflectorModules.Shared;
+
+    /// <summary>
+    /// A module whose constructor throws — used to assert instantiation-failure isolation (the phase-α
+    /// catch around Activator.CreateInstance). Discovery must skip+log it while the surviving sibling and
+    /// tool registration are unaffected. Lives in its OWN namespace so a test can isolate it from the
+    /// Configure-throwing fixtures.
+    /// </summary>
+    public sealed class ThrowingCtorModule : IReflectorModule
+    {
+        public ThrowingCtorModule()
+            => throw new InvalidOperationException("Intentional failure from ThrowingCtorModule constructor.");
+
+        public int Order => 0;
+
+        public void Configure(IReflectorModuleContext ctx)
+            => OrderSink.Record(nameof(ThrowingCtorModule));
+    }
+
+    /// <summary>A healthy module sitting alongside the throwing-ctor one — must still run.</summary>
+    public sealed class CtorSurvivingModule : IReflectorModule
+    {
+        public const string Id = nameof(CtorSurvivingModule);
+        public int Order => 1;
+
+        public void Configure(IReflectorModuleContext ctx)
+            => OrderSink.Record(Id);
+    }
+}
+
 namespace com.IvanMurzak.McpPlugin.Tests.Data.ReflectorModules.Ordering
 {
     using com.IvanMurzak.McpPlugin.Tests.Data.ReflectorModules.Shared;

--- a/McpPlugin.Tests/Data/ReflectorModules/ReflectorModuleFixtures.cs
+++ b/McpPlugin.Tests/Data/ReflectorModules/ReflectorModuleFixtures.cs
@@ -1,0 +1,235 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+// Reflector-module test fixtures. Each behavioral scenario lives in its OWN namespace so a test can
+// isolate the module(s) it wants by registering the test assembly for module scan and then calling
+// IgnoreNamespaces(...) on every sibling fixture namespace it does NOT want discovered. (Phase-α
+// discovery honors the core namespace prune, mirroring ProcessAllAssemblies' type filter.)
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using com.IvanMurzak.ReflectorNet.Converter;
+
+namespace com.IvanMurzak.McpPlugin.Tests.Data.ReflectorModules.Shared
+{
+    /// <summary>Marker payload type a fixture module registers a JSON converter for.</summary>
+    public sealed class ModulePayload
+    {
+        public string Value { get; set; } = string.Empty;
+    }
+
+    /// <summary>Type a fixture module registers a reflection converter for.</summary>
+    public sealed class ModuleReflectedType
+    {
+        public int Number { get; set; }
+    }
+
+    /// <summary>Type a fixture module blacklists from serialization.</summary>
+    public sealed class ModuleBlacklistedType
+    {
+        public string Secret { get; set; } = string.Empty;
+    }
+
+    /// <summary>A System.Text.Json converter contributed by a fixture module.</summary>
+    public sealed class ModulePayloadJsonConverter : JsonConverter<ModulePayload>
+    {
+        public override ModulePayload Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            => new ModulePayload { Value = reader.GetString() ?? string.Empty };
+
+        public override void Write(Utf8JsonWriter writer, ModulePayload value, JsonSerializerOptions options)
+            => writer.WriteStringValue(value.Value);
+    }
+
+    /// <summary>
+    /// A reflection converter contributed by a fixture module. Extends ReflectorNet's concrete
+    /// generic converter so it satisfies <see cref="IReflectionConverter"/> with a parameterless ctor.
+    /// </summary>
+    public sealed class ModuleReflectionConverter : GenericReflectionConverter<ModuleReflectedType>
+    {
+    }
+
+    /// <summary>Shared, lock-guarded sink that records the order discovered modules ran in.</summary>
+    public static class OrderSink
+    {
+        private static readonly object _lock = new();
+        private static List<string>? _active;
+
+        public static IDisposable Begin()
+        {
+            lock (_lock)
+            {
+                _active = new List<string>();
+                return new Scope();
+            }
+        }
+
+        public static void Record(string id)
+        {
+            lock (_lock)
+            {
+                _active?.Add(id);
+            }
+        }
+
+        public static IReadOnlyList<string> Snapshot()
+        {
+            lock (_lock)
+            {
+                return _active != null ? new List<string>(_active) : new List<string>();
+            }
+        }
+
+        private sealed class Scope : IDisposable
+        {
+            public void Dispose()
+            {
+                lock (_lock)
+                {
+                    _active = null;
+                }
+            }
+        }
+    }
+}
+
+namespace com.IvanMurzak.McpPlugin.Tests.Data.ReflectorModules.FullContribution
+{
+    using com.IvanMurzak.McpPlugin.Tests.Data.ReflectorModules.Shared;
+
+    /// <summary>
+    /// The flagship fixture: a single discoverable module that contributes a JSON converter, a
+    /// reflection converter, a serialization-blacklist type, AND scan-ignore entries (assembly +
+    /// namespace). Used to assert each contribution reaches effect.
+    /// </summary>
+    public sealed class FullContributionModule : IReflectorModule
+    {
+        // A non-existent assembly prefix — safe to contribute (cannot collide with any protected
+        // assembly). Asserting assembly-prune *effect* end-to-end would require a second on-disk
+        // assembly; the namespace-prune below gives an observable behavioral effect instead, and the
+        // SafetyRail fixture covers the rejection path of both surfaces.
+        public const string IgnoredAssemblyPrefix = "Some.Nonexistent.Extension.Assembly";
+
+        // A REAL namespace hosting a dummy tool (PrunedByModuleToolClass). The module ignores it, so
+        // the dummy tool must NOT be registered after build — an observable scan-ignore effect.
+        public const string PrunedNamespace = "com.IvanMurzak.McpPlugin.Tests.Data.ReflectorModules.FullContribution.Pruned";
+
+        public int Order => 10;
+
+        public void Configure(IReflectorModuleContext ctx)
+        {
+            ctx.Reflector.JsonSerializer.AddConverter(new ModulePayloadJsonConverter());
+            ctx.Reflector.Converters.Add(new ModuleReflectionConverter());
+            ctx.Reflector.Converters.BlacklistType(typeof(ModuleBlacklistedType));
+            ctx.Scan
+                .IgnoreAssemblies(IgnoredAssemblyPrefix)
+                .IgnoreNamespaces(PrunedNamespace);
+        }
+    }
+}
+
+namespace com.IvanMurzak.McpPlugin.Tests.Data.ReflectorModules.FullContribution.Pruned
+{
+    /// <summary>
+    /// A tool whose namespace the FullContributionModule contributes to the scan-ignore set. After a
+    /// build that discovers that module, this tool must NOT be registered — the observable proof that
+    /// a module-contributed namespace scan-ignore reached effect.
+    /// </summary>
+    [AiToolType]
+    internal class PrunedByModuleToolClass
+    {
+        [AiTool("pruned-by-module-tool", "Should be pruned by a module's scan-ignore")]
+        public static string Tool() => "pruned";
+    }
+}
+
+namespace com.IvanMurzak.McpPlugin.Tests.Data.ReflectorModules.FullContribution
+{
+    /// <summary>
+    /// A control tool that lives directly under the FullContribution namespace (NOT the Pruned
+    /// sub-namespace the module ignores). It must remain registered — proving the module-contributed
+    /// namespace prune is scoped, not a blanket prune.
+    /// </summary>
+    [AiToolType]
+    internal class FullContributionControlToolClass
+    {
+        [AiTool("full-contribution-control-tool", "Control tool that should survive")]
+        public static string Tool() => "control";
+    }
+}
+
+namespace com.IvanMurzak.McpPlugin.Tests.Data.ReflectorModules.Throwing
+{
+    using com.IvanMurzak.McpPlugin.Tests.Data.ReflectorModules.Shared;
+
+    /// <summary>A module that throws during Configure — used to assert failure isolation.</summary>
+    public sealed class ThrowingModule : IReflectorModule
+    {
+        public int Order => 0;
+
+        public void Configure(IReflectorModuleContext ctx)
+            => throw new InvalidOperationException("Intentional failure from ThrowingModule.");
+    }
+
+    /// <summary>A healthy module sitting alongside the throwing one — must still run.</summary>
+    public sealed class SurvivingModule : IReflectorModule
+    {
+        public const string Id = nameof(SurvivingModule);
+        public int Order => 1;
+
+        public void Configure(IReflectorModuleContext ctx)
+            => OrderSink.Record(Id);
+    }
+}
+
+namespace com.IvanMurzak.McpPlugin.Tests.Data.ReflectorModules.Ordering
+{
+    using com.IvanMurzak.McpPlugin.Tests.Data.ReflectorModules.Shared;
+
+    // Two ordering fixtures with intentionally inverted (Order, name) so deterministic sort is observable.
+    public sealed class OrderModuleHigh : IReflectorModule
+    {
+        public const string Id = nameof(OrderModuleHigh);
+        public int Order => 20;
+
+        public void Configure(IReflectorModuleContext ctx) => OrderSink.Record(Id);
+    }
+
+    public sealed class OrderModuleLow : IReflectorModule
+    {
+        public const string Id = nameof(OrderModuleLow);
+        public int Order => 5;
+
+        public void Configure(IReflectorModuleContext ctx) => OrderSink.Record(Id);
+    }
+}
+
+namespace com.IvanMurzak.McpPlugin.Tests.Data.ReflectorModules.SafetyRail
+{
+    using com.IvanMurzak.McpPlugin.Tests.Data.ReflectorModules.Shared;
+
+    /// <summary>
+    /// A module that attempts to ignore the very assembly + namespace that host it (and other
+    /// modules/tools). The safety rail must reject both contributions with a warning.
+    /// </summary>
+    public sealed class SelfPruningModule : IReflectorModule
+    {
+        public int Order => 0;
+
+        public void Configure(IReflectorModuleContext ctx)
+        {
+            // Both of these would prune a module/tool-hosting assembly → must be rejected by the rail.
+            var ownAssemblyName = ctx.OwningAssembly.GetName().Name ?? string.Empty;
+            ctx.Scan.IgnoreAssemblies(ownAssemblyName);
+            ctx.Scan.IgnoreNamespaces("com.IvanMurzak.McpPlugin.Tests");
+        }
+    }
+}

--- a/McpPlugin.Tests/Mcp/ReflectorModuleDiscoveryTests.cs
+++ b/McpPlugin.Tests/Mcp/ReflectorModuleDiscoveryTests.cs
@@ -35,12 +35,13 @@ namespace com.IvanMurzak.McpPlugin.Tests.Mcp
         // it wants by ignoring the rest (phase-α discovery honors the core namespace prune).
         private const string NsFullContribution = "com.IvanMurzak.McpPlugin.Tests.Data.ReflectorModules.FullContribution";
         private const string NsThrowing = "com.IvanMurzak.McpPlugin.Tests.Data.ReflectorModules.Throwing";
+        private const string NsCtorFailure = "com.IvanMurzak.McpPlugin.Tests.Data.ReflectorModules.CtorFailure";
         private const string NsOrdering = "com.IvanMurzak.McpPlugin.Tests.Data.ReflectorModules.Ordering";
         private const string NsSafetyRail = "com.IvanMurzak.McpPlugin.Tests.Data.ReflectorModules.SafetyRail";
 
         private static readonly string[] AllModuleNamespaces =
         {
-            NsFullContribution, NsThrowing, NsOrdering, NsSafetyRail
+            NsFullContribution, NsThrowing, NsCtorFailure, NsOrdering, NsSafetyRail
         };
 
         public ReflectorModuleDiscoveryTests(ITestOutputHelper output)
@@ -108,6 +109,40 @@ namespace com.IvanMurzak.McpPlugin.Tests.Mcp
 
                 // Assert — the healthy sibling module still ran...
                 OrderSink.Snapshot().ShouldContain(Data.ReflectorModules.Throwing.SurvivingModule.Id);
+
+                // ...and tool registration (which runs after the module phase) is unaffected.
+                var response = await plugin.McpManager.ToolManager!.RunListTool(new RequestListTool());
+                response.Value.ShouldNotBeNull();
+                response.Value!.ShouldContain(t => t.Name == "include-test-tool");
+            }
+        }
+
+        // ── Failure isolation: a module whose ctor throws is skipped; others + tools survive ──
+
+        [Fact]
+        public async Task FailureIsolation_ThrowingCtorModuleSkipped_OthersAndToolsSurvive()
+        {
+            // Arrange — keep only the CtorFailure namespace (ThrowingCtorModule whose constructor throws +
+            // CtorSurvivingModule), plus tools. ThrowingCtorModule must be skipped during phase-α
+            // instantiation (Activator.CreateInstance throws) without aborting discovery.
+            var reflector = new Reflector();
+            var builder = new McpPluginBuilder(_version, _loggerProvider)
+                .WithToolsFromAssembly(TestAssembly)
+                .WithReflectorModulesFromAssembly(new[] { TestAssembly })
+                .IgnoreNamespaces(NamespacesToIgnoreExcept(NsCtorFailure));
+
+            using (OrderSink.Begin())
+            {
+                // Act — build must NOT throw despite ThrowingCtorModule's throwing constructor.
+                var plugin = builder.Build(reflector);
+
+                var snapshot = OrderSink.Snapshot();
+
+                // Assert — the healthy sibling module still ran...
+                snapshot.ShouldContain(Data.ReflectorModules.CtorFailure.CtorSurvivingModule.Id);
+
+                // ...the throwing-ctor module never reached Configure (it was skipped at instantiation)...
+                snapshot.ShouldNotContain(nameof(Data.ReflectorModules.CtorFailure.ThrowingCtorModule));
 
                 // ...and tool registration (which runs after the module phase) is unaffected.
                 var response = await plugin.McpManager.ToolManager!.RunListTool(new RequestListTool());

--- a/McpPlugin.Tests/Mcp/ReflectorModuleDiscoveryTests.cs
+++ b/McpPlugin.Tests/Mcp/ReflectorModuleDiscoveryTests.cs
@@ -1,0 +1,204 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.Common.Model;
+using com.IvanMurzak.McpPlugin.Tests.Data.ReflectorModules.FullContribution;
+using com.IvanMurzak.McpPlugin.Tests.Data.ReflectorModules.Shared;
+using com.IvanMurzak.McpPlugin.Tests.Infrastructure;
+using com.IvanMurzak.ReflectorNet;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+using Version = com.IvanMurzak.McpPlugin.Common.Version;
+
+namespace com.IvanMurzak.McpPlugin.Tests.Mcp
+{
+    [Collection("McpPlugin")]
+    public class ReflectorModuleDiscoveryTests
+    {
+        private readonly XunitTestOutputLoggerProvider _loggerProvider;
+        private readonly Version _version = new Version();
+        private static readonly Assembly TestAssembly = typeof(FullContributionModule).Assembly;
+
+        // Every fixture-module namespace under Data/ReflectorModules. A test keeps only the namespaces
+        // it wants by ignoring the rest (phase-α discovery honors the core namespace prune).
+        private const string NsFullContribution = "com.IvanMurzak.McpPlugin.Tests.Data.ReflectorModules.FullContribution";
+        private const string NsThrowing = "com.IvanMurzak.McpPlugin.Tests.Data.ReflectorModules.Throwing";
+        private const string NsOrdering = "com.IvanMurzak.McpPlugin.Tests.Data.ReflectorModules.Ordering";
+        private const string NsSafetyRail = "com.IvanMurzak.McpPlugin.Tests.Data.ReflectorModules.SafetyRail";
+
+        private static readonly string[] AllModuleNamespaces =
+        {
+            NsFullContribution, NsThrowing, NsOrdering, NsSafetyRail
+        };
+
+        public ReflectorModuleDiscoveryTests(ITestOutputHelper output)
+        {
+            _loggerProvider = new XunitTestOutputLoggerProvider(output);
+        }
+
+        /// <summary>Returns every fixture-module namespace EXCEPT the ones to keep.</summary>
+        private static string[] NamespacesToIgnoreExcept(params string[] keep)
+            => AllModuleNamespaces.Where(ns => !keep.Contains(ns)).ToArray();
+
+        // ── Discovery: a module in a non-ignored assembly is picked up ──────────────────
+
+        [Fact]
+        public void Discovery_PicksUpModule_InNonIgnoredAssembly()
+        {
+            // Arrange
+            var reflector = new Reflector();
+            var builder = new McpPluginBuilder(_version, _loggerProvider)
+                .WithReflectorModulesFromAssembly(new[] { TestAssembly })
+                .IgnoreNamespaces(NamespacesToIgnoreExcept(NsFullContribution));
+
+            // Act
+            builder.Build(reflector);
+
+            // Assert — the FullContributionModule ran, proven by its JSON converter being registered.
+            reflector.JsonSerializer.GetJsonConverter(typeof(ModulePayload)).ShouldNotBeNull();
+        }
+
+        // ── Discovery is pruned when the hosting assembly is core-ignored ───────────────
+
+        [Fact]
+        public void Discovery_SkipsModule_WhenHostingAssemblyIsIgnored()
+        {
+            // Arrange — register the assembly for module scan, then ignore that very assembly.
+            var reflector = new Reflector();
+            var builder = new McpPluginBuilder(_version, _loggerProvider)
+                .WithReflectorModulesFromAssembly(new[] { TestAssembly })
+                .IgnoreAssembly(TestAssembly);
+
+            // Act
+            builder.Build(reflector);
+
+            // Assert — module never ran: no converter, type not blacklisted.
+            reflector.JsonSerializer.GetJsonConverter(typeof(ModulePayload)).ShouldBeNull();
+            reflector.Converters.IsTypeBlacklisted(typeof(ModuleBlacklistedType)).ShouldBeFalse();
+        }
+
+        // ── Failure isolation: a throwing module is caught; others + tools survive ──────
+
+        [Fact]
+        public async Task FailureIsolation_ThrowingModuleCaught_OthersAndToolsSurvive()
+        {
+            // Arrange — keep only the Throwing namespace (ThrowingModule + SurvivingModule), plus tools.
+            var reflector = new Reflector();
+            var builder = new McpPluginBuilder(_version, _loggerProvider)
+                .WithToolsFromAssembly(TestAssembly)
+                .WithReflectorModulesFromAssembly(new[] { TestAssembly })
+                .IgnoreNamespaces(NamespacesToIgnoreExcept(NsThrowing));
+
+            using (OrderSink.Begin())
+            {
+                // Act — build must NOT throw despite ThrowingModule.
+                var plugin = builder.Build(reflector);
+
+                // Assert — the healthy sibling module still ran...
+                OrderSink.Snapshot().ShouldContain(Data.ReflectorModules.Throwing.SurvivingModule.Id);
+
+                // ...and tool registration (which runs after the module phase) is unaffected.
+                var response = await plugin.McpManager.ToolManager!.RunListTool(new RequestListTool());
+                response.Value.ShouldNotBeNull();
+                response.Value!.ShouldContain(t => t.Name == "include-test-tool");
+            }
+        }
+
+        // ── Deterministic ordering: Order then assembly name ────────────────────────────
+
+        [Fact]
+        public void Ordering_IsDeterministic_ByOrderThenAssemblyName()
+        {
+            // Arrange — keep only the Ordering namespace (OrderModuleLow Order=5, OrderModuleHigh Order=20).
+            var reflector = new Reflector();
+            var builder = new McpPluginBuilder(_version, _loggerProvider)
+                .WithReflectorModulesFromAssembly(new[] { TestAssembly })
+                .IgnoreNamespaces(NamespacesToIgnoreExcept(NsOrdering));
+
+            using (OrderSink.Begin())
+            {
+                // Act
+                builder.Build(reflector);
+
+                // Assert — ascending Order: Low (5) before High (20).
+                var order = OrderSink.Snapshot();
+                order.ShouldBe(new[]
+                {
+                    Data.ReflectorModules.Ordering.OrderModuleLow.Id,
+                    Data.ReflectorModules.Ordering.OrderModuleHigh.Id
+                });
+            }
+        }
+
+        // ── Full contribution: JSON + reflection converter + blacklist + scan-ignore ────
+
+        [Fact]
+        public async Task FullContribution_EachContributionReachesEffect()
+        {
+            // Arrange — keep only the FullContribution namespace; register tools from the same assembly
+            // so the module-contributed namespace scan-ignore has an observable target.
+            var reflector = new Reflector();
+            var builder = new McpPluginBuilder(_version, _loggerProvider)
+                .WithToolsFromAssembly(TestAssembly)
+                .WithReflectorModulesFromAssembly(new[] { TestAssembly })
+                .IgnoreNamespaces(NamespacesToIgnoreExcept(NsFullContribution));
+
+            // Act
+            var plugin = builder.Build(reflector);
+
+            // Assert — (1) JSON converter registered.
+            reflector.JsonSerializer.GetJsonConverter(typeof(ModulePayload)).ShouldNotBeNull();
+
+            // (2) Reflection converter registered (resolvable for the target type).
+            reflector.Converters.GetConverter(typeof(ModuleReflectedType)).ShouldNotBeNull();
+            reflector.Converters.GetAllSerializers()
+                .Any(c => c is ModuleReflectionConverter).ShouldBeTrue();
+
+            // (3) Serialization blacklist applied.
+            reflector.Converters.IsTypeBlacklisted(typeof(ModuleBlacklistedType)).ShouldBeTrue();
+
+            // (4) Scan-ignore (namespace) reached effect: the tool in the module-ignored sub-namespace
+            // is pruned, while the control tool in the parent namespace survives.
+            var response = await plugin.McpManager.ToolManager!.RunListTool(new RequestListTool());
+            response.Value.ShouldNotBeNull();
+            response.Value!.ShouldNotContain(t => t.Name == "pruned-by-module-tool");
+            response.Value!.ShouldContain(t => t.Name == "full-contribution-control-tool");
+        }
+
+        // ── Safety rail: a contributed scan-ignore must not prune a module/tool-hosting assembly ──
+
+        [Fact]
+        public async Task SafetyRail_RejectsSelfPrune_OfModuleAndToolHostingAssembly()
+        {
+            // Arrange — keep only the SafetyRail namespace; register tools from the same assembly.
+            // SelfPruningModule attempts to ignore the test assembly's name AND the test root namespace.
+            var reflector = new Reflector();
+            var builder = new McpPluginBuilder(_version, _loggerProvider)
+                .WithToolsFromAssembly(TestAssembly)
+                .WithReflectorModulesFromAssembly(new[] { TestAssembly })
+                .IgnoreNamespaces(NamespacesToIgnoreExcept(NsSafetyRail));
+
+            // Act — both self-prune attempts must be rejected by the rail.
+            var plugin = builder.Build(reflector);
+
+            // Assert — the test tool (namespace under com.IvanMurzak.McpPlugin.Tests) is STILL registered,
+            // proving the namespace self-prune was rejected. If the rail had let it through, the tool's
+            // type would have been hidden from the attribute scan.
+            var response = await plugin.McpManager.ToolManager!.RunListTool(new RequestListTool());
+            response.Value.ShouldNotBeNull();
+            response.Value!.ShouldContain(t => t.Name == "include-test-tool");
+        }
+    }
+}

--- a/McpPlugin/src/McpPlugin/Builder/IMcpPluginBuilder.cs
+++ b/McpPlugin/src/McpPlugin/Builder/IMcpPluginBuilder.cs
@@ -69,6 +69,10 @@ namespace com.IvanMurzak.McpPlugin
         IMcpPluginBuilder WithConfigFromArgsOrEnv(string[]? args = null);
         IMcpPluginBuilder WithSkillFileGenerator<T>() where T : class, ISkillFileGenerator;
         IMcpPluginBuilder WithSkillFileGenerator(ISkillFileGenerator instance);
+
+        // Reflector module discovery
+        IMcpPluginBuilder WithReflectorModulesFromAssembly(IEnumerable<Assembly> assemblies);
+
         IMcpPlugin Build(Reflector reflector);
 
         // Ignore Assembly methods

--- a/McpPlugin/src/McpPlugin/Builder/McpPluginBuilder.ReflectorModules.cs
+++ b/McpPlugin/src/McpPlugin/Builder/McpPluginBuilder.ReflectorModules.cs
@@ -1,0 +1,246 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using com.IvanMurzak.ReflectorNet;
+using com.IvanMurzak.ReflectorNet.Utils;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace com.IvanMurzak.McpPlugin
+{
+    public partial class McpPluginBuilder
+    {
+        // Assemblies the builder will scan for IReflectorModule implementors.
+        protected readonly List<Assembly> _reflectorModuleAssemblies = new();
+
+        /// <summary>
+        /// Registers one or more assemblies to be scanned for <see cref="IReflectorModule"/>
+        /// implementors during <see cref="Build"/>. Discovery is cheap (top-level type +
+        /// <c>IsAssignableFrom</c>, no method/schema work) and reuses the existing core ignore-config
+        /// prune, so heavy assemblies pruned by name are never type-enumerated.
+        /// </summary>
+        /// <param name="assemblies">The assemblies to scan. Null entries are skipped.</param>
+        /// <returns>The current builder instance for method chaining.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="assemblies"/> is null.</exception>
+        /// <exception cref="InvalidOperationException">Thrown if the builder has already been built.</exception>
+        public virtual IMcpPluginBuilder WithReflectorModulesFromAssembly(IEnumerable<Assembly> assemblies)
+        {
+            ThrowIfBuilt();
+
+            if (assemblies == null)
+                throw new ArgumentNullException(nameof(assemblies));
+
+            foreach (var assembly in assemblies)
+            {
+                if (assembly == null)
+                    continue;
+                _reflectorModuleAssemblies.Add(assembly);
+            }
+            return this;
+        }
+
+        /// <summary>
+        /// Runs the phased reflector-module bootstrap: (α) cheap discovery of <see cref="IReflectorModule"/>
+        /// implementors in non-ignored registered assemblies; (β) ordered, failure-isolated invocation of
+        /// each module's <see cref="IReflectorModule.Configure"/>; the host's heavy attribute scan (γ) runs
+        /// afterwards in <see cref="Build"/>. Must be called strictly BEFORE <c>ProcessAllAssemblies()</c>.
+        /// </summary>
+        protected virtual void BootstrapReflectorModules(Reflector reflector)
+        {
+            // ── Phase α: cheap discovery ───────────────────────────────────────────────
+            // Enumerate types ONLY in registered assemblies that survive the static core
+            // ignore-config prune. Heavy assemblies pruned by name are never type-enumerated.
+            var modules = new List<IReflectorModule>();
+            var moduleAssemblies = new HashSet<Assembly>();
+            // Namespaces that host a discovered module. The namespace safety rail protects these so a
+            // contributed namespace prune cannot hide a module's own namespace (which would defeat the
+            // discovery the host just performed). A module may still prune OTHER namespaces (e.g. a
+            // sub-namespace of unrelated tools) — that is the feature's whole point.
+            var moduleNamespaces = new HashSet<string>(StringComparer.Ordinal);
+
+            foreach (var assembly in _reflectorModuleAssemblies.Distinct())
+            {
+                if (_ignoreConfig.IsIgnored(assembly))
+                    continue;
+
+                foreach (var type in AssemblyUtils.GetAssemblyTypes(assembly))
+                {
+                    // Honor the core namespace prune too, mirroring ProcessAllAssemblies' type filter:
+                    // a module in a core-ignored namespace is not discovered.
+                    if (_ignoreConfig.IsIgnored(type))
+                        continue;
+
+                    // Top-level shape gate only — no GetMethods / schema work.
+                    if (type.IsAbstract || type.IsInterface || type.IsGenericTypeDefinition)
+                        continue;
+                    if (!typeof(IReflectorModule).IsAssignableFrom(type))
+                        continue;
+
+                    IReflectorModule? module;
+                    try
+                    {
+                        module = (IReflectorModule?)Activator.CreateInstance(type);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger?.LogError(ex, "Failed to instantiate reflector module '{Module}'. Skipping it. A public parameterless constructor is required.", type.FullName);
+                        continue;
+                    }
+
+                    if (module == null)
+                        continue;
+
+                    modules.Add(module);
+                    moduleAssemblies.Add(assembly);
+                    if (!string.IsNullOrEmpty(type.Namespace))
+                        moduleNamespaces.Add(type.Namespace!);
+                }
+            }
+
+            if (modules.Count == 0)
+                return;
+
+            // The protected set: assemblies that host a discovered module OR are registered as a
+            // tool/prompt/resource/skill assembly. A contributed scan-ignore entry must never prune
+            // any of these (safety rail, enforced inside ReflectorModuleContext.Scan).
+            var protectedAssemblies = new HashSet<Assembly>(moduleAssemblies);
+            protectedAssemblies.UnionWith(_toolAssemblies);
+            protectedAssemblies.UnionWith(_promptAssemblies);
+            protectedAssemblies.UnionWith(_resourceAssemblies);
+            protectedAssemblies.UnionWith(_skillAssemblies);
+
+            // ── Phase β: ordered, failure-isolated contribution ────────────────────────
+            // Sort by Order, then by owning-assembly full name for a deterministic tie-break.
+            var ordered = modules
+                .Select(m => new { Module = m, Assembly = m.GetType().Assembly })
+                .OrderBy(x => x.Module.Order)
+                .ThenBy(x => x.Assembly.FullName, StringComparer.Ordinal)
+                .ToList();
+
+            foreach (var entry in ordered)
+            {
+                var moduleType = entry.Module.GetType();
+                var moduleLogger = _loggerProvider?.CreateLogger(moduleType.FullName ?? nameof(IReflectorModule))
+                    ?? (ILogger)NullLogger.Instance;
+                var ctx = new ReflectorModuleContext(reflector, entry.Assembly, moduleLogger, _ignoreConfig, protectedAssemblies, moduleNamespaces, _logger);
+
+                try
+                {
+                    entry.Module.Configure(ctx);
+                }
+                catch (Exception ex)
+                {
+                    // Failure isolation: one throwing module must not abort the build or stop the rest.
+                    _logger?.LogError(ex, "Reflector module '{Module}' threw during Configure and was skipped. Other modules and tools are unaffected.", moduleType.FullName);
+                }
+            }
+            // ── Phase γ runs next in Build(): ProcessAllAssemblies() under the augmented config. ──
+        }
+
+        /// <summary>
+        /// Default <see cref="IReflectorModuleContext"/> implementation. Wraps the host reflector and
+        /// exposes a guarded <see cref="IScanIgnoreBuilder"/> that refuses to prune any assembly hosting
+        /// a discovered module or registered tool/prompt/resource/skill.
+        /// </summary>
+        protected sealed class ReflectorModuleContext : IReflectorModuleContext, IScanIgnoreBuilder
+        {
+            private readonly McpPluginBuilderIgnoreConfig _ignore;
+            private readonly IReadOnlyCollection<Assembly> _protectedAssemblies;
+            private readonly IReadOnlyCollection<string> _moduleNamespaces;
+            private readonly ILogger? _hostLogger;
+
+            public Reflector Reflector { get; }
+            public Assembly OwningAssembly { get; }
+            public ILogger Logger { get; }
+            public IScanIgnoreBuilder Scan => this;
+
+            public ReflectorModuleContext(
+                Reflector reflector,
+                Assembly owningAssembly,
+                ILogger logger,
+                McpPluginBuilderIgnoreConfig ignore,
+                IReadOnlyCollection<Assembly> protectedAssemblies,
+                IReadOnlyCollection<string> moduleNamespaces,
+                ILogger? hostLogger)
+            {
+                Reflector = reflector ?? throw new ArgumentNullException(nameof(reflector));
+                OwningAssembly = owningAssembly ?? throw new ArgumentNullException(nameof(owningAssembly));
+                Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+                _ignore = ignore ?? throw new ArgumentNullException(nameof(ignore));
+                _protectedAssemblies = protectedAssemblies ?? throw new ArgumentNullException(nameof(protectedAssemblies));
+                _moduleNamespaces = moduleNamespaces ?? throw new ArgumentNullException(nameof(moduleNamespaces));
+                _hostLogger = hostLogger;
+            }
+
+            public IScanIgnoreBuilder IgnoreAssemblies(params string[] assemblyNamePrefixes)
+            {
+                if (assemblyNamePrefixes == null)
+                    return this;
+
+                foreach (var prefix in assemblyNamePrefixes)
+                {
+                    if (string.IsNullOrEmpty(prefix))
+                        continue;
+
+                    // Safety rail: reject a prefix that would prune a module/tool-hosting assembly.
+                    var collision = _protectedAssemblies.FirstOrDefault(a =>
+                    {
+                        var name = a.GetName().Name;
+                        return !string.IsNullOrEmpty(name) && name!.StartsWith(prefix, StringComparison.Ordinal);
+                    });
+                    if (collision != null)
+                    {
+                        _hostLogger?.LogWarning(
+                            "Reflector module from '{Owner}' tried to ignore assembly prefix '{Prefix}', which would prune '{Protected}' that hosts a discovered module or registered tools. Ignoring this entry.",
+                            OwningAssembly.GetName().Name, prefix, collision.GetName().Name);
+                        continue;
+                    }
+
+                    _ignore.IgnoredAssemblyNames.Add(prefix);
+                }
+                _ignore.InvalidateCaches();
+                return this;
+            }
+
+            public IScanIgnoreBuilder IgnoreNamespaces(params string[] namespacePrefixes)
+            {
+                if (namespacePrefixes == null)
+                    return this;
+
+                foreach (var prefix in namespacePrefixes)
+                {
+                    if (string.IsNullOrEmpty(prefix))
+                        continue;
+
+                    // Safety rail: reject a namespace prefix that would hide a DISCOVERED MODULE's own
+                    // namespace (which would defeat the discovery just performed). A module may still
+                    // prune any other namespace — pruning unrelated tool namespaces is the feature's
+                    // purpose, so we deliberately do NOT block those.
+                    var collision = _moduleNamespaces
+                        .FirstOrDefault(ns => ns.StartsWith(prefix, StringComparison.Ordinal));
+                    if (collision != null)
+                    {
+                        _hostLogger?.LogWarning(
+                            "Reflector module from '{Owner}' tried to ignore namespace prefix '{Prefix}', which would prune discovered-module namespace '{Protected}'. Ignoring this entry.",
+                            OwningAssembly.GetName().Name, prefix, collision);
+                        continue;
+                    }
+
+                    _ignore.IgnoredNamespaces.Add(prefix);
+                }
+                _ignore.InvalidateCaches();
+                return this;
+            }
+        }
+    }
+}

--- a/McpPlugin/src/McpPlugin/Builder/McpPluginBuilder.ReflectorModules.cs
+++ b/McpPlugin/src/McpPlugin/Builder/McpPluginBuilder.ReflectorModules.cs
@@ -120,11 +120,14 @@ namespace com.IvanMurzak.McpPlugin
             protectedAssemblies.UnionWith(_skillAssemblies);
 
             // ── Phase β: ordered, failure-isolated contribution ────────────────────────
-            // Sort by Order, then by owning-assembly full name for a deterministic tie-break.
+            // Sort by Order, then by owning-assembly full name, then by module type full name for a
+            // fully-deterministic tie-break (so two modules in the SAME assembly with equal Order do
+            // not fall back to unstable reflection GetTypes() order across recompiles/runtimes).
             var ordered = modules
                 .Select(m => new { Module = m, Assembly = m.GetType().Assembly })
                 .OrderBy(x => x.Module.Order)
                 .ThenBy(x => x.Assembly.FullName, StringComparer.Ordinal)
+                .ThenBy(x => x.Module.GetType().FullName, StringComparer.Ordinal)
                 .ToList();
 
             foreach (var entry in ordered)

--- a/McpPlugin/src/McpPlugin/Builder/McpPluginBuilder.cs
+++ b/McpPlugin/src/McpPlugin/Builder/McpPluginBuilder.cs
@@ -319,6 +319,11 @@ namespace com.IvanMurzak.McpPlugin
             if (reflector == null)
                 throw new ArgumentNullException(nameof(reflector));
 
+            // Reflector-module bootstrap (phases α→β): discover IReflectorModule implementors and let
+            // them contribute converters + prune rules. MUST run strictly BEFORE ProcessAllAssemblies()
+            // so any contributed scan-ignore entries take effect for the heavy attribute scan (phase γ).
+            BootstrapReflectorModules(reflector);
+
             // Process all assemblies with caching optimization
             ProcessAllAssemblies();
 

--- a/McpPlugin/src/McpPlugin/Reflector/IReflectorModule.cs
+++ b/McpPlugin/src/McpPlugin/Reflector/IReflectorModule.cs
@@ -1,0 +1,106 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+using System.Reflection;
+using com.IvanMurzak.ReflectorNet;
+using Microsoft.Extensions.Logging;
+
+namespace com.IvanMurzak.McpPlugin
+{
+    /// <summary>
+    /// A unit of ReflectorNet contribution that an assembly (the core plugin OR an externally
+    /// added extension) can supply. Modules are discovered automatically by assembly scan during
+    /// <see cref="McpPluginBuilder.Build"/> — there is no hardcoded extension list. A discovered
+    /// module may register JSON converters, reflection converters, serialization blacklist entries,
+    /// and additional attribute-scan ignore rules via the supplied <see cref="IReflectorModuleContext"/>.
+    /// </summary>
+    /// <remarks>
+    /// Discovery requirements: a module type must be a concrete (non-abstract, non-generic) class
+    /// that implements <see cref="IReflectorModule"/> and exposes a public parameterless constructor
+    /// (instantiated via <see cref="System.Activator.CreateInstance(System.Type)"/>). Modules placed in
+    /// an assembly the core ignore-config prunes (e.g. via <c>IgnoreAssembly</c>) are never discovered,
+    /// because such assemblies are not type-enumerated.
+    /// </remarks>
+    public interface IReflectorModule
+    {
+        /// <summary>
+        /// Relative ordering lever applied when more than one module is discovered. Modules run in
+        /// ascending <see cref="Order"/>, then by owning-assembly full name (deterministic tie-break).
+        /// The core baseline module uses <c>0</c>; extensions typically use a value greater than <c>0</c>
+        /// so they run after the core and may override an overlapping core JSON converter.
+        /// </summary>
+        int Order { get; }
+
+        /// <summary>
+        /// Contributes this module's converters and prune rules through the supplied context.
+        /// Invoked once during <see cref="McpPluginBuilder.Build"/>, strictly before the heavy
+        /// attribute scan. A thrown exception is caught and logged by the host; it does not abort the
+        /// build nor prevent other modules (or tools) from being registered.
+        /// </summary>
+        /// <param name="ctx">The contribution surface (reflector, scan-ignore facade, owning assembly, logger).</param>
+        void Configure(IReflectorModuleContext ctx);
+    }
+
+    /// <summary>
+    /// The contribution surface handed to <see cref="IReflectorModule.Configure"/>. Exposes the
+    /// <see cref="ReflectorNet.Reflector"/> (for JSON / reflection converters and serialization
+    /// blacklisting) and a narrow <see cref="IScanIgnoreBuilder"/> facade (for attribute-scan prunes).
+    /// </summary>
+    public interface IReflectorModuleContext
+    {
+        /// <summary>
+        /// The reflector being built. Use <c>Reflector.JsonSerializer.AddConverter(...)</c> for JSON
+        /// converters, <c>Reflector.Converters.Add(...)</c> for reflection converters, and
+        /// <c>Reflector.Converters.BlacklistType*(...)</c> for serialization blacklist entries.
+        /// </summary>
+        Reflector Reflector { get; }
+
+        /// <summary>
+        /// Narrow facade onto the host's attribute-scan ignore configuration. Lets a module prune
+        /// whole assemblies / namespaces from the heavy attribute scan that runs after all modules
+        /// have contributed.
+        /// </summary>
+        IScanIgnoreBuilder Scan { get; }
+
+        /// <summary>
+        /// The assembly the discovered module type lives in. Useful for self-relative ignore rules
+        /// and diagnostics.
+        /// </summary>
+        Assembly OwningAssembly { get; }
+
+        /// <summary>
+        /// Logger scoped to module bootstrap. Backed by the host's logger provider (or a no-op when
+        /// none was supplied to the builder).
+        /// </summary>
+        ILogger Logger { get; }
+    }
+
+    /// <summary>
+    /// Narrow facade a module uses to contribute attribute-scan prune rules. Mirrors the host
+    /// builder's <c>IgnoreAssemblies</c> / <c>IgnoreNamespaces</c> by-prefix surface, without
+    /// exposing the rest of the builder. A contributed entry that would prune an assembly hosting a
+    /// discovered module/tool is rejected with a logged warning (safety rail) — see
+    /// <see cref="McpPluginBuilder"/> bootstrap.
+    /// </summary>
+    public interface IScanIgnoreBuilder
+    {
+        /// <summary>
+        /// Excludes assemblies whose name starts with any of the supplied prefixes from the
+        /// attribute scan. Returns this builder for chaining.
+        /// </summary>
+        IScanIgnoreBuilder IgnoreAssemblies(params string[] assemblyNamePrefixes);
+
+        /// <summary>
+        /// Excludes types whose namespace starts with any of the supplied prefixes from the
+        /// attribute scan. Returns this builder for chaining.
+        /// </summary>
+        IScanIgnoreBuilder IgnoreNamespaces(params string[] namespacePrefixes);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `IReflectorModule` / `IReflectorModuleContext` / `IScanIgnoreBuilder` so any host or extension assembly can contribute ReflectorNet JSON + reflection converters, serialization-blacklist types, and attribute-scan prune rules — discovered by assembly scan, no hardcoded extension list.
- Add `McpPluginBuilder.WithReflectorModulesFromAssembly(...)` and a phased α→β→γ bootstrap inside `Build(reflector)`, strictly before `ProcessAllAssemblies()` (cheap discovery reusing the core ignore-config prune; ordered + failure-isolated `Configure`; existing heavy scan under the augmented config).
- Safety rail: a contributed scan-ignore entry cannot prune a module/tool-hosting assembly or a discovered-module namespace (guard + warning). ReflectorNet is consumed only, not modified.

## Test plan
- [x] Target-specific local tests passed (see profile test.md): `dotnet test` 0-fail across `McpPlugin.Tests` + `McpPlugin.Server.Tests` on both `net8.0` and `net9.0` (415 + 268 per TFM).
- [x] New xUnit coverage: discovery in a non-ignored assembly; skip when hosting assembly is core-ignored; failure isolation (throwing module caught, siblings + tools survive); deterministic ordering (Order then assembly name); full contribution (JSON converter + reflection converter + serialization-blacklist + namespace scan-ignore each reaching effect); safety-rail self-prune rejection.

Closes #115