### PR TITLE
build(deps): bump ModelContextProtocol 1.3.0 → 1.4.0

### DIFF
--- a/McpPlugin.Server/McpPlugin.Server.csproj
+++ b/McpPlugin.Server/McpPlugin.Server.csproj
@@ -36,8 +36,8 @@
     <ProjectReference Include="./../McpPlugin.Common/McpPlugin.Common.csproj" />
     <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="5.3.1" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.3" />
-    <PackageReference Include="ModelContextProtocol" Version="1.3.0" />
-    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.3.0" />
+    <PackageReference Include="ModelContextProtocol" Version="1.4.0" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.4.0" />
     <PackageReference Include="NLog.Web.AspNetCore" Version="6.1.2" />
     <PackageReference Include="R3" Version="1.3.0" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- Bump `ModelContextProtocol` and `ModelContextProtocol.AspNetCore` pins in `McpPlugin.Server/McpPlugin.Server.csproj` from 1.3.0 → 1.4.0.
- v1.4.0 is purely additive (new `IdentityAssertionGrantProvider`, `InheritEnvironmentVariables` option, stdio/HTTP security hardening) — no breaking API changes, so no source migration was required.
- Did NOT touch `<Version>` in `McpPlugin/McpPlugin.csproj` (owned by the separate release pipeline).

## Test plan
- [x] `dotnet build McpPlugin.sln --configuration Release` clean — 0 warnings, 0 errors across netstandard2.1 + net8.0 + net9.0.
- [x] `dotnet test --no-build --configuration Release` green — 416/416 across `McpPlugin.Tests` + `McpPlugin.Server.Tests`, both TFMs.

Closes #117