### PR TITLE
fix(transport): bound streamableHttp idle session retention to stop memory leak

### DIFF
--- a/McpPlugin.Common/src/Utils/Consts.MCP.cs
+++ b/McpPlugin.Common/src/Utils/Consts.MCP.cs
@@ -56,6 +56,7 @@ namespace com.IvanMurzak.McpPlugin.Common
                     public const string Token = "token";
                     public const string Authorization = "authorization";
                     public const string IdleTimeoutSeconds = "idle-timeout-seconds";
+                    public const string MaxIdleSessionCount = "max-idle-session-count";
                 }
 
                 public static partial class Env
@@ -66,6 +67,7 @@ namespace com.IvanMurzak.McpPlugin.Common
                     public const string Token = "MCP_PLUGIN_TOKEN";
                     public const string Authorization = "MCP_AUTHORIZATION";
                     public const string IdleTimeoutSeconds = "MCP_PLUGIN_IDLE_TIMEOUT_SECONDS";
+                    public const string MaxIdleSessionCount = "MCP_PLUGIN_MAX_IDLE_SESSION_COUNT";
                 }
 
                 /// <summary>
@@ -73,14 +75,41 @@ namespace com.IvanMurzak.McpPlugin.Common
                 /// <c>HttpServerTransportOptions.IdleTimeout</c>. An idle MCP session is evicted
                 /// from the server's in-memory session tracker after this much time without
                 /// activity; the next request on an evicted session fails with
-                /// <c>HTTP 404</c> / JSON-RPC <c>-32001 "Session not found"</c>. We set 6 hours
-                /// (21600 seconds) — well above the SDK's own 2-hour default — so the long idle
-                /// gaps between an AI agent's tool calls don't evict an otherwise-live session.
-                /// The tracker footprint stays bounded by <c>MaxIdleSessionCount</c>. Override via
-                /// the <see cref="Args.IdleTimeoutSeconds"/> CLI argument or
+                /// <c>HTTP 404</c> / JSON-RPC <c>-32001 "Session not found"</c> and the client
+                /// re-initializes (the 404 → reinit reconnect contract).
+                /// <para>
+                /// The idle timeout only reaps sessions that have <b>no</b> in-flight request and
+                /// <b>no</b> open server→client SSE stream: the SDK protects any session whose
+                /// <c>IsActive</c> flag is set (a long-running tool call such as a 10-minute
+                /// <c>script-execute</c>, or a connected client holding its SSE GET open) from
+                /// eviction regardless of this value. A short window is therefore safe for
+                /// otherwise-live sessions and reaps only genuinely-disconnected (zombie)
+                /// sessions, each of which would otherwise pin its grown <c>SseEventWriter</c>
+                /// buffer (up to tens of MiB after a large screenshot / response) until disposed.
+                /// We default to 10 minutes (600 seconds) to keep the in-memory footprint bounded;
+                /// <see cref="DefaultMaxIdleSessionCount"/> provides the complementary hard ceiling.
+                /// Override via the <see cref="Args.IdleTimeoutSeconds"/> CLI argument or
                 /// <see cref="Env.IdleTimeoutSeconds"/> environment variable.
+                /// </para>
                 /// </summary>
-                public const int DefaultIdleTimeoutSeconds = 21600;
+                public const int DefaultIdleTimeoutSeconds = 600;
+
+                /// <summary>
+                /// Default hard ceiling for the streamableHttp transport's
+                /// <c>HttpServerTransportOptions.MaxIdleSessionCount</c>. When the number of idle
+                /// (non-<c>IsActive</c>) MCP sessions exceeds this value, the SDK prunes the
+                /// least-recently-active idle sessions first — disposing them and returning their
+                /// per-session <c>SseEventWriter</c> buffers to the array pool — even before
+                /// <see cref="DefaultIdleTimeoutSeconds"/> elapses. This bounds worst-case
+                /// retained per-session buffer memory under connection churn. The SDK's own
+                /// default is 10,000; we lower it to give generous headroom over real concurrency
+                /// while capping the footprint an order of magnitude below the SDK default.
+                /// Active sessions (in-flight request or open SSE stream) are never pruned by this
+                /// ceiling, so it cannot interrupt a long-running call. Override via the
+                /// <see cref="Args.MaxIdleSessionCount"/> CLI argument or
+                /// <see cref="Env.MaxIdleSessionCount"/> environment variable.
+                /// </summary>
+                public const int DefaultMaxIdleSessionCount = 1000;
 
                 public const string DefaultBodyPath = "mcpServers";
                 public const string DefaultServerName = "McpPlugin";

--- a/McpPlugin.Common/src/Utils/DataArguments.cs
+++ b/McpPlugin.Common/src/Utils/DataArguments.cs
@@ -18,6 +18,7 @@ namespace com.IvanMurzak.McpPlugin.Common.Utils
         int Port { get; }
         int PluginTimeoutMs { get; }
         int IdleTimeoutSeconds { get; }
+        int MaxIdleSessionCount { get; }
         Consts.MCP.Server.TransportMethod ClientTransport { get; }
         Consts.MCP.Server.AuthOption Authorization { get; }
         string? Token { get; }
@@ -40,6 +41,7 @@ namespace com.IvanMurzak.McpPlugin.Common.Utils
         public int Port { get; private set; } = 8080;
         public int PluginTimeoutMs { get; private set; }
         public int IdleTimeoutSeconds { get; private set; } = Consts.MCP.Server.DefaultIdleTimeoutSeconds;
+        public int MaxIdleSessionCount { get; private set; } = Consts.MCP.Server.DefaultMaxIdleSessionCount;
         public Consts.MCP.Server.TransportMethod ClientTransport { get; private set; }
         public Consts.MCP.Server.AuthOption Authorization { get; private set; } = Consts.MCP.Server.AuthOption.none;
         public string? Token { get; private set; }
@@ -88,6 +90,10 @@ namespace com.IvanMurzak.McpPlugin.Common.Utils
             var envIdleTimeoutSeconds = Environment.GetEnvironmentVariable(Consts.MCP.Server.Env.IdleTimeoutSeconds);
             if (envIdleTimeoutSeconds != null && int.TryParse(envIdleTimeoutSeconds, out var parsedEnvIdleTimeoutSeconds) && parsedEnvIdleTimeoutSeconds > 0)
                 IdleTimeoutSeconds = parsedEnvIdleTimeoutSeconds;
+
+            var envMaxIdleSessionCount = Environment.GetEnvironmentVariable(Consts.MCP.Server.Env.MaxIdleSessionCount);
+            if (envMaxIdleSessionCount != null && int.TryParse(envMaxIdleSessionCount, out var parsedEnvMaxIdleSessionCount) && parsedEnvMaxIdleSessionCount > 0)
+                MaxIdleSessionCount = parsedEnvMaxIdleSessionCount;
 
             // --- Client variables ---
 
@@ -166,6 +172,10 @@ namespace com.IvanMurzak.McpPlugin.Common.Utils
             var argIdleTimeoutSeconds = commandLineArgs.GetValueOrDefault(Consts.MCP.Server.Args.IdleTimeoutSeconds.TrimStart('-'));
             if (argIdleTimeoutSeconds != null && int.TryParse(argIdleTimeoutSeconds, out var parsedArgIdleTimeoutSeconds) && parsedArgIdleTimeoutSeconds > 0)
                 IdleTimeoutSeconds = parsedArgIdleTimeoutSeconds;
+
+            var argMaxIdleSessionCount = commandLineArgs.GetValueOrDefault(Consts.MCP.Server.Args.MaxIdleSessionCount.TrimStart('-'));
+            if (argMaxIdleSessionCount != null && int.TryParse(argMaxIdleSessionCount, out var parsedArgMaxIdleSessionCount) && parsedArgMaxIdleSessionCount > 0)
+                MaxIdleSessionCount = parsedArgMaxIdleSessionCount;
 
             // --- Client variables ---
 

--- a/McpPlugin.Server.Tests/DataArgumentsMaxIdleSessionCountTests.cs
+++ b/McpPlugin.Server.Tests/DataArgumentsMaxIdleSessionCountTests.cs
@@ -1,0 +1,97 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+using com.IvanMurzak.McpPlugin.Common;
+using com.IvanMurzak.McpPlugin.Common.Utils;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.Server.Tests
+{
+    [Collection("McpPlugin.Server")]
+    public class DataArgumentsMaxIdleSessionCountTests : IDisposable
+    {
+        // The Env-var test path mutates process-wide environment state. We snapshot+restore
+        // the variable so parallel xUnit runs and downstream tests are not affected.
+        private readonly string? _originalEnv;
+
+        public DataArgumentsMaxIdleSessionCountTests()
+        {
+            _originalEnv = Environment.GetEnvironmentVariable(Consts.MCP.Server.Env.MaxIdleSessionCount);
+            Environment.SetEnvironmentVariable(Consts.MCP.Server.Env.MaxIdleSessionCount, null);
+        }
+
+        public void Dispose()
+        {
+            Environment.SetEnvironmentVariable(Consts.MCP.Server.Env.MaxIdleSessionCount, _originalEnv);
+        }
+
+        [Fact]
+        public void MaxIdleSessionCount_WhenNoArgs_UsesDefault()
+        {
+            var args = new DataArguments(Array.Empty<string>());
+
+            args.MaxIdleSessionCount.ShouldBe(Consts.MCP.Server.DefaultMaxIdleSessionCount);
+        }
+
+        [Fact]
+        public void MaxIdleSessionCount_FromCli_PositiveValue_IsApplied()
+        {
+            var args = new DataArguments(new[] { "max-idle-session-count=256" });
+
+            args.MaxIdleSessionCount.ShouldBe(256);
+        }
+
+        [Fact]
+        public void MaxIdleSessionCount_FromCli_NonPositive_FallsBackToDefault()
+        {
+            var args = new DataArguments(new[] { "max-idle-session-count=0" });
+
+            args.MaxIdleSessionCount.ShouldBe(Consts.MCP.Server.DefaultMaxIdleSessionCount);
+        }
+
+        [Fact]
+        public void MaxIdleSessionCount_FromCli_Negative_FallsBackToDefault()
+        {
+            var args = new DataArguments(new[] { "max-idle-session-count=-10" });
+
+            args.MaxIdleSessionCount.ShouldBe(Consts.MCP.Server.DefaultMaxIdleSessionCount);
+        }
+
+        [Fact]
+        public void MaxIdleSessionCount_FromCli_NonInteger_FallsBackToDefault()
+        {
+            var args = new DataArguments(new[] { "max-idle-session-count=not-a-number" });
+
+            args.MaxIdleSessionCount.ShouldBe(Consts.MCP.Server.DefaultMaxIdleSessionCount);
+        }
+
+        [Fact]
+        public void MaxIdleSessionCount_FromEnv_PositiveValue_IsApplied()
+        {
+            Environment.SetEnvironmentVariable(Consts.MCP.Server.Env.MaxIdleSessionCount, "2048");
+
+            var args = new DataArguments(Array.Empty<string>());
+
+            args.MaxIdleSessionCount.ShouldBe(2048);
+        }
+
+        [Fact]
+        public void MaxIdleSessionCount_CliOverridesEnv()
+        {
+            Environment.SetEnvironmentVariable(Consts.MCP.Server.Env.MaxIdleSessionCount, "2048");
+
+            var args = new DataArguments(new[] { "max-idle-session-count=512" });
+
+            args.MaxIdleSessionCount.ShouldBe(512);
+        }
+    }
+}

--- a/McpPlugin.Server.Tests/McpSessionTrackerTests.cs
+++ b/McpPlugin.Server.Tests/McpSessionTrackerTests.cs
@@ -110,6 +110,40 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
             _tracker.GetServerData("phys-1").IsAiAgentConnected.ShouldBeFalse();
         }
 
+        // Regression guard for the production memory leak (issue #119): once a session's last
+        // reference is removed, the per-session entry must leave the dictionary so its retained
+        // state can be collected. Asserts the tracked count returns to baseline after disconnect.
+        [Fact]
+        public void ActiveSessionCount_AfterUpdateThenRemove_ReturnsToBaseline()
+        {
+            _tracker.ActiveSessionCount.ShouldBe(0);
+
+            _tracker.Update("phys-1", null, new McpClientData { IsConnected = true, ClientName = "Leaky" }, new McpServerData());
+            _tracker.AddRef("phys-1");
+            _tracker.ActiveSessionCount.ShouldBe(1);
+
+            var isLast = _tracker.Remove("phys-1");
+
+            isLast.ShouldBeTrue();
+            _tracker.ActiveSessionCount.ShouldBe(0);
+        }
+
+        [Fact]
+        public void ActiveSessionCount_ManySessions_AllRemoved_ReturnsToBaseline()
+        {
+            for (var i = 0; i < 50; i++)
+            {
+                _tracker.Update($"phys-{i}", null, new McpClientData { IsConnected = true }, new McpServerData());
+                _tracker.AddRef($"phys-{i}");
+            }
+            _tracker.ActiveSessionCount.ShouldBe(50);
+
+            for (var i = 0; i < 50; i++)
+                _tracker.Remove($"phys-{i}");
+
+            _tracker.ActiveSessionCount.ShouldBe(0);
+        }
+
         [Fact]
         public void Remove_NonexistentSession_ReturnsTrueAndDoesNotThrow()
         {

--- a/McpPlugin.Server.Tests/StreamableHttpTransportLayerOptionsTests.cs
+++ b/McpPlugin.Server.Tests/StreamableHttpTransportLayerOptionsTests.cs
@@ -1,0 +1,74 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+using com.IvanMurzak.McpPlugin.Common.Utils;
+using com.IvanMurzak.McpPlugin.Server.Transport;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using ModelContextProtocol.AspNetCore;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.Server.Tests
+{
+    // Regression guard for the production memory leak (issue #119): the streamableHttp transport
+    // MUST configure the SDK's session-eviction knobs (IdleTimeout + MaxIdleSessionCount) from
+    // DataArguments. Without MaxIdleSessionCount the SDK default (10,000) let zombie sessions —
+    // each pinning a grown SseEventWriter buffer — accumulate to multi-GB.
+    [Collection("McpPlugin.Server")]
+    public class StreamableHttpTransportLayerOptionsTests
+    {
+        static HttpServerTransportOptions ConfigureAndResolve(DataArguments dataArguments)
+        {
+            var services = new ServiceCollection();
+            var mcpServerBuilder = services.AddMcpServer();
+
+            new StreamableHttpTransportLayer().ConfigureTransport(mcpServerBuilder, dataArguments);
+
+            using var provider = services.BuildServiceProvider();
+            return provider.GetRequiredService<IOptions<HttpServerTransportOptions>>().Value;
+        }
+
+        [Fact]
+        public void ConfigureTransport_WiresIdleTimeoutAndMaxIdleSessionCount_FromExplicitArgs()
+        {
+            var args = new DataArguments(new[] { "idle-timeout-seconds=123", "max-idle-session-count=77" });
+
+            var options = ConfigureAndResolve(args);
+
+            options.IdleTimeout.ShouldBe(TimeSpan.FromSeconds(123));
+            options.MaxIdleSessionCount.ShouldBe(77);
+        }
+
+        [Fact]
+        public void ConfigureTransport_WiresDefaults_FromDataArguments()
+        {
+            var args = new DataArguments(Array.Empty<string>());
+
+            var options = ConfigureAndResolve(args);
+
+            // Assert the options mirror the resolved DataArguments (robust to ambient env vars).
+            options.IdleTimeout.ShouldBe(TimeSpan.FromSeconds(args.IdleTimeoutSeconds));
+            options.MaxIdleSessionCount.ShouldBe(args.MaxIdleSessionCount);
+        }
+
+        [Fact]
+        public void ConfigureTransport_KeepsStatefulPerSessionLifecycle()
+        {
+            // Stateful + per-session execution context are load-bearing for the session lifecycle
+            // (StartAsync/StopAsync via RunSessionHandler). Guard against accidental regression.
+            var options = ConfigureAndResolve(new DataArguments(Array.Empty<string>()));
+
+            options.Stateless.ShouldBeFalse();
+            options.PerSessionExecutionContext.ShouldBeTrue();
+        }
+    }
+}

--- a/McpPlugin.Server/src/Transport/StreamableHttpTransportLayer.cs
+++ b/McpPlugin.Server/src/Transport/StreamableHttpTransportLayer.cs
@@ -37,11 +37,17 @@ namespace com.IvanMurzak.McpPlugin.Server.Transport
         {
             return mcpServerBuilder.WithHttpTransport(options =>
             {
-                logger?.Debug("Http transport configuration. IdleTimeout={idleTimeoutSeconds}s", dataArguments.IdleTimeoutSeconds);
+                logger?.Debug("Http transport configuration. IdleTimeout={idleTimeoutSeconds}s, MaxIdleSessionCount={maxIdleSessionCount}",
+                    dataArguments.IdleTimeoutSeconds, dataArguments.MaxIdleSessionCount);
 
                 options.Stateless = false;
                 options.PerSessionExecutionContext = true;
                 options.IdleTimeout = TimeSpan.FromSeconds(dataArguments.IdleTimeoutSeconds);
+                // Hard ceiling on retained idle sessions. Without this the SDK default (10,000)
+                // lets disconnected (zombie) sessions accumulate, each pinning its grown
+                // SseEventWriter buffer (up to tens of MiB), which leaked multi-GB in production.
+                // Active sessions (in-flight request / open SSE stream) are never pruned by this.
+                options.MaxIdleSessionCount = dataArguments.MaxIdleSessionCount;
                 // ConfigureSessionOptions cannot replace RunSessionHandler here because we need
                 // full session lifecycle management (StartAsync/StopAsync for McpServerService).
                 // Suppressing MCPEXP002 as RunSessionHandler is the only mechanism that provides

--- a/README.md
+++ b/README.md
@@ -231,7 +231,8 @@ Command-line arguments take priority over environment variables.
 | `port` | `MCP_PLUGIN_PORT` | The port the SignalR hub listens on. | `8080` |
 | `client-transport` | `MCP_PLUGIN_CLIENT_TRANSPORT` | Transport method: `stdio` or `streamableHttp`. | `streamableHttp` |
 | `plugin-timeout` | `MCP_PLUGIN_CLIENT_TIMEOUT` | Timeout for plugin operations (ms). | `10000` |
-| `idle-timeout-seconds` | `MCP_PLUGIN_IDLE_TIMEOUT_SECONDS` | `streamableHttp` only: idle window before an MCP session is evicted from the in-memory tracker. Longer values reduce reconnect 404s / session-migration rehydrates at the cost of higher in-memory footprint (bounded by `MaxIdleSessionCount`). The SDK's own default is `7200` (2 h). | `600` |
+| `idle-timeout-seconds` | `MCP_PLUGIN_IDLE_TIMEOUT_SECONDS` | `streamableHttp` only: idle window before an MCP session is evicted from the in-memory tracker. Longer values reduce reconnect 404s / session-migration rehydrates at the cost of higher in-memory footprint (bounded by `max-idle-session-count`). Only sessions with no in-flight request and no open SSE stream are evicted, so this never interrupts a long-running call. The SDK's own default is `7200` (2 h). | `600` |
+| `max-idle-session-count` | `MCP_PLUGIN_MAX_IDLE_SESSION_COUNT` | `streamableHttp` only: hard ceiling on retained **idle** MCP sessions. When exceeded, the least-recently-active idle sessions are pruned (disposed, buffers returned to the pool) before the idle timeout elapses. Bounds worst-case per-session buffer memory under connection churn. Active sessions are never counted/pruned. The SDK's own default is `10000`. | `1000` |
 | `token` | `MCP_PLUGIN_TOKEN` | Bearer token required from connecting plugins. | *(none)* |
 | `authorization` | `MCP_AUTHORIZATION` | Authorization mode: `none` or `required`. | `none` |
 

--- a/docs/architecture-transport-auth.md
+++ b/docs/architecture-transport-auth.md
@@ -53,13 +53,28 @@ Controls `HttpServerTransportOptions.IdleTimeout` for the streamableHttp transpo
 
 **Default**: `600` (10 minutes). The MCP SDK's own default is `7200` (2 hours).
 
+**Eviction only targets genuinely-idle sessions.** The SDK protects any session whose `IsActive` flag is set — a session with an in-flight request (e.g. a 10-minute `script-execute`) or with an open server→client SSE stream is **never** evicted by the idle timeout, regardless of how short it is. The idle timeout therefore reaps only disconnected (zombie) sessions, each of which would otherwise pin its grown `SseEventWriter` buffer until disposed. A short window is safe for live clients and keeps the in-memory footprint bounded.
+
 Trade-off:
 
 - **Longer values** reduce 404s and migration-rehydrate cost for slow-reconnecting clients (consumer reconnect latencies routinely exceed 30 s).
-- **Shorter values** keep the in-memory session-tracker footprint bounded — though `HttpServerTransportOptions.MaxIdleSessionCount` already provides a hard upper bound.
+- **Shorter values** keep the in-memory session-tracker footprint bounded.
 - Test scenarios that intentionally exercise eviction may want a small value (e.g. `5`). Non-positive values are rejected and the default is used.
 
 This setting is ignored when `client-transport=stdio` (the stdio transport has no idle-eviction concept).
+
+### Max Idle Session Count — streamableHttp hard ceiling on retained idle sessions
+
+Controls `HttpServerTransportOptions.MaxIdleSessionCount`. When the number of idle (non-`IsActive`) MCP sessions exceeds this value, the SDK prunes the least-recently-active idle sessions first — disposing them and returning their per-session `SseEventWriter` buffers to the array pool — even before `idle-timeout-seconds` elapses. This is the hard upper bound that keeps worst-case per-session buffer memory bounded under connection churn. Active sessions (in-flight request or open SSE stream) are never counted toward this ceiling and are never pruned by it.
+
+| Source           | Key                                          | Values            |
+|------------------|----------------------------------------------|-------------------|
+| CLI argument     | `max-idle-session-count=<int>`               | Positive integer  |
+| Environment var  | `MCP_PLUGIN_MAX_IDLE_SESSION_COUNT=<int>`    | Positive integer  |
+
+**Default**: `1000`. The MCP SDK's own default is `10000`. Non-positive values are rejected and the default is used. This setting is ignored when `client-transport=stdio`.
+
+> **Why both knobs matter (issue #119).** Production accumulated thousands of zombie `StreamableHttpSession` entries — each pinning a `PooledByteBufferWriter` grown to the largest SSE event it ever served (up to tens of MiB) — leaking multiple GB. The fix is purely lifecycle/eviction tuning: a documented 10-minute idle window reaps disconnected sessions promptly, and an explicit `MaxIdleSessionCount` caps the retained idle set an order of magnitude below the SDK default. Neither change touches the wire protocol, image/screenshot transfer, or auth semantics.
 
 **Optional at server launch** when `authorization=required`. When absent, the server enters dynamic-pairing mode — any plugin token is accepted and plugins/clients are paired by token equality. When present, only that exact token is accepted from connecting plugins. Ignored (but accepted) when `authorization=none`. Note: connecting plugins must always provide a token in `auth=required` mode regardless.
 


### PR DESCRIPTION
## Summary
- Production `mcp-server` leaked ~3.15 GB: thousands of zombie `StreamableHttpSession` entries in the SDK's `StatefulSessionManager`, each pinning a grown `SseEventWriter`/`PooledByteBufferWriter` buffer (up to tens of MiB), never evicted.
- Root cause was eviction config drift, not an SDK bug (we are already on the latest SDK, 1.4.0): `IdleTimeout` defaulted to `21600s` (6h) vs the documented `600s`, and `MaxIdleSessionCount` was never configured (SDK default 10,000). The SDK protects `IsActive` sessions (in-flight request or open SSE stream) from eviction regardless of timeout, so the long window only delayed reaping of genuine zombies.
- Reconciled `DefaultIdleTimeoutSeconds` to the documented `600`, added a configurable `max-idle-session-count` / `MCP_PLUGIN_MAX_IDLE_SESSION_COUNT` (default `1000`), and wired both into `HttpServerTransportOptions`. Our `McpSessionTracker` leak was a transitive symptom and is resolved once the SDK disposes sessions (token cancel → `RunSessionHandler` returns → `StopAsync` → `Remove`).

## Constraints honoured
- No change to wire protocol, image/screenshot transfer (SignalR + streamable HTTP), or auth semantics.
- Long-running (10+ min) `script-execute` calls are unaffected — `IsActive` sessions are never evicted.
- Idle-eviction / 404 → reinit reconnect contract preserved.

## Memory verification method
- gcdump retention-path analysis of the prod heap (`.claude/tmp/gcdump-analysis/report.txt`) pinned 98% of leaked bytes to the `StatefulSessionManager` → `StreamableHttpSession` → `SseEventWriter` → `byte[]` chain with 4,566 sessions vs ~206 live.
- SDK eviction semantics confirmed against the `csharp-sdk` v1.4.0 source (`HttpServerTransportOptions` defaults; `StatefulSessionManager` prunes only non-`IsActive` idle sessions, capacity-bounded by `MaxIdleSessionCount`).

## Test plan
- [x] Full xUnit suite green: 416 tests, net8.0 + net9.0, 0 failures.
- [x] New regression tests: `max-idle-session-count` parsing, transport options wiring (`IdleTimeout` + `MaxIdleSessionCount` + stateful lifecycle), session-tracker count returns to baseline after disconnect.

Closes #119