### PR TITLE
feat(tool): add dynamic ProxyTool API with runtime schemas and async handlers

### DIFF
--- a/McpPlugin.Tests/Mcp/ProxyToolTests.cs
+++ b/McpPlugin.Tests/Mcp/ProxyToolTests.cs
@@ -1,0 +1,277 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.Common.Model;
+using com.IvanMurzak.ReflectorNet;
+using Microsoft.Extensions.DependencyInjection;
+using R3;
+using Shouldly;
+using Xunit;
+using Version = com.IvanMurzak.McpPlugin.Common.Version;
+
+namespace com.IvanMurzak.McpPlugin.Tests.Mcp
+{
+    [Collection("McpPlugin")]
+    public class ProxyToolTests
+    {
+        private readonly Version _version = new Version();
+
+        private const string InputSchemaJson =
+            "{\"type\":\"object\",\"properties\":{\"value\":{\"type\":\"string\"}},\"required\":[\"value\"]}";
+        private const string OutputSchemaJson =
+            "{\"type\":\"object\",\"properties\":{\"ok\":{\"type\":\"boolean\"}}}";
+
+        private static Func<string, IReadOnlyDictionary<string, JsonElement>?, CancellationToken, Task<ResponseCallTool>> NoopHandler()
+            => (_, _, _) => Task.FromResult(ResponseCallTool.Success("noop"));
+
+        [Fact]
+        public void WithDynamicToolFactory_ShouldRegisterFactoryAsSingleton()
+        {
+            // Arrange
+            var reflector = new Reflector();
+            var builder = new McpPluginBuilder(_version);
+            builder.WithDynamicToolFactory();
+
+            // Act
+            builder.Build(reflector);
+            var factory1 = builder.ServiceProvider!.GetRequiredService<IDynamicToolFactory>();
+            var factory2 = builder.ServiceProvider!.GetRequiredService<IDynamicToolFactory>();
+
+            // Assert
+            factory1.ShouldNotBeNull();
+            factory1.ShouldBeOfType<ProxyToolFactory>();
+            factory2.ShouldBeSameAs(factory1); // singleton
+        }
+
+        [Fact]
+        public void CreateProxyTool_ShouldReturnIRunTool_WithSettableEnabledDefaultingTrue()
+        {
+            // Arrange
+            IDynamicToolFactory factory = new ProxyToolFactory();
+
+            // Act
+            var tool = factory.CreateProxyTool(
+                name: "proxy-create",
+                title: "Proxy Create",
+                description: "A runtime tool.",
+                skillDescription: null,
+                skillBody: null,
+                inputSchema: JsonNode.Parse(InputSchemaJson),
+                outputSchema: JsonNode.Parse(OutputSchemaJson),
+                readOnlyHint: true,
+                destructiveHint: false,
+                idempotentHint: null,
+                openWorldHint: null,
+                handler: NoopHandler());
+
+            // Assert
+            tool.ShouldNotBeNull();
+            tool.ShouldBeAssignableTo<IRunTool>();
+            tool.Name.ShouldBe("proxy-create");
+            tool.Enabled.ShouldBeTrue(); // default true
+
+            tool.Enabled = false; // settable
+            tool.Enabled.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void Constructor_ShouldThrow_WhenNameOrHandlerIsNull()
+        {
+            Should.Throw<ArgumentNullException>(() => new ProxyTool(
+                name: null!, title: null, description: null, skillDescription: null, skillBody: null,
+                inputSchema: null, outputSchema: null,
+                readOnlyHint: null, destructiveHint: null, idempotentHint: null, openWorldHint: null,
+                handler: NoopHandler()));
+
+            Should.Throw<ArgumentNullException>(() => new ProxyTool(
+                name: "n", title: null, description: null, skillDescription: null, skillBody: null,
+                inputSchema: null, outputSchema: null,
+                readOnlyHint: null, destructiveHint: null, idempotentHint: null, openWorldHint: null,
+                handler: null!));
+        }
+
+        [Fact]
+        public async Task ProxyTool_Lifecycle_AddListChangedCallRemove_RoutesThroughHandler()
+        {
+            // Arrange
+            var reflector = new Reflector();
+            var builder = new McpPluginBuilder(_version);
+            builder.WithDynamicToolFactory();
+            var plugin = builder.Build(reflector);
+            var toolManager = plugin.McpManager.ToolManager!;
+            var factory = builder.ServiceProvider!.GetRequiredService<IDynamicToolFactory>();
+
+            var updates = 0;
+            using var sub = toolManager.OnToolsUpdated.Subscribe(_ => updates++);
+
+            var handlerInvoked = false;
+            string? capturedRequestId = null;
+            IReadOnlyDictionary<string, JsonElement>? capturedArgs = null;
+
+            var proxy = factory.CreateProxyTool(
+                name: "proxy-echo",
+                title: "Proxy Echo",
+                description: "Echoes the value argument back.",
+                skillDescription: null,
+                skillBody: null,
+                inputSchema: JsonNode.Parse(InputSchemaJson),
+                outputSchema: JsonNode.Parse(OutputSchemaJson),
+                readOnlyHint: true,
+                destructiveHint: false,
+                idempotentHint: true,
+                openWorldHint: false,
+                handler: (requestId, args, _) =>
+                {
+                    handlerInvoked = true;
+                    capturedRequestId = requestId;
+                    capturedArgs = args;
+                    return Task.FromResult(ResponseCallTool.Success("proxy-handled"));
+                });
+
+            // Act + Assert — AddTool fires list_changed
+            toolManager.AddTool("proxy-echo", proxy).ShouldBeTrue();
+            updates.ShouldBe(1);
+            toolManager.HasTool("proxy-echo").ShouldBeTrue();
+
+            // The tool appears in the listing with its externally supplied schema
+            var listResponse = await toolManager.RunListTool(new RequestListTool());
+            listResponse.Status.ShouldBe(ResponseStatus.Success);
+            var listed = Array.Find(listResponse.Value!, t => t.Name == "proxy-echo");
+            listed.ShouldNotBeNull();
+            listed!.Title.ShouldBe("Proxy Echo");
+            listed.Enabled.ShouldBeTrue();
+
+            // Call dispatch routes through the proxy handler
+            var args = new Dictionary<string, JsonElement>
+            {
+                ["value"] = JsonSerializer.SerializeToElement("hello")
+            };
+            var callResponse = await toolManager.RunCallTool(new RequestCallTool("req-1", "proxy-echo", args));
+
+            handlerInvoked.ShouldBeTrue();
+            capturedRequestId.ShouldBe("req-1");
+            capturedArgs.ShouldNotBeNull();
+            capturedArgs!.ContainsKey("value").ShouldBeTrue();
+            callResponse.Status.ShouldBe(ResponseStatus.Success);
+            callResponse.Value.ShouldNotBeNull();
+            callResponse.Value!.GetMessage().ShouldBe("proxy-handled");
+
+            // RemoveTool fires list_changed again and the tool is gone
+            toolManager.RemoveTool("proxy-echo").ShouldBeTrue();
+            updates.ShouldBe(2);
+            toolManager.HasTool("proxy-echo").ShouldBeFalse();
+        }
+
+        [Fact]
+        public async Task ProxyTool_DisabledToggle_FiltersOutOfEnabledView()
+        {
+            // Arrange
+            var reflector = new Reflector();
+            var builder = new McpPluginBuilder(_version);
+            builder.WithDynamicToolFactory();
+            var plugin = builder.Build(reflector);
+            var toolManager = plugin.McpManager.ToolManager!;
+            var factory = builder.ServiceProvider!.GetRequiredService<IDynamicToolFactory>();
+
+            var enabledProxy = factory.CreateProxyTool(
+                "proxy-enabled", "Enabled", "Enabled proxy.", null, null,
+                JsonNode.Parse(InputSchemaJson), JsonNode.Parse(OutputSchemaJson),
+                null, null, null, null, NoopHandler());
+
+            var toggledProxy = factory.CreateProxyTool(
+                "proxy-toggled", "Toggled", "Toggled proxy.", null, null,
+                JsonNode.Parse(InputSchemaJson), JsonNode.Parse(OutputSchemaJson),
+                null, null, null, null, NoopHandler());
+
+            // Act + Assert
+            toolManager.AddTool("proxy-enabled", enabledProxy).ShouldBeTrue();
+            toolManager.AddTool("proxy-toggled", toggledProxy).ShouldBeTrue();
+
+            toolManager.TotalToolsCount.ShouldBe(2);
+            toolManager.EnabledToolsCount.ShouldBe(2);
+            var bothEnabledTokens = toolManager.EnabledToolsTokenCount;
+
+            // Disable one — it must drop out of the enabled view (count + token sum) but stay registered
+            toolManager.SetToolEnabled("proxy-toggled", false).ShouldBeTrue();
+
+            toolManager.IsToolEnabled("proxy-toggled").ShouldBeFalse();
+            toolManager.TotalToolsCount.ShouldBe(2);
+            toolManager.EnabledToolsCount.ShouldBe(1);
+            toolManager.EnabledToolsTokenCount.ShouldBe(bothEnabledTokens - toggledProxy.TokenCount);
+
+            // The listing still includes it, flagged disabled
+            var listResponse = await toolManager.RunListTool(new RequestListTool());
+            var listed = Array.Find(listResponse.Value!, t => t.Name == "proxy-toggled");
+            listed.ShouldNotBeNull();
+            listed!.Enabled.ShouldBeFalse();
+
+            // Re-enabling restores it
+            toolManager.SetToolEnabled("proxy-toggled", true).ShouldBeTrue();
+            toolManager.EnabledToolsCount.ShouldBe(2);
+            toolManager.EnabledToolsTokenCount.ShouldBe(bothEnabledTokens);
+        }
+
+        [Fact]
+        public void TokenCount_ShouldMatch_RunToolCharsOver4Formula()
+        {
+            // Arrange
+            const string name = "proxy-token";
+            const string title = "Proxy Token";
+            const string description = "A proxy tool used to verify token-count parity.";
+
+            var proxy = new ProxyTool(
+                name, title, description, null, null,
+                JsonNode.Parse(InputSchemaJson), JsonNode.Parse(OutputSchemaJson),
+                null, null, null, null, NoopHandler());
+
+            // Independently replicate the chars/4 formula over the same JSON shape with fresh node instances.
+            var expectedObject = new JsonObject
+            {
+                ["name"] = name,
+                ["title"] = title,
+                ["description"] = description,
+                ["inputSchema"] = JsonNode.Parse(JsonNode.Parse(InputSchemaJson)!.ToJsonString()),
+                ["outputSchema"] = JsonNode.Parse(JsonNode.Parse(OutputSchemaJson)!.ToJsonString())
+            };
+            var expected = (int)Math.Ceiling(expectedObject.ToJsonString().Length / 4.0);
+
+            // Act + Assert
+            proxy.TokenCount.ShouldBeGreaterThan(0);
+            proxy.TokenCount.ShouldBe(expected);
+
+            // Cached: repeated reads return the same value.
+            proxy.TokenCount.ShouldBe(expected);
+        }
+
+        [Fact]
+        public void TokenCount_ShouldBeHigher_WhenDescriptionPresent()
+        {
+            // Arrange
+            var withDescription = new ProxyTool(
+                "proxy-desc", "Proxy", "A reasonably long description that adds characters.", null, null,
+                JsonNode.Parse(InputSchemaJson), JsonNode.Parse(OutputSchemaJson),
+                null, null, null, null, NoopHandler());
+
+            var withoutDescription = new ProxyTool(
+                "proxy-desc", "Proxy", null, null, null,
+                JsonNode.Parse(InputSchemaJson), JsonNode.Parse(OutputSchemaJson),
+                null, null, null, null, NoopHandler());
+
+            // Act + Assert
+            withDescription.TokenCount.ShouldBeGreaterThan(withoutDescription.TokenCount);
+        }
+    }
+}

--- a/McpPlugin/src/Mcp/Tool/IDynamicToolFactory.cs
+++ b/McpPlugin/src/Mcp/Tool/IDynamicToolFactory.cs
@@ -1,0 +1,79 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.Common.Model;
+
+namespace com.IvanMurzak.McpPlugin
+{
+    /// <summary>
+    /// Factory for constructing runtime tools whose schemas are supplied externally and whose body is an
+    /// async delegate. Registered as a DI singleton via
+    /// <see cref="McpPluginBuilder.WithDynamicToolFactory"/>, so a host can resolve it and create
+    /// <see cref="IRunTool"/> instances to register against the tool manager at runtime.
+    /// </summary>
+    public interface IDynamicToolFactory
+    {
+        /// <summary>
+        /// Creates a runtime/proxy <see cref="IRunTool"/> from externally supplied schemas and an async handler.
+        /// </summary>
+        IRunTool CreateProxyTool(
+            string name,
+            string? title,
+            string? description,
+            string? skillDescription,
+            string? skillBody,
+            JsonNode? inputSchema,
+            JsonNode? outputSchema,
+            bool? readOnlyHint,
+            bool? destructiveHint,
+            bool? idempotentHint,
+            bool? openWorldHint,
+            Func<string, IReadOnlyDictionary<string, JsonElement>?, CancellationToken, Task<ResponseCallTool>> handler);
+    }
+
+    /// <summary>
+    /// Default <see cref="IDynamicToolFactory"/> implementation that produces <see cref="ProxyTool"/> instances.
+    /// </summary>
+    public sealed class ProxyToolFactory : IDynamicToolFactory
+    {
+        public IRunTool CreateProxyTool(
+            string name,
+            string? title,
+            string? description,
+            string? skillDescription,
+            string? skillBody,
+            JsonNode? inputSchema,
+            JsonNode? outputSchema,
+            bool? readOnlyHint,
+            bool? destructiveHint,
+            bool? idempotentHint,
+            bool? openWorldHint,
+            Func<string, IReadOnlyDictionary<string, JsonElement>?, CancellationToken, Task<ResponseCallTool>> handler)
+            => new ProxyTool(
+                name: name,
+                title: title,
+                description: description,
+                skillDescription: skillDescription,
+                skillBody: skillBody,
+                inputSchema: inputSchema,
+                outputSchema: outputSchema,
+                readOnlyHint: readOnlyHint,
+                destructiveHint: destructiveHint,
+                idempotentHint: idempotentHint,
+                openWorldHint: openWorldHint,
+                handler: handler);
+    }
+}

--- a/McpPlugin/src/Mcp/Tool/IDynamicToolFactory.cs
+++ b/McpPlugin/src/Mcp/Tool/IDynamicToolFactory.cs
@@ -23,6 +23,11 @@ namespace com.IvanMurzak.McpPlugin
     /// async delegate. Registered as a DI singleton via
     /// <see cref="McpPluginBuilder.WithDynamicToolFactory"/>, so a host can resolve it and create
     /// <see cref="IRunTool"/> instances to register against the tool manager at runtime.
+    /// <para>
+    /// <b>Thread-safety:</b> the tool manager's backing store is not synchronized, so a host must serialize
+    /// the runtime <c>AddTool</c>/<c>RemoveTool</c> calls that register the produced tools with respect to
+    /// listing and dispatch; mutating the tool set concurrently with enumeration is not supported.
+    /// </para>
     /// </summary>
     public interface IDynamicToolFactory
     {

--- a/McpPlugin/src/Mcp/Tool/ProxyTool.cs
+++ b/McpPlugin/src/Mcp/Tool/ProxyTool.cs
@@ -1,0 +1,125 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.Common.Model;
+
+namespace com.IvanMurzak.McpPlugin
+{
+    /// <summary>
+    /// An <see cref="IRunTool"/> whose JSON schemas are supplied externally at runtime and whose body is an
+    /// async delegate, rather than a reflected method. This is the building block for hosts that define their
+    /// tool set dynamically (e.g. a sidecar that mirrors an external editor's tool manifest): the
+    /// <see cref="InputSchema"/>/<see cref="OutputSchema"/> arrive as plain <see cref="JsonNode"/>s and the
+    /// <see cref="Run"/> implementation forwards the raw arguments to the supplied <paramref name="handler"/>.
+    ///
+    /// <para>
+    /// Register a proxy tool against a built plugin via
+    /// <c>plugin.McpManager.ToolManager.AddTool(name, proxyTool)</c> (which fires the tools-updated /
+    /// list-changed notification), and remove it via <c>RemoveTool(name)</c>. Toggle visibility with the
+    /// settable <see cref="Enabled"/> property (default <see langword="true"/>).
+    /// </para>
+    /// </summary>
+    public sealed class ProxyTool : IRunTool
+    {
+        private readonly Func<string, IReadOnlyDictionary<string, JsonElement>?, CancellationToken, Task<ResponseCallTool>> _handler;
+        private int? _cachedTokenCount;
+
+        public string Name { get; }
+        public string? Title { get; }
+        public string? Description { get; }
+        public string? SkillDescription { get; }
+        public string? SkillBody { get; }
+        public JsonNode? InputSchema { get; }
+        public JsonNode? OutputSchema { get; }
+        public bool? ReadOnlyHint { get; }
+        public bool? DestructiveHint { get; }
+        public bool? IdempotentHint { get; }
+        public bool? OpenWorldHint { get; }
+
+        /// <summary>
+        /// Whether this tool is exposed to MCP clients. Settable so a host can toggle a runtime tool on/off;
+        /// disabled tools are filtered out of the enabled-tools view by the tool manager. Defaults to <see langword="true"/>.
+        /// </summary>
+        public bool Enabled { get; set; } = true;
+
+        /// <summary>
+        /// Semantic token count for this tool, computed once (then cached) from the same chars/4 approximation
+        /// used by <see cref="RunTool"/> via the shared <see cref="ToolTokenCount.Calculate"/> helper.
+        /// </summary>
+        public int TokenCount
+        {
+            get
+            {
+                if (_cachedTokenCount.HasValue)
+                    return _cachedTokenCount.Value;
+
+                _cachedTokenCount = ToolTokenCount.Calculate(Name, Title, Description, InputSchema, OutputSchema);
+                return _cachedTokenCount.Value;
+            }
+        }
+
+        /// <summary>
+        /// Creates a runtime/proxy tool.
+        /// </summary>
+        /// <param name="name">Unique tool name. Required.</param>
+        /// <param name="title">Human-readable title. Optional.</param>
+        /// <param name="description">Tool description shown to the AI client. Optional.</param>
+        /// <param name="skillDescription">Optional concise SKILL.md description override.</param>
+        /// <param name="skillBody">Optional long-form SKILL.md body.</param>
+        /// <param name="inputSchema">JSON Schema for the tool inputs, supplied externally. Optional.</param>
+        /// <param name="outputSchema">JSON Schema for the tool output, supplied externally. Optional.</param>
+        /// <param name="readOnlyHint">MCP read-only behavior hint. Optional.</param>
+        /// <param name="destructiveHint">MCP destructive behavior hint. Optional.</param>
+        /// <param name="idempotentHint">MCP idempotency behavior hint. Optional.</param>
+        /// <param name="openWorldHint">MCP open-world behavior hint. Optional.</param>
+        /// <param name="handler">Async delegate invoked on each call with the request id, raw named arguments, and a cancellation token. Required.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="name"/> or <paramref name="handler"/> is <see langword="null"/>.</exception>
+        public ProxyTool(
+            string name,
+            string? title,
+            string? description,
+            string? skillDescription,
+            string? skillBody,
+            JsonNode? inputSchema,
+            JsonNode? outputSchema,
+            bool? readOnlyHint,
+            bool? destructiveHint,
+            bool? idempotentHint,
+            bool? openWorldHint,
+            Func<string, IReadOnlyDictionary<string, JsonElement>?, CancellationToken, Task<ResponseCallTool>> handler)
+        {
+            Name = name ?? throw new ArgumentNullException(nameof(name));
+            Title = title;
+            Description = description;
+            SkillDescription = skillDescription;
+            SkillBody = skillBody;
+            InputSchema = inputSchema;
+            OutputSchema = outputSchema;
+            ReadOnlyHint = readOnlyHint;
+            DestructiveHint = destructiveHint;
+            IdempotentHint = idempotentHint;
+            OpenWorldHint = openWorldHint;
+            _handler = handler ?? throw new ArgumentNullException(nameof(handler));
+        }
+
+        /// <summary>
+        /// Dispatches the call to the supplied async handler. The raw <paramref name="namedParameters"/> are
+        /// forwarded unmodified — the handler owns argument interpretation against the external schema.
+        /// </summary>
+        public Task<ResponseCallTool> Run(string requestId, IReadOnlyDictionary<string, JsonElement>? namedParameters, CancellationToken cancellationToken = default)
+            => _handler(requestId, namedParameters, cancellationToken);
+    }
+}

--- a/McpPlugin/src/Mcp/Tool/ProxyTool.cs
+++ b/McpPlugin/src/Mcp/Tool/ProxyTool.cs
@@ -23,13 +23,21 @@ namespace com.IvanMurzak.McpPlugin
     /// async delegate, rather than a reflected method. This is the building block for hosts that define their
     /// tool set dynamically (e.g. a sidecar that mirrors an external editor's tool manifest): the
     /// <see cref="InputSchema"/>/<see cref="OutputSchema"/> arrive as plain <see cref="JsonNode"/>s and the
-    /// <see cref="Run"/> implementation forwards the raw arguments to the supplied <paramref name="handler"/>.
+    /// <see cref="Run"/> implementation forwards the raw arguments to the supplied <c>handler</c>.
     ///
     /// <para>
     /// Register a proxy tool against a built plugin via
     /// <c>plugin.McpManager.ToolManager.AddTool(name, proxyTool)</c> (which fires the tools-updated /
-    /// list-changed notification), and remove it via <c>RemoveTool(name)</c>. Toggle visibility with the
-    /// settable <see cref="Enabled"/> property (default <see langword="true"/>).
+    /// list-changed notification), and remove it via <c>RemoveTool(name)</c>. To toggle visibility after
+    /// registration, call <c>IToolManager.SetToolEnabled(name, enabled)</c> (which fires the list-changed
+    /// notification) rather than setting <see cref="Enabled"/> directly — a direct set updates the tool but
+    /// leaves connected clients with a stale listing.
+    /// </para>
+    ///
+    /// <para>
+    /// <b>Thread-safety:</b> the tool manager's backing store is not synchronized, so a host must serialize
+    /// runtime tool-set mutations (<c>AddTool</c>/<c>RemoveTool</c>) with respect to listing and dispatch;
+    /// mutating the tool set concurrently with enumeration is not supported.
     /// </para>
     /// </summary>
     public sealed class ProxyTool : IRunTool
@@ -52,6 +60,11 @@ namespace com.IvanMurzak.McpPlugin
         /// <summary>
         /// Whether this tool is exposed to MCP clients. Settable so a host can toggle a runtime tool on/off;
         /// disabled tools are filtered out of the enabled-tools view by the tool manager. Defaults to <see langword="true"/>.
+        /// <para>
+        /// For post-registration toggling prefer <c>IToolManager.SetToolEnabled(name, enabled)</c>: it both
+        /// flips this flag and fires the list-changed notification, whereas setting this property directly
+        /// leaves connected clients with a stale listing.
+        /// </para>
         /// </summary>
         public bool Enabled { get; set; } = true;
 
@@ -66,7 +79,17 @@ namespace com.IvanMurzak.McpPlugin
                 if (_cachedTokenCount.HasValue)
                     return _cachedTokenCount.Value;
 
-                _cachedTokenCount = ToolTokenCount.Calculate(Name, Title, Description, InputSchema, OutputSchema);
+                try
+                {
+                    _cachedTokenCount = ToolTokenCount.Calculate(Name, Title, Description, InputSchema, OutputSchema);
+                }
+                catch
+                {
+                    // Mirror RunTool.CalculateTokenCount's resilience: a tool whose externally supplied schema
+                    // fails to serialize must not poison IToolManager.EnabledToolsTokenCount, which sums
+                    // TokenCount over every enabled tool. ProxyTool has no logger, so the fallback is silent.
+                    _cachedTokenCount = 0;
+                }
                 return _cachedTokenCount.Value;
             }
         }
@@ -106,8 +129,13 @@ namespace com.IvanMurzak.McpPlugin
             Description = description;
             SkillDescription = skillDescription;
             SkillBody = skillBody;
-            InputSchema = inputSchema;
-            OutputSchema = outputSchema;
+            // Detach the externally supplied schemas via a round-trip clone so the proxy owns immutable,
+            // self-consistent copies: post-registration mutation of the caller's live node cannot desync the
+            // listed schema (re-read per listing) from the cached TokenCount (computed once), and the same node
+            // can safely back more than one tool. Round-trip (rather than JsonNode.DeepClone) keeps this working
+            // on the netstandard2.1 leg whose System.Text.Json predates DeepClone (STJ 8).
+            InputSchema = inputSchema is null ? null : JsonNode.Parse(inputSchema.ToJsonString());
+            OutputSchema = outputSchema is null ? null : JsonNode.Parse(outputSchema.ToJsonString());
             ReadOnlyHint = readOnlyHint;
             DestructiveHint = destructiveHint;
             IdempotentHint = idempotentHint;

--- a/McpPlugin/src/Mcp/Tool/RunTool.TokenCount.cs
+++ b/McpPlugin/src/Mcp/Tool/RunTool.TokenCount.cs
@@ -9,8 +9,6 @@
 */
 
 using System;
-using System.Text.Json.Nodes;
-using com.IvanMurzak.ReflectorNet.Utils;
 using Microsoft.Extensions.Logging;
 
 namespace com.IvanMurzak.McpPlugin
@@ -48,38 +46,14 @@ namespace com.IvanMurzak.McpPlugin
         /// Calculates the semantic token count for this tool.
         /// The calculation is based on the JSON Schema including name, title, description, input schema, and output schema.
         /// Uses a simple approximation: characters / 4 for semantic tokens (common for many LLM tokenizers).
+        /// Delegates to the shared <see cref="ToolTokenCount.Calculate"/> helper so that the formula is
+        /// identical to <see cref="ProxyTool"/>.
         /// </summary>
         private int CalculateTokenCount()
         {
             try
             {
-                // Build a JSON representation of the tool's schema using JsonObject
-                var jsonObject = new JsonObject();
-
-                // Add basic tool information
-                if (!string.IsNullOrEmpty(Name))
-                    jsonObject["name"] = Name;
-
-                if (!string.IsNullOrEmpty(Title))
-                    jsonObject["title"] = Title;
-
-                if (!string.IsNullOrEmpty(Description))
-                    jsonObject["description"] = Description;
-
-                // Add schemas directly as JSON nodes
-                if (InputSchema != null)
-                    jsonObject["inputSchema"] = InputSchema;
-
-                if (OutputSchema != null)
-                    jsonObject["outputSchema"] = OutputSchema;
-
-                // Serialize to JSON string (ensures proper escaping)
-                var jsonString = jsonObject.ToJsonString();
-
-                // Calculate tokens: using a common approximation of 1 token per 4 characters
-                // This is a reasonable estimate for English text and JSON structures
-                var tokenCount = (int)Math.Ceiling(jsonString.Length / 4.0);
-                return tokenCount;
+                return ToolTokenCount.Calculate(Name, Title, Description, InputSchema, OutputSchema);
             }
             catch (Exception ex)
             {

--- a/McpPlugin/src/Mcp/Tool/ToolTokenCount.cs
+++ b/McpPlugin/src/Mcp/Tool/ToolTokenCount.cs
@@ -1,0 +1,75 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+using System.Text.Json.Nodes;
+
+namespace com.IvanMurzak.McpPlugin
+{
+    /// <summary>
+    /// Shared helper for the semantic token-count approximation used by tools.
+    /// Extracted from <see cref="RunTool.CalculateTokenCount"/> so that both the reflection-based
+    /// <see cref="RunTool"/> and the runtime/proxy-based <see cref="ProxyTool"/> compute token counts
+    /// from the identical chars/4 formula over the same JSON shape.
+    ///
+    /// <para>
+    /// <b>Note:</b> This uses a simplified approximation of 1 token per 4 characters, which is a common
+    /// heuristic but may not accurately reflect actual LLM tokenization. Different models use different
+    /// tokenizers (e.g., GPT uses tiktoken, Claude uses a different tokenization scheme).
+    /// This approximation provides a reasonable estimate for planning and capacity management but should
+    /// not be relied upon for exact token accounting.
+    /// </para>
+    /// </summary>
+    internal static class ToolTokenCount
+    {
+        /// <summary>
+        /// Calculates the semantic token count from a tool's name, title, description, input schema, and
+        /// output schema. The calculation builds a JSON object containing the non-empty fields and the
+        /// (non-null) schema nodes, serializes it, and returns <c>ceil(length / 4)</c>.
+        /// </summary>
+        /// <remarks>
+        /// The schema nodes are inserted via a detached deep copy (round-trip through
+        /// <see cref="JsonNode.ToJsonString(System.Text.Json.JsonSerializerOptions)"/> +
+        /// <see cref="JsonNode.Parse(string, System.Text.Json.Nodes.JsonNodeOptions?, System.Text.Json.JsonDocumentOptions)"/>)
+        /// so that the caller's live <see cref="JsonNode"/> is never re-parented (a <see cref="JsonNode"/>
+        /// may only have a single parent). The serialized JSON — and therefore the resulting count — is
+        /// identical to assigning the node directly, so this is behavior-preserving for the numeric result.
+        /// </remarks>
+        public static int Calculate(string? name, string? title, string? description, JsonNode? inputSchema, JsonNode? outputSchema)
+        {
+            // Build a JSON representation of the tool's schema using JsonObject
+            var jsonObject = new JsonObject();
+
+            // Add basic tool information
+            if (!string.IsNullOrEmpty(name))
+                jsonObject["name"] = name;
+
+            if (!string.IsNullOrEmpty(title))
+                jsonObject["title"] = title;
+
+            if (!string.IsNullOrEmpty(description))
+                jsonObject["description"] = description;
+
+            // Add schemas as detached copies so the caller's live nodes are not re-parented.
+            if (inputSchema != null)
+                jsonObject["inputSchema"] = JsonNode.Parse(inputSchema.ToJsonString());
+
+            if (outputSchema != null)
+                jsonObject["outputSchema"] = JsonNode.Parse(outputSchema.ToJsonString());
+
+            // Serialize to JSON string (ensures proper escaping)
+            var jsonString = jsonObject.ToJsonString();
+
+            // Calculate tokens: using a common approximation of 1 token per 4 characters
+            // This is a reasonable estimate for English text and JSON structures
+            return (int)Math.Ceiling(jsonString.Length / 4.0);
+        }
+    }
+}

--- a/McpPlugin/src/McpPlugin/Builder/IMcpPluginBuilder.cs
+++ b/McpPlugin/src/McpPlugin/Builder/IMcpPluginBuilder.cs
@@ -70,6 +70,9 @@ namespace com.IvanMurzak.McpPlugin
         IMcpPluginBuilder WithSkillFileGenerator<T>() where T : class, ISkillFileGenerator;
         IMcpPluginBuilder WithSkillFileGenerator(ISkillFileGenerator instance);
 
+        // Dynamic / proxy tool factory
+        IMcpPluginBuilder WithDynamicToolFactory();
+
         // Reflector module discovery
         IMcpPluginBuilder WithReflectorModulesFromAssembly(IEnumerable<Assembly> assemblies);
 

--- a/McpPlugin/src/McpPlugin/Builder/McpPluginBuilder.DynamicToolFactory.cs
+++ b/McpPlugin/src/McpPlugin/Builder/McpPluginBuilder.DynamicToolFactory.cs
@@ -1,0 +1,30 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace com.IvanMurzak.McpPlugin
+{
+    public partial class McpPluginBuilder
+    {
+        /// <summary>
+        /// Registers the <see cref="IDynamicToolFactory"/> (backed by <see cref="ProxyToolFactory"/>) as a
+        /// DI singleton. Resolve it from the built plugin's service provider to create runtime
+        /// <see cref="ProxyTool"/> instances and add them to the tool manager at runtime.
+        /// </summary>
+        public virtual IMcpPluginBuilder WithDynamicToolFactory()
+        {
+            ThrowIfBuilt();
+
+            _services.AddSingleton<IDynamicToolFactory, ProxyToolFactory>();
+            return this;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `public sealed ProxyTool : IRunTool` — externally supplied `JsonNode` input/output schemas, an async delegate handler, and a settable `Enabled` (default `true`).
- Extract a shared internal `ToolTokenCount.Calculate(...)` helper from `RunTool.TokenCount.cs`; `RunTool` now delegates to it with no behavior change (identical chars/4 result).
- Add `IDynamicToolFactory` + `ProxyToolFactory.CreateProxyTool(...) -> IRunTool` and `McpPluginBuilder.WithDynamicToolFactory()` (DI singleton).

Additive only — no existing public-API behavior changes, no version bump.

## Test plan
- [x] Target-specific local tests passed (see profile test.md): `dotnet test` 0 failures across `McpPlugin.Tests` + `McpPlugin.Server.Tests` on both `net8.0` and `net9.0`.
- [x] New `ProxyToolTests`: runtime `AddTool` -> `OnToolsUpdated`/list_changed -> call dispatch through the proxy handler -> `RemoveTool`; `Enabled` toggle filtering; `TokenCount` parity with the chars/4 formula; factory singleton registration; ctor null-arg guards.

Closes #121