### PR TITLE
feat(agent-config): extract engine-agnostic AI-agent configurator module

### DIFF
--- a/McpPlugin.Tests/AgentConfig/AiAgentConfigTestBase.cs
+++ b/McpPlugin.Tests/AgentConfig/AiAgentConfigTestBase.cs
@@ -1,0 +1,46 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+using System;
+using System.IO;
+
+namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
+{
+    /// <summary>
+    /// Shared fixture for the ported AI-agent config tests: a per-test temp config file
+    /// (deleted on dispose) plus the stand-in values for the engine-supplied settings
+    /// (executable path, port, host, timeout) the original Unity tests read from
+    /// <c>McpServerManager</c> / <c>UnityMcpPluginEditor</c>.
+    /// </summary>
+    public abstract class AiAgentConfigTestBase : IDisposable
+    {
+        protected readonly string TempConfigPath;
+
+        // Stand-ins for the Unity statics the original tests referenced.
+        protected const string ExecutableName = "ai-game-developer-mcp-server";
+        protected static readonly string ExecutableFullPath = OperatingSystem.IsWindows()
+            ? $"C:/Tools/{ExecutableName}.exe"
+            : $"/usr/local/bin/{ExecutableName}";
+        protected const int Port = 50000;
+        protected const int TimeoutMs = 30000;
+        protected const string Host = "http://localhost:50000/mcp";
+
+        protected AiAgentConfigTestBase()
+        {
+            TempConfigPath = Path.GetTempFileName();
+        }
+
+        public void Dispose()
+        {
+            if (File.Exists(TempConfigPath))
+                File.Delete(TempConfigPath);
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/McpPlugin.Tests/AgentConfig/AiAgentConfiguratorTests.cs
+++ b/McpPlugin.Tests/AgentConfig/AiAgentConfiguratorTests.cs
@@ -1,0 +1,153 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+using System.IO;
+using System.Linq;
+using com.IvanMurzak.McpPlugin.AgentConfig.Impl;
+using com.IvanMurzak.McpPlugin.Common;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
+{
+    using TransportMethod = Consts.MCP.Server.TransportMethod;
+
+    /// <summary>
+    /// Covers the redesigned engine-agnostic configurator surface: the registry shape,
+    /// the settings-driven config building, and the UI-description DTO (incl. the new
+    /// <see cref="ConfigurationItemKind.EditableField"/> for the Custom agent).
+    /// </summary>
+    public class AiAgentConfiguratorTests
+    {
+        private static AgentConfiguratorSettings Settings(string root) => new(
+            operatingSystem: OperatingSystemKind.Windows,
+            projectRootPath: root,
+            executableFullPath: "C:/Tools/ai-game-developer-mcp-server.exe",
+            port: 50000,
+            timeoutMs: 30000,
+            host: "http://localhost:50000/mcp");
+
+        [Fact]
+        public void Registry_Has18Configurators_CustomLast()
+        {
+            AiAgentConfiguratorRegistry.All.Count.ShouldBe(16); // 15 sorted + Custom
+            AiAgentConfiguratorRegistry.All.Last().ShouldBeOfType<CustomConfigurator>();
+        }
+
+        [Fact]
+        public void Registry_LookupByIdAndName_Work()
+        {
+            AiAgentConfiguratorRegistry.GetByAgentId("claude-code").ShouldBeOfType<ClaudeCodeConfigurator>();
+            AiAgentConfiguratorRegistry.GetByAgentName("Codex").ShouldBeOfType<CodexConfigurator>();
+            AiAgentConfiguratorRegistry.GetByAgentId("nope").ShouldBeNull();
+            AiAgentConfiguratorRegistry.GetIndexByAgentId("claude-code").ShouldBeGreaterThanOrEqualTo(0);
+        }
+
+        [Fact]
+        public void AgentIdsAndNames_AreUnique()
+        {
+            AiAgentConfiguratorRegistry.GetAgentIds().Distinct().Count().ShouldBe(AiAgentConfiguratorRegistry.All.Count);
+            AiAgentConfiguratorRegistry.GetAgentNames().Distinct().Count().ShouldBe(AiAgentConfiguratorRegistry.All.Count);
+        }
+
+        [Fact]
+        public void Configurator_BuildsAndConfigures_StdioAndHttp()
+        {
+            var root = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(root);
+            try
+            {
+                var c = new ClaudeCodeConfigurator();
+                var settings = Settings(root);
+
+                var stdio = c.GetStdioConfig(settings);
+                stdio.Configure().ShouldBeTrue();
+                c.IsConfigured(settings, TransportMethod.stdio).ShouldBeTrue();
+
+                var http = c.GetHttpConfig(settings);
+                http.Configure().ShouldBeTrue();
+                c.IsConfigured(settings, TransportMethod.streamableHttp).ShouldBeTrue();
+            }
+            finally
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+
+        [Fact]
+        public void Codex_IsTomlBased_AndAuthInjectsEnvVar()
+        {
+            var root = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(root);
+            try
+            {
+                var c = new CodexConfigurator();
+                var settings = new AgentConfiguratorSettings(
+                    OperatingSystemKind.Windows, root, "C:/Tools/srv.exe", 50000, 30000,
+                    "http://localhost:50000/mcp", token: "secret",
+                    authOption: Consts.MCP.Server.AuthOption.required);
+
+                var http = c.GetHttpConfig(settings);
+                http.ShouldBeOfType<TomlAiAgentConfig>();
+                http.ExpectedFileContent.ShouldContain("bearer_token_env_var");
+            }
+            finally
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+
+        [Fact]
+        public void Description_CarriesIdentityIconNameAndSections()
+        {
+            var c = new ClaudeCodeConfigurator();
+            var desc = c.Describe(Settings(Path.GetTempPath()), TransportMethod.stdio);
+
+            desc.AgentName.ShouldBe("Claude Code");
+            desc.AgentId.ShouldBe("claude-code");
+            desc.IconName.ShouldBe("claude-64.png"); // name, not bytes
+            desc.Sections.ShouldNotBeEmpty();
+            desc.Sections[0].ExpandedFirst.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void Custom_Description_ExposesEditableFieldForSkillsPath()
+        {
+            var c = new CustomConfigurator { EditableSkillsPath = ".my/skills" };
+            var desc = c.Describe(Settings(Path.GetTempPath()), TransportMethod.stdio);
+
+            desc.IsConfigured.ShouldBeFalse();
+            var editable = desc.Sections
+                .SelectMany(s => s.Items)
+                .Single(i => i.Kind == ConfigurationItemKind.EditableField);
+            editable.Text.ShouldBe(".my/skills");
+        }
+
+        [Fact]
+        public void CloudMode_ForcesHttpAuthRequired()
+        {
+            var settings = new AgentConfiguratorSettings(
+                OperatingSystemKind.Linux, "/proj", "/bin/srv", 50000, 30000,
+                "https://cloud.ai-game.dev/mcp", token: "tok",
+                connectionMode: ConnectionMode.Cloud);
+            settings.IsHttpAuthRequired.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void AllConfigurators_DescribeWithoutThrowing_BothTransports()
+        {
+            var settings = Settings(Path.GetTempPath());
+            foreach (var c in AiAgentConfiguratorRegistry.All)
+            {
+                c.Describe(settings, TransportMethod.stdio).Sections.ShouldNotBeNull();
+                c.Describe(settings, TransportMethod.streamableHttp).Sections.ShouldNotBeNull();
+            }
+        }
+    }
+}

--- a/McpPlugin.Tests/AgentConfig/JsonAiAgentConfigCommandArrayTests.cs
+++ b/McpPlugin.Tests/AgentConfig/JsonAiAgentConfigCommandArrayTests.cs
@@ -1,0 +1,167 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+using System.IO;
+using System.Linq;
+using System.Text.Json.Nodes;
+using com.IvanMurzak.McpPlugin.Common;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
+{
+    using TransportMethod = Consts.MCP.Server.TransportMethod;
+
+    /// <summary>Ported from Unity-MCP's <c>JsonAiAgentConfigCommandArrayTests</c> (UIToolkit-free).</summary>
+    public class JsonAiAgentConfigCommandArrayTests : AiAgentConfigTestBase
+    {
+        private JsonAiAgentConfig CreateCommandArrayConfig(string configPath, string bodyPath = "mcpServers")
+        {
+            return new JsonAiAgentConfig("Test", configPath, bodyPath)
+                .SetProperty("type", JsonValue.Create("local")!, requiredForConfiguration: true)
+                .SetProperty("enabled", JsonValue.Create(true)!, requiredForConfiguration: true)
+                .SetProperty("command", new JsonArray
+                {
+                    ExecutableFullPath.Replace('\\', '/'),
+                    $"{Consts.MCP.Server.Args.Port}={Port}",
+                    $"{Consts.MCP.Server.Args.PluginTimeout}={TimeoutMs}",
+                    $"{Consts.MCP.Server.Args.ClientTransportMethod}={TransportMethod.stdio}"
+                }, requiredForConfiguration: true)
+                .SetPropertyToRemove("url")
+                .SetPropertyToRemove("args");
+        }
+
+        [Fact]
+        public void Configure_SimpleBodyPath_CreatesCommandArrayFormat()
+        {
+            var config = CreateCommandArrayConfig(TempConfigPath);
+            config.Configure().ShouldBeTrue();
+            File.Exists(TempConfigPath).ShouldBeTrue();
+
+            var serverEntry = JsonNode.Parse(File.ReadAllText(TempConfigPath))!["mcpServers"]?[AiAgentConfig.DefaultMcpServerName]?.AsObject();
+            serverEntry.ShouldNotBeNull();
+            serverEntry!["type"]?.GetValue<string>().ShouldBe("local");
+            serverEntry["enabled"]?.GetValue<bool>().ShouldBe(true);
+
+            var commandArray = serverEntry["command"]?.AsArray();
+            commandArray.ShouldNotBeNull();
+            commandArray![0]?.GetValue<string>().ShouldContain(ExecutableName);
+        }
+
+        [Fact]
+        public void Configure_CommandArrayContainsAllRequiredArguments()
+        {
+            var config = CreateCommandArrayConfig(TempConfigPath);
+            config.Configure().ShouldBeTrue();
+
+            var commandArray = JsonNode.Parse(File.ReadAllText(TempConfigPath))!["mcpServers"]?[AiAgentConfig.DefaultMcpServerName]?["command"]?.AsArray();
+            commandArray.ShouldNotBeNull();
+
+            var argStrings = commandArray!.Skip(1).Select(a => a?.GetValue<string>() ?? string.Empty).ToList();
+            argStrings.Any(a => a.StartsWith($"{Consts.MCP.Server.Args.Port}=")).ShouldBeTrue();
+            argStrings.Any(a => a.StartsWith($"{Consts.MCP.Server.Args.PluginTimeout}=")).ShouldBeTrue();
+            argStrings.Any(a => a.Contains($"{Consts.MCP.Server.Args.ClientTransportMethod}=stdio")).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void Configure_DeepNestedBodyPath_CreatesFullStructure()
+        {
+            var d = Consts.MCP.Server.BodyPathDelimiter;
+            var bodyPath = $"level1{d}level2{d}level3{d}mcpServers";
+            var config = CreateCommandArrayConfig(TempConfigPath, bodyPath);
+            config.Configure().ShouldBeTrue();
+
+            var rootObj = JsonNode.Parse(File.ReadAllText(TempConfigPath))?.AsObject();
+            var mcpServers = rootObj!["level1"]?["level2"]?["level3"]?["mcpServers"]?.AsObject();
+            mcpServers![AiAgentConfig.DefaultMcpServerName]?["command"].ShouldNotBeNull();
+        }
+
+        [Fact]
+        public void Configure_ExistingFileSimpleStructure_PreservesContent()
+        {
+            File.WriteAllText(TempConfigPath, @"{ ""otherProperty"": ""shouldBePreserved"", ""mcpServers"": { ""existingServer"": { ""command"": [""other-command"", ""--arg1""], ""type"": ""local"" } } }");
+            CreateCommandArrayConfig(TempConfigPath).Configure().ShouldBeTrue();
+
+            var rootObj = JsonNode.Parse(File.ReadAllText(TempConfigPath))?.AsObject();
+            rootObj!["otherProperty"]?.GetValue<string>().ShouldBe("shouldBePreserved");
+            var mcpServers = rootObj["mcpServers"]?.AsObject();
+            mcpServers!["existingServer"].ShouldNotBeNull();
+            mcpServers.Count.ShouldBeGreaterThan(1);
+        }
+
+        [Fact]
+        public void Configure_ExistingFileWithDuplicateCommand_ReplacesEntry()
+        {
+            var duplicateCommand = ExecutableFullPath.Replace('\\', '/');
+            File.WriteAllText(TempConfigPath, $@"{{ ""mcpServers"": {{ ""Unity-MCP-Duplicate"": {{ ""command"": [""{duplicateCommand}"", ""--old-port=9999""], ""type"": ""local"", ""enabled"": true }}, ""otherServer"": {{ ""command"": [""other-command"", ""--other-arg""] }} }} }}");
+            CreateCommandArrayConfig(TempConfigPath).Configure().ShouldBeTrue();
+
+            var mcpServers = JsonNode.Parse(File.ReadAllText(TempConfigPath))!["mcpServers"]?.AsObject();
+            mcpServers!["otherServer"].ShouldNotBeNull();
+
+            var commandArray = mcpServers[AiAgentConfig.DefaultMcpServerName]?["command"]?.AsArray();
+            commandArray![0]?.GetValue<string>().ShouldBe(duplicateCommand);
+            commandArray.ToString().ShouldContain($"{Consts.MCP.Server.Args.Port}={Port}");
+        }
+
+        [Fact]
+        public void Configure_InvalidJsonFile_ReplacesWithNewConfig()
+        {
+            File.WriteAllText(TempConfigPath, "{ invalid json }");
+            CreateCommandArrayConfig(TempConfigPath).Configure().ShouldBeTrue();
+            JsonNode.Parse(File.ReadAllText(TempConfigPath))!["mcpServers"].ShouldNotBeNull();
+        }
+
+        [Fact]
+        public void IsConfigured_NestedBodyPath_DetectsCorrectly()
+        {
+            var d = Consts.MCP.Server.BodyPathDelimiter;
+            var config = CreateCommandArrayConfig(TempConfigPath, $"projects{d}myProject{d}mcpServers");
+            config.Configure();
+            config.IsConfigured().ShouldBeTrue();
+        }
+
+        [Fact]
+        public void IsConfigured_WrongType_ReturnsFalse()
+        {
+            var executable = ExecutableFullPath.Replace('\\', '/');
+            File.WriteAllText(TempConfigPath, $@"{{ ""mcpServers"": {{ ""{AiAgentConfig.DefaultMcpServerName}"": {{ ""command"": [""{executable}"", ""{Consts.MCP.Server.Args.Port}={Port}"", ""{Consts.MCP.Server.Args.PluginTimeout}={TimeoutMs}"", ""{Consts.MCP.Server.Args.ClientTransportMethod}=stdio""], ""type"": ""wrong-type"", ""enabled"": true }} }} }}");
+            CreateCommandArrayConfig(TempConfigPath).IsConfigured().ShouldBeFalse();
+        }
+
+        [Fact]
+        public void IsConfigured_WrongCommandArray_ReturnsFalse()
+        {
+            File.WriteAllText(TempConfigPath, $@"{{ ""mcpServers"": {{ ""{AiAgentConfig.DefaultMcpServerName}"": {{ ""command"": [""wrong-executable"", ""{Consts.MCP.Server.Args.Port}={Port}""], ""type"": ""local"", ""enabled"": true }} }} }}");
+            CreateCommandArrayConfig(TempConfigPath).IsConfigured().ShouldBeFalse();
+        }
+
+        [Fact]
+        public void ExpectedFileContent_NestedBodyPath_ReturnsCorrectNestedStructure()
+        {
+            var d = Consts.MCP.Server.BodyPathDelimiter;
+            var content = CreateCommandArrayConfig(TempConfigPath, $"level1{d}level2{d}mcpServers").ExpectedFileContent;
+            var rootObj = JsonNode.Parse(content)?.AsObject();
+            rootObj!["level1"]?["level2"]?["mcpServers"].ShouldNotBeNull();
+        }
+
+        [Fact]
+        public void Configure_MultipleCalls_UpdatesConfiguration()
+        {
+            var config = CreateCommandArrayConfig(TempConfigPath);
+            config.Configure().ShouldBeTrue();
+            config.Configure().ShouldBeTrue();
+            config.IsConfigured().ShouldBeTrue();
+
+            var mcpServers = JsonNode.Parse(File.ReadAllText(TempConfigPath))!["mcpServers"]?.AsObject();
+            mcpServers!.Count.ShouldBe(1);
+            mcpServers[AiAgentConfig.DefaultMcpServerName].ShouldNotBeNull();
+        }
+    }
+}

--- a/McpPlugin.Tests/AgentConfig/JsonAiAgentConfigTests.cs
+++ b/McpPlugin.Tests/AgentConfig/JsonAiAgentConfigTests.cs
@@ -1,0 +1,388 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+using System.IO;
+using System.Linq;
+using System.Text.Json.Nodes;
+using com.IvanMurzak.McpPlugin.Common;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
+{
+    using TransportMethod = Consts.MCP.Server.TransportMethod;
+
+    /// <summary>Ported from Unity-MCP's <c>JsonAiAgentConfigTests</c> (UIToolkit-free).</summary>
+    public class JsonAiAgentConfigTests : AiAgentConfigTestBase
+    {
+        private JsonAiAgentConfig CreateStdioConfig(string configPath, string bodyPath = "mcpServers")
+        {
+            return new JsonAiAgentConfig("Test", configPath, bodyPath)
+                .SetProperty("type", JsonValue.Create("stdio")!, requiredForConfiguration: true)
+                .SetProperty("command", JsonValue.Create(ExecutableFullPath.Replace('\\', '/'))!, requiredForConfiguration: true)
+                .SetProperty("args", new JsonArray
+                {
+                    $"{Consts.MCP.Server.Args.Port}={Port}",
+                    $"{Consts.MCP.Server.Args.PluginTimeout}={TimeoutMs}",
+                    $"{Consts.MCP.Server.Args.ClientTransportMethod}={TransportMethod.stdio}"
+                }, requiredForConfiguration: true)
+                .SetPropertyToRemove("url");
+        }
+
+        private JsonAiAgentConfig CreateHttpConfig(string configPath, string bodyPath = "mcpServers")
+        {
+            return new JsonAiAgentConfig("Test", configPath, bodyPath)
+                .SetProperty("type", JsonValue.Create($"{TransportMethod.streamableHttp}")!, requiredForConfiguration: true)
+                .SetProperty("url", JsonValue.Create(Host)!, requiredForConfiguration: true)
+                .SetPropertyToRemove("command")
+                .SetPropertyToRemove("args");
+        }
+
+        [Fact]
+        public void Configure_Stdio_CreatesCorrectFormat()
+        {
+            var config = CreateStdioConfig(TempConfigPath);
+
+            config.Configure().ShouldBeTrue();
+            File.Exists(TempConfigPath).ShouldBeTrue();
+
+            var rootObj = JsonNode.Parse(File.ReadAllText(TempConfigPath))?.AsObject();
+            rootObj.ShouldNotBeNull();
+            var serverEntry = rootObj!["mcpServers"]?[AiAgentConfig.DefaultMcpServerName]?.AsObject();
+            serverEntry.ShouldNotBeNull();
+            serverEntry!["command"].ShouldNotBeNull();
+            serverEntry["args"].ShouldNotBeNull();
+            serverEntry["url"].ShouldBeNull();
+        }
+
+        [Fact]
+        public void Configure_Stdio_ContainsCorrectArguments()
+        {
+            var config = CreateStdioConfig(TempConfigPath);
+            config.Configure().ShouldBeTrue();
+
+            var serverEntry = JsonNode.Parse(File.ReadAllText(TempConfigPath))!["mcpServers"]?[AiAgentConfig.DefaultMcpServerName]?.AsObject();
+            var command = serverEntry!["command"]?.GetValue<string>();
+            command.ShouldNotBeNull();
+            command!.ShouldContain(ExecutableName);
+
+            var args = serverEntry["args"]?.AsArray();
+            args.ShouldNotBeNull();
+            args!.Any(a => a?.GetValue<string>()?.StartsWith($"{Consts.MCP.Server.Args.Port}=") == true).ShouldBeTrue();
+            args.Any(a => a?.GetValue<string>()?.StartsWith($"{Consts.MCP.Server.Args.PluginTimeout}=") == true).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void Configure_Http_CreatesCorrectFormat()
+        {
+            var config = CreateHttpConfig(TempConfigPath);
+            config.Configure().ShouldBeTrue();
+
+            var serverEntry = JsonNode.Parse(File.ReadAllText(TempConfigPath))!["mcpServers"]?[AiAgentConfig.DefaultMcpServerName]?.AsObject();
+            serverEntry.ShouldNotBeNull();
+            serverEntry!["url"].ShouldNotBeNull();
+            serverEntry["type"]?.GetValue<string>().ShouldBe($"{TransportMethod.streamableHttp}");
+            serverEntry["command"].ShouldBeNull();
+            serverEntry["args"].ShouldBeNull();
+        }
+
+        [Fact]
+        public void Configure_Http_ContainsCorrectUrl()
+        {
+            var config = CreateHttpConfig(TempConfigPath);
+            config.Configure().ShouldBeTrue();
+
+            var serverEntry = JsonNode.Parse(File.ReadAllText(TempConfigPath))!["mcpServers"]?[AiAgentConfig.DefaultMcpServerName]?.AsObject();
+            serverEntry!["url"]?.GetValue<string>().ShouldBe(Host);
+        }
+
+        [Fact]
+        public void Configure_Http_NestedBodyPath_CreatesCorrectStructure()
+        {
+            var bodyPath = $"projects{Consts.MCP.Server.BodyPathDelimiter}myProject{Consts.MCP.Server.BodyPathDelimiter}mcpServers";
+            var config = CreateHttpConfig(TempConfigPath, bodyPath);
+            config.Configure().ShouldBeTrue();
+
+            var rootObj = JsonNode.Parse(File.ReadAllText(TempConfigPath))?.AsObject();
+            var serverEntry = rootObj!["projects"]?["myProject"]?["mcpServers"]?[AiAgentConfig.DefaultMcpServerName]?.AsObject();
+            serverEntry!["url"].ShouldNotBeNull();
+            serverEntry["type"]?.GetValue<string>().ShouldBe($"{TransportMethod.streamableHttp}");
+        }
+
+        [Fact]
+        public void Configure_SwitchFromStdioToHttp_RemovesStdioProperties()
+        {
+            CreateStdioConfig(TempConfigPath).Configure();
+            CreateHttpConfig(TempConfigPath).Configure().ShouldBeTrue();
+
+            var serverEntry = JsonNode.Parse(File.ReadAllText(TempConfigPath))!["mcpServers"]?[AiAgentConfig.DefaultMcpServerName]?.AsObject();
+            serverEntry!["url"].ShouldNotBeNull();
+            serverEntry["command"].ShouldBeNull();
+            serverEntry["args"].ShouldBeNull();
+        }
+
+        [Fact]
+        public void Configure_SwitchFromHttpToStdio_RemovesHttpProperties()
+        {
+            CreateHttpConfig(TempConfigPath).Configure();
+            CreateStdioConfig(TempConfigPath).Configure().ShouldBeTrue();
+
+            var serverEntry = JsonNode.Parse(File.ReadAllText(TempConfigPath))!["mcpServers"]?[AiAgentConfig.DefaultMcpServerName]?.AsObject();
+            serverEntry!["command"].ShouldNotBeNull();
+            serverEntry["args"].ShouldNotBeNull();
+            serverEntry["url"].ShouldBeNull();
+        }
+
+        [Fact]
+        public void Configure_SwitchTransport_PreservesOtherServers()
+        {
+            File.WriteAllText(TempConfigPath, @"{ ""mcpServers"": { ""otherServer"": { ""command"": ""other-command"", ""args"": [""--other-arg""] } } }");
+            CreateStdioConfig(TempConfigPath).Configure();
+            CreateHttpConfig(TempConfigPath).Configure().ShouldBeTrue();
+
+            var mcpServers = JsonNode.Parse(File.ReadAllText(TempConfigPath))!["mcpServers"]?.AsObject();
+            mcpServers!["otherServer"].ShouldNotBeNull();
+            mcpServers[AiAgentConfig.DefaultMcpServerName]?["url"].ShouldNotBeNull();
+        }
+
+        [Fact]
+        public void IsConfigured_Stdio_ValidConfig_ReturnsTrue()
+        {
+            var config = CreateStdioConfig(TempConfigPath);
+            config.Configure();
+            config.IsConfigured().ShouldBeTrue();
+        }
+
+        [Fact]
+        public void IsConfigured_Stdio_WithUrlProperty_ReturnsFalse()
+        {
+            var executable = ExecutableFullPath.Replace('\\', '/');
+            File.WriteAllText(TempConfigPath, $@"{{ ""mcpServers"": {{ ""{AiAgentConfig.DefaultMcpServerName}"": {{ ""command"": ""{executable}"", ""args"": [""{Consts.MCP.Server.Args.Port}={Port}"", ""{Consts.MCP.Server.Args.PluginTimeout}={TimeoutMs}""], ""url"": ""http://localhost:50000/mcp"" }} }} }}");
+            CreateStdioConfig(TempConfigPath).IsConfigured().ShouldBeFalse();
+        }
+
+        [Fact]
+        public void IsConfigured_Stdio_MissingCommand_ReturnsFalse()
+        {
+            File.WriteAllText(TempConfigPath, $@"{{ ""mcpServers"": {{ ""{AiAgentConfig.DefaultMcpServerName}"": {{ ""args"": [""{Consts.MCP.Server.Args.Port}={Port}""] }} }} }}");
+            CreateStdioConfig(TempConfigPath).IsConfigured().ShouldBeFalse();
+        }
+
+        [Fact]
+        public void IsConfigured_Stdio_WrongPort_ReturnsFalse()
+        {
+            var executable = ExecutableFullPath.Replace('\\', '/');
+            File.WriteAllText(TempConfigPath, $@"{{ ""mcpServers"": {{ ""{AiAgentConfig.DefaultMcpServerName}"": {{ ""command"": ""{executable}"", ""args"": [""{Consts.MCP.Server.Args.Port}=99999"", ""{Consts.MCP.Server.Args.PluginTimeout}={TimeoutMs}""] }} }} }}");
+            CreateStdioConfig(TempConfigPath).IsConfigured().ShouldBeFalse();
+        }
+
+        [Fact]
+        public void IsConfigured_Http_ValidConfig_ReturnsTrue()
+        {
+            var config = CreateHttpConfig(TempConfigPath);
+            config.Configure();
+            config.IsConfigured().ShouldBeTrue();
+        }
+
+        [Fact]
+        public void IsConfigured_Http_WithCommandProperty_ReturnsFalse()
+        {
+            File.WriteAllText(TempConfigPath, $@"{{ ""mcpServers"": {{ ""{AiAgentConfig.DefaultMcpServerName}"": {{ ""url"": ""{Host}"", ""type"": ""{TransportMethod.streamableHttp}"", ""command"": ""some-command"" }} }} }}");
+            CreateHttpConfig(TempConfigPath).IsConfigured().ShouldBeFalse();
+        }
+
+        [Fact]
+        public void IsConfigured_Http_MissingUrl_ReturnsFalse()
+        {
+            File.WriteAllText(TempConfigPath, $@"{{ ""mcpServers"": {{ ""{AiAgentConfig.DefaultMcpServerName}"": {{ ""type"": ""{TransportMethod.streamableHttp}"" }} }} }}");
+            CreateHttpConfig(TempConfigPath).IsConfigured().ShouldBeFalse();
+        }
+
+        [Fact]
+        public void IsConfigured_Http_WrongType_ReturnsFalse()
+        {
+            File.WriteAllText(TempConfigPath, $@"{{ ""mcpServers"": {{ ""{AiAgentConfig.DefaultMcpServerName}"": {{ ""url"": ""{Host}"", ""type"": ""stdio"" }} }} }}");
+            CreateHttpConfig(TempConfigPath).IsConfigured().ShouldBeFalse();
+        }
+
+        [Fact]
+        public void IsConfigured_StdioTransport_WithHttpConfig_ReturnsFalse()
+        {
+            CreateHttpConfig(TempConfigPath).Configure();
+            CreateStdioConfig(TempConfigPath).IsConfigured().ShouldBeFalse();
+        }
+
+        [Fact]
+        public void IsConfigured_HttpTransport_WithStdioConfig_ReturnsFalse()
+        {
+            CreateStdioConfig(TempConfigPath).Configure();
+            CreateHttpConfig(TempConfigPath).IsConfigured().ShouldBeFalse();
+        }
+
+        [Fact]
+        public void ExpectedFileContent_Stdio_ReturnsCorrectFormat()
+        {
+            var content = CreateStdioConfig(TempConfigPath).ExpectedFileContent;
+            var serverEntry = JsonNode.Parse(content)!["mcpServers"]?[AiAgentConfig.DefaultMcpServerName]?.AsObject();
+            serverEntry!["command"].ShouldNotBeNull();
+            serverEntry["args"].ShouldNotBeNull();
+            serverEntry["url"].ShouldBeNull();
+        }
+
+        [Fact]
+        public void IsConfigured_NonExistentFile_ReturnsFalse()
+        {
+            var nonExistentPath = Path.Combine(Path.GetTempPath(), "non_existent_config_12345.json");
+            CreateStdioConfig(nonExistentPath).IsConfigured().ShouldBeFalse();
+            CreateHttpConfig(nonExistentPath).IsConfigured().ShouldBeFalse();
+        }
+
+        [Fact]
+        public void IsConfigured_EmptyFile_ReturnsFalse()
+        {
+            File.WriteAllText(TempConfigPath, "");
+            CreateStdioConfig(TempConfigPath).IsConfigured().ShouldBeFalse();
+            CreateHttpConfig(TempConfigPath).IsConfigured().ShouldBeFalse();
+        }
+
+        [Fact]
+        public void Configure_EmptyConfigPath_ReturnsFalse()
+        {
+            CreateStdioConfig("").Configure().ShouldBeFalse();
+            CreateHttpConfig("").Configure().ShouldBeFalse();
+        }
+
+        [Fact]
+        public void Configure_MultipleCalls_SameTransport_UpdatesConfiguration()
+        {
+            var config = CreateHttpConfig(TempConfigPath);
+            config.Configure().ShouldBeTrue();
+            config.Configure().ShouldBeTrue();
+            config.IsConfigured().ShouldBeTrue();
+
+            var mcpServers = JsonNode.Parse(File.ReadAllText(TempConfigPath))!["mcpServers"]?.AsObject();
+            mcpServers!.Count(kv => !string.IsNullOrEmpty(kv.Value?["url"]?.GetValue<string>())).ShouldBe(1);
+        }
+
+        [Fact]
+        public void IsConfigured_OtherServerMatches_ButDefaultMissing_ReturnsFalse()
+        {
+            var executable = ExecutableFullPath.Replace('\\', '/');
+            File.WriteAllText(TempConfigPath, $@"{{ ""mcpServers"": {{ ""otherServer"": {{ ""type"": ""stdio"", ""command"": ""{executable}"", ""args"": [""{Consts.MCP.Server.Args.Port}={Port}"", ""{Consts.MCP.Server.Args.PluginTimeout}={TimeoutMs}"", ""{Consts.MCP.Server.Args.ClientTransportMethod}=stdio""] }} }} }}");
+            CreateStdioConfig(TempConfigPath).IsConfigured().ShouldBeFalse();
+        }
+
+        [Fact]
+        public void ExpectedFileContent_PropertiesInAlphabeticalOrder()
+        {
+            var config = new JsonAiAgentConfig("Test", TempConfigPath, "mcpServers")
+                .SetProperty("zebra", JsonValue.Create("last")!)
+                .SetProperty("alpha", JsonValue.Create("first")!)
+                .SetProperty("middle", JsonValue.Create("mid")!);
+
+            var serverEntry = JsonNode.Parse(config.ExpectedFileContent)!["mcpServers"]?[AiAgentConfig.DefaultMcpServerName]?.AsObject();
+            var keys = serverEntry!.Select(kv => kv.Key).ToList();
+            keys[0].ShouldBe("alpha");
+            keys[1].ShouldBe("middle");
+            keys[2].ShouldBe("zebra");
+        }
+
+        [Fact]
+        public void Configure_Stdio_RemovesDuplicateByCommand()
+        {
+            var executable = ExecutableFullPath.Replace('\\', '/');
+            File.WriteAllText(TempConfigPath, $@"{{ ""mcpServers"": {{ ""my-custom-name"": {{ ""type"": ""stdio"", ""command"": ""{executable}"", ""args"": [""--old-arg""] }} }} }}");
+            CreateStdioConfig(TempConfigPath).Configure();
+
+            var mcpServers = JsonNode.Parse(File.ReadAllText(TempConfigPath))!["mcpServers"]?.AsObject();
+            mcpServers!["my-custom-name"].ShouldBeNull();
+            mcpServers[AiAgentConfig.DefaultMcpServerName].ShouldNotBeNull();
+        }
+
+        [Fact]
+        public void Configure_Http_RemovesDuplicateByServerUrl()
+        {
+            File.WriteAllText(TempConfigPath, $@"{{ ""mcpServers"": {{ ""my-custom-name"": {{ ""serverUrl"": ""{Host}"" }} }} }}");
+            var config = new JsonAiAgentConfig("Test", TempConfigPath, "mcpServers")
+                .AddIdentityKey("serverUrl")
+                .SetProperty("serverUrl", JsonValue.Create(Host)!, requiredForConfiguration: true)
+                .SetPropertyToRemove("command")
+                .SetPropertyToRemove("args")
+                .SetPropertyToRemove("url");
+            config.Configure();
+
+            var mcpServers = JsonNode.Parse(File.ReadAllText(TempConfigPath))!["mcpServers"]?.AsObject();
+            mcpServers!["my-custom-name"].ShouldBeNull();
+            mcpServers[AiAgentConfig.DefaultMcpServerName].ShouldNotBeNull();
+        }
+
+        [Fact]
+        public void Configure_Http_DefaultIdentityKeys_DoNotRemoveByServerUrl()
+        {
+            File.WriteAllText(TempConfigPath, $@"{{ ""mcpServers"": {{ ""my-custom-name"": {{ ""serverUrl"": ""{Host}"" }} }} }}");
+            CreateHttpConfig(TempConfigPath).Configure();
+
+            var mcpServers = JsonNode.Parse(File.ReadAllText(TempConfigPath))!["mcpServers"]?.AsObject();
+            mcpServers!["my-custom-name"].ShouldNotBeNull();
+            mcpServers[AiAgentConfig.DefaultMcpServerName].ShouldNotBeNull();
+        }
+
+        [Fact]
+        public void IsDetected_DeprecatedName_ReturnsTrue()
+        {
+            File.WriteAllText(TempConfigPath, $@"{{ ""mcpServers"": {{ ""Unity-MCP"": {{ ""type"": ""stdio"", ""command"": ""/some/path"" }} }} }}");
+            CreateStdioConfig(TempConfigPath).IsDetected().ShouldBeTrue();
+        }
+
+        [Fact]
+        public void Unconfigure_DeprecatedAndCurrentPresent_RemovesBoth()
+        {
+            File.WriteAllText(TempConfigPath, $@"{{ ""mcpServers"": {{ ""Unity-MCP"": {{ ""command"": ""/old/path"" }}, ""{AiAgentConfig.DefaultMcpServerName}"": {{ ""command"": ""/some/path"" }} }} }}");
+            CreateStdioConfig(TempConfigPath).Unconfigure().ShouldBeTrue();
+
+            var mcpServers = JsonNode.Parse(File.ReadAllText(TempConfigPath))!["mcpServers"]?.AsObject();
+            mcpServers!["Unity-MCP"].ShouldBeNull();
+            mcpServers[AiAgentConfig.DefaultMcpServerName].ShouldBeNull();
+        }
+
+        [Fact]
+        public void Unconfigure_NothingPresent_ReturnsFalse()
+        {
+            File.WriteAllText(TempConfigPath, $@"{{ ""mcpServers"": {{ ""other-server"": {{ ""command"": ""completely-different-command"" }} }} }}");
+            CreateStdioConfig(TempConfigPath).Unconfigure().ShouldBeFalse();
+        }
+
+        [Fact]
+        public void IsConfigured_PathComparison_BackslashEqualsForwardSlash()
+        {
+            File.WriteAllText(TempConfigPath, $@"{{ ""mcpServers"": {{ ""{AiAgentConfig.DefaultMcpServerName}"": {{ ""command"": ""C:\\Users\\test\\app.exe"" }} }} }}");
+            var config = new JsonAiAgentConfig("Test", TempConfigPath, "mcpServers")
+                .SetProperty("command", JsonValue.Create("C:/Users/test/app.exe")!, requiredForConfiguration: true, comparison: ValueComparisonMode.Path);
+            config.IsConfigured().ShouldBeTrue();
+        }
+
+        [Fact]
+        public void IsConfigured_UrlComparison_SchemeCaseInsensitive()
+        {
+            File.WriteAllText(TempConfigPath, $@"{{ ""mcpServers"": {{ ""{AiAgentConfig.DefaultMcpServerName}"": {{ ""url"": ""HTTP://LOCALHOST:5000/mcp"" }} }} }}");
+            var config = new JsonAiAgentConfig("Test", TempConfigPath, "mcpServers")
+                .SetProperty("url", JsonValue.Create("http://localhost:5000/mcp")!, requiredForConfiguration: true, comparison: ValueComparisonMode.Url);
+            config.IsConfigured().ShouldBeTrue();
+        }
+
+        [Fact]
+        public void IsConfigured_ExactComparison_RejectsDifferentPaths()
+        {
+            File.WriteAllText(TempConfigPath, $@"{{ ""mcpServers"": {{ ""{AiAgentConfig.DefaultMcpServerName}"": {{ ""command"": ""C:\\Users\\test\\app.exe"" }} }} }}");
+            var config = new JsonAiAgentConfig("Test", TempConfigPath, "mcpServers")
+                .SetProperty("command", JsonValue.Create("C:/Users/test/app.exe")!, requiredForConfiguration: true);
+            config.IsConfigured().ShouldBeFalse();
+        }
+    }
+}

--- a/McpPlugin.Tests/AgentConfig/TomlAiAgentConfigTests.cs
+++ b/McpPlugin.Tests/AgentConfig/TomlAiAgentConfigTests.cs
@@ -1,0 +1,445 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+using System.IO;
+using System.Linq;
+using com.IvanMurzak.McpPlugin.Common;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
+{
+    using TransportMethod = Consts.MCP.Server.TransportMethod;
+
+    /// <summary>Ported from Unity-MCP's <c>TomlAiAgentConfigTests</c> (UIToolkit-free).</summary>
+    public class TomlAiAgentConfigTests : AiAgentConfigTestBase
+    {
+        private TomlAiAgentConfig CreateStdioConfig(string configPath, string bodyPath = "mcp_servers")
+        {
+            return new TomlAiAgentConfig("Test", configPath, bodyPath)
+                .SetProperty("command", ExecutableFullPath.Replace('\\', '/'), requiredForConfiguration: true)
+                .SetProperty("args", new[]
+                {
+                    $"{Consts.MCP.Server.Args.Port}={Port}",
+                    $"{Consts.MCP.Server.Args.PluginTimeout}={TimeoutMs}",
+                    $"{Consts.MCP.Server.Args.ClientTransportMethod}={TransportMethod.stdio}"
+                }, requiredForConfiguration: true)
+                .SetPropertyToRemove("url");
+        }
+
+        private TomlAiAgentConfig CreateHttpConfig(string configPath, string bodyPath = "mcp_servers")
+        {
+            return new TomlAiAgentConfig("Test", configPath, bodyPath)
+                .SetProperty("url", Host, requiredForConfiguration: true)
+                .SetPropertyToRemove("command")
+                .SetPropertyToRemove("args");
+        }
+
+        [Fact]
+        public void Configure_NewFile_CreatesCorrectStructure()
+        {
+            File.Delete(TempConfigPath);
+            CreateStdioConfig(TempConfigPath).Configure().ShouldBeTrue();
+            File.Exists(TempConfigPath).ShouldBeTrue();
+
+            var content = File.ReadAllText(TempConfigPath);
+            content.ShouldContain($"[mcp_servers.{AiAgentConfig.DefaultMcpServerName}]");
+            content.ShouldContain("command = ");
+            content.ShouldContain("args = [");
+        }
+
+        [Fact]
+        public void Configure_NewFile_ContainsAllArguments()
+        {
+            File.Delete(TempConfigPath);
+            CreateStdioConfig(TempConfigPath).Configure();
+
+            var content = File.ReadAllText(TempConfigPath);
+            content.ShouldContain($"{Consts.MCP.Server.Args.Port}={Port}");
+            content.ShouldContain($"{Consts.MCP.Server.Args.PluginTimeout}={TimeoutMs}");
+            content.ShouldContain($"{Consts.MCP.Server.Args.ClientTransportMethod}=stdio");
+        }
+
+        [Fact]
+        public void Configure_HttpConfig_NewFile_CreatesCorrectStructure()
+        {
+            File.Delete(TempConfigPath);
+            CreateHttpConfig(TempConfigPath).Configure().ShouldBeTrue();
+
+            var content = File.ReadAllText(TempConfigPath);
+            content.ShouldContain($"[mcp_servers.{AiAgentConfig.DefaultMcpServerName}]");
+            content.ShouldContain($"url = \"{Host}\"");
+            content.ShouldNotContain("command = ");
+            content.ShouldNotContain("args = [");
+        }
+
+        [Fact]
+        public void Configure_ExistingFile_PreservesOtherSections()
+        {
+            File.WriteAllText(TempConfigPath, "[other_section]\nkey = \"value\"\n");
+            CreateStdioConfig(TempConfigPath).Configure().ShouldBeTrue();
+
+            var content = File.ReadAllText(TempConfigPath);
+            content.ShouldContain("[other_section]");
+            content.ShouldContain("key = \"value\"");
+            content.ShouldContain($"[mcp_servers.{AiAgentConfig.DefaultMcpServerName}]");
+        }
+
+        [Fact]
+        public void Configure_ExistingSection_MergesProperties()
+        {
+            var sectionName = $"mcp_servers.{AiAgentConfig.DefaultMcpServerName}";
+            File.WriteAllText(TempConfigPath, $"[{sectionName}]\ncommand = \"old-command\"\ncustom_prop = \"should-stay\"\n");
+            CreateStdioConfig(TempConfigPath).Configure().ShouldBeTrue();
+
+            var content = File.ReadAllText(TempConfigPath);
+            content.ShouldContain("custom_prop = \"should-stay\"");
+            content.ShouldNotContain("old-command");
+        }
+
+        [Fact]
+        public void Configure_ExistingSection_RemovesSpecifiedProperties()
+        {
+            var sectionName = $"mcp_servers.{AiAgentConfig.DefaultMcpServerName}";
+            File.WriteAllText(TempConfigPath, $"[{sectionName}]\ncommand = \"old-command\"\nurl = \"http://old-url\"\n");
+            CreateStdioConfig(TempConfigPath).Configure().ShouldBeTrue();
+            File.ReadAllText(TempConfigPath).ShouldNotContain("url = ");
+        }
+
+        [Fact]
+        public void Configure_MultipleCalls_DoesNotDuplicate()
+        {
+            var config = CreateStdioConfig(TempConfigPath);
+            config.Configure();
+            config.Configure();
+
+            var content = File.ReadAllText(TempConfigPath);
+            var sectionHeader = $"[mcp_servers.{AiAgentConfig.DefaultMcpServerName}]";
+            var firstIndex = content.IndexOf(sectionHeader, System.StringComparison.Ordinal);
+            content.IndexOf(sectionHeader, firstIndex + 1, System.StringComparison.Ordinal).ShouldBe(-1);
+        }
+
+        [Fact]
+        public void Configure_EmptyConfigPath_ReturnsFalse()
+        {
+            new TomlAiAgentConfig("Test", "", "mcp_servers")
+                .SetProperty("command", "some-command", requiredForConfiguration: true)
+                .Configure().ShouldBeFalse();
+        }
+
+        [Fact]
+        public void IsConfigured_AfterConfigure_ReturnsTrue()
+        {
+            var config = CreateStdioConfig(TempConfigPath);
+            config.Configure();
+            config.IsConfigured().ShouldBeTrue();
+        }
+
+        [Fact]
+        public void IsConfigured_HttpAfterConfigure_ReturnsTrue()
+        {
+            var config = CreateHttpConfig(TempConfigPath);
+            config.Configure();
+            config.IsConfigured().ShouldBeTrue();
+        }
+
+        [Fact]
+        public void IsConfigured_EmptyFile_ReturnsFalse()
+        {
+            File.WriteAllText(TempConfigPath, "");
+            CreateStdioConfig(TempConfigPath).IsConfigured().ShouldBeFalse();
+        }
+
+        [Fact]
+        public void IsConfigured_WrongCommand_ReturnsFalse()
+        {
+            var sectionName = $"mcp_servers.{AiAgentConfig.DefaultMcpServerName}";
+            File.WriteAllText(TempConfigPath, $"[{sectionName}]\ncommand = \"wrong-command\"\nargs = [\"{Consts.MCP.Server.Args.Port}={Port}\",\"{Consts.MCP.Server.Args.PluginTimeout}={TimeoutMs}\",\"{Consts.MCP.Server.Args.ClientTransportMethod}=stdio\"]\n");
+            CreateStdioConfig(TempConfigPath).IsConfigured().ShouldBeFalse();
+        }
+
+        [Fact]
+        public void IsConfigured_MissingArgs_ReturnsFalse()
+        {
+            var executable = ExecutableFullPath.Replace('\\', '/');
+            var sectionName = $"mcp_servers.{AiAgentConfig.DefaultMcpServerName}";
+            File.WriteAllText(TempConfigPath, $"[{sectionName}]\ncommand = \"{executable}\"\n");
+            CreateStdioConfig(TempConfigPath).IsConfigured().ShouldBeFalse();
+        }
+
+        [Fact]
+        public void IsConfigured_HasPropertyToRemove_ReturnsFalse()
+        {
+            var executable = ExecutableFullPath.Replace('\\', '/');
+            var sectionName = $"mcp_servers.{AiAgentConfig.DefaultMcpServerName}";
+            var argsStr = $"\"{Consts.MCP.Server.Args.Port}={Port}\",\"{Consts.MCP.Server.Args.PluginTimeout}={TimeoutMs}\",\"{Consts.MCP.Server.Args.ClientTransportMethod}=stdio\"";
+            File.WriteAllText(TempConfigPath, $"[{sectionName}]\ncommand = \"{executable}\"\nargs = [{argsStr}]\nurl = \"http://some-url\"\n");
+            CreateStdioConfig(TempConfigPath).IsConfigured().ShouldBeFalse();
+        }
+
+        [Fact]
+        public void IsConfigured_DifferentBodyPath_ReturnsFalse()
+        {
+            CreateStdioConfig(TempConfigPath, "mcp_servers").Configure();
+            CreateStdioConfig(TempConfigPath, "other_path").IsConfigured().ShouldBeFalse();
+        }
+
+        [Fact]
+        public void Configure_CodexLikeConfig_IsConfiguredReturnsTrue()
+        {
+            File.Delete(TempConfigPath);
+            var config = new TomlAiAgentConfig("Codex", TempConfigPath, "mcp_servers")
+                .SetProperty("enabled", true, requiredForConfiguration: true)
+                .SetProperty("command", ExecutableFullPath.Replace('\\', '/'), requiredForConfiguration: true)
+                .SetProperty("args", new[]
+                {
+                    $"{Consts.MCP.Server.Args.Port}={Port}",
+                    $"{Consts.MCP.Server.Args.PluginTimeout}={TimeoutMs}",
+                    $"{Consts.MCP.Server.Args.ClientTransportMethod}={TransportMethod.stdio}"
+                }, requiredForConfiguration: true)
+                .SetProperty("tool_timeout_sec", 300, requiredForConfiguration: false)
+                .SetPropertyToRemove("url")
+                .SetPropertyToRemove("type");
+
+            config.Configure().ShouldBeTrue();
+            config.IsConfigured().ShouldBeTrue();
+        }
+
+        [Fact]
+        public void Configure_WithBooleanProperty_IsConfiguredReturnsTrue()
+        {
+            File.Delete(TempConfigPath);
+            var config = new TomlAiAgentConfig("Test", TempConfigPath, "mcp_servers")
+                .SetProperty("enabled", true, requiredForConfiguration: true);
+            config.Configure().ShouldBeTrue();
+            config.IsConfigured().ShouldBeTrue();
+        }
+
+        [Fact]
+        public void Configure_WithIntegerProperty_IsConfiguredReturnsTrue()
+        {
+            File.Delete(TempConfigPath);
+            var config = new TomlAiAgentConfig("Test", TempConfigPath, "mcp_servers")
+                .SetProperty("timeout", 300, requiredForConfiguration: true);
+            config.Configure().ShouldBeTrue();
+            config.IsConfigured().ShouldBeTrue();
+        }
+
+        [Fact]
+        public void ExpectedFileContent_CustomBodyPath_UsesCorrectSection()
+        {
+            var content = CreateStdioConfig(TempConfigPath, "custom_path").ExpectedFileContent;
+            content.ShouldContain($"[custom_path.{AiAgentConfig.DefaultMcpServerName}]");
+        }
+
+        [Fact]
+        public void Configure_WithIntArray_IsConfiguredReturnsTrue()
+        {
+            File.Delete(TempConfigPath);
+            var config = new TomlAiAgentConfig("Test", TempConfigPath, "mcp_servers")
+                .SetProperty("ports", new[] { 8080, 8081, 8082 }, requiredForConfiguration: true);
+            config.Configure().ShouldBeTrue();
+            config.IsConfigured().ShouldBeTrue();
+            File.ReadAllText(TempConfigPath).ShouldContain("ports = [8080,8081,8082]");
+        }
+
+        [Fact]
+        public void Configure_WithBoolArray_IsConfiguredReturnsTrue()
+        {
+            File.Delete(TempConfigPath);
+            var config = new TomlAiAgentConfig("Test", TempConfigPath, "mcp_servers")
+                .SetProperty("flags", new[] { true, false, true }, requiredForConfiguration: true);
+            config.Configure().ShouldBeTrue();
+            config.IsConfigured().ShouldBeTrue();
+            File.ReadAllText(TempConfigPath).ShouldContain("flags = [true,false,true]");
+        }
+
+        [Fact]
+        public void Configure_WithStringArray_IsConfiguredReturnsTrue()
+        {
+            File.Delete(TempConfigPath);
+            var config = new TomlAiAgentConfig("Test", TempConfigPath, "mcp_servers")
+                .SetProperty("names", new[] { "alpha", "beta", "gamma" }, requiredForConfiguration: true);
+            config.Configure().ShouldBeTrue();
+            config.IsConfigured().ShouldBeTrue();
+            File.ReadAllText(TempConfigPath).ShouldContain("names = [\"alpha\",\"beta\",\"gamma\"]");
+        }
+
+        [Fact]
+        public void IsConfigured_ExistingIntArray_MatchesCorrectly()
+        {
+            var sectionName = $"mcp_servers.{AiAgentConfig.DefaultMcpServerName}";
+            File.WriteAllText(TempConfigPath, $"[{sectionName}]\nports = [8080, 8081, 8082]\n");
+            new TomlAiAgentConfig("Test", TempConfigPath, "mcp_servers")
+                .SetProperty("ports", new[] { 8080, 8081, 8082 }, requiredForConfiguration: true)
+                .IsConfigured().ShouldBeTrue();
+        }
+
+        [Fact]
+        public void IsConfigured_MismatchedIntArray_ReturnsFalse()
+        {
+            var sectionName = $"mcp_servers.{AiAgentConfig.DefaultMcpServerName}";
+            File.WriteAllText(TempConfigPath, $"[{sectionName}]\nports = [9000, 9001]\n");
+            new TomlAiAgentConfig("Test", TempConfigPath, "mcp_servers")
+                .SetProperty("ports", new[] { 8080, 8081, 8082 }, requiredForConfiguration: true)
+                .IsConfigured().ShouldBeFalse();
+        }
+
+        [Fact]
+        public void Configure_NegativeIntArray_HandledCorrectly()
+        {
+            File.Delete(TempConfigPath);
+            var config = new TomlAiAgentConfig("Test", TempConfigPath, "mcp_servers")
+                .SetProperty("offsets", new[] { -10, 0, 10 }, requiredForConfiguration: true);
+            config.Configure().ShouldBeTrue();
+            config.IsConfigured().ShouldBeTrue();
+            File.ReadAllText(TempConfigPath).ShouldContain("offsets = [-10,0,10]");
+        }
+
+        [Fact]
+        public void ExpectedFileContent_PropertiesInAlphabeticalOrder()
+        {
+            var config = new TomlAiAgentConfig("Test", TempConfigPath, "mcp_servers")
+                .SetProperty("zebra", "last")
+                .SetProperty("alpha", "first")
+                .SetProperty("middle", "mid");
+
+            var propLines = config.ExpectedFileContent.Split('\n')
+                .Select(line => line.Trim())
+                .Where(t => !string.IsNullOrEmpty(t) && !t.StartsWith("[") && t.Contains(" = "))
+                .ToList();
+
+            propLines.Count.ShouldBe(3);
+            propLines[0].ShouldStartWith("alpha");
+            propLines[1].ShouldStartWith("middle");
+            propLines[2].ShouldStartWith("zebra");
+        }
+
+        [Fact]
+        public void Configure_Stdio_RemovesDuplicateByCommand()
+        {
+            var executable = ExecutableFullPath.Replace('\\', '/');
+            File.WriteAllText(TempConfigPath, $"[mcp_servers.my-custom-name]\ncommand = \"{executable}\"\nargs = [\"--old-arg\"]\n");
+            CreateStdioConfig(TempConfigPath).Configure();
+
+            var content = File.ReadAllText(TempConfigPath);
+            content.ShouldNotContain("[mcp_servers.my-custom-name]");
+            content.ShouldContain($"[mcp_servers.{AiAgentConfig.DefaultMcpServerName}]");
+        }
+
+        [Fact]
+        public void Configure_Http_RemovesDuplicateByServerUrl()
+        {
+            File.WriteAllText(TempConfigPath, $"[mcp_servers.my-custom-name]\nserverUrl = \"{Host}\"\n");
+            new TomlAiAgentConfig("Test", TempConfigPath, "mcp_servers")
+                .AddIdentityKey("serverUrl")
+                .SetProperty("serverUrl", Host, requiredForConfiguration: true)
+                .SetPropertyToRemove("command")
+                .SetPropertyToRemove("args")
+                .SetPropertyToRemove("url")
+                .Configure();
+
+            var content = File.ReadAllText(TempConfigPath);
+            content.ShouldNotContain("[mcp_servers.my-custom-name]");
+            content.ShouldContain($"[mcp_servers.{AiAgentConfig.DefaultMcpServerName}]");
+        }
+
+        [Fact]
+        public void IsDetected_DeprecatedName_ReturnsTrue()
+        {
+            File.WriteAllText(TempConfigPath, "[mcp_servers.Unity-MCP]\ncommand = \"/some/path\"\n");
+            CreateStdioConfig(TempConfigPath).IsDetected().ShouldBeTrue();
+        }
+
+        [Fact]
+        public void Unconfigure_DeprecatedAndCurrentPresent_RemovesBoth()
+        {
+            var existingToml = "[mcp_servers.Unity-MCP]\ncommand = \"/old/path\"\n\n" +
+                               $"[mcp_servers.{AiAgentConfig.DefaultMcpServerName}]\ncommand = \"/some/path\"\n";
+            File.WriteAllText(TempConfigPath, existingToml);
+            CreateStdioConfig(TempConfigPath).Unconfigure().ShouldBeTrue();
+
+            var content = File.ReadAllText(TempConfigPath);
+            content.ShouldNotContain("[mcp_servers.Unity-MCP]");
+            content.ShouldNotContain($"[mcp_servers.{AiAgentConfig.DefaultMcpServerName}]");
+        }
+
+        [Fact]
+        public void Unconfigure_NothingPresent_ReturnsFalse()
+        {
+            File.WriteAllText(TempConfigPath, "[mcp_servers.other-server]\ncommand = \"completely-different-command\"\n");
+            CreateStdioConfig(TempConfigPath).Unconfigure().ShouldBeFalse();
+        }
+
+        [Fact]
+        public void Configure_ExistingSection_PreservesFloatValue()
+        {
+            var sectionName = $"mcp_servers.{AiAgentConfig.DefaultMcpServerName}";
+            File.WriteAllText(TempConfigPath, $"[{sectionName}]\ncommand = \"old-command\"\ntimeout = 1.5\n");
+            CreateStdioConfig(TempConfigPath).Configure();
+
+            var content = File.ReadAllText(TempConfigPath);
+            content.ShouldContain("timeout = 1.5");
+            content.ShouldNotContain("timeout = \"1.5\"");
+        }
+
+        [Fact]
+        public void Configure_ExistingSection_InlineCommentOnInt()
+        {
+            var sectionName = $"mcp_servers.{AiAgentConfig.DefaultMcpServerName}";
+            File.WriteAllText(TempConfigPath, $"[{sectionName}]\ncommand = \"old-command\"\nport = 8080 # default port\n");
+            CreateStdioConfig(TempConfigPath).Configure();
+
+            var content = File.ReadAllText(TempConfigPath);
+            content.ShouldContain("port = 8080");
+            content.ShouldNotContain("# default port");
+            content.ShouldNotContain("port = \"");
+        }
+
+        [Fact]
+        public void IsConfigured_StringArrayWithHashInsideQuotes_MatchesCorrectly()
+        {
+            var sectionName = $"mcp_servers.{AiAgentConfig.DefaultMcpServerName}";
+            File.WriteAllText(TempConfigPath, $"[{sectionName}]\ntags = [\"C#\", \"F#\"] # languages\n");
+            new TomlAiAgentConfig("Test", TempConfigPath, "mcp_servers")
+                .SetProperty("tags", new[] { "C#", "F#" }, requiredForConfiguration: true)
+                .IsConfigured().ShouldBeTrue();
+        }
+
+        [Fact]
+        public void IsConfigured_PathComparison_BackslashEqualsForwardSlash()
+        {
+            var sectionName = $"mcp_servers.{AiAgentConfig.DefaultMcpServerName}";
+            File.WriteAllText(TempConfigPath, $"[{sectionName}]\ncommand = \"C:\\\\Users\\\\test\\\\app.exe\"\n");
+            new TomlAiAgentConfig("Test", TempConfigPath, "mcp_servers")
+                .SetProperty("command", "C:/Users/test/app.exe", requiredForConfiguration: true, comparison: ValueComparisonMode.Path)
+                .IsConfigured().ShouldBeTrue();
+        }
+
+        [Fact]
+        public void IsConfigured_UrlComparison_SchemeCaseInsensitive()
+        {
+            var sectionName = $"mcp_servers.{AiAgentConfig.DefaultMcpServerName}";
+            File.WriteAllText(TempConfigPath, $"[{sectionName}]\nurl = \"HTTP://LOCALHOST:5000/mcp\"\n");
+            new TomlAiAgentConfig("Test", TempConfigPath, "mcp_servers")
+                .SetProperty("url", "http://localhost:5000/mcp", requiredForConfiguration: true, comparison: ValueComparisonMode.Url)
+                .IsConfigured().ShouldBeTrue();
+        }
+
+        [Fact]
+        public void IsConfigured_ExactComparison_RejectsDifferentPaths()
+        {
+            var sectionName = $"mcp_servers.{AiAgentConfig.DefaultMcpServerName}";
+            File.WriteAllText(TempConfigPath, $"[{sectionName}]\ncommand = \"C:\\\\Users\\\\test\\\\app.exe\"\n");
+            new TomlAiAgentConfig("Test", TempConfigPath, "mcp_servers")
+                .SetProperty("command", "C:/Users/test/app.exe", requiredForConfiguration: true)
+                .IsConfigured().ShouldBeFalse();
+        }
+    }
+}

--- a/McpPlugin/src/AgentConfig/AgentConfigBuilders.cs
+++ b/McpPlugin/src/AgentConfig/AgentConfigBuilders.cs
@@ -1,0 +1,71 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System.Text.Json.Nodes;
+using com.IvanMurzak.McpPlugin.Common;
+using Microsoft.Extensions.Logging;
+using static com.IvanMurzak.McpPlugin.Common.Consts.MCP.Server;
+
+namespace com.IvanMurzak.McpPlugin.AgentConfig
+{
+    /// <summary>
+    /// Helpers that build the recurring stdio / http server-entry shapes shared by most
+    /// JSON-based configurators. Centralises the <c>command</c> + <c>args</c> (stdio) and
+    /// <c>type=http</c> + <c>url</c> (http) patterns so each agent only declares its deltas.
+    /// </summary>
+    internal static class AgentConfigBuilders
+    {
+        /// <summary>The standard stdio arg array (port, plugin-timeout, client-transport, authorization).</summary>
+        public static JsonArray StdioArgs(AgentConfiguratorSettings s) => new()
+        {
+            $"{Args.Port}={s.Port}",
+            $"{Args.PluginTimeout}={s.TimeoutMs}",
+            $"{Args.ClientTransportMethod}={TransportMethod.stdio}",
+            $"{Args.Authorization}={s.AuthOption}"
+        };
+
+        /// <summary>
+        /// Standard JSON stdio entry: <c>type=stdio</c>, <c>command</c> (path comparison),
+        /// <c>args</c>, removing <c>url</c>.
+        /// </summary>
+        public static JsonAiAgentConfig JsonStdio(
+            string name,
+            string configPath,
+            AgentConfiguratorSettings settings,
+            ILogger? logger,
+            string bodyPath = Consts.MCP.Server.DefaultBodyPath)
+        {
+            return new JsonAiAgentConfig(name, configPath, bodyPath, logger)
+                .SetProperty("type", JsonValue.Create("stdio")!, requiredForConfiguration: true)
+                .SetProperty("command", JsonValue.Create(settings.ExecutableFullPath.Replace('\\', '/'))!, requiredForConfiguration: true, comparison: ValueComparisonMode.Path)
+                .SetProperty("args", StdioArgs(settings), requiredForConfiguration: true)
+                .SetPropertyToRemove("url");
+        }
+
+        /// <summary>
+        /// Standard JSON http entry: <c>type=http</c>, <c>url</c> (url comparison),
+        /// removing <c>command</c> + <c>args</c>.
+        /// </summary>
+        public static JsonAiAgentConfig JsonHttp(
+            string name,
+            string configPath,
+            AgentConfiguratorSettings settings,
+            ILogger? logger,
+            string bodyPath = Consts.MCP.Server.DefaultBodyPath)
+        {
+            return new JsonAiAgentConfig(name, configPath, bodyPath, logger)
+                .SetProperty("type", JsonValue.Create("http")!, requiredForConfiguration: true)
+                .SetProperty("url", JsonValue.Create(settings.Host)!, requiredForConfiguration: true, comparison: ValueComparisonMode.Url)
+                .SetPropertyToRemove("command")
+                .SetPropertyToRemove("args");
+        }
+    }
+}

--- a/McpPlugin/src/AgentConfig/AgentConfiguratorDescription.cs
+++ b/McpPlugin/src/AgentConfig/AgentConfiguratorDescription.cs
@@ -1,0 +1,134 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System.Collections.Generic;
+
+namespace com.IvanMurzak.McpPlugin.AgentConfig
+{
+    /// <summary>
+    /// The closed element vocabulary every engine's configurator UI already speaks. A
+    /// consuming engine renders each item with its own widget toolkit (UIToolkit in Unity,
+    /// Slate in Unreal, Control nodes in Godot) — this DTO carries only the engine-agnostic
+    /// content, never a UI handle.
+    /// </summary>
+    public enum ConfigurationItemKind
+    {
+        /// <summary>Plain descriptive text.</summary>
+        Description,
+        /// <summary>A warning line (e.g. "Authorization is enabled. Set the env var first").</summary>
+        Warning,
+        /// <summary>An alert / call-to-action line.</summary>
+        Alert,
+        /// <summary>A non-editable, copy-pasteable value (command line, JSON/TOML snippet, path).</summary>
+        ReadOnlyField,
+        /// <summary>An editable value the user can change (the Custom agent's editable config-path).</summary>
+        EditableField
+    }
+
+    /// <summary>
+    /// A single rendered element inside a <see cref="ConfigurationSection"/>.
+    /// </summary>
+    public sealed class ConfigurationItem
+    {
+        /// <summary>How this item should be rendered.</summary>
+        public ConfigurationItemKind Kind { get; }
+
+        /// <summary>
+        /// The item's text. For <see cref="ConfigurationItemKind.Description"/> /
+        /// <see cref="ConfigurationItemKind.Warning"/> / <see cref="ConfigurationItemKind.Alert"/>
+        /// it is the message; for <see cref="ConfigurationItemKind.ReadOnlyField"/> /
+        /// <see cref="ConfigurationItemKind.EditableField"/> it is the field value.
+        /// </summary>
+        public string Text { get; }
+
+        public ConfigurationItem(ConfigurationItemKind kind, string text)
+        {
+            Kind = kind;
+            Text = text;
+        }
+
+        public static ConfigurationItem Description(string text) => new(ConfigurationItemKind.Description, text);
+        public static ConfigurationItem Warning(string text) => new(ConfigurationItemKind.Warning, text);
+        public static ConfigurationItem Alert(string text) => new(ConfigurationItemKind.Alert, text);
+        public static ConfigurationItem ReadOnlyField(string value) => new(ConfigurationItemKind.ReadOnlyField, value);
+        public static ConfigurationItem EditableField(string value) => new(ConfigurationItemKind.EditableField, value);
+    }
+
+    /// <summary>
+    /// A foldout / collapsible group of <see cref="ConfigurationItem"/>s (e.g. "Start",
+    /// "Manual Configuration Steps", "Troubleshooting"). Mirrors the engines' existing
+    /// foldout sections.
+    /// </summary>
+    public sealed class ConfigurationSection
+    {
+        /// <summary>The section heading shown on the foldout.</summary>
+        public string Heading { get; }
+
+        /// <summary>Whether the section is expanded by default (the first/"Start" section usually is).</summary>
+        public bool ExpandedFirst { get; }
+
+        /// <summary>The ordered items inside the section.</summary>
+        public IReadOnlyList<ConfigurationItem> Items { get; }
+
+        public ConfigurationSection(string heading, bool expandedFirst, IReadOnlyList<ConfigurationItem> items)
+        {
+            Heading = heading;
+            ExpandedFirst = expandedFirst;
+            Items = items;
+        }
+    }
+
+    /// <summary>
+    /// Engine-agnostic description of a configurator's UI for one transport, plus the
+    /// agent identity and current status. A consuming engine reads this to render the
+    /// agent panel without the shared library taking any UI dependency.
+    /// </summary>
+    public sealed class AgentConfiguratorDescription
+    {
+        /// <summary>Display name of the AI agent (e.g. "Claude Code").</summary>
+        public string AgentName { get; }
+
+        /// <summary>Stable identifier of the AI agent (e.g. "claude-code").</summary>
+        public string AgentId { get; }
+
+        /// <summary>Icon file NAME only (e.g. "claude-64.png"), never the bytes. Null when no icon.</summary>
+        public string? IconName { get; }
+
+        /// <summary>Whether the MCP config file currently has this server entry (detected on disk).</summary>
+        public bool IsConfigured { get; }
+
+        /// <summary>
+        /// Whether the agent's tooling is considered installed/available. Engines that cannot
+        /// detect installation leave this false; it is part of the closed status vocabulary so
+        /// every engine reports the same shape.
+        /// </summary>
+        public bool IsInstalled { get; }
+
+        /// <summary>The ordered UI sections to render.</summary>
+        public IReadOnlyList<ConfigurationSection> Sections { get; }
+
+        public AgentConfiguratorDescription(
+            string agentName,
+            string agentId,
+            string? iconName,
+            bool isConfigured,
+            bool isInstalled,
+            IReadOnlyList<ConfigurationSection> sections)
+        {
+            AgentName = agentName;
+            AgentId = agentId;
+            IconName = iconName;
+            IsConfigured = isConfigured;
+            IsInstalled = isInstalled;
+            Sections = sections;
+        }
+    }
+}

--- a/McpPlugin/src/AgentConfig/AgentConfiguratorSettings.cs
+++ b/McpPlugin/src/AgentConfig/AgentConfiguratorSettings.cs
@@ -1,0 +1,109 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using com.IvanMurzak.McpPlugin.Common;
+
+namespace com.IvanMurzak.McpPlugin.AgentConfig
+{
+    /// <summary>
+    /// The operating-system family a configurator builds a config for. Engine-agnostic
+    /// replacement for the <c>#if UNITY_EDITOR_WIN</c> / <c>#if UNITY_EDITOR_OSX</c>
+    /// compile-time branches in the original Unity implementation. The consuming engine
+    /// detects the host OS and passes the matching value.
+    /// </summary>
+    public enum OperatingSystemKind
+    {
+        Windows,
+        MacOS,
+        Linux
+    }
+
+    /// <summary>
+    /// Where the plugin connects: a locally launched server or the ai-game.dev cloud.
+    /// Engine-agnostic replacement for the Unity editor's <c>ConnectionMode</c>. In Cloud
+    /// mode authorization is always required (the cloud server enforces it).
+    /// </summary>
+    public enum ConnectionMode
+    {
+        Local,
+        Cloud
+    }
+
+    /// <summary>
+    /// All the engine-supplied values a configurator needs to build an MCP config entry.
+    /// Replaces the Unity statics (<c>UnityMcpPluginEditor.Port</c>, <c>.Host</c>,
+    /// <c>.Token</c>, …, and <c>McpServerManager.ExecutableFullPath</c>) the original
+    /// implementation read from. The consuming engine constructs this and hands it to the
+    /// registry / configurators; nothing here touches an editor UI or engine runtime type.
+    /// </summary>
+    public sealed class AgentConfiguratorSettings
+    {
+        /// <summary>Host OS the config is being generated for (drives per-OS config-file locations).</summary>
+        public OperatingSystemKind OperatingSystem { get; }
+
+        /// <summary>Absolute path to the consuming project's root (where project-local config files live).</summary>
+        public string ProjectRootPath { get; }
+
+        /// <summary>Absolute path to the MCP server executable (stdio transport <c>command</c>).</summary>
+        public string ExecutableFullPath { get; }
+
+        /// <summary>The MCP server port (stdio transport arg).</summary>
+        public int Port { get; }
+
+        /// <summary>Plugin timeout in milliseconds (stdio transport arg).</summary>
+        public int TimeoutMs { get; }
+
+        /// <summary>The streamableHttp server URL (http transport <c>url</c>).</summary>
+        public string Host { get; }
+
+        /// <summary>Bearer token, or empty/null when auth is not configured.</summary>
+        public string? Token { get; }
+
+        /// <summary>Whether the plugin connects to a local server or the cloud.</summary>
+        public ConnectionMode ConnectionMode { get; }
+
+        /// <summary>Whether bearer-token auth is required (independent of cloud enforcement).</summary>
+        public Consts.MCP.Server.AuthOption AuthOption { get; }
+
+        public AgentConfiguratorSettings(
+            OperatingSystemKind operatingSystem,
+            string projectRootPath,
+            string executableFullPath,
+            int port,
+            int timeoutMs,
+            string host,
+            string? token = null,
+            ConnectionMode connectionMode = ConnectionMode.Local,
+            Consts.MCP.Server.AuthOption authOption = Consts.MCP.Server.AuthOption.none)
+        {
+            OperatingSystem = operatingSystem;
+            ProjectRootPath = projectRootPath;
+            ExecutableFullPath = executableFullPath;
+            Port = port;
+            TimeoutMs = timeoutMs;
+            Host = host;
+            Token = token;
+            ConnectionMode = connectionMode;
+            AuthOption = authOption;
+        }
+
+        /// <summary>True when HTTP authorization should be injected (cloud always requires it).</summary>
+        public bool IsHttpAuthRequired =>
+            ConnectionMode == ConnectionMode.Cloud || AuthOption == Consts.MCP.Server.AuthOption.required;
+
+        /// <summary>True when STDIO authorization (token arg) should be injected.</summary>
+        public bool IsStdioAuthRequired =>
+            AuthOption == Consts.MCP.Server.AuthOption.required;
+
+        /// <summary>Convenience: <see cref="OperatingSystem"/> is <see cref="OperatingSystemKind.Windows"/>.</summary>
+        public bool IsWindows => OperatingSystem == OperatingSystemKind.Windows;
+    }
+}

--- a/McpPlugin/src/AgentConfig/AiAgentConfig.cs
+++ b/McpPlugin/src/AgentConfig/AiAgentConfig.cs
@@ -1,0 +1,103 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System.Collections.Generic;
+using com.IvanMurzak.McpPlugin.Common;
+using Microsoft.Extensions.Logging;
+
+namespace com.IvanMurzak.McpPlugin.AgentConfig
+{
+    /// <summary>
+    /// How a configured value is compared against the value present on disk when
+    /// deciding whether an AI-agent config file is already correctly configured.
+    /// </summary>
+    public enum ValueComparisonMode
+    {
+        /// <summary>Byte-for-byte string equality.</summary>
+        Exact,
+        /// <summary>Filesystem-path equality (separator-insensitive, trailing-slash-insensitive).</summary>
+        Path,
+        /// <summary>URL equality (scheme/host case-insensitive, trailing-slash-insensitive).</summary>
+        Url
+    }
+
+    /// <summary>
+    /// Engine-agnostic base for an AI-agent MCP config file (JSON or TOML).
+    /// Holds the server-entry shape (name, body path, identity keys) and the
+    /// install / remove / status contract. No editor-UI or engine dependency.
+    /// </summary>
+    public abstract class AiAgentConfig
+    {
+        /// <summary>Server-entry names written by older plugin versions that should be cleaned up on configure/unconfigure.</summary>
+        public static readonly string[] DeprecatedMcpServerNames = { "Unity-MCP" };
+
+        /// <summary>The canonical server-entry name written under the body path.</summary>
+        public const string DefaultMcpServerName = "ai-game-developer";
+
+        /// <summary>Property keys used to recognise the same server entry written under a different name.</summary>
+        public static readonly string[] DefaultIdentityKeys = { "command", "url" };
+
+        protected readonly List<string> _identityKeys = new(DefaultIdentityKeys);
+        protected readonly ILogger? _logger;
+
+        public string Name { get; set; }
+        public string ConfigPath { get; set; }
+        public string BodyPath { get; set; }
+        public abstract string ExpectedFileContent { get; }
+        public IReadOnlyList<string> IdentityKeys => _identityKeys;
+
+        protected AiAgentConfig(
+            string name,
+            string configPath,
+            string bodyPath = Consts.MCP.Server.DefaultBodyPath,
+            ILogger? logger = null)
+        {
+            Name = name;
+            ConfigPath = configPath;
+            BodyPath = bodyPath;
+            _logger = logger;
+        }
+
+        public AiAgentConfig AddIdentityKey(string key)
+        {
+            if (!_identityKeys.Contains(key))
+                _identityKeys.Add(key);
+            return this;
+        }
+
+        public abstract bool Configure();
+        public abstract bool Unconfigure();
+        public abstract bool IsDetected();
+        public abstract bool IsConfigured();
+
+        /// <summary>
+        /// Applies HTTP authorization to this config.
+        /// Override in format-specific subclasses to inject authorization headers or tokens.
+        /// </summary>
+        /// <param name="isRequired">True when auth is required and token is non-empty.</param>
+        /// <param name="token">The bearer token value, or null/empty if not set.</param>
+        public virtual void ApplyHttpAuthorization(bool isRequired, string? token)
+        {
+            // Default: no-op. Subclasses override for format-specific injection.
+        }
+
+        /// <summary>
+        /// Applies STDIO authorization to this config.
+        /// Override in format-specific subclasses to add or remove the token argument from args.
+        /// </summary>
+        /// <param name="isRequired">True when auth is required and token is non-empty.</param>
+        /// <param name="token">The bearer token value, or null/empty if not set.</param>
+        public virtual void ApplyStdioAuthorization(bool isRequired, string? token)
+        {
+            // Default: no-op. Subclasses override for format-specific injection.
+        }
+    }
+}

--- a/McpPlugin/src/AgentConfig/AiAgentConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/AiAgentConfigurator.cs
@@ -1,0 +1,197 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Extensions.Logging;
+
+namespace com.IvanMurzak.McpPlugin.AgentConfig
+{
+    /// <summary>
+    /// Engine-agnostic base for an AI-agent configurator. Each subclass knows one agent's
+    /// config-file location(s) and the stdio/http server-entry shape; it produces
+    /// <see cref="AiAgentConfig"/> instances (install/remove/status) and an engine-agnostic
+    /// <see cref="AgentConfiguratorDescription"/> for the UI. No editor-UI / engine dependency.
+    /// </summary>
+    /// <remarks>
+    /// This is the pure-logic split of Unity's UIToolkit-coupled <c>AiAgentConfigurator</c>:
+    /// the original mixed config building with <c>VisualElement</c> creation, <c>UnityMcpPluginEditor</c>
+    /// statics, and <c>McpServerManager</c>. Here all engine state arrives via
+    /// <see cref="AgentConfiguratorSettings"/> and the result is described, not rendered.
+    /// </remarks>
+    public abstract class AiAgentConfigurator
+    {
+        /// <summary>The display name of the AI agent.</summary>
+        public abstract string AgentName { get; }
+
+        /// <summary>The stable identifier for this agent (used for persisted keys and lookup).</summary>
+        public abstract string AgentId { get; }
+
+        /// <summary>The download URL for the AI agent.</summary>
+        public abstract string DownloadUrl { get; }
+
+        /// <summary>
+        /// The relative (or absolute) path where skill files should be generated for this agent.
+        /// Return null if the agent does not support skills.
+        /// </summary>
+        public virtual string? SkillsPath => null;
+
+        /// <summary>Whether this agent supports skill-file generation.</summary>
+        public bool SupportsSkills => SkillsPath != null;
+
+        /// <summary>The tutorial URL for configuring the AI agent, or empty if none.</summary>
+        public virtual string TutorialUrl => string.Empty;
+
+        /// <summary>
+        /// Icon file NAME for this agent (e.g. "claude-64.png"), or null when no icon.
+        /// Engines resolve the name to bytes themselves — the shared library never carries bytes.
+        /// </summary>
+        public abstract string? IconName { get; }
+
+        /// <summary>
+        /// Builds the STDIO transport config for the given settings. Override per agent.
+        /// Authorization is applied by <see cref="GetStdioConfig"/>; subclasses build the base entry only.
+        /// </summary>
+        protected abstract AiAgentConfig CreateStdioConfig(AgentConfiguratorSettings settings, ILogger? logger);
+
+        /// <summary>
+        /// Builds the HTTP transport config for the given settings. Override per agent.
+        /// Authorization is applied by <see cref="GetHttpConfig"/>; subclasses build the base entry only.
+        /// </summary>
+        protected abstract AiAgentConfig CreateHttpConfig(AgentConfiguratorSettings settings, ILogger? logger);
+
+        /// <summary>
+        /// Returns the STDIO config with STDIO authorization applied, ready to <c>Configure()</c> / inspect.
+        /// </summary>
+        public AiAgentConfig GetStdioConfig(AgentConfiguratorSettings settings, ILogger? logger = null)
+        {
+            var config = CreateStdioConfig(settings, logger);
+            ApplyStdioAuthorization(config, settings);
+            return config;
+        }
+
+        /// <summary>
+        /// Returns the HTTP config with HTTP authorization applied, ready to <c>Configure()</c> / inspect.
+        /// </summary>
+        public AiAgentConfig GetHttpConfig(AgentConfiguratorSettings settings, ILogger? logger = null)
+        {
+            var config = CreateHttpConfig(settings, logger);
+            ApplyHttpAuthorization(config, settings);
+            return config;
+        }
+
+        /// <summary>
+        /// Applies STDIO authorization to a config. Override for agent-specific token handling.
+        /// </summary>
+        protected virtual void ApplyStdioAuthorization(AiAgentConfig config, AgentConfiguratorSettings settings)
+        {
+            config.ApplyStdioAuthorization(settings.IsStdioAuthRequired, settings.Token);
+        }
+
+        /// <summary>
+        /// Applies HTTP authorization to a config. Override for agent-specific token handling
+        /// (e.g. Codex's bearer-token env-var indirection).
+        /// </summary>
+        protected virtual void ApplyHttpAuthorization(AiAgentConfig config, AgentConfiguratorSettings settings)
+        {
+            config.ApplyHttpAuthorization(settings.IsHttpAuthRequired, settings.Token);
+        }
+
+        /// <summary>
+        /// True when an MCP config for this agent is present on disk in either transport.
+        /// </summary>
+        public bool IsDetected(AgentConfiguratorSettings settings, ILogger? logger = null)
+        {
+            return GetStdioConfig(settings, logger).IsDetected()
+                || GetHttpConfig(settings, logger).IsDetected();
+        }
+
+        /// <summary>
+        /// True when the MCP config for the supplied transport is present AND matches the
+        /// current settings. The Custom configurator has no detectable config and returns false.
+        /// </summary>
+        public virtual bool IsConfigured(
+            AgentConfiguratorSettings settings,
+            Common.Consts.MCP.Server.TransportMethod transport,
+            ILogger? logger = null)
+        {
+            var config = transport == Common.Consts.MCP.Server.TransportMethod.stdio
+                ? GetStdioConfig(settings, logger)
+                : GetHttpConfig(settings, logger);
+            return config.IsConfigured();
+        }
+
+        /// <summary>
+        /// Builds the engine-agnostic UI description for the requested transport. Subclasses
+        /// supply the per-transport sections via <see cref="BuildSections"/>; this method wraps
+        /// them with identity + status so every engine sees a uniform shape.
+        /// </summary>
+        public AgentConfiguratorDescription Describe(
+            AgentConfiguratorSettings settings,
+            Common.Consts.MCP.Server.TransportMethod transport,
+            ILogger? logger = null)
+        {
+            var sections = BuildSections(settings, transport, logger);
+            var isConfigured = IsConfigured(settings, transport, logger);
+            return new AgentConfiguratorDescription(
+                agentName: AgentName,
+                agentId: AgentId,
+                iconName: IconName,
+                isConfigured: isConfigured,
+                isInstalled: false,
+                sections: sections);
+        }
+
+        /// <summary>
+        /// Builds the ordered UI sections for the requested transport. Override per agent.
+        /// </summary>
+        protected abstract IReadOnlyList<ConfigurationSection> BuildSections(
+            AgentConfiguratorSettings settings,
+            Common.Consts.MCP.Server.TransportMethod transport,
+            ILogger? logger);
+
+        /// <summary>
+        /// Default single-section description used by agents that simply expose their
+        /// expected config-file content for the user to write. Concrete agents with richer
+        /// step-by-step UIs override <see cref="BuildSections"/> instead.
+        /// </summary>
+        protected IReadOnlyList<ConfigurationSection> DefaultConfigurationSections(
+            AgentConfiguratorSettings settings,
+            Common.Consts.MCP.Server.TransportMethod transport,
+            ILogger? logger)
+        {
+            var config = transport == Common.Consts.MCP.Server.TransportMethod.stdio
+                ? GetStdioConfig(settings, logger)
+                : GetHttpConfig(settings, logger);
+            return new[]
+            {
+                new ConfigurationSection("Configuration", true, new[]
+                {
+                    ConfigurationItem.Description($"Use the Configure button to write the MCP entry into {AgentName}'s config file."),
+                    ConfigurationItem.ReadOnlyField(config.ExpectedFileContent)
+                })
+            };
+        }
+
+        /// <summary>
+        /// Resolves a (possibly project-relative) skills path to an absolute filesystem path,
+        /// mirroring the Unity editor's resolution but operating on the supplied value.
+        /// </summary>
+        protected static string ResolveAbsoluteSkillsPath(string projectRootPath, string folder)
+        {
+            if (string.IsNullOrEmpty(folder))
+                return folder;
+            return Path.IsPathRooted(folder)
+                ? folder
+                : Path.GetFullPath(Path.Combine(projectRootPath, folder));
+        }
+    }
+}

--- a/McpPlugin/src/AgentConfig/AiAgentConfiguratorRegistry.cs
+++ b/McpPlugin/src/AgentConfig/AiAgentConfiguratorRegistry.cs
@@ -1,0 +1,102 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System.Collections.Generic;
+using System.Linq;
+using com.IvanMurzak.McpPlugin.AgentConfig.Impl;
+
+namespace com.IvanMurzak.McpPlugin.AgentConfig
+{
+    /// <summary>
+    /// Registry of all built-in AI-agent configurators. Lookup by agent id or name; the
+    /// list is sorted by display name with the Custom configurator always pinned last
+    /// (mirroring the Unity registry's ordering contract).
+    /// </summary>
+    public static class AiAgentConfiguratorRegistry
+    {
+        private static readonly IReadOnlyList<AiAgentConfigurator> _configurators = new AiAgentConfigurator[]
+            {
+                new ClaudeCodeConfigurator(),
+                new ClaudeDesktopConfigurator(),
+                new VisualStudioCodeCopilotConfigurator(),
+                new VisualStudioCopilotConfigurator(),
+                new RiderConfigurator(),
+                new CursorConfigurator(),
+                new GitHubCopilotCliConfigurator(),
+                new GeminiConfigurator(),
+                new AntigravityConfigurator(),
+                new ClineConfigurator(),
+                new OpenCodeConfigurator(),
+                new CodexConfigurator(),
+                new KiloCodeConfigurator(),
+                new UnityAiConfigurator(),
+                new ZooCodeConfigurator(),
+            }
+            .OrderBy(c => c.AgentName)
+            .Append(new CustomConfigurator()) // Ensure CustomConfigurator is always last
+            .ToList();
+
+        /// <summary>All registered configurators (sorted by name, Custom last).</summary>
+        public static IReadOnlyList<AiAgentConfigurator> All => _configurators;
+
+        /// <summary>All agent display names, in registry order.</summary>
+        public static List<string> GetAgentNames() => _configurators.Select(c => c.AgentName).ToList();
+
+        /// <summary>All agent ids, in registry order.</summary>
+        public static List<string> GetAgentIds() => _configurators.Select(c => c.AgentId).ToList();
+
+        /// <summary>Gets a configurator by its agent id, or null when not found.</summary>
+        public static AiAgentConfigurator? GetByAgentId(string? agentId)
+        {
+            if (string.IsNullOrEmpty(agentId))
+                return null;
+
+            return _configurators.FirstOrDefault(c => c.AgentId == agentId);
+        }
+
+        /// <summary>Gets a configurator by its display name, or null when not found.</summary>
+        public static AiAgentConfigurator? GetByAgentName(string? agentName)
+        {
+            if (string.IsNullOrEmpty(agentName))
+                return null;
+
+            return _configurators.FirstOrDefault(c => c.AgentName == agentName);
+        }
+
+        /// <summary>Gets the registry index of a configurator by agent id, or -1 when not found.</summary>
+        public static int GetIndexByAgentId(string? agentId)
+        {
+            if (string.IsNullOrEmpty(agentId))
+                return -1;
+
+            for (int i = 0; i < _configurators.Count; i++)
+            {
+                if (_configurators[i].AgentId == agentId)
+                    return i;
+            }
+            return -1;
+        }
+
+        /// <summary>Gets the registry index of a configurator by display name, or -1 when not found.</summary>
+        public static int GetIndexByAgentName(string? agentName)
+        {
+            if (string.IsNullOrEmpty(agentName))
+                return -1;
+
+            for (int i = 0; i < _configurators.Count; i++)
+            {
+                if (_configurators[i].AgentName == agentName)
+                    return i;
+            }
+            return -1;
+        }
+    }
+}

--- a/McpPlugin/src/AgentConfig/Impl/AntigravityConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/Impl/AntigravityConfigurator.cs
@@ -1,0 +1,60 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.Logging;
+using static com.IvanMurzak.McpPlugin.Common.Consts.MCP.Server;
+
+namespace com.IvanMurzak.McpPlugin.AgentConfig.Impl
+{
+    /// <summary>
+    /// Configurator for the Antigravity AI agent (global config, <c>serverUrl</c> for http,
+    /// <c>disabled</c> flag).
+    /// </summary>
+    public sealed class AntigravityConfigurator : AiAgentConfigurator
+    {
+        public override string AgentName => "Antigravity";
+        public override string AgentId => "antigravity";
+        public override string DownloadUrl => "https://antigravity.google/download";
+        public override string? SkillsPath => ".agent/skills";
+        public override string? IconName => "antigravity-64.png";
+
+        private static string GlobalConfigPath(AgentConfiguratorSettings s) => Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".gemini", "config", "mcp_config.json");
+
+        protected override AiAgentConfig CreateStdioConfig(AgentConfiguratorSettings settings, ILogger? logger)
+            => new JsonAiAgentConfig(AgentName, GlobalConfigPath(settings), bodyPath: "mcpServers", logger: logger)
+                .AddIdentityKey("serverUrl")
+                .SetProperty("disabled", JsonValue.Create(false)!, requiredForConfiguration: true)
+                .SetProperty("command", JsonValue.Create(settings.ExecutableFullPath.Replace('\\', '/'))!, requiredForConfiguration: true, comparison: ValueComparisonMode.Path)
+                .SetProperty("args", AgentConfigBuilders.StdioArgs(settings), requiredForConfiguration: true)
+                .SetPropertyToRemove("url")
+                .SetPropertyToRemove("serverUrl")
+                .SetPropertyToRemove("type");
+
+        protected override AiAgentConfig CreateHttpConfig(AgentConfiguratorSettings settings, ILogger? logger)
+            => new JsonAiAgentConfig(AgentName, GlobalConfigPath(settings), bodyPath: "mcpServers", logger: logger)
+                .AddIdentityKey("serverUrl")
+                .SetProperty("disabled", JsonValue.Create(false)!, requiredForConfiguration: true)
+                .SetProperty("serverUrl", JsonValue.Create(settings.Host)!, requiredForConfiguration: true, comparison: ValueComparisonMode.Url)
+                .SetPropertyToRemove("command")
+                .SetPropertyToRemove("args")
+                .SetPropertyToRemove("url")
+                .SetPropertyToRemove("type");
+
+        protected override IReadOnlyList<ConfigurationSection> BuildSections(
+            AgentConfiguratorSettings settings, TransportMethod transport, ILogger? logger)
+            => DefaultConfigurationSections(settings, transport, logger);
+    }
+}

--- a/McpPlugin/src/AgentConfig/Impl/ClaudeCodeConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/Impl/ClaudeCodeConfigurator.cs
@@ -62,7 +62,7 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Impl
                     }),
                     new ConfigurationSection("Manual Configuration Steps", false, new[]
                     {
-                        ConfigurationItem.Description("Run the following command in the folder of the Unity project to configure Claude Code"),
+                        ConfigurationItem.Description("Run the following command in the project folder to configure Claude Code"),
                         ConfigurationItem.ReadOnlyField(addCommand),
                         ConfigurationItem.Description("Restart or start Claude Code to apply the configuration"),
                         ConfigurationItem.ReadOnlyField("claude")
@@ -83,7 +83,7 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Impl
                 }),
                 new ConfigurationSection("Manual Configuration Steps", false, new[]
                 {
-                    ConfigurationItem.Description("Run the following command in the folder of the Unity project to configure Claude Code"),
+                    ConfigurationItem.Description("Run the following command in the project folder to configure Claude Code"),
                     ConfigurationItem.ReadOnlyField(addCommandHttp),
                     ConfigurationItem.Description("Restart or start Claude Code to apply the configuration"),
                     ConfigurationItem.ReadOnlyField("claude")

--- a/McpPlugin/src/AgentConfig/Impl/ClaudeCodeConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/Impl/ClaudeCodeConfigurator.cs
@@ -1,0 +1,94 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.Logging;
+using static com.IvanMurzak.McpPlugin.Common.Consts.MCP.Server;
+
+namespace com.IvanMurzak.McpPlugin.AgentConfig.Impl
+{
+    /// <summary>Configurator for the Claude Code AI agent.</summary>
+    public sealed class ClaudeCodeConfigurator : AiAgentConfigurator
+    {
+        public override string AgentName => "Claude Code";
+        public override string AgentId => "claude-code";
+        public override string DownloadUrl => "https://docs.anthropic.com/en/docs/claude-code/overview";
+        public override string TutorialUrl => "https://youtu.be/Sknh2p12W8c";
+        public override string? SkillsPath => ".claude/skills";
+        public override string? IconName => "claude-64.png";
+
+        private static string LocalConfigPath(AgentConfiguratorSettings s) => Path.Combine(s.ProjectRootPath, ".mcp.json");
+
+        protected override AiAgentConfig CreateStdioConfig(AgentConfiguratorSettings settings, ILogger? logger)
+            => new JsonAiAgentConfig(AgentName, LocalConfigPath(settings), bodyPath: "mcpServers", logger: logger)
+                .SetProperty("command", JsonValue.Create(settings.ExecutableFullPath.Replace('\\', '/'))!, requiredForConfiguration: true, comparison: ValueComparisonMode.Path)
+                .SetProperty("args", AgentConfigBuilders.StdioArgs(settings), requiredForConfiguration: true)
+                .SetPropertyToRemove("type")
+                .SetPropertyToRemove("url");
+
+        protected override AiAgentConfig CreateHttpConfig(AgentConfiguratorSettings settings, ILogger? logger)
+            => AgentConfigBuilders.JsonHttp(AgentName, LocalConfigPath(settings), settings, logger, bodyPath: "mcpServers");
+
+        protected override IReadOnlyList<ConfigurationSection> BuildSections(
+            AgentConfiguratorSettings settings, TransportMethod transport, ILogger? logger)
+        {
+            var isAuthRequired = settings.IsHttpAuthRequired;
+            var token = !string.IsNullOrEmpty(settings.Token) ? settings.Token! : "<token>";
+
+            if (transport == TransportMethod.stdio)
+            {
+                var authArgs = settings.IsStdioAuthRequired
+                    ? $" {Args.Authorization}={AuthOption.required} {Args.Token}={token}"
+                    : string.Empty;
+                var addCommand = $"claude mcp add {AiAgentConfig.DefaultMcpServerName} \"{settings.ExecutableFullPath}\" port={settings.Port} plugin-timeout={settings.TimeoutMs} client-transport=stdio{authArgs}";
+                return new[]
+                {
+                    new ConfigurationSection("Start", true, new[]
+                    {
+                        ConfigurationItem.Description("Navigate to project root"),
+                        ConfigurationItem.ReadOnlyField($"cd \"{settings.ProjectRootPath}\""),
+                        ConfigurationItem.Description("Launch Claude Code"),
+                        ConfigurationItem.ReadOnlyField("claude")
+                    }),
+                    new ConfigurationSection("Manual Configuration Steps", false, new[]
+                    {
+                        ConfigurationItem.Description("Run the following command in the folder of the Unity project to configure Claude Code"),
+                        ConfigurationItem.ReadOnlyField(addCommand),
+                        ConfigurationItem.Description("Restart or start Claude Code to apply the configuration"),
+                        ConfigurationItem.ReadOnlyField("claude")
+                    })
+                };
+            }
+
+            var authHeader = isAuthRequired ? $" --header \"Authorization: Bearer {token}\"" : string.Empty;
+            var addCommandHttp = $"claude mcp add --transport http {AiAgentConfig.DefaultMcpServerName} {settings.Host}{authHeader}";
+            return new[]
+            {
+                new ConfigurationSection("Start", true, new[]
+                {
+                    ConfigurationItem.Description("Navigate to project root"),
+                    ConfigurationItem.ReadOnlyField($"cd \"{settings.ProjectRootPath}\""),
+                    ConfigurationItem.Description("Launch Claude Code"),
+                    ConfigurationItem.ReadOnlyField("claude")
+                }),
+                new ConfigurationSection("Manual Configuration Steps", false, new[]
+                {
+                    ConfigurationItem.Description("Run the following command in the folder of the Unity project to configure Claude Code"),
+                    ConfigurationItem.ReadOnlyField(addCommandHttp),
+                    ConfigurationItem.Description("Restart or start Claude Code to apply the configuration"),
+                    ConfigurationItem.ReadOnlyField("claude")
+                })
+            };
+        }
+    }
+}

--- a/McpPlugin/src/AgentConfig/Impl/ClaudeDesktopConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/Impl/ClaudeDesktopConfigurator.cs
@@ -1,0 +1,42 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Extensions.Logging;
+using static com.IvanMurzak.McpPlugin.Common.Consts.MCP.Server;
+
+namespace com.IvanMurzak.McpPlugin.AgentConfig.Impl
+{
+    /// <summary>Configurator for the Claude Desktop AI agent (global, per-OS config path).</summary>
+    public sealed class ClaudeDesktopConfigurator : AiAgentConfigurator
+    {
+        public override string AgentName => "Claude Desktop";
+        public override string AgentId => "claude-desktop";
+        public override string DownloadUrl => "https://code.claude.com/docs/en/desktop";
+        public override string? IconName => "claude-64.png";
+
+        private static string ConfigPath(AgentConfiguratorSettings s) => s.IsWindows
+            ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Claude", "claude_desktop_config.json")
+            : Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Library", "Application Support", "Claude", "claude_desktop_config.json");
+
+        protected override AiAgentConfig CreateStdioConfig(AgentConfiguratorSettings settings, ILogger? logger)
+            => AgentConfigBuilders.JsonStdio(AgentName, ConfigPath(settings), settings, logger);
+
+        protected override AiAgentConfig CreateHttpConfig(AgentConfiguratorSettings settings, ILogger? logger)
+            => AgentConfigBuilders.JsonHttp(AgentName, ConfigPath(settings), settings, logger);
+
+        protected override IReadOnlyList<ConfigurationSection> BuildSections(
+            AgentConfiguratorSettings settings, TransportMethod transport, ILogger? logger)
+            => DefaultConfigurationSections(settings, transport, logger);
+    }
+}

--- a/McpPlugin/src/AgentConfig/Impl/ClineConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/Impl/ClineConfigurator.cs
@@ -1,0 +1,64 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.Logging;
+using static com.IvanMurzak.McpPlugin.Common.Consts.MCP.Server;
+
+namespace com.IvanMurzak.McpPlugin.AgentConfig.Impl
+{
+    /// <summary>
+    /// Configurator for the Cline AI agent (global per-OS config; http uses
+    /// <c>type=streamableHttp</c>).
+    /// </summary>
+    public sealed class ClineConfigurator : AiAgentConfigurator
+    {
+        public override string AgentName => "Cline";
+        public override string AgentId => "cline";
+        public override string DownloadUrl => "https://cline.bot/";
+        public override string? SkillsPath => ".cline/skills";
+        public override string? IconName => "cline-64.png";
+
+        private static string GlobalConfigPath(AgentConfiguratorSettings s)
+        {
+            const string relSettings = "globalStorage";
+            switch (s.OperatingSystem)
+            {
+                case OperatingSystemKind.Windows:
+                    return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                        "Code", "User", relSettings, "saoudrizwan.claude-dev", "settings", "cline_mcp_settings.json");
+                case OperatingSystemKind.MacOS:
+                    return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                        "Library", "Application Support", "Code", "User", relSettings, "saoudrizwan.claude-dev", "settings", "cline_mcp_settings.json");
+                default: // Linux
+                    return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                        ".config", "Code", "User", relSettings, "saoudrizwan.claude-dev", "settings", "cline_mcp_settings.json");
+            }
+        }
+
+        protected override AiAgentConfig CreateStdioConfig(AgentConfiguratorSettings settings, ILogger? logger)
+            => AgentConfigBuilders.JsonStdio(AgentName, GlobalConfigPath(settings), settings, logger);
+
+        protected override AiAgentConfig CreateHttpConfig(AgentConfiguratorSettings settings, ILogger? logger)
+            => new JsonAiAgentConfig(AgentName, GlobalConfigPath(settings), bodyPath: DefaultBodyPath, logger: logger)
+                .SetProperty("type", JsonValue.Create($"{TransportMethod.streamableHttp}")!, requiredForConfiguration: true)
+                .SetProperty("url", JsonValue.Create(settings.Host)!, requiredForConfiguration: true, comparison: ValueComparisonMode.Url)
+                .SetPropertyToRemove("command")
+                .SetPropertyToRemove("args");
+
+        protected override IReadOnlyList<ConfigurationSection> BuildSections(
+            AgentConfiguratorSettings settings, TransportMethod transport, ILogger? logger)
+            => DefaultConfigurationSections(settings, transport, logger);
+    }
+}

--- a/McpPlugin/src/AgentConfig/Impl/CodexConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/Impl/CodexConfigurator.cs
@@ -90,9 +90,9 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Impl
                 {
                     new ConfigurationSection("Manual Configuration Steps - Option 1", true, new[]
                     {
-                        ConfigurationItem.Description("1. Open a terminal and run the following command to be in the folder of the Unity project"),
+                        ConfigurationItem.Description("1. Open a terminal and run the following command to be in the project folder"),
                         ConfigurationItem.ReadOnlyField($"cd \"{settings.ProjectRootPath}\""),
-                        ConfigurationItem.Description("2. Run the following command in the folder of the Unity project to configure Codex"),
+                        ConfigurationItem.Description("2. Run the following command in the project folder to configure Codex"),
                         ConfigurationItem.ReadOnlyField(addStdio),
                         ConfigurationItem.Description("3. Start Codex"),
                         ConfigurationItem.ReadOnlyField("codex")
@@ -114,9 +114,9 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Impl
                     ? ConfigurationItem.ReadOnlyField($"setx {EnvVarNameAuthToken} \"{settings.Token}\"")
                     : ConfigurationItem.ReadOnlyField($"export {EnvVarNameAuthToken}=\"{settings.Token}\""));
             }
-            items.Add(ConfigurationItem.Description("1. Open a terminal and run the following command to be in the folder of the Unity project"));
+            items.Add(ConfigurationItem.Description("1. Open a terminal and run the following command to be in the project folder"));
             items.Add(ConfigurationItem.ReadOnlyField($"cd \"{settings.ProjectRootPath}\""));
-            items.Add(ConfigurationItem.Description("2. Run the following command in the folder of the Unity project to configure Codex"));
+            items.Add(ConfigurationItem.Description("2. Run the following command in the project folder to configure Codex"));
             items.Add(ConfigurationItem.ReadOnlyField(addHttp));
             items.Add(ConfigurationItem.Description("3. Start Codex"));
             items.Add(ConfigurationItem.ReadOnlyField("codex"));

--- a/McpPlugin/src/AgentConfig/Impl/CodexConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/Impl/CodexConfigurator.cs
@@ -1,0 +1,136 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Extensions.Logging;
+using static com.IvanMurzak.McpPlugin.Common.Consts.MCP.Server;
+
+namespace com.IvanMurzak.McpPlugin.AgentConfig.Impl
+{
+    /// <summary>
+    /// Configurator for the Codex AI agent — the only TOML-based agent. HTTP auth is injected
+    /// via a <c>bearer_token_env_var</c> indirection rather than an inline header.
+    /// </summary>
+    public sealed class CodexConfigurator : AiAgentConfigurator
+    {
+        private const string EnvVarNameAuthToken = "GAME_DEV_AUTH_TOKEN";
+        private const string EnvVarNameBearerToken = "bearer_token_env_var";
+
+        public override string AgentName => "Codex";
+        public override string AgentId => "codex";
+        public override string DownloadUrl => "https://openai.com/codex/";
+        public override string? SkillsPath => ".agents/skills";
+        public override string? IconName => "codex-64.png";
+
+        private static string LocalConfigPath(AgentConfiguratorSettings s) => Path.Combine(s.ProjectRootPath, ".codex", "config.toml");
+
+        protected override AiAgentConfig CreateStdioConfig(AgentConfiguratorSettings settings, ILogger? logger)
+            => new TomlAiAgentConfig(AgentName, LocalConfigPath(settings), bodyPath: "mcp_servers", logger: logger)
+                .SetProperty("enabled", true, requiredForConfiguration: true)
+                .SetProperty("command", settings.ExecutableFullPath.Replace('\\', '/'), requiredForConfiguration: true, comparison: ValueComparisonMode.Path)
+                .SetProperty("args", new[]
+                {
+                    $"{Args.Port}={settings.Port}",
+                    $"{Args.PluginTimeout}={settings.TimeoutMs}",
+                    $"{Args.ClientTransportMethod}={TransportMethod.stdio}",
+                    $"{Args.Authorization}={settings.AuthOption}"
+                }, requiredForConfiguration: true)
+                .SetProperty("tool_timeout_sec", 300, requiredForConfiguration: false)
+                .SetPropertyToRemove("url")
+                .SetPropertyToRemove("type")
+                .SetPropertyToRemove("startup_timeout_sec");
+
+        protected override AiAgentConfig CreateHttpConfig(AgentConfiguratorSettings settings, ILogger? logger)
+            => new TomlAiAgentConfig(AgentName, LocalConfigPath(settings), bodyPath: "mcp_servers", logger: logger)
+                .SetProperty("enabled", true, requiredForConfiguration: true)
+                .SetProperty("url", settings.Host, requiredForConfiguration: true, comparison: ValueComparisonMode.Url)
+                .SetProperty("tool_timeout_sec", 300, requiredForConfiguration: false)
+                .SetProperty("startup_timeout_sec", 30, requiredForConfiguration: false)
+                .SetPropertyToRemove("command")
+                .SetPropertyToRemove("args")
+                .SetPropertyToRemove("type");
+
+        protected override void ApplyHttpAuthorization(AiAgentConfig config, AgentConfiguratorSettings settings)
+        {
+            base.ApplyHttpAuthorization(config, settings);
+
+            var tomlConfig = config as TomlAiAgentConfig
+                ?? throw new InvalidCastException($"Expected TomlAiAgentConfig for Codex HTTP configuration but got {config.GetType().Name}");
+
+            if (settings.IsHttpAuthRequired && !string.IsNullOrEmpty(settings.Token))
+                tomlConfig.SetProperty(EnvVarNameBearerToken, EnvVarNameAuthToken, requiredForConfiguration: true);
+            else
+                tomlConfig.SetPropertyToRemove(EnvVarNameBearerToken);
+        }
+
+        protected override IReadOnlyList<ConfigurationSection> BuildSections(
+            AgentConfiguratorSettings settings, TransportMethod transport, ILogger? logger)
+        {
+            var addStdio = $"codex mcp add {AiAgentConfig.DefaultMcpServerName} \"{settings.ExecutableFullPath}\" port={settings.Port} plugin-timeout={settings.TimeoutMs} client-transport=stdio";
+            var addHttp = $"codex mcp add {AiAgentConfig.DefaultMcpServerName} --url {settings.Host}";
+            if (settings.IsHttpAuthRequired)
+            {
+                addStdio += $" --bearer-token-env-var={EnvVarNameAuthToken}";
+                addHttp += $" --bearer-token-env-var={EnvVarNameAuthToken}";
+            }
+
+            if (transport == TransportMethod.stdio)
+            {
+                return new[]
+                {
+                    new ConfigurationSection("Manual Configuration Steps - Option 1", true, new[]
+                    {
+                        ConfigurationItem.Description("1. Open a terminal and run the following command to be in the folder of the Unity project"),
+                        ConfigurationItem.ReadOnlyField($"cd \"{settings.ProjectRootPath}\""),
+                        ConfigurationItem.Description("2. Run the following command in the folder of the Unity project to configure Codex"),
+                        ConfigurationItem.ReadOnlyField(addStdio),
+                        ConfigurationItem.Description("3. Start Codex"),
+                        ConfigurationItem.ReadOnlyField("codex")
+                    }),
+                    new ConfigurationSection("Manual Configuration Steps - Option 2", false, new[]
+                    {
+                        ConfigurationItem.Description("1. Open or create file '.codex/config.toml'"),
+                        ConfigurationItem.Description("2. Copy and paste the configuration TOML into the file."),
+                        ConfigurationItem.ReadOnlyField(GetStdioConfig(settings, logger).ExpectedFileContent)
+                    })
+                };
+            }
+
+            var items = new List<ConfigurationItem>();
+            if (settings.IsHttpAuthRequired)
+            {
+                items.Add(ConfigurationItem.Warning($"Authorization is enabled. Set the '{EnvVarNameAuthToken}' environment variable before starting Codex in terminal."));
+                items.Add(settings.IsWindows
+                    ? ConfigurationItem.ReadOnlyField($"setx {EnvVarNameAuthToken} \"{settings.Token}\"")
+                    : ConfigurationItem.ReadOnlyField($"export {EnvVarNameAuthToken}=\"{settings.Token}\""));
+            }
+            items.Add(ConfigurationItem.Description("1. Open a terminal and run the following command to be in the folder of the Unity project"));
+            items.Add(ConfigurationItem.ReadOnlyField($"cd \"{settings.ProjectRootPath}\""));
+            items.Add(ConfigurationItem.Description("2. Run the following command in the folder of the Unity project to configure Codex"));
+            items.Add(ConfigurationItem.ReadOnlyField(addHttp));
+            items.Add(ConfigurationItem.Description("3. Start Codex"));
+            items.Add(ConfigurationItem.ReadOnlyField("codex"));
+
+            return new[]
+            {
+                new ConfigurationSection("Manual Configuration Steps - Option 1", true, items),
+                new ConfigurationSection("Manual Configuration Steps - Option 2", false, new[]
+                {
+                    ConfigurationItem.Description("1. Open or create file '.codex/config.toml'"),
+                    ConfigurationItem.Description("2. Copy and paste the configuration TOML into the file."),
+                    ConfigurationItem.ReadOnlyField(GetHttpConfig(settings, logger).ExpectedFileContent)
+                })
+            };
+        }
+    }
+}

--- a/McpPlugin/src/AgentConfig/Impl/CursorConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/Impl/CursorConfigurator.cs
@@ -1,0 +1,41 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Extensions.Logging;
+using static com.IvanMurzak.McpPlugin.Common.Consts.MCP.Server;
+
+namespace com.IvanMurzak.McpPlugin.AgentConfig.Impl
+{
+    /// <summary>Configurator for the Cursor AI agent.</summary>
+    public sealed class CursorConfigurator : AiAgentConfigurator
+    {
+        public override string AgentName => "Cursor";
+        public override string AgentId => "cursor";
+        public override string DownloadUrl => "https://cursor.com/download";
+        public override string TutorialUrl => "https://www.youtube.com/watch?v=dyk-4gTolSU";
+        public override string? SkillsPath => ".cursor/skills";
+        public override string? IconName => "cursor-64.png";
+
+        private static string LocalConfigPath(AgentConfiguratorSettings s) => Path.Combine(s.ProjectRootPath, ".cursor", "mcp.json");
+
+        protected override AiAgentConfig CreateStdioConfig(AgentConfiguratorSettings settings, ILogger? logger)
+            => AgentConfigBuilders.JsonStdio(AgentName, LocalConfigPath(settings), settings, logger);
+
+        protected override AiAgentConfig CreateHttpConfig(AgentConfiguratorSettings settings, ILogger? logger)
+            => AgentConfigBuilders.JsonHttp(AgentName, LocalConfigPath(settings), settings, logger);
+
+        protected override IReadOnlyList<ConfigurationSection> BuildSections(
+            AgentConfiguratorSettings settings, TransportMethod transport, ILogger? logger)
+            => DefaultConfigurationSections(settings, transport, logger);
+    }
+}

--- a/McpPlugin/src/AgentConfig/Impl/CustomConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/Impl/CustomConfigurator.cs
@@ -1,0 +1,78 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using com.IvanMurzak.McpPlugin.Common;
+using Microsoft.Extensions.Logging;
+using static com.IvanMurzak.McpPlugin.Common.Consts.MCP.Server;
+
+namespace com.IvanMurzak.McpPlugin.AgentConfig.Impl
+{
+    /// <summary>
+    /// Configurator for a custom / unlisted MCP client. It has no auto-detectable config file;
+    /// the user copies the generated snippet manually, and the skills path is user-editable
+    /// (exposed via an <see cref="ConfigurationItemKind.EditableField"/>).
+    /// </summary>
+    public sealed class CustomConfigurator : AiAgentConfigurator
+    {
+        /// <summary>
+        /// The user-editable skills path. Defaults to the standard skills folder; engines
+        /// set this from their persisted value and persist edits made through the editable field.
+        /// </summary>
+        public string EditableSkillsPath { get; set; } = ".claude/skills";
+
+        public override string AgentName => "Other - Custom";
+        public override string AgentId => "other-custom";
+        public override string DownloadUrl => "NA";
+        public override string? SkillsPath => EditableSkillsPath;
+        public override string? IconName => null;
+
+        protected override AiAgentConfig CreateStdioConfig(AgentConfiguratorSettings settings, ILogger? logger)
+            => throw new NotImplementedException("CustomConfigurator has no auto-detectable config; use the generated snippet from the description instead.");
+
+        protected override AiAgentConfig CreateHttpConfig(AgentConfiguratorSettings settings, ILogger? logger)
+            => throw new NotImplementedException("CustomConfigurator has no auto-detectable config; use the generated snippet from the description instead.");
+
+        // The custom configurator cannot detect an MCP config on disk.
+        public override bool IsConfigured(AgentConfiguratorSettings settings, TransportMethod transport, ILogger? logger = null) => false;
+
+        protected override IReadOnlyList<ConfigurationSection> BuildSections(
+            AgentConfiguratorSettings settings, TransportMethod transport, ILogger? logger)
+        {
+            var items = new List<ConfigurationItem>
+            {
+                ConfigurationItem.Description("Skills output path (editable):"),
+                ConfigurationItem.EditableField(EditableSkillsPath)
+            };
+
+            if (transport == TransportMethod.stdio)
+            {
+                var snippet = Consts.MCP.Server.Config(
+                    executablePath: settings.ExecutableFullPath.Replace('\\', '/'),
+                    serverName: AiAgentConfig.DefaultMcpServerName,
+                    bodyPath: "mcpServers",
+                    port: settings.Port,
+                    timeoutMs: settings.TimeoutMs).ToString();
+                items.Add(ConfigurationItem.Description("Copy paste the json into your MCP Client to configure it."));
+                items.Add(ConfigurationItem.ReadOnlyField(snippet));
+            }
+            else
+            {
+                items.Add(ConfigurationItem.Description("Copy paste the json into your MCP Client to configure it."));
+                items.Add(ConfigurationItem.ReadOnlyField(
+                    $"{{\"mcpServers\":{{\"{AiAgentConfig.DefaultMcpServerName}\":{{\"type\":\"http\",\"url\":\"{settings.Host}\"}}}}}}"));
+            }
+
+            return new[] { new ConfigurationSection("Configuration", true, items) };
+        }
+    }
+}

--- a/McpPlugin/src/AgentConfig/Impl/GeminiConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/Impl/GeminiConfigurator.cs
@@ -1,0 +1,40 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Extensions.Logging;
+using static com.IvanMurzak.McpPlugin.Common.Consts.MCP.Server;
+
+namespace com.IvanMurzak.McpPlugin.AgentConfig.Impl
+{
+    /// <summary>Configurator for the Gemini CLI AI agent.</summary>
+    public sealed class GeminiConfigurator : AiAgentConfigurator
+    {
+        public override string AgentName => "Gemini";
+        public override string AgentId => "gemini";
+        public override string DownloadUrl => "https://geminicli.com/docs/get-started/installation/";
+        public override string? SkillsPath => ".gemini/skills";
+        public override string? IconName => "gemini-64.png";
+
+        private static string LocalConfigPath(AgentConfiguratorSettings s) => Path.Combine(s.ProjectRootPath, ".gemini", "settings.json");
+
+        protected override AiAgentConfig CreateStdioConfig(AgentConfiguratorSettings settings, ILogger? logger)
+            => AgentConfigBuilders.JsonStdio(AgentName, LocalConfigPath(settings), settings, logger);
+
+        protected override AiAgentConfig CreateHttpConfig(AgentConfiguratorSettings settings, ILogger? logger)
+            => AgentConfigBuilders.JsonHttp(AgentName, LocalConfigPath(settings), settings, logger);
+
+        protected override IReadOnlyList<ConfigurationSection> BuildSections(
+            AgentConfiguratorSettings settings, TransportMethod transport, ILogger? logger)
+            => DefaultConfigurationSections(settings, transport, logger);
+    }
+}

--- a/McpPlugin/src/AgentConfig/Impl/GitHubCopilotCliConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/Impl/GitHubCopilotCliConfigurator.cs
@@ -1,0 +1,47 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.Logging;
+using static com.IvanMurzak.McpPlugin.Common.Consts.MCP.Server;
+
+namespace com.IvanMurzak.McpPlugin.AgentConfig.Impl
+{
+    /// <summary>Configurator for the GitHub Copilot CLI AI agent.</summary>
+    public sealed class GitHubCopilotCliConfigurator : AiAgentConfigurator
+    {
+        public override string AgentName => "GitHub Copilot CLI";
+        public override string AgentId => "github-copilot-cli";
+        public override string DownloadUrl => "https://github.com/features/copilot/cli";
+        public override string? SkillsPath => ".claude/skills";
+        public override string? IconName => "github-copilot-64.png";
+
+        private static string LocalConfigPath(AgentConfiguratorSettings s) => Path.Combine(s.ProjectRootPath, ".mcp.json");
+
+        protected override AiAgentConfig CreateStdioConfig(AgentConfiguratorSettings settings, ILogger? logger)
+            => new JsonAiAgentConfig(AgentName, LocalConfigPath(settings), bodyPath: "mcpServers", logger: logger)
+                .SetProperty("command", JsonValue.Create(settings.ExecutableFullPath.Replace('\\', '/'))!, requiredForConfiguration: true, comparison: ValueComparisonMode.Path)
+                .SetProperty("args", AgentConfigBuilders.StdioArgs(settings), requiredForConfiguration: true)
+                .SetProperty("tools", new JsonArray { "*" }, requiredForConfiguration: false)
+                .SetPropertyToRemove("url")
+                .SetPropertyToRemove("type");
+
+        protected override AiAgentConfig CreateHttpConfig(AgentConfiguratorSettings settings, ILogger? logger)
+            => AgentConfigBuilders.JsonHttp(AgentName, LocalConfigPath(settings), settings, logger, bodyPath: "mcpServers")
+                .SetProperty("tools", new JsonArray { "*" }, requiredForConfiguration: false);
+
+        protected override IReadOnlyList<ConfigurationSection> BuildSections(
+            AgentConfiguratorSettings settings, TransportMethod transport, ILogger? logger)
+            => DefaultConfigurationSections(settings, transport, logger);
+    }
+}

--- a/McpPlugin/src/AgentConfig/Impl/KiloCodeConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/Impl/KiloCodeConfigurator.cs
@@ -1,0 +1,40 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Extensions.Logging;
+using static com.IvanMurzak.McpPlugin.Common.Consts.MCP.Server;
+
+namespace com.IvanMurzak.McpPlugin.AgentConfig.Impl
+{
+    /// <summary>Configurator for the Kilo Code AI agent.</summary>
+    public sealed class KiloCodeConfigurator : AiAgentConfigurator
+    {
+        public override string AgentName => "Kilo Code";
+        public override string AgentId => "kilo-code";
+        public override string DownloadUrl => "https://app.kilo.ai/get-started";
+        public override string? SkillsPath => ".kilocode/skills";
+        public override string? IconName => "kilo-code-64.png";
+
+        private static string LocalConfigPath(AgentConfiguratorSettings s) => Path.Combine(s.ProjectRootPath, ".kilocode", "mcp.json");
+
+        protected override AiAgentConfig CreateStdioConfig(AgentConfiguratorSettings settings, ILogger? logger)
+            => AgentConfigBuilders.JsonStdio(AgentName, LocalConfigPath(settings), settings, logger);
+
+        protected override AiAgentConfig CreateHttpConfig(AgentConfiguratorSettings settings, ILogger? logger)
+            => AgentConfigBuilders.JsonHttp(AgentName, LocalConfigPath(settings), settings, logger);
+
+        protected override IReadOnlyList<ConfigurationSection> BuildSections(
+            AgentConfiguratorSettings settings, TransportMethod transport, ILogger? logger)
+            => DefaultConfigurationSections(settings, transport, logger);
+    }
+}

--- a/McpPlugin/src/AgentConfig/Impl/OpenCodeConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/Impl/OpenCodeConfigurator.cs
@@ -1,0 +1,75 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.Logging;
+using static com.IvanMurzak.McpPlugin.Common.Consts.MCP.Server;
+
+namespace com.IvanMurzak.McpPlugin.AgentConfig.Impl
+{
+    /// <summary>
+    /// Configurator for the Open Code AI agent. Open Code uses a single <c>command</c>
+    /// array (executable + inline args) rather than separate <c>command</c> + <c>args</c>,
+    /// and <c>type</c> = <c>local</c>/<c>remote</c>.
+    /// </summary>
+    public sealed class OpenCodeConfigurator : AiAgentConfigurator
+    {
+        public override string AgentName => "Open Code";
+        public override string AgentId => "open-code";
+        public override string DownloadUrl => "https://opencode.ai/download";
+        public override string? SkillsPath => ".opencode/skills";
+        public override string? IconName => "open-code-64.png";
+
+        private static string LocalConfigPath(AgentConfiguratorSettings s) => Path.Combine(s.ProjectRootPath, "opencode.json");
+
+        protected override AiAgentConfig CreateStdioConfig(AgentConfiguratorSettings settings, ILogger? logger)
+        {
+            var commandArray = new JsonArray
+            {
+                settings.ExecutableFullPath.Replace('\\', '/'),
+                $"{Args.Port}={settings.Port}",
+                $"{Args.PluginTimeout}={settings.TimeoutMs}",
+                $"{Args.ClientTransportMethod}={TransportMethod.stdio}",
+                $"{Args.Authorization}={settings.AuthOption}"
+            };
+            if (settings.IsStdioAuthRequired && !string.IsNullOrEmpty(settings.Token))
+                commandArray.Add($"{Args.Token}={settings.Token}");
+
+            return new JsonAiAgentConfig(AgentName, LocalConfigPath(settings), bodyPath: "mcp", logger: logger)
+                .SetProperty("type", JsonValue.Create("local")!, requiredForConfiguration: true)
+                .SetProperty("enabled", JsonValue.Create(true)!, requiredForConfiguration: true)
+                .SetProperty("command", commandArray, requiredForConfiguration: true)
+                .SetPropertyToRemove("url")
+                .SetPropertyToRemove("args");
+        }
+
+        protected override AiAgentConfig CreateHttpConfig(AgentConfiguratorSettings settings, ILogger? logger)
+            => new JsonAiAgentConfig(AgentName, LocalConfigPath(settings), bodyPath: "mcp", logger: logger)
+                .SetProperty("type", JsonValue.Create("remote")!, requiredForConfiguration: true)
+                .SetProperty("enabled", JsonValue.Create(true)!, requiredForConfiguration: true)
+                .SetProperty("url", JsonValue.Create(settings.Host)!, requiredForConfiguration: true, comparison: ValueComparisonMode.Url)
+                .SetPropertyToRemove("command")
+                .SetPropertyToRemove("args");
+
+        // OpenCode embeds the token in the command array (not the args), so the base
+        // args-based STDIO authorization injection does not apply.
+        protected override void ApplyStdioAuthorization(AiAgentConfig config, AgentConfiguratorSettings settings)
+        {
+            // no-op: token is handled inline in CreateStdioConfig's command array.
+        }
+
+        protected override IReadOnlyList<ConfigurationSection> BuildSections(
+            AgentConfiguratorSettings settings, TransportMethod transport, ILogger? logger)
+            => DefaultConfigurationSections(settings, transport, logger);
+    }
+}

--- a/McpPlugin/src/AgentConfig/Impl/RiderConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/Impl/RiderConfigurator.cs
@@ -1,0 +1,56 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.Logging;
+using static com.IvanMurzak.McpPlugin.Common.Consts.MCP.Server;
+
+namespace com.IvanMurzak.McpPlugin.AgentConfig.Impl
+{
+    /// <summary>
+    /// Configurator for the Rider (Junie) AI agent. Junie uses <c>enabled</c> (not
+    /// <c>disabled</c>) and a project-local <c>.junie/mcp/mcp.json</c>.
+    /// </summary>
+    public sealed class RiderConfigurator : AiAgentConfigurator
+    {
+        public override string AgentName => "Rider (Junie)";
+        public override string AgentId => "rider-junie";
+        public override string DownloadUrl => "https://www.jetbrains.com/rider/download/";
+        public override string? SkillsPath => ".junie/skills";
+        public override string? IconName => "rider-64.png";
+
+        private static string JunieConfigPath(AgentConfiguratorSettings s) => Path.Combine(s.ProjectRootPath, ".junie", "mcp", "mcp.json");
+
+        protected override AiAgentConfig CreateStdioConfig(AgentConfiguratorSettings settings, ILogger? logger)
+            => new JsonAiAgentConfig(AgentName, JunieConfigPath(settings), bodyPath: DefaultBodyPath, logger: logger)
+                .SetProperty("enabled", JsonValue.Create(true)!, requiredForConfiguration: true)
+                .SetPropertyToRemove("disabled")
+                .SetProperty("type", JsonValue.Create("stdio")!, requiredForConfiguration: true)
+                .SetProperty("command", JsonValue.Create(settings.ExecutableFullPath.Replace('\\', '/'))!, requiredForConfiguration: true, comparison: ValueComparisonMode.Path)
+                .SetProperty("args", AgentConfigBuilders.StdioArgs(settings), requiredForConfiguration: true)
+                .SetPropertyToRemove("url");
+
+        protected override AiAgentConfig CreateHttpConfig(AgentConfiguratorSettings settings, ILogger? logger)
+            => new JsonAiAgentConfig(AgentName, JunieConfigPath(settings), bodyPath: DefaultBodyPath, logger: logger)
+                .SetProperty("enabled", JsonValue.Create(true)!, requiredForConfiguration: true)
+                .SetPropertyToRemove("disabled")
+                .SetProperty("type", JsonValue.Create("http")!, requiredForConfiguration: true)
+                .SetProperty("url", JsonValue.Create(settings.Host)!, requiredForConfiguration: true, comparison: ValueComparisonMode.Url)
+                .SetPropertyToRemove("command")
+                .SetPropertyToRemove("args");
+
+        protected override IReadOnlyList<ConfigurationSection> BuildSections(
+            AgentConfiguratorSettings settings, TransportMethod transport, ILogger? logger)
+            => DefaultConfigurationSections(settings, transport, logger);
+    }
+}

--- a/McpPlugin/src/AgentConfig/Impl/UnityAiConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/Impl/UnityAiConfigurator.cs
@@ -1,0 +1,39 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Extensions.Logging;
+using static com.IvanMurzak.McpPlugin.Common.Consts.MCP.Server;
+
+namespace com.IvanMurzak.McpPlugin.AgentConfig.Impl
+{
+    /// <summary>Configurator for the Unity AI agent.</summary>
+    public sealed class UnityAiConfigurator : AiAgentConfigurator
+    {
+        public override string AgentName => "Unity AI";
+        public override string AgentId => "unity-ai";
+        public override string DownloadUrl => "https://unity.com/features/ai";
+        public override string? IconName => "unity-64.png";
+
+        private static string LocalConfigPath(AgentConfiguratorSettings s) => Path.Combine(s.ProjectRootPath, "UserSettings", "mcp.json");
+
+        protected override AiAgentConfig CreateStdioConfig(AgentConfiguratorSettings settings, ILogger? logger)
+            => AgentConfigBuilders.JsonStdio(AgentName, LocalConfigPath(settings), settings, logger);
+
+        protected override AiAgentConfig CreateHttpConfig(AgentConfiguratorSettings settings, ILogger? logger)
+            => AgentConfigBuilders.JsonHttp(AgentName, LocalConfigPath(settings), settings, logger);
+
+        protected override IReadOnlyList<ConfigurationSection> BuildSections(
+            AgentConfiguratorSettings settings, TransportMethod transport, ILogger? logger)
+            => DefaultConfigurationSections(settings, transport, logger);
+    }
+}

--- a/McpPlugin/src/AgentConfig/Impl/VisualStudioCodeCopilotConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/Impl/VisualStudioCodeCopilotConfigurator.cs
@@ -1,0 +1,41 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Extensions.Logging;
+using static com.IvanMurzak.McpPlugin.Common.Consts.MCP.Server;
+
+namespace com.IvanMurzak.McpPlugin.AgentConfig.Impl
+{
+    /// <summary>Configurator for the Visual Studio Code (Copilot) AI agent.</summary>
+    public sealed class VisualStudioCodeCopilotConfigurator : AiAgentConfigurator
+    {
+        public override string AgentName => "Visual Studio Code (Copilot)";
+        public override string AgentId => "vscode-copilot";
+        public override string DownloadUrl => "https://code.visualstudio.com/download";
+        public override string TutorialUrl => "https://www.youtube.com/watch?v=ZhP7Ju91mOE";
+        public override string? SkillsPath => ".claude/skills";
+        public override string? IconName => "vs-code-64.png";
+
+        private static string LocalConfigPath(AgentConfiguratorSettings s) => Path.Combine(s.ProjectRootPath, ".vscode", "mcp.json");
+
+        protected override AiAgentConfig CreateStdioConfig(AgentConfiguratorSettings settings, ILogger? logger)
+            => AgentConfigBuilders.JsonStdio(AgentName, LocalConfigPath(settings), settings, logger, bodyPath: "servers");
+
+        protected override AiAgentConfig CreateHttpConfig(AgentConfiguratorSettings settings, ILogger? logger)
+            => AgentConfigBuilders.JsonHttp(AgentName, LocalConfigPath(settings), settings, logger, bodyPath: "servers");
+
+        protected override IReadOnlyList<ConfigurationSection> BuildSections(
+            AgentConfiguratorSettings settings, TransportMethod transport, ILogger? logger)
+            => DefaultConfigurationSections(settings, transport, logger);
+    }
+}

--- a/McpPlugin/src/AgentConfig/Impl/VisualStudioCopilotConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/Impl/VisualStudioCopilotConfigurator.cs
@@ -1,0 +1,41 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Extensions.Logging;
+using static com.IvanMurzak.McpPlugin.Common.Consts.MCP.Server;
+
+namespace com.IvanMurzak.McpPlugin.AgentConfig.Impl
+{
+    /// <summary>Configurator for the Visual Studio (Copilot) AI agent.</summary>
+    public sealed class VisualStudioCopilotConfigurator : AiAgentConfigurator
+    {
+        public override string AgentName => "Visual Studio (Copilot)";
+        public override string AgentId => "vs-copilot";
+        public override string DownloadUrl => "https://visualstudio.microsoft.com/downloads/";
+        public override string TutorialUrl => "https://www.youtube.com/watch?v=RGdak4T69mc";
+        public override string? SkillsPath => ".github/skills";
+        public override string? IconName => "visual-studio-64.png";
+
+        private static string LocalConfigPath(AgentConfiguratorSettings s) => Path.Combine(s.ProjectRootPath, ".vs", "mcp.json");
+
+        protected override AiAgentConfig CreateStdioConfig(AgentConfiguratorSettings settings, ILogger? logger)
+            => AgentConfigBuilders.JsonStdio(AgentName, LocalConfigPath(settings), settings, logger, bodyPath: "servers");
+
+        protected override AiAgentConfig CreateHttpConfig(AgentConfiguratorSettings settings, ILogger? logger)
+            => AgentConfigBuilders.JsonHttp(AgentName, LocalConfigPath(settings), settings, logger, bodyPath: "servers");
+
+        protected override IReadOnlyList<ConfigurationSection> BuildSections(
+            AgentConfiguratorSettings settings, TransportMethod transport, ILogger? logger)
+            => DefaultConfigurationSections(settings, transport, logger);
+    }
+}

--- a/McpPlugin/src/AgentConfig/Impl/ZooCodeConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/Impl/ZooCodeConfigurator.cs
@@ -1,0 +1,40 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Extensions.Logging;
+using static com.IvanMurzak.McpPlugin.Common.Consts.MCP.Server;
+
+namespace com.IvanMurzak.McpPlugin.AgentConfig.Impl
+{
+    /// <summary>Configurator for the Zoo Code AI agent.</summary>
+    public sealed class ZooCodeConfigurator : AiAgentConfigurator
+    {
+        public override string AgentName => "Zoo Code";
+        public override string AgentId => "zoo-code";
+        public override string DownloadUrl => "https://www.zoocode.dev/";
+        public override string? SkillsPath => ".roo/skills";
+        public override string? IconName => "zoo-code-64.png";
+
+        private static string LocalConfigPath(AgentConfiguratorSettings s) => Path.Combine(s.ProjectRootPath, ".roo", "mcp.json");
+
+        protected override AiAgentConfig CreateStdioConfig(AgentConfiguratorSettings settings, ILogger? logger)
+            => AgentConfigBuilders.JsonStdio(AgentName, LocalConfigPath(settings), settings, logger);
+
+        protected override AiAgentConfig CreateHttpConfig(AgentConfiguratorSettings settings, ILogger? logger)
+            => AgentConfigBuilders.JsonHttp(AgentName, LocalConfigPath(settings), settings, logger);
+
+        protected override IReadOnlyList<ConfigurationSection> BuildSections(
+            AgentConfiguratorSettings settings, TransportMethod transport, ILogger? logger)
+            => DefaultConfigurationSections(settings, transport, logger);
+    }
+}

--- a/McpPlugin/src/AgentConfig/JsonAiAgentConfig.cs
+++ b/McpPlugin/src/AgentConfig/JsonAiAgentConfig.cs
@@ -1,0 +1,517 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using com.IvanMurzak.McpPlugin.Common;
+using Microsoft.Extensions.Logging;
+using static com.IvanMurzak.McpPlugin.Common.Consts.MCP.Server;
+
+namespace com.IvanMurzak.McpPlugin.AgentConfig
+{
+    public class JsonAiAgentConfig : AiAgentConfig
+    {
+        private static readonly JsonSerializerOptions WriteOptions = new() { WriteIndented = true };
+
+        private readonly Dictionary<string, (JsonNode value, bool required, ValueComparisonMode comparison)> _properties = new();
+        private readonly HashSet<string> _propertiesToRemove = new();
+
+        public override string ExpectedFileContent
+        {
+            get
+            {
+                var serverConfig = BuildServerEntry();
+                var pathSegments = Consts.MCP.Server.BodyPathSegments(BodyPath);
+
+                var innerContent = new JsonObject
+                {
+                    [DefaultMcpServerName] = serverConfig
+                };
+
+                // Build nested structure from innermost to outermost
+                var result = innerContent;
+                for (int i = pathSegments.Length - 1; i >= 0; i--)
+                {
+                    result = new JsonObject { [pathSegments[i]] = result };
+                }
+
+                return result.ToString();
+            }
+        }
+
+        public JsonAiAgentConfig(
+            string name,
+            string configPath,
+            string bodyPath = Consts.MCP.Server.DefaultBodyPath,
+            ILogger? logger = null)
+            : base(
+                name: name,
+                configPath: configPath,
+                bodyPath: bodyPath,
+                logger: logger)
+        {
+            // empty
+        }
+
+        public JsonAiAgentConfig SetProperty(string key, JsonNode value, bool requiredForConfiguration = false, ValueComparisonMode comparison = ValueComparisonMode.Exact)
+        {
+            _properties[key] = (value, requiredForConfiguration, comparison);
+            return this;
+        }
+
+        public JsonAiAgentConfig SetPropertyToRemove(string key)
+        {
+            _propertiesToRemove.Add(key);
+            return this;
+        }
+
+        public new JsonAiAgentConfig AddIdentityKey(string key)
+        {
+            base.AddIdentityKey(key);
+            return this;
+        }
+
+        public override void ApplyHttpAuthorization(bool isRequired, string? token)
+        {
+            if (isRequired && !string.IsNullOrEmpty(token))
+            {
+                SetProperty(
+                    key: "headers",
+                    value: new JsonObject { ["Authorization"] = JsonValue.Create($"Bearer {token}") },
+                    requiredForConfiguration: true
+                );
+            }
+            else
+            {
+                SetPropertyToRemove("headers");
+            }
+        }
+
+        public override void ApplyStdioAuthorization(bool isRequired, string? token)
+        {
+            // Remove HTTP-specific headers — not applicable to STDIO
+            SetPropertyToRemove("headers");
+
+            // Modify args: add or remove the token argument
+            if (!_properties.TryGetValue("args", out var argsProp) || argsProp.value is not JsonArray currentArgs)
+                return;
+
+            var tokenPrefix = $"{Args.Token}=";
+            var newArgs = new JsonArray();
+
+            foreach (var item in currentArgs)
+            {
+                if (item is JsonValue jsonVal && jsonVal.TryGetValue<string>(out var str) && str.StartsWith(tokenPrefix, StringComparison.Ordinal))
+                    continue; // Remove existing token arg
+
+                newArgs.Add(item != null ? JsonNode.Parse(item.ToJsonString()) : null);
+            }
+
+            if (isRequired && !string.IsNullOrEmpty(token))
+                newArgs.Add(JsonValue.Create($"{tokenPrefix}{token}"));
+
+            SetProperty("args", newArgs, argsProp.required, argsProp.comparison);
+        }
+
+        public override bool Configure()
+        {
+            if (string.IsNullOrEmpty(ConfigPath))
+                return false;
+
+            _logger?.LogInformation("Configuring MCP client with path: {ConfigPath}, bodyPath: {BodyPath}", ConfigPath, BodyPath);
+
+            try
+            {
+                if (!File.Exists(ConfigPath))
+                {
+                    // Create all necessary directories
+                    var directory = Path.GetDirectoryName(ConfigPath);
+                    if (!string.IsNullOrEmpty(directory))
+                        Directory.CreateDirectory(directory);
+
+                    // Create the file with expected content
+                    File.WriteAllText(path: ConfigPath, contents: ExpectedFileContent);
+                    return true;
+                }
+
+                var json = File.ReadAllText(ConfigPath);
+                JsonObject? rootObj = null;
+
+                try
+                {
+                    rootObj = JsonNode.Parse(json)?.AsObject();
+                    if (rootObj == null)
+                        throw new Exception("Config file is not a valid JSON object.");
+                }
+                catch
+                {
+                    File.WriteAllText(path: ConfigPath, contents: ExpectedFileContent);
+                    return true;
+                }
+
+                var pathSegments = Consts.MCP.Server.BodyPathSegments(BodyPath);
+
+                // Navigate to or create the target location in the existing JSON
+                var targetObj = EnsureJsonPathExists(rootObj, pathSegments);
+
+                // Remove deprecated server entries
+                foreach (var name in DeprecatedMcpServerNames)
+                    targetObj.Remove(name);
+
+                // Remove duplicate entries that represent the same server under a different name
+                RemoveDuplicateServerEntries(targetObj);
+
+                // Get or create the server entry under DefaultMcpServerName
+                JsonObject serverEntry;
+                if (targetObj[DefaultMcpServerName]?.AsObject() is JsonObject existingEntry)
+                {
+                    serverEntry = existingEntry;
+                }
+                else
+                {
+                    serverEntry = new JsonObject();
+                    targetObj[DefaultMcpServerName] = serverEntry;
+                }
+
+                // Remove specified properties from the entry
+                foreach (var key in _propertiesToRemove)
+                    serverEntry.Remove(key);
+
+                // Set properties on the entry (sorted for deterministic output)
+                foreach (var key in _properties.Keys.OrderBy(k => k, StringComparer.Ordinal))
+                {
+                    var clonedValue = _properties[key].value.ToJsonString() is string jsonStr
+                        ? JsonNode.Parse(jsonStr)
+                        : null;
+                    serverEntry[key] = clonedValue;
+                }
+
+                // Write back to file
+                File.WriteAllText(ConfigPath, rootObj.ToJsonString(WriteOptions));
+
+                return IsConfigured();
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogError(ex, "Error reading config file: {Message}", ex.Message);
+                return false;
+            }
+        }
+
+        public override bool Unconfigure()
+        {
+            if (string.IsNullOrEmpty(ConfigPath) || !File.Exists(ConfigPath))
+                return false;
+
+            try
+            {
+                var json = File.ReadAllText(ConfigPath);
+                var rootObj = JsonNode.Parse(json)?.AsObject();
+                if (rootObj == null)
+                    return false;
+
+                var pathSegments = Consts.MCP.Server.BodyPathSegments(BodyPath);
+                var targetObj = NavigateToJsonPath(rootObj, pathSegments);
+                if (targetObj == null)
+                    return false;
+
+                var removed = false;
+
+                if (targetObj[DefaultMcpServerName] != null)
+                {
+                    targetObj.Remove(DefaultMcpServerName);
+                    removed = true;
+                }
+
+                foreach (var name in DeprecatedMcpServerNames)
+                {
+                    if (targetObj[name] != null)
+                    {
+                        targetObj.Remove(name);
+                        removed = true;
+                    }
+                }
+
+                var duplicateKeys = FindDuplicateServerEntryKeys(targetObj);
+                if (duplicateKeys.Count > 0)
+                {
+                    foreach (var key in duplicateKeys)
+                        targetObj.Remove(key);
+                    removed = true;
+                }
+
+                if (!removed)
+                    return false;
+
+                File.WriteAllText(ConfigPath, rootObj.ToJsonString(WriteOptions));
+                return true;
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogError(ex, "Error unconfiguring MCP client: {Message}", ex.Message);
+                return false;
+            }
+        }
+
+        public override bool IsDetected()
+        {
+            if (string.IsNullOrEmpty(ConfigPath) || !File.Exists(ConfigPath))
+                return false;
+
+            try
+            {
+                var json = File.ReadAllText(ConfigPath);
+
+                if (string.IsNullOrWhiteSpace(json))
+                    return false;
+
+                var rootObj = JsonNode.Parse(json)?.AsObject();
+                if (rootObj == null)
+                    return false;
+
+                var pathSegments = Consts.MCP.Server.BodyPathSegments(BodyPath);
+                var targetObj = NavigateToJsonPath(rootObj, pathSegments);
+                if (targetObj == null)
+                    return false;
+
+                if (targetObj[DefaultMcpServerName] != null)
+                    return true;
+
+                foreach (var name in DeprecatedMcpServerNames)
+                    if (targetObj[name] != null)
+                        return true;
+
+                return FindDuplicateServerEntryKeys(targetObj).Count > 0;
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogError(ex, "Error reading config file: {Message}", ex.Message);
+                return false;
+            }
+        }
+
+        public override bool IsConfigured()
+        {
+            if (string.IsNullOrEmpty(ConfigPath) || !File.Exists(ConfigPath))
+                return false;
+
+            try
+            {
+                var json = File.ReadAllText(ConfigPath);
+
+                if (string.IsNullOrWhiteSpace(json))
+                    return false;
+
+                var rootObj = JsonNode.Parse(json)?.AsObject();
+                if (rootObj == null)
+                    return false;
+
+                var pathSegments = Consts.MCP.Server.BodyPathSegments(BodyPath);
+
+                // Navigate to the target location using bodyPath segments
+                var targetObj = NavigateToJsonPath(rootObj, pathSegments);
+                if (targetObj == null)
+                    return false;
+
+                var serverEntry = targetObj[DefaultMcpServerName];
+                if (serverEntry == null)
+                    return false;
+
+                return AreRequiredPropertiesMatching(serverEntry) && !HasPropertiesToRemove(serverEntry);
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogError(ex, "Error reading config file: {Message}", ex.Message);
+                return false;
+            }
+        }
+
+        private JsonObject BuildServerEntry()
+        {
+            var obj = new JsonObject();
+            foreach (var key in _properties.Keys.OrderBy(k => k, StringComparer.Ordinal))
+            {
+                var clonedValue = _properties[key].value.ToJsonString() is string jsonStr
+                    ? JsonNode.Parse(jsonStr)
+                    : null;
+                obj[key] = clonedValue;
+            }
+            return obj;
+        }
+
+        private bool AreRequiredPropertiesMatching(JsonNode? serverEntry)
+        {
+            if (serverEntry == null)
+                return false;
+
+            foreach (var prop in _properties)
+            {
+                if (!prop.Value.required)
+                    continue;
+
+                var existingValue = serverEntry[prop.Key];
+                if (existingValue == null)
+                    return false;
+
+                if (!AreJsonValuesEquivalent(prop.Value.comparison, prop.Value.value, existingValue))
+                    return false;
+            }
+
+            return true;
+        }
+
+        private static bool AreJsonValuesEquivalent(ValueComparisonMode comparison, JsonNode expected, JsonNode actual)
+        {
+            if (comparison == ValueComparisonMode.Path
+                && TryGetStringValue(expected, out var expectedPath)
+                && TryGetStringValue(actual, out var actualPath))
+            {
+                return NormalizePath(expectedPath) == NormalizePath(actualPath);
+            }
+
+            if (comparison == ValueComparisonMode.Url
+                && TryGetStringValue(expected, out var expectedUrl)
+                && TryGetStringValue(actual, out var actualUrl))
+            {
+                return string.Equals(NormalizeUrl(expectedUrl), NormalizeUrl(actualUrl), StringComparison.OrdinalIgnoreCase);
+            }
+
+            return expected.ToJsonString() == actual.ToJsonString();
+        }
+
+        private static bool TryGetStringValue(JsonNode node, out string value)
+        {
+            if (node is JsonValue jsonValue && jsonValue.TryGetValue<string>(out var str) && str != null)
+            {
+                value = str;
+                return true;
+            }
+            value = default!;
+            return false;
+        }
+
+        /// <summary>Normalizes a file path by unifying separators.</summary>
+        private static string NormalizePath(string path)
+        {
+            return path.Replace('\\', '/').TrimEnd('/');
+        }
+
+        /// <summary>Normalizes a URL by lowercasing scheme+host and trimming trailing slashes.</summary>
+        private static string NormalizeUrl(string url)
+        {
+            if (Uri.TryCreate(url, UriKind.Absolute, out var uri))
+            {
+                var authority = uri.GetLeftPart(UriPartial.Authority).ToLowerInvariant();
+                var pathPart = uri.AbsolutePath.TrimEnd('/');
+                return authority + pathPart + uri.Query;
+            }
+            return url.TrimEnd('/');
+        }
+
+        private bool HasPropertiesToRemove(JsonNode? serverEntry)
+        {
+            if (serverEntry == null || _propertiesToRemove.Count == 0)
+                return false;
+
+            return _propertiesToRemove.Any(key => serverEntry[key] != null);
+        }
+
+        private static JsonObject? NavigateToJsonPath(JsonObject rootObj, string[] pathSegments)
+        {
+            JsonObject? current = rootObj;
+
+            foreach (var segment in pathSegments)
+            {
+                if (current == null)
+                    return null;
+
+                current = current[segment]?.AsObject();
+            }
+
+            return current;
+        }
+
+        /// <summary>
+        /// Returns the keys of sibling server entries that represent the same server under a different
+        /// name, identified by matching identity key property values (e.g. "command", "url", "serverUrl").
+        /// </summary>
+        private List<string> FindDuplicateServerEntryKeys(JsonObject targetObj)
+        {
+            var ourIdentityValues = new Dictionary<string, (JsonNode value, ValueComparisonMode comparison)>();
+            foreach (var identityKey in _identityKeys)
+            {
+                if (_properties.TryGetValue(identityKey, out var prop))
+                    ourIdentityValues[identityKey] = (prop.value, prop.comparison);
+            }
+
+            if (ourIdentityValues.Count == 0)
+                return new List<string>();
+
+            var keys = new List<string>();
+            foreach (var kv in targetObj)
+            {
+                if (kv.Key == DefaultMcpServerName)
+                    continue;
+
+                var entry = kv.Value?.AsObject();
+                if (entry == null)
+                    continue;
+
+                foreach (var identity in ourIdentityValues)
+                {
+                    var existingValue = entry[identity.Key];
+                    if (existingValue != null && AreJsonValuesEquivalent(identity.Value.comparison, identity.Value.value, existingValue))
+                    {
+                        keys.Add(kv.Key);
+                        break;
+                    }
+                }
+            }
+
+            return keys;
+        }
+
+        /// <summary>
+        /// Removes sibling server entries that represent the same server under a different name,
+        /// identified by matching identity key property values (e.g. "command", "url", "serverUrl").
+        /// </summary>
+        private void RemoveDuplicateServerEntries(JsonObject targetObj)
+        {
+            foreach (var key in FindDuplicateServerEntryKeys(targetObj))
+                targetObj.Remove(key);
+        }
+
+        private static JsonObject EnsureJsonPathExists(JsonObject rootObj, string[] pathSegments)
+        {
+            JsonObject current = rootObj;
+
+            foreach (var segment in pathSegments)
+            {
+                if (current[segment]?.AsObject() is JsonObject existingObj)
+                {
+                    current = existingObj;
+                }
+                else
+                {
+                    var newObj = new JsonObject();
+                    current[segment] = newObj;
+                    current = newObj;
+                }
+            }
+
+            return current;
+        }
+    }
+}

--- a/McpPlugin/src/AgentConfig/TomlAiAgentConfig.cs
+++ b/McpPlugin/src/AgentConfig/TomlAiAgentConfig.cs
@@ -1,0 +1,857 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using com.IvanMurzak.McpPlugin.Common;
+using Microsoft.Extensions.Logging;
+using static com.IvanMurzak.McpPlugin.Common.Consts.MCP.Server;
+
+namespace com.IvanMurzak.McpPlugin.AgentConfig
+{
+    public class TomlAiAgentConfig : AiAgentConfig
+    {
+        private readonly Dictionary<string, (object value, bool required, ValueComparisonMode comparison)> _properties = new();
+        private readonly HashSet<string> _propertiesToRemove = new();
+
+        /// <summary>
+        /// Wraps a raw TOML value string for types not explicitly supported by the parser
+        /// (e.g., floats, dates). The value is written back verbatim during serialization.
+        /// </summary>
+        private sealed class RawTomlValue
+        {
+            public string Value { get; }
+            public RawTomlValue(string value) => Value = value;
+        }
+
+        public override string ExpectedFileContent
+        {
+            get
+            {
+                var sectionName = $"{BodyPath}.{DefaultMcpServerName}";
+                var sb = new StringBuilder();
+                sb.AppendLine($"[{sectionName}]");
+                foreach (var key in _properties.Keys.OrderBy(k => k, StringComparer.Ordinal))
+                {
+                    sb.AppendLine(FormatTomlProperty(key, _properties[key].value));
+                }
+                return sb.ToString();
+            }
+        }
+
+        public TomlAiAgentConfig(
+            string name,
+            string configPath,
+            string bodyPath = Consts.MCP.Server.DefaultBodyPath,
+            ILogger? logger = null)
+            : base(
+                name: name,
+                configPath: configPath,
+                bodyPath: bodyPath,
+                logger: logger)
+        {
+            // empty
+        }
+
+        public TomlAiAgentConfig SetProperty(string key, object value, bool requiredForConfiguration = false, ValueComparisonMode comparison = ValueComparisonMode.Exact)
+        {
+            _properties[key] = (value, requiredForConfiguration, comparison);
+            return this;
+        }
+
+        public TomlAiAgentConfig SetProperty(string key, object[] values, bool requiredForConfiguration = false, ValueComparisonMode comparison = ValueComparisonMode.Exact)
+        {
+            _properties[key] = (values, requiredForConfiguration, comparison);
+            return this;
+        }
+
+        public TomlAiAgentConfig SetPropertyToRemove(string key)
+        {
+            _propertiesToRemove.Add(key);
+            return this;
+        }
+
+        public new TomlAiAgentConfig AddIdentityKey(string key)
+        {
+            base.AddIdentityKey(key);
+            return this;
+        }
+
+        public override void ApplyHttpAuthorization(bool isRequired, string? token)
+        {
+            // TOML HTTP config format does not currently support injecting
+            // authorization headers. Implement when TOML HTTP auth is needed.
+        }
+
+        public override void ApplyStdioAuthorization(bool isRequired, string? token)
+        {
+            if (!_properties.TryGetValue("args", out var argsProp) || argsProp.value is not string[] currentArgs)
+                return;
+
+            var tokenPrefix = $"{Args.Token}=";
+            var filtered = currentArgs
+                .Where(arg => !arg.StartsWith(tokenPrefix, StringComparison.Ordinal))
+                .ToList();
+
+            if (isRequired && !string.IsNullOrEmpty(token))
+                filtered.Add($"{tokenPrefix}{token}");
+
+            SetProperty("args", filtered.ToArray(), argsProp.required, argsProp.comparison);
+        }
+
+        public override bool Configure()
+        {
+            if (string.IsNullOrEmpty(ConfigPath))
+                return false;
+
+            _logger?.LogInformation("Configuring MCP client TOML with path: {ConfigPath} and bodyPath: {BodyPath}", ConfigPath, BodyPath);
+
+            try
+            {
+                var sectionName = $"{BodyPath}.{DefaultMcpServerName}";
+
+                if (!File.Exists(ConfigPath))
+                {
+                    // Create all necessary directories
+                    var directory = Path.GetDirectoryName(ConfigPath);
+                    if (!string.IsNullOrEmpty(directory))
+                        Directory.CreateDirectory(directory);
+
+                    File.WriteAllText(ConfigPath, ExpectedFileContent);
+                    return true;
+                }
+
+                // Read existing TOML file
+                var lines = File.ReadAllLines(ConfigPath).ToList();
+
+                // Remove deprecated sections
+                foreach (var deprecatedName in DeprecatedMcpServerNames)
+                {
+                    var deprecatedSection = $"{BodyPath}.{deprecatedName}";
+                    var deprecatedIndex = FindTomlSection(lines, deprecatedSection);
+                    if (deprecatedIndex >= 0)
+                    {
+                        var deprecatedEnd = FindSectionEnd(lines, deprecatedIndex);
+                        lines.RemoveRange(deprecatedIndex, deprecatedEnd - deprecatedIndex);
+                    }
+                }
+
+                // Remove duplicate sections that represent the same server under a different name
+                RemoveDuplicateServerSections(lines, sectionName);
+
+                var sectionIndex = FindTomlSection(lines, sectionName);
+                if (sectionIndex >= 0)
+                {
+                    // Section exists - merge properties
+                    var sectionEndIndex = FindSectionEnd(lines, sectionIndex);
+                    var existingProps = ParseSectionProperties(lines, sectionIndex + 1, sectionEndIndex);
+
+                    // Remove specified properties
+                    foreach (var key in _propertiesToRemove)
+                        existingProps.Remove(key);
+
+                    // Set/overwrite properties from _properties
+                    foreach (var prop in _properties)
+                        existingProps[prop.Key] = prop.Value.value;
+
+                    // Remove old section lines
+                    lines.RemoveRange(sectionIndex, sectionEndIndex - sectionIndex);
+
+                    // Generate new section from merged properties
+                    var newSection = GenerateTomlSectionFromDict(sectionName, existingProps);
+                    lines.Insert(sectionIndex, newSection.TrimEnd());
+                }
+                else
+                {
+                    // Section doesn't exist - append
+                    if (lines.Count > 0 && !string.IsNullOrWhiteSpace(lines[^1]))
+                        lines.Add("");
+
+                    var propsDict = _properties.ToDictionary(p => p.Key, p => p.Value.value);
+                    lines.Add(GenerateTomlSectionFromDict(sectionName, propsDict).TrimEnd());
+                }
+
+                // Write back to file
+                File.WriteAllText(ConfigPath, string.Join(Environment.NewLine, lines));
+
+                return IsConfigured();
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogError(ex, "Error configuring TOML file: {Message}", ex.Message);
+                return false;
+            }
+        }
+
+        public override bool Unconfigure()
+        {
+            if (string.IsNullOrEmpty(ConfigPath) || !File.Exists(ConfigPath))
+                return false;
+
+            try
+            {
+                var sectionName = $"{BodyPath}.{DefaultMcpServerName}";
+                var lines = File.ReadAllLines(ConfigPath).ToList();
+                var changed = false;
+
+                var sectionIndex = FindTomlSection(lines, sectionName);
+                if (sectionIndex >= 0)
+                {
+                    var sectionEnd = FindSectionEnd(lines, sectionIndex);
+                    lines.RemoveRange(sectionIndex, sectionEnd - sectionIndex);
+                    changed = true;
+                }
+
+                foreach (var deprecatedName in DeprecatedMcpServerNames)
+                {
+                    var deprecatedSection = $"{BodyPath}.{deprecatedName}";
+                    var deprecatedIndex = FindTomlSection(lines, deprecatedSection);
+                    if (deprecatedIndex >= 0)
+                    {
+                        var deprecatedEnd = FindSectionEnd(lines, deprecatedIndex);
+                        lines.RemoveRange(deprecatedIndex, deprecatedEnd - deprecatedIndex);
+                        changed = true;
+                    }
+                }
+
+                var countBefore = lines.Count;
+                RemoveDuplicateServerSections(lines, sectionName);
+                if (lines.Count != countBefore)
+                    changed = true;
+
+                if (!changed)
+                    return false;
+
+                File.WriteAllText(ConfigPath, string.Join(Environment.NewLine, lines));
+                return true;
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogError(ex, "Error unconfiguring TOML MCP client: {Message}", ex.Message);
+                return false;
+            }
+        }
+
+        public override bool IsDetected()
+        {
+            if (string.IsNullOrEmpty(ConfigPath) || !File.Exists(ConfigPath))
+                return false;
+
+            try
+            {
+                var lines = File.ReadAllLines(ConfigPath).ToList();
+                var sectionName = $"{BodyPath}.{DefaultMcpServerName}";
+                if (FindTomlSection(lines, sectionName) >= 0)
+                    return true;
+
+                foreach (var deprecatedName in DeprecatedMcpServerNames)
+                    if (FindTomlSection(lines, $"{BodyPath}.{deprecatedName}") >= 0)
+                        return true;
+
+                return FindDuplicateServerSectionIndices(lines, sectionName).Count > 0;
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogError(ex, "Error reading TOML config file: {Message}", ex.Message);
+                return false;
+            }
+        }
+
+        public override bool IsConfigured()
+        {
+            if (string.IsNullOrEmpty(ConfigPath) || !File.Exists(ConfigPath))
+                return false;
+
+            try
+            {
+                var lines = File.ReadAllLines(ConfigPath).ToList();
+                var sectionName = $"{BodyPath}.{DefaultMcpServerName}";
+                var sectionIndex = FindTomlSection(lines, sectionName);
+                if (sectionIndex < 0)
+                    return false;
+
+                var sectionEndIndex = FindSectionEnd(lines, sectionIndex);
+                var existingProps = ParseSectionProperties(lines, sectionIndex + 1, sectionEndIndex);
+
+                return AreRequiredPropertiesMatching(existingProps) && !HasPropertiesToRemove(existingProps);
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogError(ex, "Error reading TOML config file: {Message}", ex.Message);
+                return false;
+            }
+        }
+
+        private bool AreRequiredPropertiesMatching(Dictionary<string, object> existingProps)
+        {
+            foreach (var prop in _properties)
+            {
+                if (!prop.Value.required)
+                    continue;
+
+                if (!existingProps.TryGetValue(prop.Key, out var existingValue))
+                    return false;
+
+                if (!ValuesMatch(prop.Value.comparison, prop.Value.value, existingValue))
+                    return false;
+            }
+
+            return true;
+        }
+
+        private bool HasPropertiesToRemove(Dictionary<string, object> existingProps)
+        {
+            if (_propertiesToRemove.Count == 0)
+                return false;
+
+            return _propertiesToRemove.Any(key => existingProps.ContainsKey(key));
+        }
+
+        private static bool ValuesMatch(ValueComparisonMode comparison, object expected, object actual)
+        {
+            return (expected, actual) switch
+            {
+                (string e, string a) => AreStringValuesEquivalent(comparison, e, a),
+                (string[] e, string[] a) => e.Length == a.Length && e.Zip(a, (x, y) => AreStringValuesEquivalent(comparison, x, y)).All(match => match),
+                (bool e, bool a) => e == a,
+                (bool[] e, bool[] a) => e.Length == a.Length && e.Zip(a, (x, y) => x == y).All(match => match),
+                (int e, int a) => e == a,
+                (int[] e, int[] a) => e.Length == a.Length && e.Zip(a, (x, y) => x == y).All(match => match),
+                (Dictionary<string, string> e, Dictionary<string, string> a) =>
+                    e.Count == a.Count && e.All(kv => a.TryGetValue(kv.Key, out var v) && AreStringValuesEquivalent(comparison, kv.Value, v)),
+                _ => false
+            };
+        }
+
+        private static bool AreStringValuesEquivalent(ValueComparisonMode comparison, string expected, string actual)
+        {
+            if (comparison == ValueComparisonMode.Path)
+                return NormalizePath(expected) == NormalizePath(actual);
+
+            if (comparison == ValueComparisonMode.Url)
+                return string.Equals(NormalizeUrl(expected), NormalizeUrl(actual), StringComparison.OrdinalIgnoreCase);
+
+            return expected == actual;
+        }
+
+        /// <summary>Normalizes a file path by unifying separators.</summary>
+        private static string NormalizePath(string path)
+        {
+            return path.Replace('\\', '/').TrimEnd('/');
+        }
+
+        /// <summary>Normalizes a URL by lowercasing scheme+host and trimming trailing slashes.</summary>
+        private static string NormalizeUrl(string url)
+        {
+            if (Uri.TryCreate(url, UriKind.Absolute, out var uri))
+            {
+                var authority = uri.GetLeftPart(UriPartial.Authority).ToLowerInvariant();
+                var pathPart = uri.AbsolutePath.TrimEnd('/');
+                return authority + pathPart + uri.Query;
+            }
+            return url.TrimEnd('/');
+        }
+
+        private static string GenerateTomlSectionFromDict(string sectionName, Dictionary<string, object> properties)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"[{sectionName}]");
+            foreach (var key in properties.Keys.OrderBy(k => k, StringComparer.Ordinal))
+            {
+                sb.AppendLine(FormatTomlProperty(key, properties[key]));
+            }
+            return sb.ToString();
+        }
+
+        private static string FormatTomlProperty(string key, object value)
+        {
+            return value switch
+            {
+                string s => $"{key} = \"{EscapeTomlString(s)}\"",
+                string[] arr => $"{key} = [{string.Join(",", arr.Select(v => $"\"{EscapeTomlString(v)}\""))}]",
+                int i => $"{key} = {i}",
+                int[] arr => $"{key} = [{string.Join(",", arr)}]",
+                bool b => $"{key} = {b.ToString().ToLower()}",
+                bool[] arr => $"{key} = [{string.Join(",", arr.Select(v => v.ToString().ToLower()))}]",
+                Dictionary<string, string> dict => FormatTomlInlineTable(key, dict),
+                RawTomlValue raw => $"{key} = {raw.Value}",
+                _ => throw new InvalidOperationException($"Unsupported TOML value type: {value.GetType()}")
+            };
+        }
+
+        private static Dictionary<string, object> ParseSectionProperties(List<string> lines, int startIndex, int endIndex)
+        {
+            var props = new Dictionary<string, object>();
+            for (int i = startIndex; i < endIndex; i++)
+            {
+                var line = lines[i].Trim();
+                if (string.IsNullOrWhiteSpace(line) || line.StartsWith("#"))
+                    continue;
+
+                var parts = line.Split('=', 2);
+                if (parts.Length != 2)
+                    continue;
+
+                var key = parts[0].Trim();
+                var rawValue = parts[1].Trim();
+
+                if (rawValue.StartsWith("["))
+                {
+                    // Array value - strip inline comment then parse with type detection
+                    var arrayValue = StripArrayInlineComment(rawValue);
+                    props[key] = ParseTypedTomlArrayValue(arrayValue);
+                }
+                else if (rawValue.StartsWith("\""))
+                {
+                    // Quoted string value
+                    var stringValue = ParseTomlStringValue(line);
+                    if (stringValue != null)
+                        props[key] = stringValue;
+                }
+                else if (rawValue.StartsWith("{"))
+                {
+                    // Inline table value: { "KEY" = "value", ... }
+                    var dictValue = ParseTomlInlineTable(rawValue);
+                    if (dictValue != null)
+                        props[key] = dictValue;
+                    else
+                        props[key] = new RawTomlValue(rawValue);
+                }
+                else
+                {
+                    // Non-string, non-array scalar - strip inline comment first
+                    var scalarValue = StripInlineComment(rawValue);
+
+                    if (scalarValue == "true" || scalarValue == "false")
+                        props[key] = scalarValue == "true";
+                    else if (int.TryParse(scalarValue, out var intValue))
+                        props[key] = intValue;
+                    else if (scalarValue.Length > 0)
+                        props[key] = new RawTomlValue(scalarValue);
+                }
+            }
+            return props;
+        }
+
+        private static string FormatTomlInlineTable(string key, Dictionary<string, string> dict)
+        {
+            var pairs = string.Join(", ", dict.Select(kv =>
+                "\"" + EscapeTomlString(kv.Key) + "\" = \"" + EscapeTomlString(kv.Value) + "\""));
+            return key + " = { " + pairs + " }";
+        }
+
+        /// <summary>
+        /// Parses a TOML inline table such as <c>{ "KEY" = "value", KEY2 = "v2" }</c>
+        /// into a <see cref="Dictionary{TKey,TValue}"/> of string pairs.
+        /// Returns null if the input cannot be parsed.
+        /// </summary>
+        private static Dictionary<string, string>? ParseTomlInlineTable(string rawValue)
+        {
+            var trimmed = rawValue.Trim();
+            var closingBrace = trimmed.LastIndexOf('}');
+            if (!trimmed.StartsWith("{") || closingBrace < 0)
+                return null;
+
+            var content = trimmed[1..closingBrace].Trim();
+            var result = new Dictionary<string, string>();
+            if (string.IsNullOrEmpty(content))
+                return result;
+
+            var pos = 0;
+            while (pos < content.Length)
+            {
+                // Skip whitespace/commas
+                while (pos < content.Length && (char.IsWhiteSpace(content[pos]) || content[pos] == ','))
+                    pos++;
+                if (pos >= content.Length) break;
+
+                // Parse key (quoted or bare)
+                string? entryKey;
+                if (content[pos] == '"')
+                    entryKey = ReadQuotedString(content, ref pos);
+                else
+                {
+                    var start = pos;
+                    while (pos < content.Length && content[pos] != '=' && content[pos] != ',')
+                        pos++;
+                    entryKey = content[start..pos].Trim();
+                }
+                if (entryKey == null) return null;
+
+                // Skip whitespace and '='
+                while (pos < content.Length && char.IsWhiteSpace(content[pos])) pos++;
+                if (pos >= content.Length || content[pos] != '=') return null;
+                pos++; // consume '='
+                while (pos < content.Length && char.IsWhiteSpace(content[pos])) pos++;
+
+                // Parse value (quoted or bare)
+                string? entryValue;
+                if (pos < content.Length && content[pos] == '"')
+                    entryValue = ReadQuotedString(content, ref pos);
+                else
+                {
+                    var start = pos;
+                    while (pos < content.Length && content[pos] != ',')
+                        pos++;
+                    entryValue = content[start..pos].Trim();
+                }
+                if (entryValue == null) return null;
+
+                result[entryKey] = entryValue;
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Reads a double-quoted TOML string starting at <paramref name="pos"/> and advances past the closing quote.
+        /// Returns null if the string is malformed.
+        /// </summary>
+        private static string? ReadQuotedString(string s, ref int pos)
+        {
+            if (pos >= s.Length || s[pos] != '"') return null;
+            pos++; // skip opening quote
+            var sb = new StringBuilder();
+            while (pos < s.Length)
+            {
+                if (s[pos] == '\\' && pos + 1 < s.Length)
+                {
+                    pos++;
+                    switch (s[pos])
+                    {
+                        case 'b':  sb.Append('\b'); pos++; break;
+                        case 't':  sb.Append('\t'); pos++; break;
+                        case 'n':  sb.Append('\n'); pos++; break;
+                        case 'f':  sb.Append('\f'); pos++; break;
+                        case 'r':  sb.Append('\r'); pos++; break;
+                        case '"':  sb.Append('"');  pos++; break;
+                        case '\\': sb.Append('\\'); pos++; break;
+                        case 'u' when pos + 4 < s.Length:
+                        {
+                            var hex = s.Substring(pos + 1, 4);
+                            if (int.TryParse(hex, System.Globalization.NumberStyles.HexNumber, null, out var cp))
+                                sb.Append((char)cp);
+                            pos += 5;
+                            break;
+                        }
+                        case 'U' when pos + 8 < s.Length:
+                        {
+                            var hex = s.Substring(pos + 1, 8);
+                            if (int.TryParse(hex, System.Globalization.NumberStyles.HexNumber, null, out var cp))
+                                sb.Append(char.ConvertFromUtf32(cp));
+                            pos += 9;
+                            break;
+                        }
+                        default:
+                            // Invalid escape — preserve as-is (best-effort)
+                            sb.Append('\\');
+                            sb.Append(s[pos]);
+                            pos++;
+                            break;
+                    }
+                }
+                else if (s[pos] == '"')
+                {
+                    pos++; // skip closing quote
+                    return sb.ToString();
+                }
+                else
+                {
+                    sb.Append(s[pos]);
+                    pos++;
+                }
+            }
+            return null; // unclosed quote
+        }
+
+        private static string EscapeTomlString(string value)
+        {
+            return value.Replace("\\", "\\\\").Replace("\"", "\\\"");
+        }
+
+        private static string StripInlineComment(string value)
+        {
+            var idx = value.IndexOf('#');
+            return idx >= 0 ? value[..idx].TrimEnd() : value;
+        }
+
+        /// <summary>
+        /// Strips an inline comment from a TOML array value while respecting quoted strings.
+        /// For example, <c>["a", "b"] # comment</c> becomes <c>["a", "b"]</c>.
+        /// </summary>
+        private static string StripArrayInlineComment(string value)
+        {
+            var depth = 0;
+            var inQuote = false;
+            var escaped = false;
+
+            for (int i = 0; i < value.Length; i++)
+            {
+                var ch = value[i];
+
+                if (escaped)
+                {
+                    escaped = false;
+                    continue;
+                }
+
+                if (ch == '\\' && inQuote)
+                {
+                    escaped = true;
+                    continue;
+                }
+
+                if (ch == '"')
+                {
+                    inQuote = !inQuote;
+                    continue;
+                }
+
+                if (inQuote)
+                    continue;
+
+                if (ch == '[') depth++;
+                else if (ch == ']')
+                {
+                    depth--;
+                    if (depth == 0)
+                        return value[..(i + 1)];
+                }
+            }
+
+            return value;
+        }
+
+        private static string? ParseTomlStringValue(string line)
+        {
+            // Parse: key = "value" or key = "value" # comment
+            var parts = line.Split('=', 2);
+            if (parts.Length != 2)
+                return null;
+
+            var value = parts[1].Trim();
+            if (!value.StartsWith("\""))
+                return value;
+
+            // Scan for closing quote, handling escape sequences
+            for (int i = 1; i < value.Length; i++)
+            {
+                if (value[i] == '\\')
+                {
+                    i++; // Skip escaped character
+                    continue;
+                }
+                if (value[i] == '"')
+                {
+                    // Found closing quote - extract and unescape
+                    var inner = value[1..i];
+                    return inner.Replace("\\\"", "\"").Replace("\\\\", "\\");
+                }
+            }
+
+            // No closing quote found - return raw value as fallback
+            return value;
+        }
+
+        private static object ParseTypedTomlArrayValue(string rawValue)
+        {
+            // Remove array brackets
+            if (!rawValue.StartsWith("[") || !rawValue.EndsWith("]"))
+                return Array.Empty<string>();
+
+            var arrayContent = rawValue[1..^1].Trim();
+            if (string.IsNullOrEmpty(arrayContent))
+                return Array.Empty<string>();
+
+            // Detect array element type by looking at the first element.
+            // Typed parsers return null when any element is invalid;
+            // fall back to RawTomlValue to preserve the original text.
+            if (arrayContent.StartsWith("\""))
+            {
+                // String array
+                return ParseTomlStringArrayContent(arrayContent);
+            }
+            else if (arrayContent.StartsWith("true", StringComparison.Ordinal) ||
+                     arrayContent.StartsWith("false", StringComparison.Ordinal))
+            {
+                // Boolean array
+                return ParseTomlBoolArrayContent(arrayContent) ?? (object)new RawTomlValue(rawValue);
+            }
+            else if (char.IsDigit(arrayContent[0]) || arrayContent[0] == '-')
+            {
+                // Integer array
+                return ParseTomlIntArrayContent(arrayContent) ?? (object)new RawTomlValue(rawValue);
+            }
+
+            // Fallback to string array
+            return ParseTomlStringArrayContent(arrayContent);
+        }
+
+        private static string[] ParseTomlStringArrayContent(string arrayContent)
+        {
+            var result = new List<string>();
+            var inQuote = false;
+            var escaped = false;
+            var currentValue = new StringBuilder();
+
+            foreach (var ch in arrayContent)
+            {
+                if (escaped)
+                {
+                    currentValue.Append(ch);
+                    escaped = false;
+                    continue;
+                }
+
+                if (ch == '\\')
+                {
+                    escaped = true;
+                    continue;
+                }
+
+                if (ch == '"')
+                {
+                    if (inQuote)
+                    {
+                        // End of quoted string
+                        var parsedValue = currentValue.ToString();
+                        parsedValue = parsedValue.Replace("\\\"", "\"").Replace("\\\\", "\\");
+                        result.Add(parsedValue);
+                        currentValue.Clear();
+                    }
+                    inQuote = !inQuote;
+                }
+                else if (inQuote)
+                {
+                    currentValue.Append(ch);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        /// <summary>
+        /// Parses a comma-separated list of boolean literals.
+        /// Returns null if any element is not a valid boolean, so the caller
+        /// can fall back to preserving the raw value.
+        /// </summary>
+        private static bool[]? ParseTomlBoolArrayContent(string arrayContent)
+        {
+            var elements = arrayContent.Split(',');
+            var result = new bool[elements.Length];
+            for (int i = 0; i < elements.Length; i++)
+            {
+                var trimmed = elements[i].Trim().ToLowerInvariant();
+                if (trimmed == "true") result[i] = true;
+                else if (trimmed == "false") result[i] = false;
+                else return null;
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Parses a comma-separated list of integer literals.
+        /// Returns null if any element is not a valid integer, so the caller
+        /// can fall back to preserving the raw value.
+        /// </summary>
+        private static int[]? ParseTomlIntArrayContent(string arrayContent)
+        {
+            var elements = arrayContent.Split(',');
+            var result = new int[elements.Length];
+            for (int i = 0; i < elements.Length; i++)
+            {
+                if (!int.TryParse(elements[i].Trim(), out result[i]))
+                    return null;
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Returns the (start, end) line index pairs of sibling TOML sections that represent the same
+        /// server under a different name, identified by matching identity key property values
+        /// (e.g. "command", "url", "serverUrl"). Pairs are in document order (top to bottom).
+        /// </summary>
+        private List<(int start, int end)> FindDuplicateServerSectionIndices(List<string> lines, string ownSectionName)
+        {
+            var ourIdentityValues = _identityKeys
+                .Where(key => _properties.TryGetValue(key, out var prop) && prop.value is string)
+                .ToDictionary(key => key, key => ((string)_properties[key].value, _properties[key].comparison));
+
+            if (ourIdentityValues.Count == 0)
+                return new List<(int, int)>();
+
+            var bodyPrefix = $"[{BodyPath}.";
+            var result = new List<(int start, int end)>();
+
+            for (int i = 0; i < lines.Count; i++)
+            {
+                var trimmed = lines[i].Trim();
+                if (!trimmed.StartsWith(bodyPrefix) || !trimmed.EndsWith("]"))
+                    continue;
+
+                var fullSectionName = trimmed[1..^1];
+                if (fullSectionName == ownSectionName)
+                    continue;
+
+                var sectionEnd = FindSectionEnd(lines, i);
+                var props = ParseSectionProperties(lines, i + 1, sectionEnd);
+
+                if (ourIdentityValues.Any(identity =>
+                        props.TryGetValue(identity.Key, out var existingValue)
+                        && existingValue is string existingStr
+                        && AreStringValuesEquivalent(identity.Value.comparison, identity.Value.Item1, existingStr)))
+                    result.Add((i, sectionEnd));
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Removes sibling TOML sections that represent the same server under a different name,
+        /// identified by matching identity key property values (e.g. "command", "url", "serverUrl").
+        /// </summary>
+        private void RemoveDuplicateServerSections(List<string> lines, string ownSectionName)
+        {
+            var sectionsToRemove = FindDuplicateServerSectionIndices(lines, ownSectionName);
+            for (int i = sectionsToRemove.Count - 1; i >= 0; i--)
+            {
+                var (start, end) = sectionsToRemove[i];
+                lines.RemoveRange(start, end - start);
+            }
+        }
+
+        private static int FindTomlSection(List<string> lines, string sectionName)
+        {
+            var sectionHeader = $"[{sectionName}]";
+            for (int i = 0; i < lines.Count; i++)
+            {
+                if (lines[i].Trim() == sectionHeader)
+                    return i;
+            }
+            return -1;
+        }
+
+        private static int FindSectionEnd(List<string> lines, int sectionStartIndex)
+        {
+            // Find the next section or end of file
+            for (int i = sectionStartIndex + 1; i < lines.Count; i++)
+            {
+                var trimmed = lines[i].Trim();
+                // New section starts with [
+                if (trimmed.StartsWith("[") && trimmed.EndsWith("]"))
+                    return i;
+            }
+            return lines.Count;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Lift Unity-MCP's UIToolkit-coupled AI-agent configurator logic into a new shared, engine-agnostic module `com.IvanMurzak.McpPlugin.AgentConfig` (under `McpPlugin/src/AgentConfig/`) so Unity, Godot, and the Unreal sidecar can consume ONE canonical C# implementation. Zero editor-UI / engine dependency.
- Pure config layer (`AiAgentConfig` / `JsonAiAgentConfig` / `TomlAiAgentConfig`), settings injection (`AgentConfiguratorSettings`, `OperatingSystemKind`, `ConnectionMode`) replacing Unity statics and `#if UNITY_EDITOR_*` branches, redesigned `AiAgentConfigurator` base + `AiAgentConfiguratorRegistry` + 16 per-agent `Impl/*Configurator`, and a UI-description DTO (`AgentConfiguratorDescription` / `ConfigurationSection` / `ConfigurationItem`) with the closed `ConfigurationItemKind` vocabulary — `Description | Warning | Alert | ReadOnlyField | EditableField` (`EditableField` is new, for the Custom agent's editable skills path) + identity + status booleans + icon NAME (string, not bytes).
- No consumer wiring in this PR (Unity / Godot / Unreal adoption are separate follow-ups). No `<Version>` bump.

## Test plan
- [x] `dotnet build McpPlugin.sln --configuration Release` — 0 warnings, 0 errors.
- [x] Target-specific local tests passed (profile test.md Suite 1): `dotnet test --no-build --configuration Release` — 514/514 pass across net8.0 + net9.0 (McpPlugin.Tests + McpPlugin.Server.Tests). The ported JSON/TOML/command-array suites add 91 AgentConfig tests, green on both TFMs.

Closes #124