### PR TITLE
feat(agentconfig): runtime OS detection + restore Rider per-OS command (Win/Mac/Linux parity)

### DIFF
--- a/McpPlugin.Tests/AgentConfig/AgentConfiguratorOsParityTests.cs
+++ b/McpPlugin.Tests/AgentConfig/AgentConfiguratorOsParityTests.cs
@@ -1,0 +1,146 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using com.IvanMurzak.McpPlugin.AgentConfig.Impl;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
+{
+    using TransportMethod = Common.Consts.MCP.Server.TransportMethod;
+
+    /// <summary>
+    /// Per-OS (Windows / macOS / Linux) parity coverage for the engine-agnostic configurators:
+    /// asserts the 3-way config-path divergence for Claude Desktop + Cline, that runtime
+    /// auto-detection (<see cref="HostOperatingSystem.Detect"/> via <see cref="AgentConfiguratorSettings.CreateForHost"/>)
+    /// picks the correct host OS, and that Rider's restored per-OS manual-setup command differs
+    /// between Windows and macOS/Linux.
+    /// </summary>
+    public class AgentConfiguratorOsParityTests
+    {
+        private static AgentConfiguratorSettings SettingsForOs(OperatingSystemKind os) => new(
+            operatingSystem: os,
+            projectRootPath: os == OperatingSystemKind.Windows ? "C:/proj" : "/proj",
+            executableFullPath: os == OperatingSystemKind.Windows ? "C:/Tools/srv.exe" : "/usr/local/bin/srv",
+            port: 50000,
+            timeoutMs: 30000,
+            host: "http://localhost:50000/mcp");
+
+        // ── Claude Desktop: Windows %APPDATA%\Claude vs Mac/Linux ~/Library/Application Support/Claude ──
+
+        [Fact]
+        public void ClaudeDesktop_StdioConfigPath_DivergesPerOs()
+        {
+            var c = new ClaudeDesktopConfigurator();
+
+            var winPath = c.GetStdioConfig(SettingsForOs(OperatingSystemKind.Windows)).ConfigPath;
+            var macPath = c.GetStdioConfig(SettingsForOs(OperatingSystemKind.MacOS)).ConfigPath;
+            var linuxPath = c.GetStdioConfig(SettingsForOs(OperatingSystemKind.Linux)).ConfigPath;
+
+            // Windows uses %APPDATA%\Claude; Mac/Linux both use ~/Library/Application Support/Claude.
+            winPath.Replace('\\', '/').ShouldContain("/Claude/claude_desktop_config.json");
+            winPath.Replace('\\', '/').ShouldNotContain("Application Support");
+
+            foreach (var p in new[] { macPath, linuxPath })
+            {
+                p.Replace('\\', '/').ShouldContain("Library/Application Support/Claude/claude_desktop_config.json");
+            }
+        }
+
+        // ── Cline: 3-way divergence (Win %APPDATA%\Code, Mac ~/Library/Application Support/Code, Linux ~/.config/Code) ──
+
+        [Fact]
+        public void Cline_StdioConfigPath_DivergesAcrossAllThreeOs()
+        {
+            var c = new ClineConfigurator();
+
+            var winPath = c.GetStdioConfig(SettingsForOs(OperatingSystemKind.Windows)).ConfigPath.Replace('\\', '/');
+            var macPath = c.GetStdioConfig(SettingsForOs(OperatingSystemKind.MacOS)).ConfigPath.Replace('\\', '/');
+            var linuxPath = c.GetStdioConfig(SettingsForOs(OperatingSystemKind.Linux)).ConfigPath.Replace('\\', '/');
+
+            // All three must be distinct.
+            new[] { winPath, macPath, linuxPath }.Distinct().Count().ShouldBe(3);
+
+            // Windows: %APPDATA%\Code\User\... (no "Application Support", no ".config").
+            winPath.ShouldContain("/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json");
+            winPath.ShouldNotContain("Application Support");
+            winPath.ShouldNotContain(".config");
+
+            // macOS: ~/Library/Application Support/Code/User/...
+            macPath.ShouldContain("Library/Application Support/Code/User/globalStorage");
+
+            // Linux: ~/.config/Code/User/...
+            linuxPath.ShouldContain(".config/Code/User/globalStorage");
+        }
+
+        // ── Auto-detection: CreateForHost / HostOperatingSystem.Detect picks the real host OS ──
+
+        [Fact]
+        public void HostOperatingSystem_Detect_MatchesRuntimeInformation()
+        {
+            var expected =
+                RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? OperatingSystemKind.Windows :
+                RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? OperatingSystemKind.MacOS :
+                OperatingSystemKind.Linux;
+
+            HostOperatingSystem.Detect().ShouldBe(expected);
+        }
+
+        [Fact]
+        public void CreateForHost_AutoDetects_NotHardcodedWindows()
+        {
+            var settings = AgentConfiguratorSettings.CreateForHost(
+                projectRootPath: Path.GetTempPath(),
+                executableFullPath: "srv",
+                port: 50000,
+                timeoutMs: 30000,
+                host: "http://localhost:50000/mcp");
+
+            settings.OperatingSystem.ShouldBe(HostOperatingSystem.Detect());
+
+            // On a non-Windows host the auto-detected OS must NOT be the enum's zero-value (Windows).
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                settings.OperatingSystem.ShouldNotBe(OperatingSystemKind.Windows);
+        }
+
+        // ── Rider: restored per-OS manual-setup terminal command (Win PowerShell vs Mac/Linux shell) ──
+
+        [Fact]
+        public void Rider_StdioManualCommand_IsWindowsPowerShell()
+        {
+            var c = new RiderConfigurator();
+            var fields = ReadOnlyFieldTexts(c, SettingsForOs(OperatingSystemKind.Windows));
+
+            fields.ShouldContain(t => t.Contains("New-Item -ItemType Directory") && t.Contains("Set-Content"));
+            fields.ShouldNotContain(t => t.Contains("mkdir -p"));
+        }
+
+        [Theory]
+        [InlineData(OperatingSystemKind.MacOS)]
+        [InlineData(OperatingSystemKind.Linux)]
+        public void Rider_StdioManualCommand_IsUnixShell(OperatingSystemKind os)
+        {
+            var c = new RiderConfigurator();
+            var fields = ReadOnlyFieldTexts(c, SettingsForOs(os));
+
+            fields.ShouldContain(t => t.Contains("mkdir -p .junie/mcp") && t.Contains("printf"));
+            fields.ShouldNotContain(t => t.Contains("New-Item -ItemType Directory"));
+        }
+
+        private static string[] ReadOnlyFieldTexts(RiderConfigurator c, AgentConfiguratorSettings settings)
+            => c.Describe(settings, TransportMethod.stdio).Sections
+                .SelectMany(s => s.Items)
+                .Where(i => i.Kind == ConfigurationItemKind.ReadOnlyField)
+                .Select(i => i.Text)
+                .ToArray();
+    }
+}

--- a/McpPlugin/src/AgentConfig/AgentConfiguratorSettings.cs
+++ b/McpPlugin/src/AgentConfig/AgentConfiguratorSettings.cs
@@ -9,6 +9,7 @@
 */
 
 #nullable enable
+using System.Runtime.InteropServices;
 using com.IvanMurzak.McpPlugin.Common;
 
 namespace com.IvanMurzak.McpPlugin.AgentConfig
@@ -24,6 +25,31 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
         Windows,
         MacOS,
         Linux
+    }
+
+    /// <summary>
+    /// Runtime host-OS detection. The engine-agnostic replacement for Unity's compile-time
+    /// <c>#if UNITY_EDITOR_WIN</c> / <c>#if UNITY_EDITOR_OSX</c> / <c>#if UNITY_EDITOR_LINUX</c>
+    /// selection. Consumers that do not know (or do not want to hard-code) the host OS get the
+    /// correct value automatically; tests and engine consumers can still force a specific value
+    /// via the explicit <see cref="AgentConfiguratorSettings"/> constructor.
+    /// </summary>
+    public static class HostOperatingSystem
+    {
+        /// <summary>
+        /// Detects the operating system the current process is running on using
+        /// <see cref="RuntimeInformation.IsOSPlatform"/>. Windows / OSX (→ <see cref="OperatingSystemKind.MacOS"/>)
+        /// / Linux are recognised; anything else falls back to <see cref="OperatingSystemKind.Linux"/>
+        /// (Unix-like path conventions).
+        /// </summary>
+        public static OperatingSystemKind Detect()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                return OperatingSystemKind.Windows;
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                return OperatingSystemKind.MacOS;
+            return OperatingSystemKind.Linux;
+        }
     }
 
     /// <summary>
@@ -93,6 +119,35 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
             Token = token;
             ConnectionMode = connectionMode;
             AuthOption = authOption;
+        }
+
+        /// <summary>
+        /// Creates settings that auto-detect the host OS at runtime (<see cref="HostOperatingSystem.Detect"/>).
+        /// This is the recommended path for consumers that simply want correct per-OS config-file
+        /// locations on the machine the process runs on — without hand-detecting and injecting the OS.
+        /// Use the OS-explicit constructor only when a specific <see cref="OperatingSystemKind"/> must be forced
+        /// (e.g. tests, or generating config for a different OS than the host).
+        /// </summary>
+        public static AgentConfiguratorSettings CreateForHost(
+            string projectRootPath,
+            string executableFullPath,
+            int port,
+            int timeoutMs,
+            string host,
+            string? token = null,
+            ConnectionMode connectionMode = ConnectionMode.Local,
+            Consts.MCP.Server.AuthOption authOption = Consts.MCP.Server.AuthOption.none)
+        {
+            return new AgentConfiguratorSettings(
+                operatingSystem: HostOperatingSystem.Detect(),
+                projectRootPath: projectRootPath,
+                executableFullPath: executableFullPath,
+                port: port,
+                timeoutMs: timeoutMs,
+                host: host,
+                token: token,
+                connectionMode: connectionMode,
+                authOption: authOption);
         }
 
         /// <summary>True when HTTP authorization should be injected (cloud always requires it).</summary>

--- a/McpPlugin/src/AgentConfig/Impl/ClaudeDesktopConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/Impl/ClaudeDesktopConfigurator.cs
@@ -25,8 +25,11 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Impl
         public override string DownloadUrl => "https://code.claude.com/docs/en/desktop";
         public override string? IconName => "claude-64.png";
 
+        // Windows %APPDATA% is built deterministically from UserProfile so the path is driven solely by the
+        // injected OperatingSystemKind, not the host OS. SpecialFolder.ApplicationData maps to ~/.config on
+        // Linux, which would make the "Windows" path host-dependent and indistinguishable from a Linux base.
         private static string ConfigPath(AgentConfiguratorSettings s) => s.IsWindows
-            ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Claude", "claude_desktop_config.json")
+            ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "AppData", "Roaming", "Claude", "claude_desktop_config.json")
             : Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Library", "Application Support", "Claude", "claude_desktop_config.json");
 
         protected override AiAgentConfig CreateStdioConfig(AgentConfiguratorSettings settings, ILogger? logger)

--- a/McpPlugin/src/AgentConfig/Impl/ClineConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/Impl/ClineConfigurator.cs
@@ -36,8 +36,11 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Impl
             switch (s.OperatingSystem)
             {
                 case OperatingSystemKind.Windows:
-                    return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-                        "Code", "User", relSettings, "saoudrizwan.claude-dev", "settings", "cline_mcp_settings.json");
+                    // Build %APPDATA% deterministically from UserProfile so the path is driven solely by the
+                    // injected OperatingSystemKind, not the host OS. SpecialFolder.ApplicationData maps to
+                    // ~/.config on Linux, which would collide with the Linux branch when run on a Linux host.
+                    return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                        "AppData", "Roaming", "Code", "User", relSettings, "saoudrizwan.claude-dev", "settings", "cline_mcp_settings.json");
                 case OperatingSystemKind.MacOS:
                     return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
                         "Library", "Application Support", "Code", "User", relSettings, "saoudrizwan.claude-dev", "settings", "cline_mcp_settings.json");

--- a/McpPlugin/src/AgentConfig/Impl/RiderConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/Impl/RiderConfigurator.cs
@@ -82,7 +82,7 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Impl
             else
             {
                 terminalDescription = "Option 1: Run this command in a terminal from the project folder";
-                terminalCommand = $"mkdir -p .junie/mcp && printf '{expectedContent.Replace("'", "'\\''")}' > {relativePath.Replace('\\', '/')}";
+                terminalCommand = $"mkdir -p .junie/mcp && printf '%s\\n' '{expectedContent.Replace("'", "'\\''")}' > {relativePath.Replace('\\', '/')}";
             }
 
             return new[]

--- a/McpPlugin/src/AgentConfig/Impl/RiderConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/Impl/RiderConfigurator.cs
@@ -51,6 +51,52 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Impl
 
         protected override IReadOnlyList<ConfigurationSection> BuildSections(
             AgentConfiguratorSettings settings, TransportMethod transport, ILogger? logger)
-            => DefaultConfigurationSections(settings, transport, logger);
+        {
+            // HTTP transport: Rider/Junie connects via stdio only (HTTP is unreliable here), so
+            // surface the warning and fall back to exposing the expected config content.
+            if (transport != TransportMethod.stdio)
+            {
+                return new[]
+                {
+                    new ConfigurationSection("Configuration", true, new[]
+                    {
+                        ConfigurationItem.Warning("Rider (Junie) connects via stdio. Switch the transport method to 'stdio' to configure this agent."),
+                        ConfigurationItem.ReadOnlyField(GetHttpConfig(settings, logger).ExpectedFileContent)
+                    })
+                };
+            }
+
+            // STDIO transport: restore Unity's per-OS manual-setup convenience command
+            // (Win PowerShell New-Item/Set-Content vs Mac/Linux mkdir -p/printf), driven by
+            // settings.OperatingSystem. Wording is engine-neutral ("the project folder").
+            var relativePath = Path.Combine(".junie", "mcp", "mcp.json");
+            var expectedContent = GetStdioConfig(settings, logger).ExpectedFileContent;
+
+            string terminalDescription;
+            string terminalCommand;
+            if (settings.IsWindows)
+            {
+                terminalDescription = "Option 1: Run this command in PowerShell from the project folder";
+                terminalCommand = $"New-Item -ItemType Directory -Force -Path .junie\\mcp | Out-Null; Set-Content -Path {relativePath.Replace('/', '\\')} -Value '{expectedContent.Replace("'", "''")}'";
+            }
+            else
+            {
+                terminalDescription = "Option 1: Run this command in a terminal from the project folder";
+                terminalCommand = $"mkdir -p .junie/mcp && printf '{expectedContent.Replace("'", "'\\''")}' > {relativePath.Replace('\\', '/')}";
+            }
+
+            return new[]
+            {
+                new ConfigurationSection("Manual Configuration Steps", true, new[]
+                {
+                    ConfigurationItem.Warning("After configuring, open Rider Settings / Tools / Junie / MCP Settings and enable the server to connect the AI agent."),
+                    ConfigurationItem.Description(terminalDescription),
+                    ConfigurationItem.ReadOnlyField(terminalCommand),
+                    ConfigurationItem.Description($"Option 2: Create or open the file '{relativePath.Replace('\\', '/')}' and paste the JSON below."),
+                    ConfigurationItem.ReadOnlyField(expectedContent),
+                    ConfigurationItem.Description("Option 3: Open Rider Settings / Tools / Junie / MCP Settings and add a new server manually.")
+                })
+            };
+        }
     }
 }


### PR DESCRIPTION
## Summary
Closes the two per-OS parity gaps found in the freshly-extracted `com.IvanMurzak.McpPlugin.AgentConfig` module so it matches Unity-MCP on Windows, macOS, and Linux.

- **Gap 1 (runtime OS detection)**: added `HostOperatingSystem.Detect()` (`RuntimeInformation.IsOSPlatform`: Windows / OSX→MacOS / Linux, unknown→Linux) and an `AgentConfiguratorSettings.CreateForHost(...)` factory that auto-detects the host OS. Consumers no longer get Windows config paths by default on Mac/Linux for Claude Desktop + Cline. The OS-explicit constructor is kept so tests and engine consumers can still force a specific OS.
- **Gap 2 (Rider per-OS command)**: restored the per-OS manual-setup terminal command in `RiderConfigurator.BuildSections` (Win PowerShell `New-Item`/`Set-Content` vs Mac/Linux `mkdir -p`/`printf`), driven by `settings.OperatingSystem`, mirroring how `CodexConfigurator` does setx-vs-export. Wording kept engine-neutral.

No `<Version>` bump (stays 6.7.1) — release is handled separately.

## Test plan
- [x] New `AgentConfiguratorOsParityTests`: 3-way (Win/Mac/Linux) config-path divergence for Claude Desktop + Cline; auto-detection equals `RuntimeInformation` (not hardcoded Windows); Rider per-OS command divergence (Win vs Mac/Linux).
- [x] Full xUnit suite green: `net8.0` + `net9.0`, `McpPlugin.Tests` + `McpPlugin.Server.Tests`, 0 failures.

Closes #126