### PR TITLE
feat(agentconfig): AgentConfig parity — Kilo/Zoo config, full TOML tests, DTO links + reconfigure status

### DIFF
--- a/McpPlugin.Tests/AgentConfig/AgentConfiguratorDescriptionTests.cs
+++ b/McpPlugin.Tests/AgentConfig/AgentConfiguratorDescriptionTests.cs
@@ -1,0 +1,137 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak)                    │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+using System.IO;
+using System.Linq;
+using com.IvanMurzak.McpPlugin.AgentConfig.Impl;
+using com.IvanMurzak.McpPlugin.Common;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
+{
+    using TransportMethod = Consts.MCP.Server.TransportMethod;
+
+    /// <summary>
+    /// Covers the GAP-3 DTO extensions: open-URL links (download + tutorial) and the three-state
+    /// configuration status (absent / configured-current / configured-but-stale), ported from
+    /// Unity's <c>AiAgentConfigurator</c> link emission and <c>IsReconfigureNeeded</c> logic.
+    /// </summary>
+    public class AgentConfiguratorDescriptionTests
+    {
+        private static AgentConfiguratorSettings Settings(string root, string executable = "C:/Tools/srv.exe") => new(
+            operatingSystem: OperatingSystemKind.Windows,
+            projectRootPath: root,
+            executableFullPath: executable,
+            port: 50000,
+            timeoutMs: 30000,
+            host: "http://localhost:50000/mcp");
+
+        [Fact]
+        public void Description_WithTutorial_CarriesDownloadAndTutorialLinks()
+        {
+            var c = new ClaudeCodeConfigurator();
+            var desc = c.Describe(Settings(Path.GetTempPath()), TransportMethod.stdio);
+
+            desc.Links.Count.ShouldBe(2);
+            desc.Links.ShouldAllBe(l => l.Kind == ConfigurationItemKind.Link);
+            desc.Links.ShouldContain(l => l.Url == c.DownloadUrl);
+            desc.Links.ShouldContain(l => l.Url == c.TutorialUrl);
+        }
+
+        [Fact]
+        public void Description_WithoutTutorial_CarriesOnlyDownloadLink()
+        {
+            var c = new KiloCodeConfigurator();
+            c.TutorialUrl.ShouldBe(string.Empty);
+            var desc = c.Describe(Settings(Path.GetTempPath()), TransportMethod.stdio);
+
+            var link = desc.Links.ShouldHaveSingleItem();
+            link.Kind.ShouldBe(ConfigurationItemKind.Link);
+            link.Url.ShouldBe(c.DownloadUrl);
+        }
+
+        [Fact]
+        public void Custom_Description_HasNoLinks()
+        {
+            var c = new CustomConfigurator();
+            c.Describe(Settings(Path.GetTempPath()), TransportMethod.stdio).Links.ShouldBeEmpty();
+        }
+
+        [Fact]
+        public void Status_NoConfigOnDisk_IsNotConfigured()
+        {
+            var root = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(root);
+            try
+            {
+                var c = new KiloCodeConfigurator();
+                var desc = c.Describe(Settings(root), TransportMethod.stdio);
+
+                desc.Status.ShouldBe(ConfiguratorStatus.NotConfigured);
+                desc.IsConfigured.ShouldBeFalse();
+            }
+            finally
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+
+        [Fact]
+        public void Status_MatchingConfigOnDisk_IsConfigured()
+        {
+            var root = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(root);
+            try
+            {
+                var c = new KiloCodeConfigurator();
+                var settings = Settings(root);
+                c.GetStdioConfig(settings).Configure().ShouldBeTrue();
+
+                var desc = c.Describe(settings, TransportMethod.stdio);
+                desc.Status.ShouldBe(ConfiguratorStatus.Configured);
+                desc.IsConfigured.ShouldBeTrue();
+            }
+            finally
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+
+        [Fact]
+        public void Status_StaleConfigOnDisk_IsReconfigureNeeded_AndPrependsAlertSection()
+        {
+            var root = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(root);
+            try
+            {
+                var c = new KiloCodeConfigurator();
+
+                // Write a config with one executable, then describe with a DIFFERENT executable:
+                // the entry is detected on disk but no longer matches the current settings.
+                c.GetStdioConfig(Settings(root, executable: "C:/Old/old-server.exe")).Configure().ShouldBeTrue();
+                var staleSettings = Settings(root, executable: "C:/New/new-server.exe");
+
+                var desc = c.Describe(staleSettings, TransportMethod.stdio);
+
+                desc.Status.ShouldBe(ConfiguratorStatus.ReconfigureNeeded);
+                desc.IsConfigured.ShouldBeFalse();
+
+                var alert = desc.Sections
+                    .SelectMany(s => s.Items)
+                    .Single(i => i.Kind == ConfigurationItemKind.Alert);
+                alert.Text.ShouldContain("outdated");
+            }
+            finally
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+    }
+}

--- a/McpPlugin.Tests/AgentConfig/KiloZooConfiguratorOutputTests.cs
+++ b/McpPlugin.Tests/AgentConfig/KiloZooConfiguratorOutputTests.cs
@@ -1,0 +1,91 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+using System.IO;
+using com.IvanMurzak.McpPlugin.AgentConfig.Impl;
+using com.IvanMurzak.McpPlugin.Common;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
+{
+    using TransportMethod = Consts.MCP.Server.TransportMethod;
+
+    /// <summary>
+    /// Output-shape parity tests for Kilo Code and Zoo Code. These configurators must reproduce
+    /// Unity-MCP's exact config: <c>disabled = false</c> on BOTH transports and HTTP
+    /// <c>type = "streamable-http"</c> (Unity KiloCodeConfigurator.cs / ZooCodeConfigurator.cs).
+    /// Their absence is why the regression slipped (no output tests existed before).
+    /// </summary>
+    public class KiloZooConfiguratorOutputTests
+    {
+        private static AgentConfiguratorSettings Settings(string root) => new(
+            operatingSystem: OperatingSystemKind.Windows,
+            projectRootPath: root,
+            executableFullPath: "C:/Tools/ai-game-developer-mcp-server.exe",
+            port: 50000,
+            timeoutMs: 30000,
+            host: "http://localhost:50000/mcp");
+
+        [Theory]
+        [InlineData("kilo-code")]
+        [InlineData("zoo-code")]
+        public void StdioConfig_HasTypeStdio_DisabledFalse(string agentId)
+        {
+            var configurator = AiAgentConfiguratorRegistry.GetByAgentId(agentId)!;
+            var content = configurator.GetStdioConfig(Settings(Path.GetTempPath())).ExpectedFileContent;
+
+            content.ShouldContain("\"type\": \"stdio\"");
+            content.ShouldContain("\"disabled\": false");
+        }
+
+        [Theory]
+        [InlineData("kilo-code")]
+        [InlineData("zoo-code")]
+        public void HttpConfig_HasStreamableHttpType_DisabledFalse(string agentId)
+        {
+            var configurator = AiAgentConfiguratorRegistry.GetByAgentId(agentId)!;
+            var content = configurator.GetHttpConfig(Settings(Path.GetTempPath())).ExpectedFileContent;
+
+            content.ShouldContain("\"type\": \"streamable-http\"");
+            content.ShouldNotContain("\"type\": \"http\"");
+            content.ShouldContain("\"disabled\": false");
+        }
+
+        [Theory]
+        [InlineData("kilo-code")]
+        [InlineData("zoo-code")]
+        public void Configure_WritesDisabledFalseAndStreamableHttp_AndIsConfigured(string agentId)
+        {
+            var root = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(root);
+            try
+            {
+                var configurator = AiAgentConfiguratorRegistry.GetByAgentId(agentId)!;
+                var settings = Settings(root);
+
+                var stdio = configurator.GetStdioConfig(settings);
+                stdio.Configure().ShouldBeTrue();
+                configurator.IsConfigured(settings, TransportMethod.stdio).ShouldBeTrue();
+
+                var http = configurator.GetHttpConfig(settings);
+                http.Configure().ShouldBeTrue();
+                configurator.IsConfigured(settings, TransportMethod.streamableHttp).ShouldBeTrue();
+
+                var written = File.ReadAllText(http.ConfigPath);
+                written.ShouldContain("\"disabled\": false");
+                written.ShouldContain("\"streamable-http\"");
+            }
+            finally
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+    }
+}

--- a/McpPlugin.Tests/AgentConfig/TomlAiAgentConfigTests.cs
+++ b/McpPlugin.Tests/AgentConfig/TomlAiAgentConfigTests.cs
@@ -441,5 +441,332 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
                 .SetProperty("command", "C:/Users/test/app.exe", requiredForConfiguration: true)
                 .IsConfigured().ShouldBeFalse();
         }
+
+        // ── Cases below ported verbatim from Unity-MCP's TomlAiAgentConfigTests to restore the
+        //    full matrix (NUnit Assert → Shouldly; UnityTest coroutine shape → plain [Fact];
+        //    test logic and data unchanged). ───────────────────────────────────────────────
+
+        [Fact]
+        public void IsConfigured_NonExistentFile_ReturnsFalse()
+        {
+            var nonExistentPath = Path.Combine(Path.GetTempPath(), "non_existent_config.toml");
+            CreateStdioConfig(nonExistentPath).IsConfigured().ShouldBeFalse();
+        }
+
+        [Fact]
+        public void ExpectedFileContent_ContainsCorrectSection()
+        {
+            var content = CreateStdioConfig(TempConfigPath).ExpectedFileContent;
+            content.ShouldContain($"[mcp_servers.{AiAgentConfig.DefaultMcpServerName}]");
+            content.ShouldContain("command = ");
+            content.ShouldContain("args = [");
+        }
+
+        [Fact]
+        public void ExpectedFileContent_HttpConfig_ContainsUrl()
+        {
+            var content = CreateHttpConfig(TempConfigPath).ExpectedFileContent;
+            content.ShouldContain($"[mcp_servers.{AiAgentConfig.DefaultMcpServerName}]");
+            content.ShouldContain($"url = \"{Host}\"");
+            content.ShouldNotContain("command = ");
+            content.ShouldNotContain("args = [");
+        }
+
+        [Fact]
+        public void IsConfigured_ExistingBoolArray_MatchesCorrectly()
+        {
+            var sectionName = $"mcp_servers.{AiAgentConfig.DefaultMcpServerName}";
+            File.WriteAllText(TempConfigPath, $"[{sectionName}]\nflags = [true, false, true]\n");
+            new TomlAiAgentConfig("Test", TempConfigPath, "mcp_servers")
+                .SetProperty("flags", new[] { true, false, true }, requiredForConfiguration: true)
+                .IsConfigured().ShouldBeTrue();
+        }
+
+        [Fact]
+        public void IsConfigured_ExistingStringArray_MatchesCorrectly()
+        {
+            var sectionName = $"mcp_servers.{AiAgentConfig.DefaultMcpServerName}";
+            File.WriteAllText(TempConfigPath, $"[{sectionName}]\nnames = [\"alpha\", \"beta\", \"gamma\"]\n");
+            new TomlAiAgentConfig("Test", TempConfigPath, "mcp_servers")
+                .SetProperty("names", new[] { "alpha", "beta", "gamma" }, requiredForConfiguration: true)
+                .IsConfigured().ShouldBeTrue();
+        }
+
+        [Fact]
+        public void IsConfigured_MismatchedBoolArray_ReturnsFalse()
+        {
+            var sectionName = $"mcp_servers.{AiAgentConfig.DefaultMcpServerName}";
+            File.WriteAllText(TempConfigPath, $"[{sectionName}]\nflags = [false, false]\n");
+            new TomlAiAgentConfig("Test", TempConfigPath, "mcp_servers")
+                .SetProperty("flags", new[] { true, false, true }, requiredForConfiguration: true)
+                .IsConfigured().ShouldBeFalse();
+        }
+
+        [Fact]
+        public void Configure_ExistingFileWithIntArray_MergesCorrectly()
+        {
+            var sectionName = $"mcp_servers.{AiAgentConfig.DefaultMcpServerName}";
+            File.WriteAllText(TempConfigPath, $"[{sectionName}]\nports = [1, 2, 3]\ncustom_prop = \"keep\"\n");
+            new TomlAiAgentConfig("Test", TempConfigPath, "mcp_servers")
+                .SetProperty("ports", new[] { 8080, 8081 }, requiredForConfiguration: true)
+                .Configure();
+
+            var content = File.ReadAllText(TempConfigPath);
+            content.ShouldContain("ports = [8080,8081]");
+            content.ShouldContain("custom_prop = \"keep\"");
+        }
+
+        [Fact]
+        public void Configure_EmptyArray_HandledCorrectly()
+        {
+            var sectionName = $"mcp_servers.{AiAgentConfig.DefaultMcpServerName}";
+            File.WriteAllText(TempConfigPath, $"[{sectionName}]\nempty = []\n");
+            var config = new TomlAiAgentConfig("Test", TempConfigPath, "mcp_servers")
+                .SetProperty("value", 42, requiredForConfiguration: true);
+            config.Configure();
+            config.IsConfigured().ShouldBeTrue();
+        }
+
+        [Fact]
+        public void IsConfigured_ExistingNegativeIntArray_MatchesCorrectly()
+        {
+            var sectionName = $"mcp_servers.{AiAgentConfig.DefaultMcpServerName}";
+            File.WriteAllText(TempConfigPath, $"[{sectionName}]\noffsets = [-10, 0, 10]\n");
+            new TomlAiAgentConfig("Test", TempConfigPath, "mcp_servers")
+                .SetProperty("offsets", new[] { -10, 0, 10 }, requiredForConfiguration: true)
+                .IsConfigured().ShouldBeTrue();
+        }
+
+        [Fact]
+        public void Configure_NewFile_PropertiesInAlphabeticalOrder()
+        {
+            File.Delete(TempConfigPath);
+            new TomlAiAgentConfig("Test", TempConfigPath, "mcp_servers")
+                .SetProperty("zebra", "last")
+                .SetProperty("alpha", "first")
+                .SetProperty("middle", "mid")
+                .Configure();
+
+            var content = File.ReadAllText(TempConfigPath);
+            var alphaIdx = content.IndexOf("alpha = ", System.StringComparison.Ordinal);
+            var middleIdx = content.IndexOf("middle = ", System.StringComparison.Ordinal);
+            var zebraIdx = content.IndexOf("zebra = ", System.StringComparison.Ordinal);
+
+            alphaIdx.ShouldBeGreaterThanOrEqualTo(0);
+            middleIdx.ShouldBeGreaterThanOrEqualTo(0);
+            zebraIdx.ShouldBeGreaterThanOrEqualTo(0);
+            alphaIdx.ShouldBeLessThan(middleIdx);
+            middleIdx.ShouldBeLessThan(zebraIdx);
+        }
+
+        [Fact]
+        public void Configure_ExistingSection_MergedPropertiesInAlphabeticalOrder()
+        {
+            var sectionName = $"mcp_servers.{AiAgentConfig.DefaultMcpServerName}";
+            File.WriteAllText(TempConfigPath, $"[{sectionName}]\nexisting = \"value\"\n");
+            new TomlAiAgentConfig("Test", TempConfigPath, "mcp_servers")
+                .SetProperty("zebra", "last")
+                .SetProperty("alpha", "first")
+                .Configure();
+
+            var content = File.ReadAllText(TempConfigPath);
+            var alphaIdx = content.IndexOf("alpha = ", System.StringComparison.Ordinal);
+            var existingIdx = content.IndexOf("existing = ", System.StringComparison.Ordinal);
+            var zebraIdx = content.IndexOf("zebra = ", System.StringComparison.Ordinal);
+
+            alphaIdx.ShouldBeGreaterThanOrEqualTo(0);
+            existingIdx.ShouldBeGreaterThanOrEqualTo(0);
+            zebraIdx.ShouldBeGreaterThanOrEqualTo(0);
+            alphaIdx.ShouldBeLessThan(existingIdx);
+            existingIdx.ShouldBeLessThan(zebraIdx);
+        }
+
+        [Fact]
+        public void Configure_Http_RemovesDuplicateByUrl()
+        {
+            File.WriteAllText(TempConfigPath, $"[mcp_servers.my-custom-name]\nurl = \"{Host}\"\n");
+            CreateHttpConfig(TempConfigPath).Configure();
+
+            var content = File.ReadAllText(TempConfigPath);
+            content.ShouldNotContain("[mcp_servers.my-custom-name]");
+            content.ShouldContain($"[mcp_servers.{AiAgentConfig.DefaultMcpServerName}]");
+        }
+
+        [Fact]
+        public void Configure_Http_DefaultIdentityKeys_DoNotRemoveByServerUrl()
+        {
+            File.WriteAllText(TempConfigPath, $"[mcp_servers.my-custom-name]\nserverUrl = \"{Host}\"\n");
+            CreateHttpConfig(TempConfigPath).Configure();
+
+            var content = File.ReadAllText(TempConfigPath);
+            content.ShouldContain("[mcp_servers.my-custom-name]");
+            content.ShouldContain($"[mcp_servers.{AiAgentConfig.DefaultMcpServerName}]");
+        }
+
+        [Fact]
+        public void Configure_PreservesUnrelatedServers()
+        {
+            File.WriteAllText(TempConfigPath, "[mcp_servers.other-server]\ncommand = \"completely-different-command\"\nargs = [\"--some-arg\"]\n");
+            CreateStdioConfig(TempConfigPath).Configure();
+
+            var content = File.ReadAllText(TempConfigPath);
+            content.ShouldContain("[mcp_servers.other-server]");
+            content.ShouldContain($"[mcp_servers.{AiAgentConfig.DefaultMcpServerName}]");
+        }
+
+        [Fact]
+        public void IsDetected_DuplicateByCommand_ReturnsTrue()
+        {
+            var executable = ExecutableFullPath.Replace('\\', '/');
+            File.WriteAllText(TempConfigPath, $"[mcp_servers.my-custom-name]\ncommand = \"{executable}\"\nargs = [\"--old-arg\"]\n");
+            CreateStdioConfig(TempConfigPath).IsDetected().ShouldBeTrue();
+        }
+
+        [Fact]
+        public void IsDetected_DuplicateByUrl_ReturnsTrue()
+        {
+            File.WriteAllText(TempConfigPath, $"[mcp_servers.my-custom-name]\nurl = \"{Host}\"\n");
+            CreateHttpConfig(TempConfigPath).IsDetected().ShouldBeTrue();
+        }
+
+        [Fact]
+        public void Unconfigure_DeprecatedName_RemovesIt()
+        {
+            File.WriteAllText(TempConfigPath, "[mcp_servers.Unity-MCP]\ncommand = \"/some/path\"\n");
+            CreateStdioConfig(TempConfigPath).Unconfigure().ShouldBeTrue();
+            File.ReadAllText(TempConfigPath).ShouldNotContain("[mcp_servers.Unity-MCP]");
+        }
+
+        [Fact]
+        public void Unconfigure_DuplicateByCommand_RemovesIt()
+        {
+            var executable = ExecutableFullPath.Replace('\\', '/');
+            File.WriteAllText(TempConfigPath, $"[mcp_servers.my-custom-name]\ncommand = \"{executable}\"\nargs = [\"--old-arg\"]\n");
+            CreateStdioConfig(TempConfigPath).Unconfigure().ShouldBeTrue();
+            File.ReadAllText(TempConfigPath).ShouldNotContain("[mcp_servers.my-custom-name]");
+        }
+
+        [Fact]
+        public void Configure_ExistingSection_PreservesDateValue()
+        {
+            var sectionName = $"mcp_servers.{AiAgentConfig.DefaultMcpServerName}";
+            File.WriteAllText(TempConfigPath, $"[{sectionName}]\ncommand = \"old-command\"\ncreated = 2024-01-01\n");
+            CreateStdioConfig(TempConfigPath).Configure();
+
+            var content = File.ReadAllText(TempConfigPath);
+            content.ShouldContain("created = 2024-01-01");
+            content.ShouldNotContain("created = \"2024-01-01\"");
+        }
+
+        [Fact]
+        public void Configure_ExistingSection_InlineCommentOnBool()
+        {
+            var sectionName = $"mcp_servers.{AiAgentConfig.DefaultMcpServerName}";
+            File.WriteAllText(TempConfigPath, $"[{sectionName}]\ncommand = \"old-command\"\nenabled = true # some flag\n");
+            CreateStdioConfig(TempConfigPath).Configure();
+
+            var content = File.ReadAllText(TempConfigPath);
+            content.ShouldContain("enabled = true");
+            content.ShouldNotContain("# some flag");
+            content.ShouldNotContain("enabled = \"");
+        }
+
+        [Fact]
+        public void Configure_ExistingSection_InlineCommentOnQuotedString()
+        {
+            var sectionName = $"mcp_servers.{AiAgentConfig.DefaultMcpServerName}";
+            File.WriteAllText(TempConfigPath, $"[{sectionName}]\ncommand = \"old-command\"\nname = \"hello\" # some note\n");
+            CreateStdioConfig(TempConfigPath).Configure();
+
+            var content = File.ReadAllText(TempConfigPath);
+            content.ShouldContain("name = \"hello\"");
+            content.ShouldNotContain("# some note");
+        }
+
+        [Fact]
+        public void Configure_ExistingSection_InlineCommentOnStringArray()
+        {
+            var sectionName = $"mcp_servers.{AiAgentConfig.DefaultMcpServerName}";
+            File.WriteAllText(TempConfigPath, $"[{sectionName}]\ncommand = \"old-command\"\nnames = [\"alpha\", \"beta\"] # some list\n");
+            CreateStdioConfig(TempConfigPath).Configure();
+
+            var content = File.ReadAllText(TempConfigPath);
+            content.ShouldContain("names = [\"alpha\",\"beta\"]");
+            content.ShouldNotContain("# some list");
+        }
+
+        [Fact]
+        public void Configure_ExistingSection_InlineCommentOnIntArray()
+        {
+            var sectionName = $"mcp_servers.{AiAgentConfig.DefaultMcpServerName}";
+            File.WriteAllText(TempConfigPath, $"[{sectionName}]\ncommand = \"old-command\"\nports = [8080, 8081] # default ports\n");
+            CreateStdioConfig(TempConfigPath).Configure();
+
+            var content = File.ReadAllText(TempConfigPath);
+            content.ShouldContain("ports = [8080,8081]");
+            content.ShouldNotContain("# default ports");
+        }
+
+        [Fact]
+        public void Configure_ExistingSection_InlineCommentOnBoolArray()
+        {
+            var sectionName = $"mcp_servers.{AiAgentConfig.DefaultMcpServerName}";
+            File.WriteAllText(TempConfigPath, $"[{sectionName}]\ncommand = \"old-command\"\nflags = [true, false] # feature flags\n");
+            CreateStdioConfig(TempConfigPath).Configure();
+
+            var content = File.ReadAllText(TempConfigPath);
+            content.ShouldContain("flags = [true,false]");
+            content.ShouldNotContain("# feature flags");
+        }
+
+        [Fact]
+        public void IsConfigured_StringArrayWithInlineComment_MatchesCorrectly()
+        {
+            var sectionName = $"mcp_servers.{AiAgentConfig.DefaultMcpServerName}";
+            File.WriteAllText(TempConfigPath, $"[{sectionName}]\nnames = [\"alpha\", \"beta\"] # a comment\n");
+            new TomlAiAgentConfig("Test", TempConfigPath, "mcp_servers")
+                .SetProperty("names", new[] { "alpha", "beta" }, requiredForConfiguration: true)
+                .IsConfigured().ShouldBeTrue();
+        }
+
+        [Fact]
+        public void IsConfigured_WithInlineComments_ReturnsTrue()
+        {
+            var config = CreateStdioConfig(TempConfigPath);
+            config.Configure();
+
+            var lines = File.ReadAllLines(TempConfigPath);
+            for (int i = 0; i < lines.Length; i++)
+            {
+                if (lines[i].TrimStart().StartsWith("command =", System.StringComparison.Ordinal))
+                {
+                    lines[i] += " # path to executable";
+                    break;
+                }
+            }
+            File.WriteAllLines(TempConfigPath, lines);
+
+            config.IsConfigured().ShouldBeTrue();
+        }
+
+        [Fact]
+        public void IsConfigured_PathComparison_TrailingSlashIgnored()
+        {
+            var sectionName = $"mcp_servers.{AiAgentConfig.DefaultMcpServerName}";
+            File.WriteAllText(TempConfigPath, $"[{sectionName}]\ncommand = \"C:/Users/test/app/\"\n");
+            new TomlAiAgentConfig("Test", TempConfigPath, "mcp_servers")
+                .SetProperty("command", "C:/Users/test/app", requiredForConfiguration: true, comparison: ValueComparisonMode.Path)
+                .IsConfigured().ShouldBeTrue();
+        }
+
+        [Fact]
+        public void IsConfigured_UrlComparison_TrailingSlashIgnored()
+        {
+            var sectionName = $"mcp_servers.{AiAgentConfig.DefaultMcpServerName}";
+            File.WriteAllText(TempConfigPath, $"[{sectionName}]\nurl = \"http://localhost:5000/mcp/\"\n");
+            new TomlAiAgentConfig("Test", TempConfigPath, "mcp_servers")
+                .SetProperty("url", "http://localhost:5000/mcp", requiredForConfiguration: true, comparison: ValueComparisonMode.Url)
+                .IsConfigured().ShouldBeTrue();
+        }
     }
 }

--- a/McpPlugin/src/AgentConfig/AgentConfigBuilders.cs
+++ b/McpPlugin/src/AgentConfig/AgentConfigBuilders.cs
@@ -34,38 +34,50 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
 
         /// <summary>
         /// Standard JSON stdio entry: <c>type=stdio</c>, <c>command</c> (path comparison),
-        /// <c>args</c>, removing <c>url</c>.
+        /// <c>args</c>, removing <c>url</c>. When <paramref name="disabled"/> is supplied an
+        /// extra required <c>disabled</c> flag is written (some agents — Kilo/Zoo — require it).
         /// </summary>
         public static JsonAiAgentConfig JsonStdio(
             string name,
             string configPath,
             AgentConfiguratorSettings settings,
             ILogger? logger,
-            string bodyPath = Consts.MCP.Server.DefaultBodyPath)
+            string bodyPath = Consts.MCP.Server.DefaultBodyPath,
+            bool? disabled = null)
         {
-            return new JsonAiAgentConfig(name, configPath, bodyPath, logger)
+            var config = new JsonAiAgentConfig(name, configPath, bodyPath, logger)
                 .SetProperty("type", JsonValue.Create("stdio")!, requiredForConfiguration: true)
                 .SetProperty("command", JsonValue.Create(settings.ExecutableFullPath.Replace('\\', '/'))!, requiredForConfiguration: true, comparison: ValueComparisonMode.Path)
                 .SetProperty("args", StdioArgs(settings), requiredForConfiguration: true)
                 .SetPropertyToRemove("url");
+            if (disabled.HasValue)
+                config.SetProperty("disabled", JsonValue.Create(disabled.Value)!, requiredForConfiguration: true);
+            return config;
         }
 
         /// <summary>
-        /// Standard JSON http entry: <c>type=http</c>, <c>url</c> (url comparison),
-        /// removing <c>command</c> + <c>args</c>.
+        /// Standard JSON http entry: <c>type</c> (default <c>http</c>; some agents require
+        /// <c>streamable-http</c>), <c>url</c> (url comparison), removing <c>command</c> +
+        /// <c>args</c>. When <paramref name="disabled"/> is supplied an extra required
+        /// <c>disabled</c> flag is written.
         /// </summary>
         public static JsonAiAgentConfig JsonHttp(
             string name,
             string configPath,
             AgentConfiguratorSettings settings,
             ILogger? logger,
-            string bodyPath = Consts.MCP.Server.DefaultBodyPath)
+            string bodyPath = Consts.MCP.Server.DefaultBodyPath,
+            string type = "http",
+            bool? disabled = null)
         {
-            return new JsonAiAgentConfig(name, configPath, bodyPath, logger)
-                .SetProperty("type", JsonValue.Create("http")!, requiredForConfiguration: true)
+            var config = new JsonAiAgentConfig(name, configPath, bodyPath, logger)
+                .SetProperty("type", JsonValue.Create(type)!, requiredForConfiguration: true)
                 .SetProperty("url", JsonValue.Create(settings.Host)!, requiredForConfiguration: true, comparison: ValueComparisonMode.Url)
                 .SetPropertyToRemove("command")
                 .SetPropertyToRemove("args");
+            if (disabled.HasValue)
+                config.SetProperty("disabled", JsonValue.Create(disabled.Value)!, requiredForConfiguration: true);
+            return config;
         }
     }
 }

--- a/McpPlugin/src/AgentConfig/AgentConfiguratorDescription.cs
+++ b/McpPlugin/src/AgentConfig/AgentConfiguratorDescription.cs
@@ -30,7 +30,13 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
         /// <summary>A non-editable, copy-pasteable value (command line, JSON/TOML snippet, path).</summary>
         ReadOnlyField,
         /// <summary>An editable value the user can change (the Custom agent's editable config-path).</summary>
-        EditableField
+        EditableField,
+        /// <summary>
+        /// A clickable open-URL link (download / tutorial). The link target lives in
+        /// <see cref="ConfigurationItem.Url"/>; <see cref="ConfigurationItem.Text"/> is the
+        /// display label. Mirrors Unity's download/tutorial links.
+        /// </summary>
+        Link
     }
 
     /// <summary>
@@ -49,10 +55,17 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
         /// </summary>
         public string Text { get; }
 
-        public ConfigurationItem(ConfigurationItemKind kind, string text)
+        /// <summary>
+        /// The open-URL target for a <see cref="ConfigurationItemKind.Link"/> item; null for
+        /// every other kind. <see cref="Text"/> carries the link's display label.
+        /// </summary>
+        public string? Url { get; }
+
+        public ConfigurationItem(ConfigurationItemKind kind, string text, string? url = null)
         {
             Kind = kind;
             Text = text;
+            Url = url;
         }
 
         public static ConfigurationItem Description(string text) => new(ConfigurationItemKind.Description, text);
@@ -60,6 +73,7 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
         public static ConfigurationItem Alert(string text) => new(ConfigurationItemKind.Alert, text);
         public static ConfigurationItem ReadOnlyField(string value) => new(ConfigurationItemKind.ReadOnlyField, value);
         public static ConfigurationItem EditableField(string value) => new(ConfigurationItemKind.EditableField, value);
+        public static ConfigurationItem Link(string label, string url) => new(ConfigurationItemKind.Link, label, url);
     }
 
     /// <summary>
@@ -87,6 +101,22 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
     }
 
     /// <summary>
+    /// The three configuration states a configurator distinguishes for the active transport,
+    /// mirroring Unity's absent / configured-current / configured-but-stale distinction
+    /// (<c>AiAgentConfigurator.IsReconfigureNeeded</c>). Consumers render a "Reconfigure
+    /// needed" alert for <see cref="ReconfigureNeeded"/>.
+    /// </summary>
+    public enum ConfiguratorStatus
+    {
+        /// <summary>No MCP config entry is present on disk for this transport.</summary>
+        NotConfigured,
+        /// <summary>A config entry is present and matches the current settings.</summary>
+        Configured,
+        /// <summary>A config entry is present but is outdated — it no longer matches the current settings.</summary>
+        ReconfigureNeeded
+    }
+
+    /// <summary>
     /// Engine-agnostic description of a configurator's UI for one transport, plus the
     /// agent identity and current status. A consuming engine reads this to render the
     /// agent panel without the shared library taking any UI dependency.
@@ -106,6 +136,20 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
         public bool IsConfigured { get; }
 
         /// <summary>
+        /// The three-state configuration status for the described transport (absent /
+        /// configured-current / configured-but-stale). <see cref="ConfiguratorStatus.ReconfigureNeeded"/>
+        /// means a config entry exists on disk but no longer matches the current settings.
+        /// </summary>
+        public ConfiguratorStatus Status { get; }
+
+        /// <summary>
+        /// Open-URL links the consuming engine should render (download / tutorial). Each item is
+        /// a <see cref="ConfigurationItemKind.Link"/> carrying a label (<see cref="ConfigurationItem.Text"/>)
+        /// and a target (<see cref="ConfigurationItem.Url"/>). Empty when the agent declares none.
+        /// </summary>
+        public IReadOnlyList<ConfigurationItem> Links { get; }
+
+        /// <summary>
         /// Whether the agent's tooling is considered installed/available. Engines that cannot
         /// detect installation leave this false; it is part of the closed status vocabulary so
         /// every engine reports the same shape.
@@ -121,7 +165,9 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
             string? iconName,
             bool isConfigured,
             bool isInstalled,
-            IReadOnlyList<ConfigurationSection> sections)
+            IReadOnlyList<ConfigurationSection> sections,
+            ConfiguratorStatus status = ConfiguratorStatus.NotConfigured,
+            IReadOnlyList<ConfigurationItem>? links = null)
         {
             AgentName = agentName;
             AgentId = agentId;
@@ -129,6 +175,8 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
             IsConfigured = isConfigured;
             IsInstalled = isInstalled;
             Sections = sections;
+            Status = status;
+            Links = links ?? System.Array.Empty<ConfigurationItem>();
         }
     }
 }

--- a/McpPlugin/src/AgentConfig/AiAgentConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/AiAgentConfigurator.cs
@@ -50,6 +50,12 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
         /// <summary>The tutorial URL for configuring the AI agent, or empty if none.</summary>
         public virtual string TutorialUrl => string.Empty;
 
+        /// <summary>The display label for the tutorial link (Unity default "YouTube Tutorial").</summary>
+        public virtual string TutorialLinkLabel => "YouTube Tutorial";
+
+        /// <summary>The display label for the download link.</summary>
+        public virtual string DownloadLinkLabel => "Download";
+
         /// <summary>
         /// Icon file NAME for this agent (e.g. "claude-64.png"), or null when no icon.
         /// Engines resolve the name to bytes themselves — the shared library never carries bytes.
@@ -130,9 +136,51 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
         }
 
         /// <summary>
+        /// Returns the three-state configuration status for the requested transport, mirroring
+        /// Unity's <c>IsReconfigureNeeded</c> logic: a config detected on disk that no longer
+        /// matches the current settings is <see cref="ConfiguratorStatus.ReconfigureNeeded"/>.
+        /// Only the config matching <paramref name="transport"/> is consulted — both transports
+        /// share the same server name, so a correctly-configured HTTP entry would otherwise make
+        /// the STDIO check false-positive (and vice versa).
+        /// </summary>
+        public virtual ConfiguratorStatus GetStatus(
+            AgentConfiguratorSettings settings,
+            Common.Consts.MCP.Server.TransportMethod transport,
+            ILogger? logger = null)
+        {
+            if (IsConfigured(settings, transport, logger))
+                return ConfiguratorStatus.Configured;
+
+            var config = transport == Common.Consts.MCP.Server.TransportMethod.stdio
+                ? GetStdioConfig(settings, logger)
+                : GetHttpConfig(settings, logger);
+
+            return config.IsDetected()
+                ? ConfiguratorStatus.ReconfigureNeeded
+                : ConfiguratorStatus.NotConfigured;
+        }
+
+        /// <summary>
+        /// Builds the open-URL links (download + tutorial) the consuming engine should render,
+        /// mirroring Unity's download/tutorial link emission. The tutorial link is omitted when
+        /// <see cref="TutorialUrl"/> is empty.
+        /// </summary>
+        public virtual IReadOnlyList<ConfigurationItem> BuildLinks()
+        {
+            var links = new List<ConfigurationItem>();
+            if (!string.IsNullOrEmpty(DownloadUrl))
+                links.Add(ConfigurationItem.Link(DownloadLinkLabel, DownloadUrl));
+            if (!string.IsNullOrEmpty(TutorialUrl))
+                links.Add(ConfigurationItem.Link(TutorialLinkLabel, TutorialUrl));
+            return links;
+        }
+
+        /// <summary>
         /// Builds the engine-agnostic UI description for the requested transport. Subclasses
         /// supply the per-transport sections via <see cref="BuildSections"/>; this method wraps
-        /// them with identity + status so every engine sees a uniform shape.
+        /// them with identity + status so every engine sees a uniform shape. When the config is
+        /// detected-but-stale (<see cref="ConfiguratorStatus.ReconfigureNeeded"/>) a
+        /// "Reconfiguration Required" alert section is prepended, mirroring Unity's reconfigure alert.
         /// </summary>
         public AgentConfiguratorDescription Describe(
             AgentConfiguratorSettings settings,
@@ -140,14 +188,30 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
             ILogger? logger = null)
         {
             var sections = BuildSections(settings, transport, logger);
-            var isConfigured = IsConfigured(settings, transport, logger);
+            var status = GetStatus(settings, transport, logger);
+
+            if (status == ConfiguratorStatus.ReconfigureNeeded)
+            {
+                var withAlert = new List<ConfigurationSection>
+                {
+                    new ConfigurationSection("Reconfiguration Required", true, new[]
+                    {
+                        ConfigurationItem.Alert("Connection settings have changed. The existing MCP configuration is outdated and needs to be updated.")
+                    })
+                };
+                withAlert.AddRange(sections);
+                sections = withAlert;
+            }
+
             return new AgentConfiguratorDescription(
                 agentName: AgentName,
                 agentId: AgentId,
                 iconName: IconName,
-                isConfigured: isConfigured,
+                isConfigured: status == ConfiguratorStatus.Configured,
                 isInstalled: false,
-                sections: sections);
+                sections: sections,
+                status: status,
+                links: BuildLinks());
         }
 
         /// <summary>

--- a/McpPlugin/src/AgentConfig/Impl/CustomConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/Impl/CustomConfigurator.cs
@@ -45,6 +45,15 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Impl
         // The custom configurator cannot detect an MCP config on disk.
         public override bool IsConfigured(AgentConfiguratorSettings settings, TransportMethod transport, ILogger? logger = null) => false;
 
+        // No detectable config => always NotConfigured (never stale). Avoids the throwing
+        // CreateStdioConfig/CreateHttpConfig that the base GetStatus would otherwise invoke.
+        public override ConfiguratorStatus GetStatus(AgentConfiguratorSettings settings, TransportMethod transport, ILogger? logger = null)
+            => ConfiguratorStatus.NotConfigured;
+
+        // Mirrors Unity's CustomConfigurator.DisableLinksContainer() — the custom agent emits no
+        // download/tutorial links (its DownloadUrl "NA" is a placeholder, not a real link target).
+        public override IReadOnlyList<ConfigurationItem> BuildLinks() => System.Array.Empty<ConfigurationItem>();
+
         protected override IReadOnlyList<ConfigurationSection> BuildSections(
             AgentConfiguratorSettings settings, TransportMethod transport, ILogger? logger)
         {

--- a/McpPlugin/src/AgentConfig/Impl/KiloCodeConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/Impl/KiloCodeConfigurator.cs
@@ -28,10 +28,10 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Impl
         private static string LocalConfigPath(AgentConfiguratorSettings s) => Path.Combine(s.ProjectRootPath, ".kilocode", "mcp.json");
 
         protected override AiAgentConfig CreateStdioConfig(AgentConfiguratorSettings settings, ILogger? logger)
-            => AgentConfigBuilders.JsonStdio(AgentName, LocalConfigPath(settings), settings, logger);
+            => AgentConfigBuilders.JsonStdio(AgentName, LocalConfigPath(settings), settings, logger, disabled: false);
 
         protected override AiAgentConfig CreateHttpConfig(AgentConfiguratorSettings settings, ILogger? logger)
-            => AgentConfigBuilders.JsonHttp(AgentName, LocalConfigPath(settings), settings, logger);
+            => AgentConfigBuilders.JsonHttp(AgentName, LocalConfigPath(settings), settings, logger, type: "streamable-http", disabled: false);
 
         protected override IReadOnlyList<ConfigurationSection> BuildSections(
             AgentConfiguratorSettings settings, TransportMethod transport, ILogger? logger)

--- a/McpPlugin/src/AgentConfig/Impl/ZooCodeConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/Impl/ZooCodeConfigurator.cs
@@ -28,10 +28,10 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Impl
         private static string LocalConfigPath(AgentConfiguratorSettings s) => Path.Combine(s.ProjectRootPath, ".roo", "mcp.json");
 
         protected override AiAgentConfig CreateStdioConfig(AgentConfiguratorSettings settings, ILogger? logger)
-            => AgentConfigBuilders.JsonStdio(AgentName, LocalConfigPath(settings), settings, logger);
+            => AgentConfigBuilders.JsonStdio(AgentName, LocalConfigPath(settings), settings, logger, disabled: false);
 
         protected override AiAgentConfig CreateHttpConfig(AgentConfiguratorSettings settings, ILogger? logger)
-            => AgentConfigBuilders.JsonHttp(AgentName, LocalConfigPath(settings), settings, logger);
+            => AgentConfigBuilders.JsonHttp(AgentName, LocalConfigPath(settings), settings, logger, type: "streamable-http", disabled: false);
 
         protected override IReadOnlyList<ConfigurationSection> BuildSections(
             AgentConfiguratorSettings settings, TransportMethod transport, ILogger? logger)


### PR DESCRIPTION
## Summary
- **GAP-1 (functional fix):** Kilo Code & Zoo Code now produce byte-identical config to Unity — `disabled=false` on both stdio + http transports and HTTP `type="streamable-http"` (the shared builder previously emitted literal `"http"` and no `disabled`). Extended `AgentConfigBuilders.JsonStdio/JsonHttp` with an optional `disabled` flag + an HTTP `type` override (both `requiredForConfiguration`, so they're part of `IsConfigured` and the written file).
- **GAP-2 (test parity):** restored the TOML inline-comment / typed-array / duplicate / unconfigure / path+url-normalization cases Unity's `TomlAiAgentConfigTests` has that the port had thinned. Ported verbatim (only NUnit→Shouldly/xUnit framework adaptation; data and logic unchanged).
- **GAP-3 (DTO extension):** `AgentConfiguratorDescription` gains an open-URL `Link` `ConfigurationItemKind` (URL + label) and a three-state `ConfiguratorStatus` (NotConfigured / Configured / ReconfigureNeeded). `Describe` populates download/tutorial links and computes stale-detection per Unity's `IsReconfigureNeeded` (`detected && !configured`), prepending a "Reconfiguration Required" alert section when stale. Custom configurator emits no links (mirrors Unity's `DisableLinksContainer`) and is never stale.

No `<Version>` bump (6.8.1 is cut separately, per the issue). Consumers (Unreal/Unity/Godot) render the new kinds later — this PR only adds + populates the DTO in the shared lib.

## Test plan
- [x] `dotnet build McpPlugin.sln --configuration Release` — 0 warnings, 0 errors.
- [x] Full xUnit suite (`McpPlugin.Tests` + `McpPlugin.Server.Tests`, net8.0 + net9.0): **561 + 280 per TFM, 0 failures**. Includes new Kilo/Zoo output tests (disabled=false + streamable-http), the restored TOML matrix, and the DTO link/status tests.

Closes #128