### PR TITLE
feat(agentconfig): port per-agent Troubleshooting + Custom-Docker content into BuildSections

### DIFF
--- a/McpPlugin.Tests/AgentConfig/AgentConfiguratorTroubleshootingTests.cs
+++ b/McpPlugin.Tests/AgentConfig/AgentConfiguratorTroubleshootingTests.cs
@@ -1,0 +1,217 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak)                    │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+using System.IO;
+using System.Linq;
+using com.IvanMurzak.McpPlugin.AgentConfig.Impl;
+using com.IvanMurzak.McpPlugin.Common;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
+{
+    using TransportMethod = Consts.MCP.Server.TransportMethod;
+
+    /// <summary>
+    /// Covers the per-agent Troubleshooting sections and the Custom agent's Docker setup/stop/remove
+    /// commands ported from Unity's configurators (issue #131). The Troubleshooting content is
+    /// appended after the configuration sections by <see cref="AiAgentConfigurator.Describe"/>.
+    /// </summary>
+    public class AgentConfiguratorTroubleshootingTests
+    {
+        private static AgentConfiguratorSettings Settings(string? root = null, string executable = "C:/Tools/srv.exe") => new(
+            operatingSystem: OperatingSystemKind.Windows,
+            projectRootPath: root ?? Path.GetTempPath(),
+            executableFullPath: executable,
+            port: 50000,
+            timeoutMs: 30000,
+            host: "http://localhost:50000/mcp");
+
+        private static ConfigurationSection? Troubleshooting(AiAgentConfigurator c, TransportMethod transport)
+            => c.Describe(Settings(), transport).Sections.FirstOrDefault(s => s.Heading == "Troubleshooting");
+
+        [Theory]
+        [InlineData(TransportMethod.stdio)]
+        [InlineData(TransportMethod.streamableHttp)]
+        public void ClaudeCode_HasTroubleshootingSection(TransportMethod transport)
+        {
+            var section = Troubleshooting(new ClaudeCodeConfigurator(), transport);
+            section.ShouldNotBeNull();
+            section!.ExpandedFirst.ShouldBeFalse();
+            section.Items.ShouldAllBe(i => i.Kind == ConfigurationItemKind.Description);
+            section.Items.ShouldContain(i => i.Text.Contains("Check that the configuration file .mcp.json exists"));
+            section.Items.ShouldContain(i => i.Text.Contains("Restart Claude Code after configuration changes"));
+        }
+
+        [Theory]
+        [InlineData(TransportMethod.stdio)]
+        [InlineData(TransportMethod.streamableHttp)]
+        public void Cursor_HasTroubleshootingSection(TransportMethod transport)
+        {
+            var section = Troubleshooting(new CursorConfigurator(), transport);
+            section.ShouldNotBeNull();
+            section!.Items.ShouldContain(i => i.Text.Contains("'.cursor/mcp.json' file must have no json syntax errors."));
+        }
+
+        [Theory]
+        [InlineData(TransportMethod.stdio)]
+        [InlineData(TransportMethod.streamableHttp)]
+        public void Codex_HasTroubleshootingSection(TransportMethod transport)
+        {
+            var section = Troubleshooting(new CodexConfigurator(), transport);
+            section.ShouldNotBeNull();
+            section!.Items.ShouldContain(i => i.Text.Contains("Ensure Codex CLI is installed and accessible from terminal"));
+        }
+
+        [Fact]
+        public void Gemini_StdioTroubleshooting_HasDebugHint_HttpDoesNot()
+        {
+            var c = new GeminiConfigurator();
+            var stdio = Troubleshooting(c, TransportMethod.stdio);
+            var http = Troubleshooting(c, TransportMethod.streamableHttp);
+
+            stdio.ShouldNotBeNull();
+            http.ShouldNotBeNull();
+            stdio!.Items.ShouldContain(i => i.Text.Contains("--debug flag"));
+            http!.Items.ShouldNotContain(i => i.Text.Contains("--debug flag"));
+        }
+
+        [Fact]
+        public void Kilo_StdioTroubleshooting_HasExecutablePathLine_HttpDoesNot()
+        {
+            var c = new KiloCodeConfigurator();
+            var stdio = Troubleshooting(c, TransportMethod.stdio);
+            var http = Troubleshooting(c, TransportMethod.streamableHttp);
+
+            stdio.ShouldNotBeNull();
+            http.ShouldNotBeNull();
+            stdio!.Items.ShouldContain(i => i.Text.Contains("Check that the executable path is correct."));
+            http!.Items.ShouldNotContain(i => i.Text.Contains("Check that the executable path is correct."));
+        }
+
+        [Fact]
+        public void ClaudeDesktop_HasTroubleshooting_ForStdioOnly()
+        {
+            var c = new ClaudeDesktopConfigurator();
+            Troubleshooting(c, TransportMethod.stdio).ShouldNotBeNull();
+            Troubleshooting(c, TransportMethod.streamableHttp).ShouldBeNull();
+        }
+
+        [Fact]
+        public void Rider_HasTroubleshooting_ForStdioOnly()
+        {
+            var c = new RiderConfigurator();
+            var stdio = Troubleshooting(c, TransportMethod.stdio);
+            stdio.ShouldNotBeNull();
+            stdio!.Items.ShouldContain(i => i.Text.Contains("Restart Rider after configuration changes"));
+            Troubleshooting(c, TransportMethod.streamableHttp).ShouldBeNull();
+        }
+
+        [Fact]
+        public void AllNonCustomAgents_EmitTroubleshooting_OnAtLeastOneTransport()
+        {
+            foreach (var c in AiAgentConfiguratorRegistry.All)
+            {
+                if (c is CustomConfigurator)
+                    continue; // Custom has Docker commands instead of a Troubleshooting foldout (matches Unity).
+
+                var hasAny = Troubleshooting(c, TransportMethod.stdio) != null
+                    || Troubleshooting(c, TransportMethod.streamableHttp) != null;
+                hasAny.ShouldBeTrue($"{c.AgentName} should emit a Troubleshooting section on at least one transport.");
+            }
+        }
+
+        [Fact]
+        public void Troubleshooting_IsAppendedAfterConfigurationSections()
+        {
+            var desc = new ClaudeCodeConfigurator().Describe(Settings(), TransportMethod.stdio);
+            var headings = desc.Sections.Select(s => s.Heading).ToList();
+
+            headings.ShouldContain("Troubleshooting");
+            // Troubleshooting comes after the configuration ("Start" / "Manual Configuration Steps") sections.
+            headings.Last().ShouldBe("Troubleshooting");
+        }
+
+        // ---- Custom agent Docker commands ----
+
+        [Fact]
+        public void Custom_HttpConfiguration_EmitsDockerSetupStartStopRemoveCommands()
+        {
+            var settings = Settings();
+            var desc = new CustomConfigurator().Describe(settings, TransportMethod.streamableHttp);
+            var values = desc.Sections
+                .SelectMany(s => s.Items)
+                .Where(i => i.Kind == ConfigurationItemKind.ReadOnlyField)
+                .Select(i => i.Text)
+                .ToList();
+
+            var container = $"gamedev-mcp-server-{settings.Port}";
+            values.ShouldContain(v => v.StartsWith("docker run -d") && v.Contains(container) && v.Contains("aigamedeveloper/mcp-server:8.0.0"));
+            values.ShouldContain($"docker start {container}");
+            values.ShouldContain($"docker stop {container}");
+            values.ShouldContain($"docker rm {container}");
+        }
+
+        [Fact]
+        public void Custom_DockerSetupRun_IncludesPortMappingAndEnvVars()
+        {
+            var settings = Settings();
+            var cmd = DockerCommands.SetupRun(settings);
+
+            cmd.ShouldContain($"-p {settings.Port}:{settings.Port}");
+            cmd.ShouldContain($"-e {Consts.MCP.Server.Env.Port}={settings.Port}");
+            cmd.ShouldContain($"-e {Consts.MCP.Server.Env.PluginTimeout}={settings.TimeoutMs}");
+            cmd.ShouldContain($"-e {Consts.MCP.Server.Env.ClientTransportMethod}={Consts.MCP.Server.TransportMethod.streamableHttp}");
+        }
+
+        [Fact]
+        public void Custom_DockerSetupRun_IncludesTokenEnvVar_OnlyWhenAuthRequiredWithToken()
+        {
+            var with = new AgentConfiguratorSettings(
+                operatingSystem: OperatingSystemKind.Windows,
+                projectRootPath: Path.GetTempPath(),
+                executableFullPath: "C:/Tools/srv.exe",
+                port: 50000,
+                timeoutMs: 30000,
+                host: "http://localhost:50000/mcp",
+                token: "secret-token",
+                authOption: Consts.MCP.Server.AuthOption.required);
+            DockerCommands.SetupRun(with).ShouldContain($"-e {Consts.MCP.Server.Env.Token}=secret-token");
+
+            // No token => no token env var, even when auth is required.
+            var without = new AgentConfiguratorSettings(
+                operatingSystem: OperatingSystemKind.Windows,
+                projectRootPath: Path.GetTempPath(),
+                executableFullPath: "C:/Tools/srv.exe",
+                port: 50000,
+                timeoutMs: 30000,
+                host: "http://localhost:50000/mcp",
+                authOption: Consts.MCP.Server.AuthOption.required);
+            DockerCommands.SetupRun(without).ShouldNotContain($"-e {Consts.MCP.Server.Env.Token}=");
+        }
+
+        [Fact]
+        public void Custom_DockerImage_RespectsEngineSuppliedVersionAndImage()
+        {
+            var settings = new AgentConfiguratorSettings(
+                operatingSystem: OperatingSystemKind.Windows,
+                projectRootPath: Path.GetTempPath(),
+                executableFullPath: "C:/Tools/srv.exe",
+                port: 12345,
+                timeoutMs: 30000,
+                host: "http://localhost:12345/mcp",
+                serverExecutableName: "custom-server",
+                serverVersion: "9.1.2",
+                dockerImage: "myrepo/mcp");
+
+            DockerCommands.SetupRun(settings).ShouldContain("myrepo/mcp:9.1.2");
+            DockerCommands.Run(settings).ShouldBe("docker start custom-server-12345");
+        }
+    }
+}

--- a/McpPlugin/src/AgentConfig/AgentConfiguratorSettings.cs
+++ b/McpPlugin/src/AgentConfig/AgentConfiguratorSettings.cs
@@ -99,6 +99,26 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
         /// <summary>Whether bearer-token auth is required (independent of cloud enforcement).</summary>
         public Consts.MCP.Server.AuthOption AuthOption { get; }
 
+        /// <summary>
+        /// Base name of the shared MCP server executable / Docker container, used to build the
+        /// Docker container name (<c>{ServerExecutableName}-{Port}</c>). Defaults to Unity's
+        /// <c>gamedev-mcp-server</c>; engines that ship a differently-named server override it.
+        /// </summary>
+        public string ServerExecutableName { get; }
+
+        /// <summary>
+        /// The pinned shared MCP server version, used as the Docker image tag
+        /// (<c>{DockerImage}:{ServerVersion}</c>). Engines pin the server release they download;
+        /// defaults to Unity's currently-pinned <c>8.0.0</c>.
+        /// </summary>
+        public string ServerVersion { get; }
+
+        /// <summary>
+        /// The Docker image repository for the shared MCP server. Defaults to the published
+        /// <c>aigamedeveloper/mcp-server</c> image.
+        /// </summary>
+        public string DockerImage { get; }
+
         public AgentConfiguratorSettings(
             OperatingSystemKind operatingSystem,
             string projectRootPath,
@@ -108,7 +128,10 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
             string host,
             string? token = null,
             ConnectionMode connectionMode = ConnectionMode.Local,
-            Consts.MCP.Server.AuthOption authOption = Consts.MCP.Server.AuthOption.none)
+            Consts.MCP.Server.AuthOption authOption = Consts.MCP.Server.AuthOption.none,
+            string serverExecutableName = "gamedev-mcp-server",
+            string serverVersion = "8.0.0",
+            string dockerImage = "aigamedeveloper/mcp-server")
         {
             OperatingSystem = operatingSystem;
             ProjectRootPath = projectRootPath;
@@ -119,6 +142,9 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
             Token = token;
             ConnectionMode = connectionMode;
             AuthOption = authOption;
+            ServerExecutableName = serverExecutableName;
+            ServerVersion = serverVersion;
+            DockerImage = dockerImage;
         }
 
         /// <summary>
@@ -136,7 +162,10 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
             string host,
             string? token = null,
             ConnectionMode connectionMode = ConnectionMode.Local,
-            Consts.MCP.Server.AuthOption authOption = Consts.MCP.Server.AuthOption.none)
+            Consts.MCP.Server.AuthOption authOption = Consts.MCP.Server.AuthOption.none,
+            string serverExecutableName = "gamedev-mcp-server",
+            string serverVersion = "8.0.0",
+            string dockerImage = "aigamedeveloper/mcp-server")
         {
             return new AgentConfiguratorSettings(
                 operatingSystem: HostOperatingSystem.Detect(),
@@ -147,7 +176,10 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
                 host: host,
                 token: token,
                 connectionMode: connectionMode,
-                authOption: authOption);
+                authOption: authOption,
+                serverExecutableName: serverExecutableName,
+                serverVersion: serverVersion,
+                dockerImage: dockerImage);
         }
 
         /// <summary>True when HTTP authorization should be injected (cloud always requires it).</summary>

--- a/McpPlugin/src/AgentConfig/AiAgentConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/AiAgentConfigurator.cs
@@ -190,6 +190,17 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
             var sections = BuildSections(settings, transport, logger);
             var status = GetStatus(settings, transport, logger);
 
+            // Append the per-agent Troubleshooting section(s) after the configuration sections,
+            // mirroring Unity's per-configurator "Troubleshooting" foldout (emitted last). Agents
+            // that declare none get an empty list and the sections are unchanged.
+            var troubleshooting = BuildTroubleshootingSections(settings, transport, logger);
+            if (troubleshooting.Count > 0)
+            {
+                var withTroubleshooting = new List<ConfigurationSection>(sections);
+                withTroubleshooting.AddRange(troubleshooting);
+                sections = withTroubleshooting;
+            }
+
             if (status == ConfiguratorStatus.ReconfigureNeeded)
             {
                 var withAlert = new List<ConfigurationSection>
@@ -221,6 +232,31 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
             AgentConfiguratorSettings settings,
             Common.Consts.MCP.Server.TransportMethod transport,
             ILogger? logger);
+
+        /// <summary>
+        /// Builds the per-agent "Troubleshooting" section(s) appended after the configuration
+        /// sections by <see cref="Describe"/>. Engine-agnostic port of each Unity configurator's
+        /// "Troubleshooting" foldout content. The base returns an empty list (no troubleshooting);
+        /// each concrete agent overrides it with its ported guidance. The transport is supplied so
+        /// agents whose stdio/http troubleshooting differs can branch on it.
+        /// </summary>
+        protected virtual IReadOnlyList<ConfigurationSection> BuildTroubleshootingSections(
+            AgentConfiguratorSettings settings,
+            Common.Consts.MCP.Server.TransportMethod transport,
+            ILogger? logger)
+            => System.Array.Empty<ConfigurationSection>();
+
+        /// <summary>
+        /// Convenience: wraps a set of plain-text troubleshooting lines into a single collapsed
+        /// "Troubleshooting" section of <see cref="ConfigurationItem.Description"/> items.
+        /// </summary>
+        protected static IReadOnlyList<ConfigurationSection> TroubleshootingSection(params string[] lines)
+        {
+            var items = new ConfigurationItem[lines.Length];
+            for (var i = 0; i < lines.Length; i++)
+                items[i] = ConfigurationItem.Description(lines[i]);
+            return new[] { new ConfigurationSection("Troubleshooting", false, items) };
+        }
 
         /// <summary>
         /// Default single-section description used by agents that simply expose their

--- a/McpPlugin/src/AgentConfig/DockerCommands.cs
+++ b/McpPlugin/src/AgentConfig/DockerCommands.cs
@@ -1,0 +1,65 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using com.IvanMurzak.McpPlugin.Common;
+using static com.IvanMurzak.McpPlugin.Common.Consts.MCP.Server;
+
+namespace com.IvanMurzak.McpPlugin.AgentConfig
+{
+    /// <summary>
+    /// Builds the Docker setup / start / stop / remove commands the Custom configurator surfaces
+    /// for running the shared MCP server in a container. Engine-agnostic port of Unity's
+    /// <c>McpServerManager.DockerSetupRunCommand / DockerRunCommand / DockerStopCommand /
+    /// DockerRemoveCommand</c>; the container name, image, and pinned version come from
+    /// <see cref="AgentConfiguratorSettings"/> so each engine can override them.
+    /// </summary>
+    public static class DockerCommands
+    {
+        /// <summary>The container name (<c>{ServerExecutableName}-{Port}</c>) the commands operate on.</summary>
+        public static string ContainerName(AgentConfiguratorSettings settings)
+            => $"{settings.ServerExecutableName}-{settings.Port}";
+
+        /// <summary>
+        /// First-time setup: <c>docker run -d</c> with port mapping, env vars (transport, port,
+        /// plugin-timeout, authorization, optional token), container name, and the pinned image.
+        /// </summary>
+        public static string SetupRun(AgentConfiguratorSettings settings)
+        {
+            var dockerPortMapping = $"-p {settings.Port}:{settings.Port}";
+            var dockerEnvVars =
+                $"-e {Env.ClientTransportMethod}={TransportMethod.streamableHttp} " +
+                $"-e {Env.Port}={settings.Port} " +
+                $"-e {Env.PluginTimeout}={settings.TimeoutMs} " +
+                $"-e {Env.Authorization}={settings.AuthOption}";
+
+            if (settings.AuthOption == AuthOption.required && !string.IsNullOrEmpty(settings.Token))
+                dockerEnvVars += $" -e {Env.Token}={settings.Token}";
+
+            var dockerContainer = $"--name {ContainerName(settings)}";
+            // The shared GameDev-MCP-Server Docker image, tagged by the pinned ServerVersion
+            // (NOT the plugin version — the two diverge).
+            var dockerImage = $"{settings.DockerImage}:{settings.ServerVersion}";
+            return $"docker run -d {dockerPortMapping} {dockerEnvVars} {dockerContainer} {dockerImage}";
+        }
+
+        /// <summary>Subsequent start of the already-created container.</summary>
+        public static string Run(AgentConfiguratorSettings settings)
+            => $"docker start {ContainerName(settings)}";
+
+        /// <summary>Stop the running container.</summary>
+        public static string Stop(AgentConfiguratorSettings settings)
+            => $"docker stop {ContainerName(settings)}";
+
+        /// <summary>Remove the (stopped) container.</summary>
+        public static string Remove(AgentConfiguratorSettings settings)
+            => $"docker rm {ContainerName(settings)}";
+    }
+}

--- a/McpPlugin/src/AgentConfig/Impl/AntigravityConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/Impl/AntigravityConfigurator.cs
@@ -56,5 +56,11 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Impl
         protected override IReadOnlyList<ConfigurationSection> BuildSections(
             AgentConfiguratorSettings settings, TransportMethod transport, ILogger? logger)
             => DefaultConfigurationSections(settings, transport, logger);
+
+        protected override IReadOnlyList<ConfigurationSection> BuildTroubleshootingSections(
+            AgentConfiguratorSettings settings, TransportMethod transport, ILogger? logger)
+            => TroubleshootingSection(
+                "- Ensure MCP configuration file doesn't have syntax errors",
+                "- Restart Antigravity after configuration changes");
     }
 }

--- a/McpPlugin/src/AgentConfig/Impl/ClaudeCodeConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/Impl/ClaudeCodeConfigurator.cs
@@ -90,5 +90,14 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Impl
                 })
             };
         }
+
+        protected override IReadOnlyList<ConfigurationSection> BuildTroubleshootingSections(
+            AgentConfiguratorSettings settings, TransportMethod transport, ILogger? logger)
+            => TroubleshootingSection(
+                "- Ensure Claude Code CLI is installed and accessible from terminal",
+                "- Ensure Claude Code CLI is started in the same folder where the project is located. This folder must contain the Assets folder inside",
+                "- Ensure Claude Code is configured with the same port as the plugin right now",
+                "- Check that the configuration file .mcp.json exists",
+                "- Restart Claude Code after configuration changes");
     }
 }

--- a/McpPlugin/src/AgentConfig/Impl/ClaudeDesktopConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/Impl/ClaudeDesktopConfigurator.cs
@@ -41,5 +41,17 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Impl
         protected override IReadOnlyList<ConfigurationSection> BuildSections(
             AgentConfiguratorSettings settings, TransportMethod transport, ILogger? logger)
             => DefaultConfigurationSections(settings, transport, logger);
+
+        // Claude Desktop only supports STDIO; Unity emits the Troubleshooting foldout for stdio
+        // only (the HTTP path shows a "no HTTP support" alert instead, no troubleshooting).
+        protected override IReadOnlyList<ConfigurationSection> BuildTroubleshootingSections(
+            AgentConfiguratorSettings settings, TransportMethod transport, ILogger? logger)
+            => transport == TransportMethod.stdio
+                ? TroubleshootingSection(
+                    "- Claude Desktop may launch two MCP server instances instead of one. If you must use Claude Desktop, manually terminate one of the instances. This behavior is unreliable — consider switching to Claude Code.",
+                    "- Claude Desktop may not detect runtime updates to MCP tools. Ensure Claude Desktop reads the MCP tools on startup.",
+                    "- Start the plugin first; the connection status should read 'Connecting...'",
+                    "- Restart Claude Desktop after configuration changes")
+                : System.Array.Empty<ConfigurationSection>();
     }
 }

--- a/McpPlugin/src/AgentConfig/Impl/ClineConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/Impl/ClineConfigurator.cs
@@ -63,5 +63,13 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Impl
         protected override IReadOnlyList<ConfigurationSection> BuildSections(
             AgentConfiguratorSettings settings, TransportMethod transport, ILogger? logger)
             => DefaultConfigurationSections(settings, transport, logger);
+
+        protected override IReadOnlyList<ConfigurationSection> BuildTroubleshootingSections(
+            AgentConfiguratorSettings settings, TransportMethod transport, ILogger? logger)
+            => TroubleshootingSection(
+                "- Ensure the configuration file has no JSON syntax errors.",
+                "- Open Cline settings in VS Code, go to 'MCP Servers' to check server status.",
+                "- The configuration is global and shared across all VS Code projects.",
+                "- Restart VS Code after configuration changes.");
     }
 }

--- a/McpPlugin/src/AgentConfig/Impl/CodexConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/Impl/CodexConfigurator.cs
@@ -132,5 +132,11 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Impl
                 })
             };
         }
+
+        protected override IReadOnlyList<ConfigurationSection> BuildTroubleshootingSections(
+            AgentConfiguratorSettings settings, TransportMethod transport, ILogger? logger)
+            => TroubleshootingSection(
+                "- Ensure Codex CLI is installed and accessible from terminal",
+                "- Restart Codex after configuration changes");
     }
 }

--- a/McpPlugin/src/AgentConfig/Impl/CursorConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/Impl/CursorConfigurator.cs
@@ -37,5 +37,11 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Impl
         protected override IReadOnlyList<ConfigurationSection> BuildSections(
             AgentConfiguratorSettings settings, TransportMethod transport, ILogger? logger)
             => DefaultConfigurationSections(settings, transport, logger);
+
+        protected override IReadOnlyList<ConfigurationSection> BuildTroubleshootingSections(
+            AgentConfiguratorSettings settings, TransportMethod transport, ILogger? logger)
+            => TroubleshootingSection(
+                "- '.cursor/mcp.json' file must have no json syntax errors.",
+                "- Open Cursor settings window, go to 'MCP Servers' to restart ai-game-developer or to get more information about the available MCP tools and the status of the server.");
     }
 }

--- a/McpPlugin/src/AgentConfig/Impl/CustomConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/Impl/CustomConfigurator.cs
@@ -76,9 +76,22 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Impl
             }
             else
             {
-                items.Add(ConfigurationItem.Description("Copy paste the json into your MCP Client to configure it."));
+                // HTTP: walk the user through running the shared MCP server in Docker, then
+                // configuring their client against it. Ported verbatim from Unity's
+                // CustomConfigurator HTTP path (McpServerManager.Docker*Command()).
+                items.Add(ConfigurationItem.Description("1. (First time or after port/version changes) Setup and start the MCP server using Docker."));
+                items.Add(ConfigurationItem.ReadOnlyField(DockerCommands.SetupRun(settings)));
+
+                items.Add(ConfigurationItem.Description("2. (Next time) Start the MCP server using Docker."));
+                items.Add(ConfigurationItem.ReadOnlyField(DockerCommands.Run(settings)));
+
+                items.Add(ConfigurationItem.Description("3. Copy paste the json into your MCP Client to configure it."));
                 items.Add(ConfigurationItem.ReadOnlyField(
                     $"{{\"mcpServers\":{{\"{AiAgentConfig.DefaultMcpServerName}\":{{\"type\":\"http\",\"url\":\"{settings.Host}\"}}}}}}"));
+
+                items.Add(ConfigurationItem.Description("4. (Optional) Stop and remove the MCP server using Docker when you are done."));
+                items.Add(ConfigurationItem.ReadOnlyField(DockerCommands.Stop(settings)));
+                items.Add(ConfigurationItem.ReadOnlyField(DockerCommands.Remove(settings)));
             }
 
             return new[] { new ConfigurationSection("Configuration", true, items) };

--- a/McpPlugin/src/AgentConfig/Impl/GeminiConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/Impl/GeminiConfigurator.cs
@@ -36,5 +36,20 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Impl
         protected override IReadOnlyList<ConfigurationSection> BuildSections(
             AgentConfiguratorSettings settings, TransportMethod transport, ILogger? logger)
             => DefaultConfigurationSections(settings, transport, logger);
+
+        // STDIO carries the extra "--debug flag" hint (it helps the stdio transport work with
+        // Gemini); HTTP omits it. Mirrors Unity's per-transport Troubleshooting content.
+        protected override IReadOnlyList<ConfigurationSection> BuildTroubleshootingSections(
+            AgentConfiguratorSettings settings, TransportMethod transport, ILogger? logger)
+            => transport == TransportMethod.stdio
+                ? TroubleshootingSection(
+                    "- Ensure Gemini CLI is installed and accessible from terminal",
+                    "- Start Gemini with --debug flag, it helps MCP server to work properly with Gemini in stdio transport mode.",
+                    "- Ensure MCP configuration file doesn't have syntax errors",
+                    "- Restart Gemini after configuration changes")
+                : TroubleshootingSection(
+                    "- Ensure Gemini CLI is installed and accessible from terminal",
+                    "- Ensure MCP configuration file doesn't have syntax errors",
+                    "- Restart Gemini after configuration changes");
     }
 }

--- a/McpPlugin/src/AgentConfig/Impl/GitHubCopilotCliConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/Impl/GitHubCopilotCliConfigurator.cs
@@ -43,5 +43,13 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Impl
         protected override IReadOnlyList<ConfigurationSection> BuildSections(
             AgentConfiguratorSettings settings, TransportMethod transport, ILogger? logger)
             => DefaultConfigurationSections(settings, transport, logger);
+
+        protected override IReadOnlyList<ConfigurationSection> BuildTroubleshootingSections(
+            AgentConfiguratorSettings settings, TransportMethod transport, ILogger? logger)
+            => TroubleshootingSection(
+                "- Ensure Copilot CLI is launched from the project root (the folder containing '.mcp.json')",
+                "- Requires GitHub Copilot CLI v1.0.12+ which discovers '.mcp.json' at project level",
+                "- Ensure MCP configuration file doesn't have syntax errors",
+                "- Restart Copilot CLI after configuration changes");
     }
 }

--- a/McpPlugin/src/AgentConfig/Impl/KiloCodeConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/Impl/KiloCodeConfigurator.cs
@@ -36,5 +36,22 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Impl
         protected override IReadOnlyList<ConfigurationSection> BuildSections(
             AgentConfiguratorSettings settings, TransportMethod transport, ILogger? logger)
             => DefaultConfigurationSections(settings, transport, logger);
+
+        // STDIO carries the extra "executable path" line (relevant only when launching the
+        // server binary); HTTP omits it. Mirrors Unity's per-transport Troubleshooting content.
+        protected override IReadOnlyList<ConfigurationSection> BuildTroubleshootingSections(
+            AgentConfiguratorSettings settings, TransportMethod transport, ILogger? logger)
+            => transport == TransportMethod.stdio
+                ? TroubleshootingSection(
+                    "- Ensure the JSON file has no syntax errors.",
+                    "- Check that the executable path is correct.",
+                    "- Verify Kilo Code has MCP support enabled.",
+                    "- The configuration file should be in your project root, next to Assets folder.",
+                    "- Restart Kilo Code after configuration changes")
+                : TroubleshootingSection(
+                    "- Ensure the JSON file has no syntax errors.",
+                    "- Verify Kilo Code has MCP support enabled.",
+                    "- The configuration file should be in your project root, next to Assets folder.",
+                    "- Restart Kilo Code after configuration changes");
     }
 }

--- a/McpPlugin/src/AgentConfig/Impl/OpenCodeConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/Impl/OpenCodeConfigurator.cs
@@ -71,5 +71,12 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Impl
         protected override IReadOnlyList<ConfigurationSection> BuildSections(
             AgentConfiguratorSettings settings, TransportMethod transport, ILogger? logger)
             => DefaultConfigurationSections(settings, transport, logger);
+
+        protected override IReadOnlyList<ConfigurationSection> BuildTroubleshootingSections(
+            AgentConfiguratorSettings settings, TransportMethod transport, ILogger? logger)
+            => TroubleshootingSection(
+                "- Ensure Open Code CLI is installed and accessible from terminal",
+                "- Ensure Open Code CLI is launched from the project root folder (the folder must contain the Assets folder inside)",
+                "- Restart Open Code after configuration changes");
     }
 }

--- a/McpPlugin/src/AgentConfig/Impl/RiderConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/Impl/RiderConfigurator.cs
@@ -98,5 +98,16 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Impl
                 })
             };
         }
+
+        // STDIO only: HTTP is disabled for Rider/Junie (the BuildSections HTTP branch surfaces a
+        // warning instead), so Unity emits the Troubleshooting foldout for stdio only.
+        protected override IReadOnlyList<ConfigurationSection> BuildTroubleshootingSections(
+            AgentConfiguratorSettings settings, TransportMethod transport, ILogger? logger)
+            => transport == TransportMethod.stdio
+                ? TroubleshootingSection(
+                    "- Ensure MCP configuration file doesn't have syntax errors",
+                    "- Restart Rider after configuration changes",
+                    "- If using Terminal, ensure you are in your project root folder.")
+                : System.Array.Empty<ConfigurationSection>();
     }
 }

--- a/McpPlugin/src/AgentConfig/Impl/UnityAiConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/Impl/UnityAiConfigurator.cs
@@ -35,5 +35,11 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Impl
         protected override IReadOnlyList<ConfigurationSection> BuildSections(
             AgentConfiguratorSettings settings, TransportMethod transport, ILogger? logger)
             => DefaultConfigurationSections(settings, transport, logger);
+
+        protected override IReadOnlyList<ConfigurationSection> BuildTroubleshootingSections(
+            AgentConfiguratorSettings settings, TransportMethod transport, ILogger? logger)
+            => TroubleshootingSection(
+                "- 'UserSettings/mcp.json' file must have no json syntax errors.",
+                "- Open Unity AI settings window\n- Go to Edit > Project Settings > AI > MCP Servers\n- Click 'Restart ai-game-developer' button or check the status of the server.");
     }
 }

--- a/McpPlugin/src/AgentConfig/Impl/VisualStudioCodeCopilotConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/Impl/VisualStudioCodeCopilotConfigurator.cs
@@ -37,5 +37,11 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Impl
         protected override IReadOnlyList<ConfigurationSection> BuildSections(
             AgentConfiguratorSettings settings, TransportMethod transport, ILogger? logger)
             => DefaultConfigurationSections(settings, transport, logger);
+
+        protected override IReadOnlyList<ConfigurationSection> BuildTroubleshootingSections(
+            AgentConfiguratorSettings settings, TransportMethod transport, ILogger? logger)
+            => TroubleshootingSection(
+                "- '.vscode/mcp.json' file must have no json syntax errors.",
+                "- Restart Visual Studio Code after configuration changes");
     }
 }

--- a/McpPlugin/src/AgentConfig/Impl/VisualStudioCopilotConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/Impl/VisualStudioCopilotConfigurator.cs
@@ -37,5 +37,12 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Impl
         protected override IReadOnlyList<ConfigurationSection> BuildSections(
             AgentConfiguratorSettings settings, TransportMethod transport, ILogger? logger)
             => DefaultConfigurationSections(settings, transport, logger);
+
+        protected override IReadOnlyList<ConfigurationSection> BuildTroubleshootingSections(
+            AgentConfiguratorSettings settings, TransportMethod transport, ILogger? logger)
+            => TroubleshootingSection(
+                "- '.vs/mcp.json' file must have no json syntax errors.",
+                "- Unity may stay 'Connecting...' until the first prompt sent is processed.",
+                "- Restart Visual Studio after configuration changes");
     }
 }

--- a/McpPlugin/src/AgentConfig/Impl/ZooCodeConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/Impl/ZooCodeConfigurator.cs
@@ -36,5 +36,13 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Impl
         protected override IReadOnlyList<ConfigurationSection> BuildSections(
             AgentConfiguratorSettings settings, TransportMethod transport, ILogger? logger)
             => DefaultConfigurationSections(settings, transport, logger);
+
+        protected override IReadOnlyList<ConfigurationSection> BuildTroubleshootingSections(
+            AgentConfiguratorSettings settings, TransportMethod transport, ILogger? logger)
+            => TroubleshootingSection(
+                "- Ensure the JSON file has no syntax errors.",
+                "- Verify Zoo Code has MCP support enabled.",
+                "- The configuration file should be in your project root, next to Assets folder.",
+                "- Restart Zoo Code after configuration changes.");
     }
 }


### PR DESCRIPTION
## Summary
- Port Unity's authoritative per-agent **Troubleshooting** UI content and the Custom agent's **Docker** setup/start/stop/remove commands into the engine-agnostic shared `AgentConfig` configurators (the T1 extraction had dropped both).
- Add a virtual `BuildTroubleshootingSections()` hook to `AiAgentConfigurator`; `Describe()` appends it after the configuration sections (mirroring Unity's collapsed "Troubleshooting" foldout, emitted last). All 15 non-Custom agents override it with Unity's exact wording/order, branching per transport where Unity does (Gemini stdio `--debug`, Kilo stdio executable-path line; Claude Desktop & Rider emit it for stdio only).
- Add a `DockerCommands` helper (SetupRun/Run/Stop/Remove) mirroring Unity's `McpServerManager.Docker*Command()`, plus engine-supplied `ServerExecutableName` / `ServerVersion` / `DockerImage` on `AgentConfiguratorSettings` (defaults match Unity: `gamedev-mcp-server` / `8.0.0` / `aigamedeveloper/mcp-server`). Custom's HTTP path now emits the full 4-step Docker flow.
- All content expressed with the existing DTO kinds (`Description` / `ReadOnlyField`) — no new `ConfigurationItemKind` was needed.

## Test plan
- [x] Target-specific local tests passed (see profile test.md): full xUnit suite green across `McpPlugin.Tests` + `McpPlugin.Server.Tests` on net8.0 + net9.0 (280 + 582 tests each TFM, 0 failures).
- [x] New `AgentConfiguratorTroubleshootingTests` (16 tests/TFM) assert Troubleshooting presence + ordering per agent/transport and the Custom agent's Docker commands.

Closes #131