### PR TITLE
feat(auth): ProjectIdentity, machine credential store, and project marker (mcp-authorize b1)

### DIFF
--- a/McpPlugin.Tests/AgentConfig/MachineCredentialStoreTests.cs
+++ b/McpPlugin.Tests/AgentConfig/MachineCredentialStoreTests.cs
@@ -1,0 +1,203 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+using com.IvanMurzak.McpPlugin.AgentConfig;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
+{
+    /// <summary>
+    /// Coverage for the shared machine credential store: read/write/rotate/delete round-trips, the
+    /// co-located JWKS cache, and the per-OS at-rest protection — <c>0600</c> file / <c>0700</c>
+    /// directory on POSIX (exercised on Linux CI) and DPAPI encryption on Windows (exercised locally).
+    /// </summary>
+    public sealed class MachineCredentialStoreTests : IDisposable
+    {
+        private const string SecretAccessToken = "eyJ.SECRET-ACCESS-TOKEN.zzz";
+        private const string SecretRefreshToken = "RT-SECRET-REFRESH-abcdef";
+
+        private static bool IsWindows => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+        private readonly string _baseDir;
+
+        public MachineCredentialStoreTests()
+        {
+            _baseDir = Path.Combine(Path.GetTempPath(), "agd-store-" + Guid.NewGuid().ToString("N"), ".ai-game-dev");
+        }
+
+        public void Dispose()
+        {
+            var parent = Path.GetDirectoryName(_baseDir);
+            if (parent != null && Directory.Exists(parent))
+                Directory.Delete(parent, recursive: true);
+        }
+
+        private MachineCredentialStore NewStore() => new MachineCredentialStore(_baseDir);
+
+        private static MachineCredentials SampleCredentials() => new MachineCredentials
+        {
+            AccessToken = SecretAccessToken,
+            RefreshToken = SecretRefreshToken,
+            ExpiresAt = new DateTimeOffset(2030, 1, 2, 3, 4, 5, TimeSpan.Zero),
+            ServerTarget = "https://ai-game.dev",
+            Subject = "account-uuid-123",
+        };
+
+        [Fact]
+        public void Read_ReturnsNull_WhenNoCredentials()
+        {
+            NewStore().Read().ShouldBeNull();
+        }
+
+        [Fact]
+        public void Write_ThenRead_RoundTripsAllFields()
+        {
+            var store = NewStore();
+            store.Write(SampleCredentials());
+
+            var read = store.Read();
+            read.ShouldNotBeNull();
+            read!.AccessToken.ShouldBe(SecretAccessToken);
+            read.RefreshToken.ShouldBe(SecretRefreshToken);
+            read.ExpiresAt.ShouldBe(new DateTimeOffset(2030, 1, 2, 3, 4, 5, TimeSpan.Zero));
+            read.ServerTarget.ShouldBe("https://ai-game.dev");
+            read.Subject.ShouldBe("account-uuid-123");
+            read.Version.ShouldBe(1);
+        }
+
+        [Fact]
+        public void Rotate_UpdatesTokens_PreservesIdentityFields()
+        {
+            var store = NewStore();
+            store.Write(SampleCredentials());
+
+            var rotated = store.Rotate(
+                accessToken: "NEW-ACCESS",
+                refreshToken: "NEW-REFRESH",
+                expiresAt: new DateTimeOffset(2031, 6, 7, 8, 9, 10, TimeSpan.Zero));
+
+            rotated.AccessToken.ShouldBe("NEW-ACCESS");
+            rotated.RefreshToken.ShouldBe("NEW-REFRESH");
+
+            var read = store.Read();
+            read!.AccessToken.ShouldBe("NEW-ACCESS");
+            read.RefreshToken.ShouldBe("NEW-REFRESH");
+            read.ExpiresAt.ShouldBe(new DateTimeOffset(2031, 6, 7, 8, 9, 10, TimeSpan.Zero));
+            // Identity fields survive a rotation.
+            read.ServerTarget.ShouldBe("https://ai-game.dev");
+            read.Subject.ShouldBe("account-uuid-123");
+        }
+
+        [Fact]
+        public void Rotate_OnEmptyStore_CreatesCredentials()
+        {
+            var store = NewStore();
+            store.Read().ShouldBeNull();
+
+            store.Rotate("A", "R");
+
+            var read = store.Read();
+            read.ShouldNotBeNull();
+            read!.AccessToken.ShouldBe("A");
+            read.RefreshToken.ShouldBe("R");
+        }
+
+        [Fact]
+        public void Delete_RemovesCredentials()
+        {
+            var store = NewStore();
+            store.Write(SampleCredentials());
+            store.Exists.ShouldBeTrue();
+
+            store.Delete();
+
+            store.Exists.ShouldBeFalse();
+            store.Read().ShouldBeNull();
+            Should.NotThrow(() => store.Delete()); // idempotent
+        }
+
+        [Fact]
+        public void JwksCache_RoundTrips_AndIsSeparateFromCredentials()
+        {
+            var store = NewStore();
+            const string jwks = "{\"keys\":[{\"kid\":\"k1\",\"kty\":\"EC\"}]}";
+
+            store.ReadJwksCache().ShouldBeNull();
+            store.WriteJwksCache(jwks);
+
+            store.ReadJwksCache().ShouldBe(jwks);
+            store.JwksCachePath.ShouldEndWith("jwks-cache.json");
+            store.JwksCachePath.ShouldNotBe(store.CredentialsPath);
+        }
+
+        [Fact]
+        public void PosixPermissions_CredentialsAre0600_DirectoryIs0700()
+        {
+            if (OperatingSystem.IsWindows())
+                return; // POSIX-only assertion; exercised on Linux CI. (analyzer-recognized guard for CA1416)
+
+            var store = NewStore();
+            store.Write(SampleCredentials());
+
+            var fileMode = File.GetUnixFileMode(store.CredentialsPath);
+            fileMode.ShouldBe(UnixFileMode.UserRead | UnixFileMode.UserWrite); // 0600 — no group/other bits
+
+            var dirMode = File.GetUnixFileMode(store.BaseDirectory);
+            dirMode.ShouldBe(UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute); // 0700
+        }
+
+        [Fact]
+        public void Posix_StoresPlaintextJson_ProtectedByPermissions()
+        {
+            if (IsWindows)
+                return; // POSIX stores plaintext (guarded by 0600); Windows uses DPAPI — see below.
+
+            var store = NewStore();
+            store.Write(SampleCredentials());
+
+            var onDisk = File.ReadAllText(store.CredentialsPath);
+            onDisk.ShouldContain(SecretAccessToken); // plaintext JSON on POSIX
+        }
+
+        [Fact]
+        public void Windows_Dpapi_EncryptsCredentialsAtRest()
+        {
+            if (!IsWindows)
+                return; // Windows-only assertion; exercised on a Windows dev machine.
+
+            var store = NewStore();
+            store.Write(SampleCredentials());
+
+            var onDiskBytes = File.ReadAllBytes(store.CredentialsPath);
+            var onDiskText = Encoding.UTF8.GetString(onDiskBytes);
+
+            // The secret must NOT appear in plaintext on disk (DPAPI-encrypted).
+            onDiskText.ShouldNotContain(SecretAccessToken);
+            onDiskText.ShouldNotContain(SecretRefreshToken);
+
+            // ...yet a round-trip through the store still recovers it.
+            store.Read()!.AccessToken.ShouldBe(SecretAccessToken);
+        }
+
+        [Fact]
+        public void DefaultBaseDirectory_IsUnderUserProfile_DotAiGameDev()
+        {
+            var store = new MachineCredentialStore();
+            var expected = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                ".ai-game-dev");
+            store.BaseDirectory.ShouldBe(expected);
+        }
+    }
+}

--- a/McpPlugin.Tests/AgentConfig/ProjectIdentityGoldenVectorTests.cs
+++ b/McpPlugin.Tests/AgentConfig/ProjectIdentityGoldenVectorTests.cs
@@ -1,0 +1,194 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using com.IvanMurzak.McpPlugin.AgentConfig;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
+{
+    /// <summary>
+    /// Verifies <see cref="ProjectIdentity"/> against the committed cross-language golden-vector file
+    /// and against the shipped Unity <c>GeneratePortFromDirectory</c> algorithm (port compatibility
+    /// gate). Also covers the C# <c>ToLowerInvariant</c> vs JS <c>toLowerCase()</c> Unicode divergence
+    /// and the user port-override precedence.
+    /// </summary>
+    public class ProjectIdentityGoldenVectorTests
+    {
+        private const string GoldenFileName = "ProjectIdentity.GoldenVectors.json";
+
+        private static string GoldenFilePath => Path.Combine(AppContext.BaseDirectory, GoldenFileName);
+
+        public static IEnumerable<object[]> GoldenVectors()
+        {
+            using var doc = JsonDocument.Parse(File.ReadAllText(GoldenFilePath));
+            foreach (var v in doc.RootElement.GetProperty("vectors").EnumerateArray())
+            {
+                yield return new object[]
+                {
+                    v.GetProperty("path").GetString()!,
+                    v.GetProperty("pin").GetString()!,
+                    v.GetProperty("port").GetInt32(),
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GoldenVectors))]
+        public void ProjectIdentity_ReproducesEveryGoldenVector(string path, string expectedPin, int expectedPort)
+        {
+            ProjectIdentity.DerivePin(path).ShouldBe(expectedPin);
+            ProjectIdentity.DerivePort(path).ShouldBe(expectedPort);
+
+            var id = ProjectIdentity.Derive(path);
+            id.Pin.ShouldBe(expectedPin);
+            id.Port.ShouldBe(expectedPort);
+            id.PortIsOverridden.ShouldBeFalse();
+        }
+
+        [Theory]
+        [MemberData(nameof(GoldenVectors))]
+        public void EveryGoldenVector_HasValidPinAndPortShape(string path, string expectedPin, int expectedPort)
+        {
+            _ = path;
+            expectedPin.Length.ShouldBe(ProjectIdentity.PinLength);
+            foreach (var c in expectedPin)
+                ((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')).ShouldBeTrue($"pin '{expectedPin}' must be lowercase hex");
+
+            expectedPort.ShouldBeInRange(ProjectIdentity.MinPort, ProjectIdentity.MaxPort);
+        }
+
+        [Theory]
+        [MemberData(nameof(GoldenVectors))]
+        public void DerivedPort_ByteMatchesUnityGeneratePortFromDirectory_ForExistingProjectPaths(
+            string path, string expectedPin, int expectedPort)
+        {
+            _ = expectedPin;
+            _ = expectedPort;
+
+            // The port-compatibility gate: for an existing project path (as Unity reports it via
+            // Environment.CurrentDirectory — no trailing separator), our derived port must equal
+            // the shipped Unity algorithm byte-for-byte. Trailing-separator variants are not paths
+            // Unity would ever hash (its CurrentDirectory never has one), so they are covered by the
+            // trimming test below instead.
+            if (HasTrailingSeparator(path))
+                return;
+
+            ProjectIdentity.DerivePort(path).ShouldBe(UnityGeneratePortFromDirectory(path));
+        }
+
+        [Fact]
+        public void TrailingSeparator_IsTrimmed_SameIdentityAsWithout()
+        {
+            ProjectIdentity.DerivePin("/home/user/my-game/").ShouldBe(ProjectIdentity.DerivePin("/home/user/my-game"));
+            ProjectIdentity.DerivePort("/home/user/my-game/").ShouldBe(ProjectIdentity.DerivePort("/home/user/my-game"));
+
+            var backslash = "C:" + Bs + "Games" + Bs + "proj";
+            ProjectIdentity.DerivePort(backslash + Bs).ShouldBe(ProjectIdentity.DerivePort(backslash));
+        }
+
+        [Fact]
+        public void Separators_AreNotNormalized_ForwardAndBackslashDiffer()
+        {
+            var forward = "C:/Users/user/my-game";
+            var backslash = "C:" + Bs + "Users" + Bs + "user" + Bs + "my-game";
+            ProjectIdentity.DerivePort(forward).ShouldNotBe(ProjectIdentity.DerivePort(backslash));
+        }
+
+        [Fact]
+        public void CaseFolding_IsApplied()
+        {
+            ProjectIdentity.DerivePin("/HOME/User/My-Game").ShouldBe(ProjectIdentity.DerivePin("/home/user/my-game"));
+        }
+
+        [Fact]
+        public void PortOverride_AlwaysWins_PinUnchanged()
+        {
+            const string path = "/home/user/my-game";
+            var overridden = ProjectIdentity.Derive(path, portOverride: 12345);
+
+            overridden.Port.ShouldBe(12345);
+            overridden.PortIsOverridden.ShouldBeTrue();
+            overridden.Pin.ShouldBe(ProjectIdentity.DerivePin(path)); // pin is never affected by the override
+        }
+
+        [Fact]
+        public void Derive_WithMarker_UsesMarkerPortOverride()
+        {
+            const string path = "/home/user/my-game";
+
+            var withOverride = ProjectIdentity.Derive(path, new ProjectMarker { PortOverride = 26000 });
+            withOverride.Port.ShouldBe(26000);
+            withOverride.PortIsOverridden.ShouldBeTrue();
+
+            var noOverride = ProjectIdentity.Derive(path, new ProjectMarker { ServerTarget = "https://ai-game.dev" });
+            noOverride.Port.ShouldBe(ProjectIdentity.DerivePort(path));
+            noOverride.PortIsOverridden.ShouldBeFalse();
+
+            var nullMarker = ProjectIdentity.Derive(path, (ProjectMarker?)null);
+            nullMarker.Port.ShouldBe(ProjectIdentity.DerivePort(path));
+        }
+
+        [Fact]
+        public void UnicodeDivergence_CanonicalIsCSharp_AndDiffersFromNaiveJs()
+        {
+            using var doc = JsonDocument.Parse(File.ReadAllText(GoldenFilePath));
+            foreach (var c in doc.RootElement.GetProperty("unicodeDivergence").GetProperty("cases").EnumerateArray())
+            {
+                var path = c.GetProperty("path").GetString()!;
+                var canonical = c.GetProperty("canonical");
+                var jsNaive = c.GetProperty("jsNaiveToLowerCase");
+
+                // The C# reference IS the canonical value.
+                ProjectIdentity.DerivePin(path).ShouldBe(canonical.GetProperty("pin").GetString());
+                ProjectIdentity.DerivePort(path).ShouldBe(canonical.GetProperty("port").GetInt32());
+
+                // ...and it genuinely differs from what a naive JS toLowerCase() port would produce,
+                // proving the divergence is real and must be special-cased by the TS port.
+                ProjectIdentity.DerivePort(path).ShouldNotBe(jsNaive.GetProperty("port").GetInt32());
+                ProjectIdentity.DerivePin(path).ShouldNotBe(jsNaive.GetProperty("pin").GetString());
+            }
+        }
+
+        [Fact]
+        public void Derive_NullPath_Throws()
+        {
+            Should.Throw<ArgumentNullException>(() => ProjectIdentity.Derive(null!));
+        }
+
+        private static string Bs => ((char)92).ToString();
+
+        private static bool HasTrailingSeparator(string path)
+            => path.Length > 0 && (path[path.Length - 1] == '/' || path[path.Length - 1] == '\\');
+
+        /// <summary>
+        /// Verbatim copy of the shipped Unity <c>UnityMcpPlugin.GeneratePortFromDirectory()</c> body
+        /// (Runtime/UnityMcpPlugin.cs), used as the external truth for the byte-match gate. Kept
+        /// deliberately independent of <see cref="ProjectIdentity"/> so the gate would catch any drift.
+        /// </summary>
+        private static int UnityGeneratePortFromDirectory(string dir)
+        {
+            const int MinPort = 20000;
+            const int MaxPort = 29999;
+            const int PortRange = MaxPort - MinPort + 1;
+
+            var currentDir = dir.ToLowerInvariant();
+            using var sha256 = SHA256.Create();
+            var hashBytes = sha256.ComputeHash(Encoding.UTF8.GetBytes(currentDir));
+            var hash = (uint)BitConverter.ToInt32(hashBytes, 0);
+            return MinPort + (int)(hash % PortRange);
+        }
+    }
+}

--- a/McpPlugin.Tests/AgentConfig/ProjectMarkerTests.cs
+++ b/McpPlugin.Tests/AgentConfig/ProjectMarkerTests.cs
@@ -1,0 +1,118 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+using System;
+using System.IO;
+using com.IvanMurzak.McpPlugin.AgentConfig;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
+{
+    /// <summary>
+    /// Round-trip + precedence coverage for the committable project marker
+    /// <c>&lt;project&gt;/.ai-game-dev/project.json</c>.
+    /// </summary>
+    public sealed class ProjectMarkerTests : IDisposable
+    {
+        private readonly string _projectRoot;
+
+        public ProjectMarkerTests()
+        {
+            _projectRoot = Path.Combine(Path.GetTempPath(), "agd-marker-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_projectRoot);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(_projectRoot))
+                Directory.Delete(_projectRoot, recursive: true);
+        }
+
+        [Fact]
+        public void PathFor_IsUnderDotAiGameDev()
+        {
+            var path = ProjectMarker.PathFor(_projectRoot);
+            path.ShouldBe(Path.Combine(_projectRoot, ".ai-game-dev", "project.json"));
+        }
+
+        [Fact]
+        public void Read_ReturnsNull_WhenMarkerAbsent()
+        {
+            ProjectMarker.Read(_projectRoot).ShouldBeNull();
+        }
+
+        [Fact]
+        public void Write_ThenRead_RoundTripsAllFields()
+        {
+            var marker = new ProjectMarker
+            {
+                ServerTarget = "https://ai-game.dev",
+                PortOverride = 26123,
+            };
+            marker.Write(_projectRoot);
+
+            File.Exists(ProjectMarker.PathFor(_projectRoot)).ShouldBeTrue();
+
+            var read = ProjectMarker.Read(_projectRoot);
+            read.ShouldNotBeNull();
+            read!.ServerTarget.ShouldBe("https://ai-game.dev");
+            read.PortOverride.ShouldBe(26123);
+        }
+
+        [Fact]
+        public void Write_CreatesDotAiGameDevDirectory()
+        {
+            new ProjectMarker { ServerTarget = "https://ai-game.dev" }.Write(_projectRoot);
+            Directory.Exists(Path.Combine(_projectRoot, ".ai-game-dev")).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void PortOverride_IsOmitted_WhenNull()
+        {
+            new ProjectMarker { ServerTarget = "https://ai-game.dev" }.Write(_projectRoot);
+
+            var json = File.ReadAllText(ProjectMarker.PathFor(_projectRoot));
+            json.ShouldNotContain("portOverride");
+
+            var read = ProjectMarker.Read(_projectRoot);
+            read!.PortOverride.ShouldBeNull();
+        }
+
+        [Fact]
+        public void OverridePrecedence_MarkerPortWins_OverDerivedPort()
+        {
+            var projectPath = "/home/user/my-game";
+            var derived = ProjectIdentity.Derive(projectPath); // no override
+            derived.PortIsOverridden.ShouldBeFalse();
+
+            new ProjectMarker { PortOverride = 27500 }.Write(_projectRoot);
+            var marker = ProjectMarker.Read(_projectRoot);
+
+            var resolved = ProjectIdentity.Derive(projectPath, marker);
+            resolved.Port.ShouldBe(27500);
+            resolved.Port.ShouldNotBe(derived.Port);
+            resolved.PortIsOverridden.ShouldBeTrue();
+            resolved.Pin.ShouldBe(derived.Pin); // pin still derived from the path, not the override
+        }
+
+        [Fact]
+        public void Read_ToleratesEmptyFile()
+        {
+            var path = ProjectMarker.PathFor(_projectRoot);
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            File.WriteAllText(path, string.Empty);
+
+            var read = ProjectMarker.Read(_projectRoot);
+            read.ShouldNotBeNull();
+            read!.ServerTarget.ShouldBeNull();
+            read.PortOverride.ShouldBeNull();
+        }
+    }
+}

--- a/McpPlugin.Tests/McpPlugin.Tests.csproj
+++ b/McpPlugin.Tests/McpPlugin.Tests.csproj
@@ -22,4 +22,10 @@
     <ProjectReference Include="../McpPlugin/McpPlugin.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Committed cross-language golden vectors for ProjectIdentity; copied next to the test
+         assembly so ProjectIdentityGoldenVectorTests can load them at runtime. -->
+    <None Include="../McpPlugin/src/AgentConfig/ProjectIdentity.GoldenVectors.json" Link="ProjectIdentity.GoldenVectors.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
 </Project>

--- a/McpPlugin/src/AgentConfig/MachineCredentialStore.cs
+++ b/McpPlugin/src/AgentConfig/MachineCredentialStore.cs
@@ -1,0 +1,269 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace com.IvanMurzak.McpPlugin.AgentConfig
+{
+    /// <summary>
+    /// The shared machine credential store at <c>~/.ai-game-dev/</c> — a single per-machine home for
+    /// the ai-game.dev account credential (<c>credentials.json</c>) and the co-located public JWKS
+    /// cache (<c>jwks-cache.json</c>). Engines, CLIs, and the local server all read this store, so
+    /// sign-in happens once per machine.
+    ///
+    /// <para><b>At-rest protection (security-critical):</b></para>
+    /// <list type="bullet">
+    ///   <item><b>POSIX</b> — <c>credentials.json</c> is written plaintext with <c>0600</c> permissions,
+    ///         inside a <c>0700</c> directory.</item>
+    ///   <item><b>Windows</b> — <c>credentials.json</c> content is DPAPI-encrypted with the current
+    ///         user's key (<c>CryptProtectData</c>, <c>CRYPTPROTECT_UI_FORBIDDEN</c>) so the on-disk
+    ///         bytes are never plaintext.</item>
+    /// </list>
+    ///
+    /// <para>The JWKS cache holds only public signing keys, so it is stored plaintext (still inside the
+    /// user-only directory). Credentials are NEVER written to a project file / VCS.</para>
+    /// </summary>
+    public sealed class MachineCredentialStore
+    {
+        /// <summary>Directory name under the user home that holds the store.</summary>
+        public const string DirectoryName = ".ai-game-dev";
+
+        /// <summary>File name of the secret credential document.</summary>
+        public const string CredentialsFileName = "credentials.json";
+
+        /// <summary>File name of the co-located public JWKS cache.</summary>
+        public const string JwksCacheFileName = "jwks-cache.json";
+
+        // 0600 (owner rw) and 0700 (owner rwx) as binary bit-patterns — C# has no octal literals.
+        private const uint PosixFilePermissions = 0b110_000_000;      // rw- --- ---
+        private const uint PosixDirectoryPermissions = 0b111_000_000; // rwx --- ---
+        private const int CRYPTPROTECT_UI_FORBIDDEN = 0x1;
+
+        private static readonly JsonSerializerOptions SerializerOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            PropertyNameCaseInsensitive = true,
+            WriteIndented = true,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        };
+
+        private readonly string _baseDirectory;
+
+        /// <summary>
+        /// Create a store rooted at <paramref name="baseDirectory"/>, or at <c>~/.ai-game-dev</c> when
+        /// null. The override exists for tests and for the <c>--project</c> per-project store; production
+        /// callers use the default machine store.
+        /// </summary>
+        public MachineCredentialStore(string? baseDirectory = null)
+        {
+            _baseDirectory = baseDirectory ?? Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                DirectoryName);
+        }
+
+        /// <summary>Absolute path of the store directory.</summary>
+        public string BaseDirectory => _baseDirectory;
+
+        /// <summary>Absolute path of the secret credential file.</summary>
+        public string CredentialsPath => Path.Combine(_baseDirectory, CredentialsFileName);
+
+        /// <summary>Absolute path of the public JWKS cache file.</summary>
+        public string JwksCachePath => Path.Combine(_baseDirectory, JwksCacheFileName);
+
+        /// <summary>True when a credential file exists in the store.</summary>
+        public bool Exists => File.Exists(CredentialsPath);
+
+        /// <summary>
+        /// Read and decrypt the stored credentials, or <c>null</c> when none are present.
+        /// </summary>
+        public MachineCredentials? Read()
+        {
+            if (!File.Exists(CredentialsPath))
+                return null;
+
+            var raw = File.ReadAllBytes(CredentialsPath);
+            if (raw.Length == 0)
+                return null;
+
+            var plaintext = IsWindows ? Unprotect(raw) : raw;
+            var json = Encoding.UTF8.GetString(plaintext);
+            if (string.IsNullOrWhiteSpace(json))
+                return null;
+
+            return JsonSerializer.Deserialize<MachineCredentials>(json, SerializerOptions);
+        }
+
+        /// <summary>
+        /// Encrypt (Windows) / restrict (POSIX) and write <paramref name="credentials"/> to the store,
+        /// creating the store directory with owner-only permissions if needed.
+        /// </summary>
+        public void Write(MachineCredentials credentials)
+        {
+            if (credentials == null)
+                throw new ArgumentNullException(nameof(credentials));
+
+            EnsureBaseDirectory();
+
+            var json = JsonSerializer.Serialize(credentials, SerializerOptions);
+            var plaintext = Encoding.UTF8.GetBytes(json);
+            var bytes = IsWindows ? Protect(plaintext) : plaintext;
+
+            File.WriteAllBytes(CredentialsPath, bytes);
+            SetPosixPermissions(CredentialsPath, PosixFilePermissions);
+        }
+
+        /// <summary>
+        /// Replace the token material (access + refresh + expiry) while preserving the stored identity
+        /// fields (<see cref="MachineCredentials.ServerTarget"/> / <see cref="MachineCredentials.Subject"/>),
+        /// then persist. Returns the written credentials.
+        /// </summary>
+        public MachineCredentials Rotate(string accessToken, string refreshToken, DateTimeOffset? expiresAt = null)
+        {
+            var current = Read() ?? new MachineCredentials();
+            current.AccessToken = accessToken;
+            current.RefreshToken = refreshToken;
+            current.ExpiresAt = expiresAt;
+            Write(current);
+            return current;
+        }
+
+        /// <summary>Delete the stored credentials (sign-out). No-op when none exist.</summary>
+        public void Delete()
+        {
+            if (File.Exists(CredentialsPath))
+                File.Delete(CredentialsPath);
+        }
+
+        /// <summary>Read the cached JWKS document (public keys), or <c>null</c> when not cached.</summary>
+        public string? ReadJwksCache()
+        {
+            return File.Exists(JwksCachePath) ? File.ReadAllText(JwksCachePath) : null;
+        }
+
+        /// <summary>Write the JWKS document (public keys; plaintext) into the store.</summary>
+        public void WriteJwksCache(string jwksJson)
+        {
+            if (jwksJson == null)
+                throw new ArgumentNullException(nameof(jwksJson));
+
+            EnsureBaseDirectory();
+            File.WriteAllText(JwksCachePath, jwksJson);
+        }
+
+        private void EnsureBaseDirectory()
+        {
+            Directory.CreateDirectory(_baseDirectory);
+            SetPosixPermissions(_baseDirectory, PosixDirectoryPermissions);
+        }
+
+        private static bool IsWindows => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+        private static void SetPosixPermissions(string path, uint mode)
+        {
+#if NET8_0_OR_GREATER
+            // OperatingSystem.IsWindows() is recognised by the platform-compatibility analyzer as a
+            // guard for File.SetUnixFileMode (CA1416); the custom IsWindows property is not.
+            if (OperatingSystem.IsWindows())
+                return;
+            File.SetUnixFileMode(path, (UnixFileMode)mode);
+#else
+            if (IsWindows)
+                return;
+            _ = chmod(path, mode);
+#endif
+        }
+
+#if !NET8_0_OR_GREATER
+        [DllImport("libc", EntryPoint = "chmod", SetLastError = true)]
+        private static extern int chmod(string path, uint mode);
+#endif
+
+        // ── Windows DPAPI (CryptProtectData / CryptUnprotectData) via P/Invoke ───────────────────
+        // Self-contained (no NuGet dependency added to this Unity-consumed library). Only invoked on
+        // Windows; the DllImports compile on every TFM but are never called on POSIX.
+
+        private static byte[] Protect(byte[] data)
+        {
+            var inBlob = new DATA_BLOB();
+            var outBlob = new DATA_BLOB();
+            try
+            {
+                inBlob.pbData = Marshal.AllocHGlobal(data.Length);
+                inBlob.cbData = data.Length;
+                Marshal.Copy(data, 0, inBlob.pbData, data.Length);
+
+                if (!CryptProtectData(ref inBlob, "ai-game-dev credentials", IntPtr.Zero, IntPtr.Zero,
+                        IntPtr.Zero, CRYPTPROTECT_UI_FORBIDDEN, ref outBlob))
+                    throw new CryptographicException(Marshal.GetLastWin32Error());
+
+                var result = new byte[outBlob.cbData];
+                Marshal.Copy(outBlob.pbData, result, 0, outBlob.cbData);
+                return result;
+            }
+            finally
+            {
+                if (inBlob.pbData != IntPtr.Zero) Marshal.FreeHGlobal(inBlob.pbData);
+                if (outBlob.pbData != IntPtr.Zero) LocalFree(outBlob.pbData);
+            }
+        }
+
+        private static byte[] Unprotect(byte[] data)
+        {
+            var inBlob = new DATA_BLOB();
+            var outBlob = new DATA_BLOB();
+            try
+            {
+                inBlob.pbData = Marshal.AllocHGlobal(data.Length);
+                inBlob.cbData = data.Length;
+                Marshal.Copy(data, 0, inBlob.pbData, data.Length);
+
+                if (!CryptUnprotectData(ref inBlob, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero,
+                        IntPtr.Zero, CRYPTPROTECT_UI_FORBIDDEN, ref outBlob))
+                    throw new CryptographicException(Marshal.GetLastWin32Error());
+
+                var result = new byte[outBlob.cbData];
+                Marshal.Copy(outBlob.pbData, result, 0, outBlob.cbData);
+                return result;
+            }
+            finally
+            {
+                if (inBlob.pbData != IntPtr.Zero) Marshal.FreeHGlobal(inBlob.pbData);
+                if (outBlob.pbData != IntPtr.Zero) LocalFree(outBlob.pbData);
+            }
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct DATA_BLOB
+        {
+            public int cbData;
+            public IntPtr pbData;
+        }
+
+        [DllImport("crypt32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool CryptProtectData(ref DATA_BLOB pDataIn, string? szDataDescr,
+            IntPtr pOptionalEntropy, IntPtr pvReserved, IntPtr pPromptStruct, int dwFlags, ref DATA_BLOB pDataOut);
+
+        [DllImport("crypt32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool CryptUnprotectData(ref DATA_BLOB pDataIn, IntPtr ppszDataDescr,
+            IntPtr pOptionalEntropy, IntPtr pvReserved, IntPtr pPromptStruct, int dwFlags, ref DATA_BLOB pDataOut);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern IntPtr LocalFree(IntPtr hMem);
+    }
+}

--- a/McpPlugin/src/AgentConfig/MachineCredentials.cs
+++ b/McpPlugin/src/AgentConfig/MachineCredentials.cs
@@ -1,0 +1,56 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Text.Json.Serialization;
+
+namespace com.IvanMurzak.McpPlugin.AgentConfig
+{
+    /// <summary>
+    /// The secret credential material persisted per machine in
+    /// <see cref="MachineCredentialStore"/> (<c>~/.ai-game-dev/credentials.json</c>).
+    ///
+    /// <para>
+    /// A single ai-game.dev account credential shared by every engine plugin, CLI, and the local
+    /// server on the machine — sign-in happens once per machine, not per engine/project. Unknown
+    /// JSON fields are ignored on read so the schema can grow forwards-compatibly.
+    /// </para>
+    ///
+    /// <para><b>Never write this to a project file or VCS</b> — it lives only in the protected
+    /// machine store (0600 on POSIX / DPAPI on Windows).</para>
+    /// </summary>
+    public sealed class MachineCredentials
+    {
+        /// <summary>Schema version of the persisted document (currently 1).</summary>
+        [JsonPropertyName("version")]
+        public int Version { get; set; } = 1;
+
+        /// <summary>The current short-lived ES256 JWT access token (MCP audience).</summary>
+        [JsonPropertyName("accessToken")]
+        public string? AccessToken { get; set; }
+
+        /// <summary>The rotating refresh token used to mint a new access token before <see cref="ExpiresAt"/>.</summary>
+        [JsonPropertyName("refreshToken")]
+        public string? RefreshToken { get; set; }
+
+        /// <summary>Absolute expiry of <see cref="AccessToken"/>; used to schedule proactive refresh.</summary>
+        [JsonPropertyName("expiresAt")]
+        public DateTimeOffset? ExpiresAt { get; set; }
+
+        /// <summary>The server target the credential was issued for (hosted <c>https://ai-game.dev</c> or a local URL). Optional.</summary>
+        [JsonPropertyName("serverTarget")]
+        public string? ServerTarget { get; set; }
+
+        /// <summary>The account id (<c>sub</c>) the credential resolves to. Optional; audit/diagnostic only.</summary>
+        [JsonPropertyName("subject")]
+        public string? Subject { get; set; }
+    }
+}

--- a/McpPlugin/src/AgentConfig/ProjectIdentity.GoldenVectors.json
+++ b/McpPlugin/src/AgentConfig/ProjectIdentity.GoldenVectors.json
@@ -1,0 +1,87 @@
+{
+  "description": "Cross-language golden vectors for ProjectIdentity (routing pin + deterministic local port). The C# reference implementation (McpPlugin/src/AgentConfig/ProjectIdentity.cs) is the origin; any TS/JS or other port MUST reproduce every `pin`/`port` in `vectors`. Byte-compatible with the shipped Unity `UnityMcpPlugin.GeneratePortFromDirectory()` for existing-project paths. Regenerate/verify via McpPlugin.Tests ProjectIdentityGoldenVectorTests.",
+  "algorithm": {
+    "steps": [
+      "1. Trim trailing directory separators ('/' and '\\') from the project root (so '/a/b' and '/a/b/' are the same project).",
+      "2. Lowercase the result. C#: string.ToLowerInvariant(). NOTE: this diverges from JS String.prototype.toLowerCase() for some Unicode chars — see `unicodeDivergence`.",
+      "3. UTF-8 encode, then SHA-256 hash.",
+      "4. pin  = the first 4 bytes of the hash as 8 lowercase hex characters.",
+      "5. port = 20000 + (littleEndianUInt32(first 4 bytes of the hash) % 10000).  Range: 20000-29999."
+    ],
+    "minPort": 20000,
+    "maxPort": 29999,
+    "pinLength": 8,
+    "separatorNormalization": "none — separators are NOT converted ('C:\\a' and 'C:/a' hash differently). Do not path.normalize()/path.resolve() before deriving.",
+    "whichStringIsHashed": "the normalized project root supplied by the caller, NOT Environment.CurrentDirectory / process.cwd()."
+  },
+  "vectors": [
+    {
+      "path": "/home/user/my-game",
+      "pin": "34ea75f2",
+      "port": 23940,
+      "note": "POSIX typical project path."
+    },
+    {
+      "path": "/home/user/my-game/",
+      "pin": "34ea75f2",
+      "port": 23940,
+      "note": "Trailing slash is trimmed -> identical to '/home/user/my-game'."
+    },
+    {
+      "path": "/home/USER/My-Game",
+      "pin": "34ea75f2",
+      "port": 23940,
+      "note": "Case-folded -> identical to '/home/user/my-game'."
+    },
+    {
+      "path": "C:\\Users\\user\\my-game",
+      "pin": "8ef72cf7",
+      "port": 29310,
+      "note": "Windows backslash form (matches Unity GeneratePortFromDirectory Environment.CurrentDirectory on Windows)."
+    },
+    {
+      "path": "C:\\Users\\user\\my-game\\",
+      "pin": "8ef72cf7",
+      "port": 29310,
+      "note": "Trailing backslash is trimmed -> identical to the backslash form."
+    },
+    {
+      "path": "C:/Users/user/my-game",
+      "pin": "5a87324e",
+      "port": 24298,
+      "note": "Forward-slash form DIFFERS from the backslash form: separators are NOT normalized."
+    },
+    {
+      "path": "/home/İstanbul/game",
+      "pin": "672d80a7",
+      "port": 25303,
+      "note": "Contains U+0130 (LATIN CAPITAL LETTER I WITH DOT ABOVE). Canonical C# value; see `unicodeDivergence` — a naive JS toLowerCase() port would compute a DIFFERENT value and must special-case this."
+    },
+    {
+      "path": "/srv/games/space sim",
+      "pin": "08c6cbb6",
+      "port": 27816,
+      "note": "Path containing a space."
+    }
+  ],
+  "unicodeDivergence": {
+    "note": "C# string.ToLowerInvariant() and JS String.prototype.toLowerCase() do NOT agree on every character. The value in `vectors` (produced by the C# origin) is canonical; a JS/TS port MUST reproduce it. This section records what a NAIVE toLowerCase() port produces so the divergence is explicit and testable in the consuming CLIs.",
+    "cases": [
+      {
+        "path": "/home/İstanbul/game",
+        "char": "U+0130 LATIN CAPITAL LETTER I WITH DOT ABOVE",
+        "canonical": {
+          "pin": "672d80a7",
+          "port": 25303,
+          "producedBy": "C# ToLowerInvariant leaves U+0130 unchanged (no case fold)."
+        },
+        "jsNaiveToLowerCase": {
+          "pin": "77300275",
+          "port": 27751,
+          "loweredCodepoints": "U+0069 U+0307 (i + COMBINING DOT ABOVE)",
+          "warning": "A naive JS/TS port would produce THIS incorrect value. It must special-case U+0130 (and any char where toLowerCase() disagrees with ToLowerInvariant) to match `canonical`."
+        }
+      }
+    ]
+  }
+}

--- a/McpPlugin/src/AgentConfig/ProjectIdentity.cs
+++ b/McpPlugin/src/AgentConfig/ProjectIdentity.cs
@@ -1,0 +1,182 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace com.IvanMurzak.McpPlugin.AgentConfig
+{
+    /// <summary>
+    /// The single canonical derivation of a project's <b>routing pin</b> and its
+    /// <b>deterministic local port</b> from the project root path.
+    ///
+    /// <para>
+    /// This is the reference implementation of the algorithm shipped in the Unity plugin as
+    /// <c>UnityMcpPlugin.GeneratePortFromDirectory()</c> and ported to the unity/unreal TS CLIs.
+    /// Single-sourcing it here (used by the Unity/Godot plugins AND the Unreal .NET sidecar) means
+    /// every runtime derives identical values with no shared state and no probing.
+    /// </para>
+    ///
+    /// <para><b>Algorithm (kept verbatim from the shipped Unity code):</b></para>
+    /// <list type="number">
+    ///   <item>Take the project root string, trim trailing directory separators
+    ///         (so <c>/a/b</c> and <c>/a/b/</c> are the same project), then lowercase it with
+    ///         <see cref="string.ToLowerInvariant"/>.</item>
+    ///   <item>UTF-8 encode and SHA-256 hash the result.</item>
+    ///   <item><b>Pin</b> = the first 4 bytes of the hash as 8 lowercase hex chars.</item>
+    ///   <item><b>Port</b> = <c>20000 + (littleEndianUInt32(firstFourBytes) % 10000)</c>,
+    ///         i.e. range 20000-29999.</item>
+    /// </list>
+    ///
+    /// <para><b>Port compatibility guarantee:</b> because the algorithm is byte-for-byte the shipped
+    /// Unity <c>GeneratePortFromDirectory</c>, feeding it the same directory string an existing Unity
+    /// project reports as its <c>Environment.CurrentDirectory</c> yields the same port an existing
+    /// user already has. The only intentional difference is <b>which string is hashed</b>: this API
+    /// hashes the explicit normalized project root the caller supplies (the plugin's reported project
+    /// path), NOT <c>Environment.CurrentDirectory</c> — so the pin/port are stable regardless of the
+    /// process's working directory.</para>
+    ///
+    /// <para><b>Little-endian is explicit</b> (byte shifts, not <see cref="BitConverter"/>) so the
+    /// value is identical on any CPU endianness and matches the TS port's <c>readInt32LE</c>.</para>
+    ///
+    /// <para>Cross-language parity (C# vs TS) is gated by the committed golden-vector file
+    /// (<c>ProjectIdentity.GoldenVectors.json</c>), which explicitly pins the C#
+    /// <c>ToLowerInvariant</c> vs JS <c>toLowerCase()</c> Unicode divergence, separator handling,
+    /// and trailing-slash handling.</para>
+    /// </summary>
+    public readonly struct ProjectIdentity
+    {
+        /// <summary>Inclusive lower bound of the deterministic local-port range.</summary>
+        public const int MinPort = 20000;
+
+        /// <summary>Inclusive upper bound of the deterministic local-port range.</summary>
+        public const int MaxPort = 29999;
+
+        /// <summary>Number of ports in the deterministic range (10000).</summary>
+        public const int PortRange = MaxPort - MinPort + 1;
+
+        /// <summary>Number of hex characters in the routing pin (first 4 bytes of the hash).</summary>
+        public const int PinLength = 8;
+
+        /// <summary>The routing pin: first 8 lowercase hex chars of the SHA-256 of the normalized project root.</summary>
+        public string Pin { get; }
+
+        /// <summary>
+        /// The resolved local port. Equal to <see cref="DerivePort"/> unless an explicit user port
+        /// override was supplied (from the project marker), in which case the override wins.
+        /// </summary>
+        public int Port { get; }
+
+        /// <summary>True when <see cref="Port"/> came from an explicit user override rather than the hash.</summary>
+        public bool PortIsOverridden { get; }
+
+        private ProjectIdentity(string pin, int port, bool portIsOverridden)
+        {
+            Pin = pin;
+            Port = port;
+            PortIsOverridden = portIsOverridden;
+        }
+
+        /// <summary>
+        /// Derive the identity for <paramref name="projectRoot"/>. When <paramref name="portOverride"/>
+        /// is non-null (the user's explicit override from the project marker) it always wins for
+        /// <see cref="Port"/>; the <see cref="Pin"/> is always hash-derived.
+        /// </summary>
+        /// <param name="projectRoot">The project root path (normalized project root the plugin reports).</param>
+        /// <param name="portOverride">Optional explicit user port override; wins when set.</param>
+        public static ProjectIdentity Derive(string projectRoot, int? portOverride = null)
+        {
+            if (projectRoot == null)
+                throw new ArgumentNullException(nameof(projectRoot));
+
+            var hash = HashOf(projectRoot);
+            var pin = ToHex(hash, PinLength / 2);
+            var derivedPort = PortFromHash(hash);
+
+            if (portOverride.HasValue)
+                return new ProjectIdentity(pin, portOverride.Value, portIsOverridden: true);
+
+            return new ProjectIdentity(pin, derivedPort, portIsOverridden: false);
+        }
+
+        /// <summary>
+        /// Convenience overload that reads the port override from a project marker (may be null).
+        /// </summary>
+        public static ProjectIdentity Derive(string projectRoot, ProjectMarker? marker)
+            => Derive(projectRoot, marker?.PortOverride);
+
+        /// <summary>The routing pin only (first 8 lowercase hex chars of the hash). Never affected by overrides.</summary>
+        public static string DerivePin(string projectRoot)
+        {
+            if (projectRoot == null)
+                throw new ArgumentNullException(nameof(projectRoot));
+            return ToHex(HashOf(projectRoot), PinLength / 2);
+        }
+
+        /// <summary>
+        /// The pure hash-derived port (ignores any override). This is the byte-for-byte equivalent of
+        /// the shipped Unity <c>GeneratePortFromDirectory</c> when given the same directory string.
+        /// </summary>
+        public static int DerivePort(string projectRoot)
+        {
+            if (projectRoot == null)
+                throw new ArgumentNullException(nameof(projectRoot));
+            return PortFromHash(HashOf(projectRoot));
+        }
+
+        /// <summary>
+        /// The exact string that is UTF-8/SHA-256 hashed: the project root with trailing directory
+        /// separators trimmed, then lowercased with <see cref="string.ToLowerInvariant"/>. Exposed so
+        /// the golden-vector tooling and cross-language ports can reproduce the pre-hash string.
+        /// </summary>
+        public static string Normalize(string projectRoot)
+        {
+            if (projectRoot == null)
+                throw new ArgumentNullException(nameof(projectRoot));
+            return TrimTrailingSeparators(projectRoot).ToLowerInvariant();
+        }
+
+        internal static byte[] HashOf(string projectRoot)
+        {
+            var normalized = Normalize(projectRoot);
+            var bytes = Encoding.UTF8.GetBytes(normalized);
+            using (var sha256 = SHA256.Create())
+            {
+                return sha256.ComputeHash(bytes);
+            }
+        }
+
+        internal static int PortFromHash(byte[] hash)
+        {
+            // First 4 bytes as an explicit little-endian uint32 (matches Unity's BitConverter.ToInt32
+            // on little-endian platforms and the TS port's Buffer.readInt32LE, independent of CPU).
+            var value = (uint)(hash[0] | (hash[1] << 8) | (hash[2] << 16) | (hash[3] << 24));
+            return MinPort + (int)(value % PortRange);
+        }
+
+        private static string TrimTrailingSeparators(string path)
+        {
+            var end = path.Length;
+            while (end > 1 && (path[end - 1] == '/' || path[end - 1] == '\\'))
+                end--;
+            return end == path.Length ? path : path.Substring(0, end);
+        }
+
+        private static string ToHex(byte[] bytes, int count)
+        {
+            var sb = new StringBuilder(count * 2);
+            for (var i = 0; i < count; i++)
+                sb.Append(bytes[i].ToString("x2"));
+            return sb.ToString();
+        }
+    }
+}

--- a/McpPlugin/src/AgentConfig/ProjectMarker.cs
+++ b/McpPlugin/src/AgentConfig/ProjectMarker.cs
@@ -1,0 +1,97 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace com.IvanMurzak.McpPlugin.AgentConfig
+{
+    /// <summary>
+    /// The tool-neutral, committable per-project marker file
+    /// <c>&lt;project&gt;/.ai-game-dev/project.json</c>.
+    ///
+    /// <para>
+    /// It records the enrolled <see cref="ServerTarget"/> (hosted vs local) and the user's optional
+    /// explicit <see cref="PortOverride"/>. <see cref="ProjectIdentity"/> resolution and every config
+    /// writer (engine UI, CLIs, <c>configure</c>) consult it, so an override or target can never
+    /// silently diverge between the plugin and a terminal-written config.
+    /// </para>
+    ///
+    /// <para><b>This file is non-secret and safe to commit.</b> Credentials are NEVER written here —
+    /// they live only in the machine credential store (<see cref="MachineCredentialStore"/>).</para>
+    /// </summary>
+    public sealed class ProjectMarker
+    {
+        /// <summary>Directory name (under the project root) that holds the marker.</summary>
+        public const string DirectoryName = ".ai-game-dev";
+
+        /// <summary>Marker file name inside <see cref="DirectoryName"/>.</summary>
+        public const string FileName = "project.json";
+
+        private static readonly JsonSerializerOptions SerializerOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            PropertyNameCaseInsensitive = true,
+            WriteIndented = true,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        };
+
+        /// <summary>The enrolled server target URL (hosted <c>https://ai-game.dev</c> or a local URL). Optional.</summary>
+        [JsonPropertyName("serverTarget")]
+        public string? ServerTarget { get; set; }
+
+        /// <summary>The user's explicit local-port override. When set it wins over the derived port. Optional.</summary>
+        [JsonPropertyName("portOverride")]
+        public int? PortOverride { get; set; }
+
+        /// <summary>Absolute path of the marker file for a given project root.</summary>
+        public static string PathFor(string projectRoot)
+        {
+            if (projectRoot == null)
+                throw new ArgumentNullException(nameof(projectRoot));
+            return Path.Combine(projectRoot, DirectoryName, FileName);
+        }
+
+        /// <summary>
+        /// Read the marker for <paramref name="projectRoot"/>. Returns <c>null</c> when the marker file
+        /// does not exist (a project that has never been enrolled / configured).
+        /// </summary>
+        public static ProjectMarker? Read(string projectRoot)
+        {
+            var path = PathFor(projectRoot);
+            if (!File.Exists(path))
+                return null;
+
+            var json = File.ReadAllText(path);
+            if (string.IsNullOrWhiteSpace(json))
+                return new ProjectMarker();
+
+            return JsonSerializer.Deserialize<ProjectMarker>(json, SerializerOptions) ?? new ProjectMarker();
+        }
+
+        /// <summary>
+        /// Write this marker into <paramref name="projectRoot"/>, creating the
+        /// <c>.ai-game-dev</c> directory if needed. Non-secret; standard file permissions.
+        /// </summary>
+        public void Write(string projectRoot)
+        {
+            var path = PathFor(projectRoot);
+            var dir = Path.GetDirectoryName(path);
+            if (!string.IsNullOrEmpty(dir))
+                Directory.CreateDirectory(dir);
+
+            var json = JsonSerializer.Serialize(this, SerializerOptions);
+            File.WriteAllText(path, json);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Foundational shared primitives for the mcp-authorize redesign (design task **b1**) — everything else in the redesign consumes these:

- **`ProjectIdentity`** (`McpPlugin/src/AgentConfig`): the single canonical derivation of the routing pin (first 8 hex chars of SHA-256) and the deterministic local port (`20000 + (LE-uint32 % 10000)`), byte-compatible with the shipped Unity `GeneratePortFromDirectory`; consults the project marker's `portOverride` first.
- **Committed cross-language golden-vector file** (`ProjectIdentity.GoldenVectors.json`) + xUnit parity/byte-match tests, pinning the C# `ToLowerInvariant` vs JS `toLowerCase()` Unicode divergence (U+0130), separator handling, and trailing-slash handling. Consumed later by the TS CLIs.
- **`MachineCredentialStore`** (`~/.ai-game-dev/`): read/write/rotate/delete + the co-located JWKS cache; `0600` file / `0700` dir on POSIX and DPAPI-at-rest on Windows. No secret material is written to the repo or logs.
- **`ProjectMarker`** (`<project>/.ai-game-dev/project.json`): non-secret, committable `serverTarget` + optional `portOverride`, with round-trip and override precedence.

No `<Version>` bump, no ReflectorNet bump, no new package dependency (DPAPI via `crypt32` P/Invoke keeps the Unity-consumed library dependency-free).

## Test plan
- [x] Target-specific local tests passed (see profile test.md): full `dotnet restore` -> `build --no-restore -c Release` -> `dotnet test` green across `net8.0` + `net9.0`, both `McpPlugin.Tests` and `McpPlugin.Server.Tests` (0 failures; 48 new tests).
- [x] Golden vectors reproduce against the C# reference AND byte-match the Unity `GeneratePortFromDirectory` algorithm for existing-project paths.
- [x] POSIX `0600`/`0700` perms test (runs for real on Linux CI); Windows DPAPI at-rest test verified locally; marker round-trip + override-precedence tests.

Closes #136