### PR TITLE
feat(auth): OAuth 2.1 resource-server mode (mcp-authorize b2)

### DIFF
--- a/DemoWebApp/src/Program.cs
+++ b/DemoWebApp/src/Program.cs
@@ -68,8 +68,8 @@ namespace com.IvanMurzak.McpPlugin.DemoWebApp
                     .WithMcpServer(dataArguments, logger)
                     .WithMcpPluginServer(dataArguments);
 
-                logger.Info($"Start listening on port: {dataArguments.Port}");
-                builder.WebHost.UseKestrelForMcpPlugin(dataArguments.Port);
+                logger.Info($"Start listening on port: {dataArguments.Port} (bind: {dataArguments.Bind ?? "loopback"})");
+                builder.WebHost.UseKestrelForMcpPlugin(dataArguments.Port, dataArguments.Bind);
 
                 // ---------------------------------------------------------------------------------
 

--- a/McpPlugin.Common/src/Utils/Consts.MCP.cs
+++ b/McpPlugin.Common/src/Utils/Consts.MCP.cs
@@ -57,6 +57,15 @@ namespace com.IvanMurzak.McpPlugin.Common
                     public const string Authorization = "authorization";
                     public const string IdleTimeoutSeconds = "idle-timeout-seconds";
                     public const string MaxIdleSessionCount = "max-idle-session-count";
+
+                    // OAuth resource-server arguments (mcp-authorize b2).
+                    // <c>auth</c> is the target-state name for <c>authorization</c> ({none|oauth});
+                    // the legacy <c>authorization</c> arg is retained until the legacy surface is
+                    // removed (mcp-authorize b5).
+                    public const string Auth = "auth";
+                    public const string AuthIssuer = "auth-issuer";
+                    public const string PublicUrl = "public-url";
+                    public const string Bind = "bind";
                 }
 
                 public static partial class Env
@@ -68,6 +77,12 @@ namespace com.IvanMurzak.McpPlugin.Common
                     public const string Authorization = "MCP_AUTHORIZATION";
                     public const string IdleTimeoutSeconds = "MCP_PLUGIN_IDLE_TIMEOUT_SECONDS";
                     public const string MaxIdleSessionCount = "MCP_PLUGIN_MAX_IDLE_SESSION_COUNT";
+
+                    // OAuth resource-server environment variables (mcp-authorize b2).
+                    public const string Auth = "MCP_AUTH";
+                    public const string AuthIssuer = "MCP_AUTH_ISSUER";
+                    public const string PublicUrl = "MCP_PUBLIC_URL";
+                    public const string Bind = "MCP_BIND";
                 }
 
                 /// <summary>
@@ -166,7 +181,15 @@ namespace com.IvanMurzak.McpPlugin.Common
                 {
                     unknown,
                     none,
-                    required
+                    required,
+
+                    /// <summary>
+                    /// OAuth 2.1 resource-server mode (mcp-authorize b2). The server validates
+                    /// ES256 JWTs against the authorization server's JWKS and opaque tokens via
+                    /// introspection; it never mints tokens. Selected via <c>--auth oauth</c> /
+                    /// <c>MCP_AUTH=oauth</c>.
+                    /// </summary>
+                    oauth
                 }
 
                 /// <summary>

--- a/McpPlugin.Common/src/Utils/DataArguments.cs
+++ b/McpPlugin.Common/src/Utils/DataArguments.cs
@@ -23,6 +23,11 @@ namespace com.IvanMurzak.McpPlugin.Common.Utils
         Consts.MCP.Server.AuthOption Authorization { get; }
         string? Token { get; }
 
+        // OAuth resource-server configuration (mcp-authorize b2)
+        string? AuthIssuer { get; }
+        string? PublicUrl { get; }
+        string? Bind { get; }
+
         // Webhook configuration
         string? WebhookToolUrl { get; }
         string? WebhookPromptUrl { get; }
@@ -45,6 +50,18 @@ namespace com.IvanMurzak.McpPlugin.Common.Utils
         public Consts.MCP.Server.TransportMethod ClientTransport { get; private set; }
         public Consts.MCP.Server.AuthOption Authorization { get; private set; } = Consts.MCP.Server.AuthOption.none;
         public string? Token { get; private set; }
+
+        // OAuth resource-server configuration (mcp-authorize b2)
+        public string? AuthIssuer { get; private set; }
+        public string? PublicUrl { get; private set; }
+
+        /// <summary>
+        /// Bind address for the streamableHttp Kestrel listener. <c>null</c>/empty defaults to
+        /// <b>loopback</b> (decision D8 — the local RS is loopback-only by default; DNS-rebinding
+        /// is still blocked by Origin validation). Set <c>--bind any</c> / <c>--bind 0.0.0.0</c>
+        /// (or a specific IP) to opt into LAN / container exposure.
+        /// </summary>
+        public string? Bind { get; private set; }
 
         // Webhook configuration
         public string? WebhookToolUrl { get; private set; }
@@ -112,6 +129,25 @@ namespace com.IvanMurzak.McpPlugin.Common.Utils
             var envDeployment = Environment.GetEnvironmentVariable(Consts.MCP.Server.Env.Authorization);
             if (envDeployment != null && Enum.TryParse(envDeployment, true, out Consts.MCP.Server.AuthOption parsedEnvDeployment))
                 Authorization = parsedEnvDeployment;
+
+            // MCP_AUTH is the target-state name for MCP_AUTHORIZATION; parsed after it so it wins.
+            var envAuth = Environment.GetEnvironmentVariable(Consts.MCP.Server.Env.Auth);
+            if (envAuth != null && Enum.TryParse(envAuth, true, out Consts.MCP.Server.AuthOption parsedEnvAuth))
+                Authorization = parsedEnvAuth;
+
+            // --- OAuth resource-server variables ---
+
+            var envAuthIssuer = Environment.GetEnvironmentVariable(Consts.MCP.Server.Env.AuthIssuer);
+            if (envAuthIssuer != null)
+                AuthIssuer = envAuthIssuer;
+
+            var envPublicUrl = Environment.GetEnvironmentVariable(Consts.MCP.Server.Env.PublicUrl);
+            if (envPublicUrl != null)
+                PublicUrl = envPublicUrl;
+
+            var envBind = Environment.GetEnvironmentVariable(Consts.MCP.Server.Env.Bind);
+            if (envBind != null)
+                Bind = envBind;
 
             // --- Webhook variables ---
 
@@ -194,6 +230,25 @@ namespace com.IvanMurzak.McpPlugin.Common.Utils
             var argDeployment = commandLineArgs.GetValueOrDefault(Consts.MCP.Server.Args.Authorization.TrimStart('-'));
             if (argDeployment != null && Enum.TryParse(argDeployment, true, out Consts.MCP.Server.AuthOption parsedArgDeployment))
                 Authorization = parsedArgDeployment;
+
+            // --auth is the target-state name for --authorization; parsed after it so it wins.
+            var argAuth = commandLineArgs.GetValueOrDefault(Consts.MCP.Server.Args.Auth.TrimStart('-'));
+            if (argAuth != null && Enum.TryParse(argAuth, true, out Consts.MCP.Server.AuthOption parsedArgAuth))
+                Authorization = parsedArgAuth;
+
+            // --- OAuth resource-server variables ---
+
+            var argAuthIssuer = commandLineArgs.GetValueOrDefault(Consts.MCP.Server.Args.AuthIssuer.TrimStart('-'));
+            if (argAuthIssuer != null)
+                AuthIssuer = argAuthIssuer;
+
+            var argPublicUrl = commandLineArgs.GetValueOrDefault(Consts.MCP.Server.Args.PublicUrl.TrimStart('-'));
+            if (argPublicUrl != null)
+                PublicUrl = argPublicUrl;
+
+            var argBind = commandLineArgs.GetValueOrDefault(Consts.MCP.Server.Args.Bind.TrimStart('-'));
+            if (argBind != null)
+                Bind = argBind;
 
             // --- Webhook variables ---
 

--- a/McpPlugin.Server.Tests/BaseHubAuthorizationTests.cs
+++ b/McpPlugin.Server.Tests/BaseHubAuthorizationTests.cs
@@ -387,5 +387,76 @@ namespace McpPlugin.Server.Tests
                     It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>()),
                 Times.Once);
         }
+
+        // --- OAuth hub credential source: Authorization header only, no ?access_token= (b2) ---
+
+        static Mock<HubCallerContext> CreateContextWithQueryAndHeader(string? queryAccessToken, string? bearerToken)
+        {
+            var mockContext = new Mock<HubCallerContext>();
+            mockContext.Setup(c => c.ConnectionId).Returns(UniqueId());
+            mockContext.Setup(c => c.ConnectionAborted).Returns(CancellationToken.None);
+
+            var httpContext = new DefaultHttpContext();
+            if (queryAccessToken != null)
+                httpContext.Request.QueryString = new QueryString("?access_token=" + queryAccessToken);
+            if (bearerToken != null)
+                httpContext.Request.Headers["Authorization"] = $"Bearer {bearerToken}";
+
+            var features = new FeatureCollection();
+            features.Set<IHttpContextFeature>(new HttpContextFeature { HttpContext = httpContext });
+            mockContext.Setup(c => c.Features).Returns(features);
+            return mockContext;
+        }
+
+        [Fact]
+        public async Task OnConnectedAsync_OAuthMode_IgnoresAccessTokenQueryParam_UsesHeader()
+        {
+            var mockContext = CreateContextWithQueryAndHeader(queryAccessToken: "QUERY-TOKEN", bearerToken: "HEADER-TOKEN");
+            var (hub, _, webhook, _) = CreateAuthModeTestHub(mockContext, authOption: Consts.MCP.Server.AuthOption.oauth);
+
+            await hub.OnConnectedAsync();
+
+            // oauth mode uses the Authorization header token; the query param is ignored.
+            webhook.Verify(w => w.AuthorizePluginAsync(
+                    It.IsAny<string>(), "HEADER-TOKEN",
+                    It.IsAny<string?>(), It.IsAny<string?>(),
+                    It.IsAny<CancellationToken>(),
+                    It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task OnConnectedAsync_OAuthMode_QueryParamOnly_TokenIgnored()
+        {
+            var mockContext = CreateContextWithQueryAndHeader(queryAccessToken: "QUERY-TOKEN", bearerToken: null);
+            var (hub, _, webhook, _) = CreateAuthModeTestHub(mockContext, authOption: Consts.MCP.Server.AuthOption.oauth);
+
+            await hub.OnConnectedAsync();
+
+            // No Authorization header ⇒ no token in oauth mode (query param NOT honored).
+            webhook.Verify(w => w.AuthorizePluginAsync(
+                    It.IsAny<string>(), null,
+                    It.IsAny<string?>(), It.IsAny<string?>(),
+                    It.IsAny<CancellationToken>(),
+                    It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task OnConnectedAsync_LegacyMode_StillHonorsAccessTokenQueryParam()
+        {
+            // Regression guard: legacy (auth=none) keeps the ?access_token= query fallback.
+            var mockContext = CreateContextWithQueryAndHeader(queryAccessToken: "QUERY-TOKEN", bearerToken: null);
+            var (hub, _, webhook, _) = CreateAuthModeTestHub(mockContext, authOption: Consts.MCP.Server.AuthOption.none);
+
+            await hub.OnConnectedAsync();
+
+            webhook.Verify(w => w.AuthorizePluginAsync(
+                    It.IsAny<string>(), "QUERY-TOKEN",
+                    It.IsAny<string?>(), It.IsAny<string?>(),
+                    It.IsAny<CancellationToken>(),
+                    It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>()),
+                Times.Once);
+        }
     }
 }

--- a/McpPlugin.Server.Tests/DataArgumentsAuthTests.cs
+++ b/McpPlugin.Server.Tests/DataArgumentsAuthTests.cs
@@ -1,0 +1,96 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using com.IvanMurzak.McpPlugin.Common;
+using com.IvanMurzak.McpPlugin.Common.Utils;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.Server.Tests
+{
+    /// <summary>Parsing of the new OAuth resource-server args/env (mcp-authorize b2).</summary>
+    [Collection("McpPlugin.Server")]
+    public class DataArgumentsAuthTests
+    {
+        [Fact]
+        public void AuthOAuth_Args_Parsed()
+        {
+            var args = new DataArguments(new[]
+            {
+                "auth=oauth",
+                "auth-issuer=https://ai-game.dev",
+                "public-url=http://localhost:23471",
+                "bind=any"
+            });
+
+            args.Authorization.ShouldBe(Consts.MCP.Server.AuthOption.oauth);
+            args.AuthIssuer.ShouldBe("https://ai-game.dev");
+            args.PublicUrl.ShouldBe("http://localhost:23471");
+            args.Bind.ShouldBe("any");
+        }
+
+        [Fact]
+        public void LegacyAuthorizationRequired_StillParsed()
+        {
+            var args = new DataArguments(new[] { "authorization=required" });
+            args.Authorization.ShouldBe(Consts.MCP.Server.AuthOption.required);
+        }
+
+        [Fact]
+        public void AuthNone_Parsed()
+        {
+            var args = new DataArguments(new[] { "auth=none" });
+            args.Authorization.ShouldBe(Consts.MCP.Server.AuthOption.none);
+        }
+
+        [Fact]
+        public void NewAuthArg_OverridesLegacyAuthorizationArg()
+        {
+            // Both supplied: the target-state --auth wins over legacy --authorization.
+            var args = new DataArguments(new[] { "authorization=required", "auth=oauth" });
+            args.Authorization.ShouldBe(Consts.MCP.Server.AuthOption.oauth);
+        }
+
+        [Fact]
+        public void BindDefault_IsNull()
+        {
+            var args = new DataArguments(Array.Empty<string>());
+            args.Bind.ShouldBeNull();
+        }
+
+        [Fact]
+        public void Env_MCP_AUTH_Parsed()
+        {
+            try
+            {
+                Environment.SetEnvironmentVariable(Consts.MCP.Server.Env.Auth, "oauth");
+                Environment.SetEnvironmentVariable(Consts.MCP.Server.Env.AuthIssuer, "https://as.example");
+                Environment.SetEnvironmentVariable(Consts.MCP.Server.Env.PublicUrl, "http://localhost:5555");
+                Environment.SetEnvironmentVariable(Consts.MCP.Server.Env.Bind, "any");
+
+                var args = new DataArguments(Array.Empty<string>());
+
+                args.Authorization.ShouldBe(Consts.MCP.Server.AuthOption.oauth);
+                args.AuthIssuer.ShouldBe("https://as.example");
+                args.PublicUrl.ShouldBe("http://localhost:5555");
+                args.Bind.ShouldBe("any");
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(Consts.MCP.Server.Env.Auth, null);
+                Environment.SetEnvironmentVariable(Consts.MCP.Server.Env.AuthIssuer, null);
+                Environment.SetEnvironmentVariable(Consts.MCP.Server.Env.PublicUrl, null);
+                Environment.SetEnvironmentVariable(Consts.MCP.Server.Env.Bind, null);
+            }
+        }
+    }
+}

--- a/McpPlugin.Server.Tests/ExtensionsWebHostBindTests.cs
+++ b/McpPlugin.Server.Tests/ExtensionsWebHostBindTests.cs
@@ -1,0 +1,74 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using com.IvanMurzak.McpPlugin.Server;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.Server.Tests
+{
+    /// <summary>
+    /// Bind-address resolution (mcp-authorize b2, decision D8): the default is loopback-only, and
+    /// <c>--bind</c> opts into all-interfaces / a specific address.
+    /// </summary>
+    public class ExtensionsWebHostBindTests
+    {
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("loopback")]
+        [InlineData("localhost")]
+        public void Default_BindsLoopbackOnly(string? bind)
+        {
+            var addresses = ExtensionsWebHost.ResolveBindAddresses(bind);
+
+            addresses.ShouldContain(IPAddress.Loopback);
+            addresses.ShouldNotContain(IPAddress.Any);
+            addresses.ShouldNotContain(IPAddress.IPv6Any);
+            if (Socket.OSSupportsIPv6)
+                addresses.ShouldContain(IPAddress.IPv6Loopback);
+        }
+
+        [Fact]
+        public void BindAny_BindsAllInterfaces()
+        {
+            var addresses = ExtensionsWebHost.ResolveBindAddresses("any");
+
+            addresses.ShouldContain(IPAddress.Any);
+            addresses.ShouldNotContain(IPAddress.Loopback);
+            if (Socket.OSSupportsIPv6)
+                addresses.ShouldContain(IPAddress.IPv6Any);
+        }
+
+        [Fact]
+        public void BindZeros_BindsIPv4Any()
+        {
+            var addresses = ExtensionsWebHost.ResolveBindAddresses("0.0.0.0");
+            addresses.ShouldBe(new[] { IPAddress.Any });
+        }
+
+        [Fact]
+        public void BindSpecificIPv4_BindsThatAddressOnly()
+        {
+            var addresses = ExtensionsWebHost.ResolveBindAddresses("192.168.1.50");
+            addresses.ShouldBe(new[] { IPAddress.Parse("192.168.1.50") });
+        }
+
+        [Fact]
+        public void BindInvalid_Throws()
+        {
+            Should.Throw<System.ArgumentException>(() => ExtensionsWebHost.ResolveBindAddresses("not-an-ip"));
+        }
+    }
+}

--- a/McpPlugin.Server.Tests/OAuth/AccessTokenValidatorTests.cs
+++ b/McpPlugin.Server.Tests/OAuth/AccessTokenValidatorTests.cs
@@ -1,0 +1,282 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.Server.Auth.OAuth;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.Server.Tests.OAuth
+{
+    /// <summary>
+    /// Resource-server validation fuzz suite (mcp-authorize b2 DoD): expired / bad-iss / bad-aud /
+    /// unknown-kid / alg-confusion (alg:none, HS256-with-the-public-key) are all rejected; the skew
+    /// edges are covered; loopback-aliased and array audiences are accepted; the opaque/introspection
+    /// path is exercised.
+    /// </summary>
+    public class AccessTokenValidatorTests
+    {
+        const string Issuer = "https://as.example";
+        const string Resource = "http://localhost:23471";
+        const string Kid = "key-1";
+        static readonly DateTimeOffset Now = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+
+        static OAuthResourceServerConfig Config() => new OAuthResourceServerConfig(Issuer, Resource);
+
+        static AccessTokenValidator Validator(ECDsa signingKey, IIntrospectionClient? introspection = null)
+        {
+            var jwks = new FakeJwksKeyProvider().Add(Kid, signingKey);
+            return new AccessTokenValidator(Config(), jwks, introspection ?? FakeIntrospectionClient.AlwaysInactive, () => Now);
+        }
+
+        static Task<OAuthValidationResult> Validate(AccessTokenValidator v, string token)
+            => v.ValidateAsync(token, CancellationToken.None);
+
+        [Fact]
+        public async Task ValidEs256Token_Succeeds()
+        {
+            using var key = TestJwt.CreateKey();
+            var token = TestJwt.SignEs256(key, Kid, TestJwt.Claims(Issuer, Resource, Now.AddHours(1)));
+
+            var result = await Validate(Validator(key), token);
+
+            result.Succeeded.ShouldBeTrue(result.FailureReason);
+            result.Subject.ShouldBe("user-123");
+            result.Scope.ShouldBe("mcp:agent");
+            result.TokenType.ShouldBe("jwt");
+        }
+
+        [Fact]
+        public async Task ExpiredToken_Rejected()
+        {
+            using var key = TestJwt.CreateKey();
+            var token = TestJwt.SignEs256(key, Kid, TestJwt.Claims(Issuer, Resource, Now.AddMinutes(-10)));
+
+            var result = await Validate(Validator(key), token);
+
+            result.Succeeded.ShouldBeFalse();
+            result.FailureReason!.ShouldContain("expired");
+        }
+
+        [Fact]
+        public async Task BadIssuer_Rejected()
+        {
+            using var key = TestJwt.CreateKey();
+            var token = TestJwt.SignEs256(key, Kid, TestJwt.Claims("https://evil.example", Resource, Now.AddHours(1)));
+
+            var result = await Validate(Validator(key), token);
+
+            result.Succeeded.ShouldBeFalse();
+            result.FailureReason!.ShouldContain("issuer");
+        }
+
+        [Fact]
+        public async Task BadAudience_Rejected()
+        {
+            using var key = TestJwt.CreateKey();
+            var token = TestJwt.SignEs256(key, Kid, TestJwt.Claims(Issuer, "http://localhost:59999", Now.AddHours(1)));
+
+            var result = await Validate(Validator(key), token);
+
+            result.Succeeded.ShouldBeFalse();
+            result.FailureReason!.ShouldContain("audience");
+        }
+
+        [Fact]
+        public async Task UnknownKid_Rejected()
+        {
+            using var key = TestJwt.CreateKey();
+            // Signed with a kid the provider does not know.
+            var token = TestJwt.SignEs256(key, "some-other-kid", TestJwt.Claims(Issuer, Resource, Now.AddHours(1)));
+
+            var result = await Validate(Validator(key), token);
+
+            result.Succeeded.ShouldBeFalse();
+            result.FailureReason!.ShouldContain("kid");
+        }
+
+        [Fact]
+        public async Task AlgNone_Rejected()
+        {
+            using var key = TestJwt.CreateKey();
+            var token = TestJwt.BuildAlgNone(Kid, TestJwt.Claims(Issuer, Resource, Now.AddHours(1)));
+
+            var result = await Validate(Validator(key), token);
+
+            result.Succeeded.ShouldBeFalse();
+            result.FailureReason!.ShouldContain("alg");
+        }
+
+        [Fact]
+        public async Task Hs256SignedWithPublicKey_Rejected()
+        {
+            using var key = TestJwt.CreateKey();
+            // Classic alg-confusion: attacker HMACs with the (public) verification key as the secret.
+            var token = TestJwt.SignHs256("HS256", Kid, TestJwt.Claims(Issuer, Resource, Now.AddHours(1)), TestJwt.PublicKeyBytes(key));
+
+            var result = await Validate(Validator(key), token);
+
+            result.Succeeded.ShouldBeFalse();
+            result.FailureReason!.ShouldContain("alg");
+        }
+
+        [Fact]
+        public async Task WrongSignature_SameKid_Rejected()
+        {
+            using var trustedKey = TestJwt.CreateKey();
+            using var attackerKey = TestJwt.CreateKey();
+            // Provider trusts trustedKey under Kid; token is signed by attackerKey but claims Kid.
+            var token = TestJwt.SignEs256(attackerKey, Kid, TestJwt.Claims(Issuer, Resource, Now.AddHours(1)));
+
+            var result = await Validate(Validator(trustedKey), token);
+
+            result.Succeeded.ShouldBeFalse();
+            result.FailureReason!.ShouldContain("signature");
+        }
+
+        [Fact]
+        public async Task Expiry_WithinSkew_Accepted()
+        {
+            using var key = TestJwt.CreateKey();
+            // 4 min in the past — inside the ±5 min skew tolerance.
+            var token = TestJwt.SignEs256(key, Kid, TestJwt.Claims(Issuer, Resource, Now.AddMinutes(-4)));
+
+            var result = await Validate(Validator(key), token);
+
+            result.Succeeded.ShouldBeTrue(result.FailureReason);
+        }
+
+        [Fact]
+        public async Task Expiry_BeyondSkew_Rejected()
+        {
+            using var key = TestJwt.CreateKey();
+            // 6 min in the past — beyond the ±5 min skew tolerance.
+            var token = TestJwt.SignEs256(key, Kid, TestJwt.Claims(Issuer, Resource, Now.AddMinutes(-6)));
+
+            var result = await Validate(Validator(key), token);
+
+            result.Succeeded.ShouldBeFalse();
+            result.FailureReason!.ShouldContain("expired");
+        }
+
+        [Fact]
+        public async Task NotBefore_WithinSkew_Accepted()
+        {
+            using var key = TestJwt.CreateKey();
+            var claims = TestJwt.Claims(Issuer, Resource, Now.AddHours(1), nbf: Now.AddMinutes(4));
+            var token = TestJwt.SignEs256(key, Kid, claims);
+
+            var result = await Validate(Validator(key), token);
+
+            result.Succeeded.ShouldBeTrue(result.FailureReason);
+        }
+
+        [Fact]
+        public async Task NotBefore_BeyondSkew_Rejected()
+        {
+            using var key = TestJwt.CreateKey();
+            var claims = TestJwt.Claims(Issuer, Resource, Now.AddHours(1), nbf: Now.AddMinutes(6));
+            var token = TestJwt.SignEs256(key, Kid, claims);
+
+            var result = await Validate(Validator(key), token);
+
+            result.Succeeded.ShouldBeFalse();
+            result.FailureReason!.ShouldContain("not yet valid");
+        }
+
+        [Fact]
+        public async Task LoopbackAliasedAudience_Accepted()
+        {
+            using var key = TestJwt.CreateKey();
+            // aud uses 127.0.0.1, --public-url uses localhost — must match after normalization.
+            var token = TestJwt.SignEs256(key, Kid, TestJwt.Claims(Issuer, "http://127.0.0.1:23471", Now.AddHours(1)));
+
+            var result = await Validate(Validator(key), token);
+
+            result.Succeeded.ShouldBeTrue(result.FailureReason);
+        }
+
+        [Fact]
+        public async Task ArrayAudienceContainingResource_Accepted()
+        {
+            using var key = TestJwt.CreateKey();
+            var claims = TestJwt.Claims(Issuer, Resource, Now.AddHours(1));
+            claims["aud"] = new[] { "https://other.example", Resource };
+            var token = TestJwt.SignEs256(key, Kid, claims);
+
+            var result = await Validate(Validator(key), token);
+
+            result.Succeeded.ShouldBeTrue(result.FailureReason);
+        }
+
+        [Fact]
+        public async Task MissingExp_Rejected()
+        {
+            using var key = TestJwt.CreateKey();
+            var claims = new Dictionary<string, object>
+            {
+                ["iss"] = Issuer,
+                ["aud"] = Resource,
+                ["sub"] = "user-123",
+                ["scope"] = "mcp:agent"
+            };
+            var token = TestJwt.SignEs256(key, Kid, claims);
+
+            var result = await Validate(Validator(key), token);
+
+            result.Succeeded.ShouldBeFalse();
+            result.FailureReason!.ShouldContain("exp");
+        }
+
+        // ── Opaque token path (introspection) ─────────────────────────────────────────────────────
+
+        [Fact]
+        public async Task OpaqueToken_ActiveIntrospection_Succeeds()
+        {
+            using var key = TestJwt.CreateKey();
+            var introspection = new FakeIntrospectionClient(t =>
+                t == "agd_pat_abc" ? new IntrospectionResult(true, "pat-user", "mcp:agent", Now.AddHours(1)) : IntrospectionResult.Inactive);
+
+            var result = await Validate(Validator(key, introspection), "agd_pat_abc");
+
+            result.Succeeded.ShouldBeTrue(result.FailureReason);
+            result.Subject.ShouldBe("pat-user");
+            result.TokenType.ShouldBe("opaque");
+        }
+
+        [Fact]
+        public async Task OpaqueToken_InactiveIntrospection_Rejected()
+        {
+            using var key = TestJwt.CreateKey();
+            var result = await Validate(Validator(key, FakeIntrospectionClient.AlwaysInactive), "agd_pat_unknown");
+
+            result.Succeeded.ShouldBeFalse();
+            result.TokenType.ShouldBe("opaque");
+        }
+
+        [Fact]
+        public async Task OpaqueToken_ActiveButExpired_Rejected()
+        {
+            using var key = TestJwt.CreateKey();
+            var introspection = new FakeIntrospectionClient(_ =>
+                new IntrospectionResult(true, "pat-user", "mcp:agent", Now.AddMinutes(-10)));
+
+            var result = await Validate(Validator(key, introspection), "agd_pat_stale");
+
+            result.Succeeded.ShouldBeFalse();
+            result.FailureReason!.ShouldContain("expired");
+        }
+    }
+}

--- a/McpPlugin.Server.Tests/OAuth/Fakes.cs
+++ b/McpPlugin.Server.Tests/OAuth/Fakes.cs
@@ -1,0 +1,68 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.Server.Auth.OAuth;
+
+namespace com.IvanMurzak.McpPlugin.Server.Tests.OAuth
+{
+    /// <summary>In-memory JWKS provider: returns a fresh ECDsa per known kid, null otherwise.</summary>
+    internal sealed class FakeJwksKeyProvider : IJwksKeyProvider
+    {
+        private readonly Dictionary<string, ECParameters> _keys = new(StringComparer.Ordinal);
+
+        public FakeJwksKeyProvider Add(string kid, ECDsa key)
+        {
+            _keys[kid] = key.ExportParameters(false);
+            return this;
+        }
+
+        public Task<ECDsa?> GetSigningKeyAsync(string kid, CancellationToken cancellationToken)
+            => Task.FromResult(_keys.TryGetValue(kid, out var p) ? ECDsa.Create(p) : null);
+    }
+
+    /// <summary>Introspection stub driven by a caller-supplied map.</summary>
+    internal sealed class FakeIntrospectionClient : IIntrospectionClient
+    {
+        private readonly Func<string, IntrospectionResult> _map;
+
+        public FakeIntrospectionClient(Func<string, IntrospectionResult> map) => _map = map;
+
+        public static FakeIntrospectionClient AlwaysInactive => new FakeIntrospectionClient(_ => IntrospectionResult.Inactive);
+
+        public Task<IntrospectionResult> IntrospectAsync(string token, CancellationToken cancellationToken)
+            => Task.FromResult(_map(token));
+    }
+
+    /// <summary>In-memory JWKS disk cache for JwksKeyProvider tests.</summary>
+    internal sealed class InMemoryJwksDiskCache : IJwksDiskCache
+    {
+        public string? Value { get; set; }
+        public int Reads { get; private set; }
+        public int Writes { get; private set; }
+
+        public string? Read()
+        {
+            Reads++;
+            return Value;
+        }
+
+        public void Write(string json)
+        {
+            Writes++;
+            Value = json;
+        }
+    }
+}

--- a/McpPlugin.Server.Tests/OAuth/IntrospectionClientTests.cs
+++ b/McpPlugin.Server.Tests/OAuth/IntrospectionClientTests.cs
@@ -1,0 +1,115 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.Server.Auth.OAuth;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.Server.Tests.OAuth
+{
+    /// <summary>Introspection caching + fail-closed behavior (mcp-authorize b2).</summary>
+    public class IntrospectionClientTests
+    {
+        static readonly DateTimeOffset Start = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+        sealed class CountingPost
+        {
+            public string? Response;
+            public bool Throw;
+            public int Calls;
+
+            public IntrospectionPost Delegate => (token, ct) =>
+            {
+                Calls++;
+                if (Throw)
+                    throw new InvalidOperationException("network");
+                return Task.FromResult(Response);
+            };
+        }
+
+        [Fact]
+        public async Task ActiveToken_ParsedAndReturned()
+        {
+            var post = new CountingPost { Response = "{\"active\":true,\"sub\":\"u1\",\"scope\":\"mcp:agent\"}" };
+            var client = new IntrospectionClient(post.Delegate, () => Start);
+
+            var result = await client.IntrospectAsync("agd_pat_x", CancellationToken.None);
+
+            result.Active.ShouldBeTrue();
+            result.Subject.ShouldBe("u1");
+            result.Scope.ShouldBe("mcp:agent");
+        }
+
+        [Fact]
+        public async Task InactiveToken_ReturnedInactive()
+        {
+            var post = new CountingPost { Response = "{\"active\":false}" };
+            var client = new IntrospectionClient(post.Delegate, () => Start);
+
+            var result = await client.IntrospectAsync("agd_pat_x", CancellationToken.None);
+
+            result.Active.ShouldBeFalse();
+        }
+
+        [Fact]
+        public async Task Result_CachedWithinTtl_ThenRefetched()
+        {
+            var now = Start;
+            var post = new CountingPost { Response = "{\"active\":true,\"sub\":\"u1\"}" };
+            var client = new IntrospectionClient(post.Delegate, () => now, TimeSpan.FromSeconds(60));
+
+            (await client.IntrospectAsync("t", CancellationToken.None)).Active.ShouldBeTrue();
+            (await client.IntrospectAsync("t", CancellationToken.None)).Active.ShouldBeTrue();
+            post.Calls.ShouldBe(1); // second served from cache
+
+            now = Start.AddSeconds(61);
+            (await client.IntrospectAsync("t", CancellationToken.None)).Active.ShouldBeTrue();
+            post.Calls.ShouldBe(2); // cache expired
+        }
+
+        [Fact]
+        public async Task TransportError_FailsClosed_AndNotCached()
+        {
+            var post = new CountingPost { Response = null }; // simulates non-2xx / transport error
+            var client = new IntrospectionClient(post.Delegate, () => Start);
+
+            (await client.IntrospectAsync("t", CancellationToken.None)).Active.ShouldBeFalse();
+            (await client.IntrospectAsync("t", CancellationToken.None)).Active.ShouldBeFalse();
+            post.Calls.ShouldBe(2); // failures are not cached — each call retries
+        }
+
+        [Fact]
+        public async Task Exception_FailsClosed()
+        {
+            var post = new CountingPost { Throw = true };
+            var client = new IntrospectionClient(post.Delegate, () => Start);
+
+            var result = await client.IntrospectAsync("t", CancellationToken.None);
+
+            result.Active.ShouldBeFalse();
+        }
+
+        [Fact]
+        public async Task MalformedResponse_FailsClosed_AndNotCached()
+        {
+            var post = new CountingPost { Response = "not json" };
+            var client = new IntrospectionClient(post.Delegate, () => Start);
+
+            (await client.IntrospectAsync("t", CancellationToken.None)).Active.ShouldBeFalse();
+            post.Calls.ShouldBe(1);
+            (await client.IntrospectAsync("t", CancellationToken.None)).Active.ShouldBeFalse();
+            post.Calls.ShouldBe(2); // malformed responses are not cached
+        }
+    }
+}

--- a/McpPlugin.Server.Tests/OAuth/JwksKeyProviderTests.cs
+++ b/McpPlugin.Server.Tests/OAuth/JwksKeyProviderTests.cs
@@ -1,0 +1,148 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.Server.Auth.OAuth;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.Server.Tests.OAuth
+{
+    /// <summary>
+    /// JWKS key-provider behavior (mcp-authorize b2): disk cache, offline grace, 24 h refresh, and
+    /// rate-limited unknown-<c>kid</c> refetch.
+    /// </summary>
+    public class JwksKeyProviderTests
+    {
+        const string Kid1 = "k1";
+        const string Kid2 = "k2";
+        static readonly DateTimeOffset Start = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+        sealed class CountingFetch
+        {
+            public string? Current;
+            public bool Fail;
+            public int Calls;
+
+            public JwksFetch Delegate => _ =>
+            {
+                Calls++;
+                if (Fail)
+                    throw new HttpRequestException("offline");
+                return Task.FromResult(Current);
+            };
+        }
+
+        static async Task<bool> Resolves(IJwksKeyProvider provider, string kid)
+        {
+            var key = await provider.GetSigningKeyAsync(kid, CancellationToken.None);
+            using (key)
+                return key != null;
+        }
+
+        [Fact]
+        public async Task FetchSuccess_ResolvesKey_AndWritesDiskCache()
+        {
+            using var key = TestJwt.CreateKey();
+            var fetch = new CountingFetch { Current = TestJwt.BuildJwks(key, Kid1) };
+            var cache = new InMemoryJwksDiskCache();
+            var provider = new JwksKeyProvider(fetch.Delegate, cache, () => Start);
+
+            (await Resolves(provider, Kid1)).ShouldBeTrue();
+            cache.Writes.ShouldBe(1);
+            cache.Value.ShouldNotBeNull();
+        }
+
+        [Fact]
+        public async Task OfflineWithCache_ResolvesFromDisk()
+        {
+            using var key = TestJwt.CreateKey();
+            var cache = new InMemoryJwksDiskCache { Value = TestJwt.BuildJwks(key, Kid1) };
+            var fetch = new CountingFetch { Fail = true };
+            var provider = new JwksKeyProvider(fetch.Delegate, cache, () => Start);
+
+            (await Resolves(provider, Kid1)).ShouldBeTrue();
+            fetch.Calls.ShouldBe(1); // attempted the network, then fell back to disk
+        }
+
+        [Fact]
+        public async Task OfflineWithoutCache_ReturnsNull()
+        {
+            var cache = new InMemoryJwksDiskCache();
+            var fetch = new CountingFetch { Fail = true };
+            var provider = new JwksKeyProvider(fetch.Delegate, cache, () => Start);
+
+            (await Resolves(provider, Kid1)).ShouldBeFalse();
+        }
+
+        [Fact]
+        public async Task UnknownKid_RefetchIsRateLimited()
+        {
+            using var key = TestJwt.CreateKey();
+            var now = Start;
+            var fetch = new CountingFetch { Current = TestJwt.BuildJwks(key, Kid1) };
+            var provider = new JwksKeyProvider(
+                fetch.Delegate, new InMemoryJwksDiskCache(), () => now,
+                unknownKidMinRefetchInterval: TimeSpan.FromSeconds(60));
+
+            (await Resolves(provider, Kid1)).ShouldBeTrue();
+            fetch.Calls.ShouldBe(1);
+
+            // Unknown kid within the rate-limit window → NO refetch.
+            (await Resolves(provider, Kid2)).ShouldBeFalse();
+            fetch.Calls.ShouldBe(1);
+
+            // After the window, an unknown kid triggers exactly one refetch — and now the AS has k2.
+            now = Start.AddSeconds(61);
+            using var key2 = TestJwt.CreateKey();
+            fetch.Current = BuildTwoKeyJwks(key, Kid1, key2, Kid2);
+            (await Resolves(provider, Kid2)).ShouldBeTrue();
+            fetch.Calls.ShouldBe(2);
+        }
+
+        [Fact]
+        public async Task StaleSet_RefreshedAfterInterval()
+        {
+            using var key = TestJwt.CreateKey();
+            var now = Start;
+            var fetch = new CountingFetch { Current = TestJwt.BuildJwks(key, Kid1) };
+            var provider = new JwksKeyProvider(
+                fetch.Delegate, new InMemoryJwksDiskCache(), () => now,
+                refreshInterval: TimeSpan.FromHours(24));
+
+            (await Resolves(provider, Kid1)).ShouldBeTrue();
+            fetch.Calls.ShouldBe(1);
+
+            // Within the window: served from memory, no refetch.
+            (await Resolves(provider, Kid1)).ShouldBeTrue();
+            fetch.Calls.ShouldBe(1);
+
+            // After 24 h: the set is refreshed.
+            now = Start.AddHours(25);
+            (await Resolves(provider, Kid1)).ShouldBeTrue();
+            fetch.Calls.ShouldBe(2);
+        }
+
+        static string BuildTwoKeyJwks(ECDsa a, string kidA, ECDsa b, string kidB)
+        {
+            // Merge two single-key JWKS documents into one { "keys": [ ... ] }.
+            var ja = TestJwt.BuildJwks(a, kidA);
+            var jb = TestJwt.BuildJwks(b, kidB);
+            var innerA = ja.Substring(ja.IndexOf('[') + 1, ja.LastIndexOf(']') - ja.IndexOf('[') - 1);
+            var innerB = jb.Substring(jb.IndexOf('[') + 1, jb.LastIndexOf(']') - jb.IndexOf('[') - 1);
+            return "{\"keys\":[" + innerA + "," + innerB + "]}";
+        }
+    }
+}

--- a/McpPlugin.Server.Tests/OAuth/OAuthResourceServerTests.cs
+++ b/McpPlugin.Server.Tests/OAuth/OAuthResourceServerTests.cs
@@ -1,0 +1,109 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using com.IvanMurzak.McpPlugin.Common;
+using com.IvanMurzak.McpPlugin.Common.Utils;
+using com.IvanMurzak.McpPlugin.Server.Auth;
+using com.IvanMurzak.McpPlugin.Server.Auth.OAuth;
+using com.IvanMurzak.McpPlugin.Server.Strategy;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.Server.Tests.OAuth
+{
+    [Collection("McpPlugin.Server")]
+    public class OAuthResourceServerTests
+    {
+        [Fact]
+        public void Config_DerivesEndpoints()
+        {
+            var config = new OAuthResourceServerConfig("https://ai-game.dev/", "http://localhost:23471");
+            config.Issuer.ShouldBe("https://ai-game.dev");
+            config.JwksUri.ShouldBe("https://ai-game.dev/.well-known/jwks.json");
+            config.IntrospectionEndpoint.ShouldBe("https://ai-game.dev/oauth/introspect");
+            config.ClockSkew.ShouldBe(TimeSpan.FromMinutes(5));
+        }
+
+        [Fact]
+        public void Config_RejectsMissingIssuerOrResource()
+        {
+            Should.Throw<ArgumentException>(() => new OAuthResourceServerConfig("", "http://localhost:1"));
+            Should.Throw<ArgumentException>(() => new OAuthResourceServerConfig("https://x", ""));
+        }
+
+        [Fact]
+        public void ProtectedResourceMetadataUrl_PathLessResource_Appends()
+        {
+            var config = new OAuthResourceServerConfig("https://as.example", "http://localhost:23471");
+            config.ProtectedResourceMetadataUrl()
+                .ShouldBe("http://localhost:23471/.well-known/oauth-protected-resource");
+        }
+
+        [Fact]
+        public void ProtectedResourceMetadataUrl_ResourceWithPath_RootInserts()
+        {
+            var config = new OAuthResourceServerConfig("https://ai-game.dev", "https://ai-game.dev/mcp");
+            config.ProtectedResourceMetadataUrl()
+                .ShouldBe("https://ai-game.dev/.well-known/oauth-protected-resource/mcp");
+        }
+
+        [Fact]
+        public void ProtectedResourceMetadata_Content()
+        {
+            var config = new OAuthResourceServerConfig("https://ai-game.dev", "https://ai-game.dev/mcp");
+            var doc = OAuthProtectedResourceMetadata.Build(config);
+
+            doc["resource"].ShouldBe("https://ai-game.dev/mcp");
+            ((string[])doc["authorization_servers"]).ShouldBe(new[] { "https://ai-game.dev" });
+            ((string[])doc["scopes_supported"]).ShouldBe(new[] { "mcp:agent" });
+            ((string[])doc["bearer_methods_supported"]).ShouldBe(new[] { "header" });
+        }
+
+        [Fact]
+        public void StrategyFactory_CreatesOAuthStrategy()
+        {
+            var strategy = new McpStrategyFactory().Create(Consts.MCP.Server.AuthOption.oauth);
+            strategy.ShouldBeOfType<OAuthMcpStrategy>();
+            strategy.AuthOption.ShouldBe(Consts.MCP.Server.AuthOption.oauth);
+        }
+
+        [Fact]
+        public void OAuthStrategy_Validate_RequiresIssuerAndPublicUrl()
+        {
+            var strategy = new OAuthMcpStrategy();
+
+            Should.Throw<ArgumentException>(() =>
+                strategy.Validate(new DataArguments(new[] { "auth=oauth" })));
+
+            // Both present → no throw.
+            strategy.Validate(new DataArguments(new[]
+            {
+                "auth=oauth", "auth-issuer=https://as.example", "public-url=http://localhost:1"
+            }));
+        }
+
+        [Fact]
+        public void OAuthStrategy_ConfigureAuthentication_SetsOAuthMode()
+        {
+            var strategy = new OAuthMcpStrategy();
+            var options = new TokenAuthenticationOptions();
+            strategy.ConfigureAuthentication(options, new DataArguments(new[]
+            {
+                "auth=oauth", "auth-issuer=https://as.example", "public-url=http://localhost:1"
+            }));
+
+            options.OAuthMode.ShouldBeTrue();
+            options.RequireToken.ShouldBeTrue();
+            options.ServerToken.ShouldBeNull();
+        }
+    }
+}

--- a/McpPlugin.Server.Tests/OAuth/TestJwt.cs
+++ b/McpPlugin.Server.Tests/OAuth/TestJwt.cs
@@ -1,0 +1,108 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+
+namespace com.IvanMurzak.McpPlugin.Server.Tests.OAuth
+{
+    /// <summary>
+    /// Test-only helpers for minting ES256 (and adversarial) JWTs and the matching JWKS document,
+    /// so the resource-server validation fuzz suite runs fully hermetically (no network, no external
+    /// identity library).
+    /// </summary>
+    internal static class TestJwt
+    {
+        public static ECDsa CreateKey() => ECDsa.Create(ECCurve.NamedCurves.nistP256);
+
+        public static string Base64UrlEncode(byte[] bytes)
+            => Convert.ToBase64String(bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+
+        public static string Base64UrlEncode(string text)
+            => Base64UrlEncode(Encoding.UTF8.GetBytes(text));
+
+        /// <summary>Build a JWKS JSON document exposing the public part of <paramref name="key"/> under <paramref name="kid"/>.</summary>
+        public static string BuildJwks(ECDsa key, string kid)
+        {
+            var p = key.ExportParameters(false);
+            var jwk = new Dictionary<string, object>
+            {
+                ["kty"] = "EC",
+                ["crv"] = "P-256",
+                ["use"] = "sig",
+                ["alg"] = "ES256",
+                ["kid"] = kid,
+                ["x"] = Base64UrlEncode(p.Q.X!),
+                ["y"] = Base64UrlEncode(p.Q.Y!)
+            };
+            var set = new Dictionary<string, object> { ["keys"] = new[] { jwk } };
+            return JsonSerializer.Serialize(set);
+        }
+
+        /// <summary>Mint a signed ES256 JWT with the given claims.</summary>
+        public static string SignEs256(ECDsa key, string kid, IDictionary<string, object> claims)
+        {
+            var header = new Dictionary<string, object> { ["alg"] = "ES256", ["typ"] = "JWT", ["kid"] = kid };
+            var headerB64 = Base64UrlEncode(JsonSerializer.Serialize(header));
+            var payloadB64 = Base64UrlEncode(JsonSerializer.Serialize(claims));
+            var signingInput = Encoding.ASCII.GetBytes(headerB64 + "." + payloadB64);
+            var sig = key.SignData(signingInput, HashAlgorithmName.SHA256, DSASignatureFormat.IeeeP1363FixedFieldConcatenation);
+            return headerB64 + "." + payloadB64 + "." + Base64UrlEncode(sig);
+        }
+
+        /// <summary>Mint a token with a caller-chosen <c>alg</c> header, signed with HMAC-SHA256 over the given secret (alg-confusion attack vector).</summary>
+        public static string SignHs256(string alg, string kid, IDictionary<string, object> claims, byte[] hmacSecret)
+        {
+            var header = new Dictionary<string, object> { ["alg"] = alg, ["typ"] = "JWT", ["kid"] = kid };
+            var headerB64 = Base64UrlEncode(JsonSerializer.Serialize(header));
+            var payloadB64 = Base64UrlEncode(JsonSerializer.Serialize(claims));
+            var signingInput = Encoding.ASCII.GetBytes(headerB64 + "." + payloadB64);
+            using var hmac = new HMACSHA256(hmacSecret);
+            var sig = hmac.ComputeHash(signingInput);
+            return headerB64 + "." + payloadB64 + "." + Base64UrlEncode(sig);
+        }
+
+        /// <summary>Mint an <c>alg:none</c> token whose signature segment is present-but-bogus (so it parses as a JWT).</summary>
+        public static string BuildAlgNone(string kid, IDictionary<string, object> claims)
+        {
+            var header = new Dictionary<string, object> { ["alg"] = "none", ["typ"] = "JWT", ["kid"] = kid };
+            var headerB64 = Base64UrlEncode(JsonSerializer.Serialize(header));
+            var payloadB64 = Base64UrlEncode(JsonSerializer.Serialize(claims));
+            return headerB64 + "." + payloadB64 + "." + Base64UrlEncode(Encoding.ASCII.GetBytes("not-a-signature"));
+        }
+
+        /// <summary>The SPKI-encoded public key bytes — a realistic secret an HS256 key-confusion attack would use.</summary>
+        public static byte[] PublicKeyBytes(ECDsa key) => key.ExportSubjectPublicKeyInfo();
+
+        public static long Unix(DateTimeOffset time) => time.ToUnixTimeSeconds();
+
+        /// <summary>Standard MCP agent claim set; override individual entries as needed.</summary>
+        public static Dictionary<string, object> Claims(
+            string iss, string aud, DateTimeOffset exp, string sub = "user-123", string scope = "mcp:agent",
+            DateTimeOffset? nbf = null, DateTimeOffset? iat = null)
+        {
+            var claims = new Dictionary<string, object>
+            {
+                ["iss"] = iss,
+                ["aud"] = aud,
+                ["sub"] = sub,
+                ["scope"] = scope,
+                ["exp"] = Unix(exp)
+            };
+            if (nbf.HasValue) claims["nbf"] = Unix(nbf.Value);
+            if (iat.HasValue) claims["iat"] = Unix(iat.Value);
+            return claims;
+        }
+    }
+}

--- a/McpPlugin.Server.Tests/OAuth/UrlNormalizationTests.cs
+++ b/McpPlugin.Server.Tests/OAuth/UrlNormalizationTests.cs
@@ -1,0 +1,56 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using com.IvanMurzak.McpPlugin.Server.Auth.OAuth;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.Server.Tests.OAuth
+{
+    public class UrlNormalizationTests
+    {
+        [Theory]
+        [InlineData("localhost", true)]
+        [InlineData("127.0.0.1", true)]
+        [InlineData("127.0.0.5", true)]
+        [InlineData("::1", true)]
+        [InlineData("[::1]", true)]
+        [InlineData("example.com", false)]
+        [InlineData("10.0.0.1", false)]
+        [InlineData("", false)]
+        public void IsLoopbackHost(string host, bool expected)
+            => UrlNormalization.IsLoopbackHost(host).ShouldBe(expected);
+
+        [Theory]
+        [InlineData("http://localhost:23471", "http://127.0.0.1:23471", true)]   // loopback alias
+        [InlineData("http://localhost:23471", "http://[::1]:23471", true)]       // ipv6 loopback alias
+        [InlineData("http://localhost:23471", "http://localhost:9999", false)]   // port differs
+        [InlineData("https://ai-game.dev/mcp", "https://ai-game.dev/mcp", true)] // path preserved
+        [InlineData("https://ai-game.dev/mcp", "https://ai-game.dev/other", false)]
+        [InlineData("https://ai-game.dev", "https://ai-game.dev:443", true)]     // default port
+        [InlineData("https://ai-game.dev/mcp/", "https://ai-game.dev/mcp", true)] // trailing slash
+        public void ResourcesMatch(string a, string b, bool expected)
+            => UrlNormalization.ResourcesMatch(a, b).ShouldBe(expected);
+
+        [Fact]
+        public void NormalizeOrigin_StripsPath_AndAliasesLoopback()
+        {
+            UrlNormalization.NormalizeOrigin("http://127.0.0.1:5000")
+                .ShouldBe("http://localhost:5000");
+            UrlNormalization.NormalizeOrigin("https://App.Example.COM")
+                .ShouldBe("https://app.example.com:443");
+        }
+
+        [Fact]
+        public void NormalizeOrigin_Malformed_ReturnsNull()
+            => UrlNormalization.NormalizeOrigin("not a url").ShouldBeNull();
+    }
+}

--- a/McpPlugin.Server.Tests/Security/OriginPolicyTests.cs
+++ b/McpPlugin.Server.Tests/Security/OriginPolicyTests.cs
@@ -1,0 +1,58 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using com.IvanMurzak.McpPlugin.Common;
+using com.IvanMurzak.McpPlugin.Server.Security;
+using Microsoft.AspNetCore.Http;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.Server.Tests.Security
+{
+    public class OriginPolicyTests
+    {
+        static readonly string Hub = Consts.Hub.RemoteApp;
+
+        [Theory]
+        [InlineData("/", true)]
+        [InlineData("/mcp", true)]
+        [InlineData("/mcp/p/3fa9c1e2", true)]
+        [InlineData("/hub/mcp-server", true)]
+        [InlineData("/hub/mcp-server/negotiate", true)]
+        [InlineData("/help", false)]
+        [InlineData("/.well-known/oauth-protected-resource", false)]
+        [InlineData("/oauth/token", false)]
+        [InlineData("/api/tools", false)]
+        public void IsGuardedPath(string path, bool expected)
+            => OriginPolicy.IsGuardedPath(new PathString(path), Hub).ShouldBe(expected);
+
+        static OriginValidationOptions Options()
+            => new OriginValidationOptions(new[] { "https://app.example:443" }, allowLoopback: true);
+
+        [Theory]
+        [InlineData(null, true)]                       // absent → allowed (native client)
+        [InlineData("", true)]                         // absent → allowed
+        [InlineData("http://localhost:5000", true)]    // loopback → allowed
+        [InlineData("http://127.0.0.1:9", true)]       // loopback → allowed
+        [InlineData("https://app.example", true)]      // explicitly allowed origin
+        [InlineData("https://evil.example", false)]    // not allowed → reject
+        [InlineData("garbage", false)]                 // malformed → reject
+        public void IsOriginAllowed(string? origin, bool expected)
+            => OriginPolicy.IsOriginAllowed(origin, Options()).ShouldBe(expected);
+
+        [Fact]
+        public void LoopbackDisallowed_WhenAllowLoopbackFalse()
+        {
+            var options = new OriginValidationOptions(System.Array.Empty<string>(), allowLoopback: false);
+            OriginPolicy.IsOriginAllowed("http://localhost:5000", options).ShouldBeFalse();
+        }
+    }
+}

--- a/McpPlugin.Server.Tests/Security/OriginValidationMiddlewareTests.cs
+++ b/McpPlugin.Server.Tests/Security/OriginValidationMiddlewareTests.cs
@@ -1,0 +1,99 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System.IO;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.Common;
+using com.IvanMurzak.McpPlugin.Server.Security;
+using Microsoft.AspNetCore.Http;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.Server.Tests.Security
+{
+    /// <summary>
+    /// Origin validation returns 403 for a present-but-non-allowed Origin on the MCP endpoint AND
+    /// the SignalR negotiate path, and passes when the Origin is absent or allowed — in the allow
+    /// sets used by BOTH none and oauth modes (mcp-authorize b2 DoD).
+    /// </summary>
+    public class OriginValidationMiddlewareTests
+    {
+        // none mode: no configured public-url → only loopback is allowed.
+        static OriginValidationOptions NoneMode() => new OriginValidationOptions(System.Array.Empty<string>(), allowLoopback: true);
+        // oauth mode: the RS public-url origin is additionally allowed.
+        static OriginValidationOptions OAuthMode() => new OriginValidationOptions(new[] { "https://app.example:443" }, allowLoopback: true);
+
+        static async Task<(int status, bool nextCalled)> Run(OriginValidationOptions options, string path, string? origin)
+        {
+            var nextCalled = false;
+            var middleware = new OriginValidationMiddleware(_ => { nextCalled = true; return Task.CompletedTask; }, options);
+
+            var ctx = new DefaultHttpContext();
+            ctx.Request.Path = new PathString(path);
+            ctx.Response.Body = new MemoryStream();
+            if (origin != null)
+                ctx.Request.Headers["Origin"] = origin;
+
+            await middleware.InvokeAsync(ctx);
+            return (ctx.Response.StatusCode, nextCalled);
+        }
+
+        [Theory]
+        [InlineData("/mcp")]
+        [InlineData("/hub/mcp-server/negotiate")]
+        public async Task NonAllowedOrigin_Returns403_InBothModes(string path)
+        {
+            var none = await Run(NoneMode(), path, "https://evil.example");
+            none.status.ShouldBe(403);
+            none.nextCalled.ShouldBeFalse();
+
+            var oauth = await Run(OAuthMode(), path, "https://evil.example");
+            oauth.status.ShouldBe(403);
+            oauth.nextCalled.ShouldBeFalse();
+        }
+
+        [Theory]
+        [InlineData("/mcp")]
+        [InlineData("/hub/mcp-server/negotiate")]
+        public async Task AbsentOrigin_Passes_InBothModes(string path)
+        {
+            (await Run(NoneMode(), path, null)).nextCalled.ShouldBeTrue();
+            (await Run(OAuthMode(), path, null)).nextCalled.ShouldBeTrue();
+        }
+
+        [Theory]
+        [InlineData("/mcp")]
+        [InlineData("/hub/mcp-server/negotiate")]
+        public async Task LoopbackOrigin_Passes_InBothModes(string path)
+        {
+            (await Run(NoneMode(), path, "http://localhost:6123")).nextCalled.ShouldBeTrue();
+            (await Run(OAuthMode(), path, "http://127.0.0.1:6123")).nextCalled.ShouldBeTrue();
+        }
+
+        [Fact]
+        public async Task PublicUrlOrigin_Allowed_OnlyInOAuthMode()
+        {
+            (await Run(OAuthMode(), "/mcp", "https://app.example")).nextCalled.ShouldBeTrue();
+
+            var none = await Run(NoneMode(), "/mcp", "https://app.example");
+            none.status.ShouldBe(403);
+            none.nextCalled.ShouldBeFalse();
+        }
+
+        [Fact]
+        public async Task NonGuardedPath_WithHostileOrigin_Passes()
+        {
+            // Discovery/help endpoints are not guarded.
+            var result = await Run(OAuthMode(), "/.well-known/oauth-protected-resource", "https://evil.example");
+            result.nextCalled.ShouldBeTrue();
+        }
+    }
+}

--- a/McpPlugin.Server.Tests/TokenAuthenticationHandlerOAuthTests.cs
+++ b/McpPlugin.Server.Tests/TokenAuthenticationHandlerOAuthTests.cs
@@ -1,0 +1,144 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.Common;
+using com.IvanMurzak.McpPlugin.Server.Auth;
+using com.IvanMurzak.McpPlugin.Server.Auth.OAuth;
+using com.IvanMurzak.McpPlugin.Server.Webhooks.Services;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.Server.Tests
+{
+    [Collection("McpPlugin.Server")]
+    public class TokenAuthenticationHandlerOAuthTests
+    {
+        sealed class FakeValidator : IOAuthTokenValidator
+        {
+            private readonly OAuthValidationResult _result;
+            public FakeValidator(OAuthValidationResult result) => _result = result;
+            public Task<OAuthValidationResult> ValidateAsync(string token, CancellationToken cancellationToken)
+                => Task.FromResult(_result);
+        }
+
+        static readonly OAuthResourceServerConfig Config = new OAuthResourceServerConfig("https://as.example", "http://localhost:23471");
+
+        static (TokenAuthenticationHandler Handler, DefaultHttpContext Context, AuthenticationScheme Scheme) Create(
+            IOAuthTokenValidator? validator)
+        {
+            var options = new TokenAuthenticationOptions { OAuthMode = true, RequireToken = true };
+            var monitor = new Mock<IOptionsMonitor<TokenAuthenticationOptions>>();
+            monitor.Setup(x => x.CurrentValue).Returns(options);
+            monitor.Setup(x => x.Get(TokenAuthenticationHandler.SchemeName)).Returns(options);
+
+            var loggerFactory = new Mock<ILoggerFactory>();
+            loggerFactory.Setup(x => x.CreateLogger(It.IsAny<string>())).Returns(new Mock<ILogger>().Object);
+
+            var handler = new TokenAuthenticationHandler(
+                monitor.Object,
+                loggerFactory.Object,
+                System.Text.Encodings.Web.UrlEncoder.Default,
+                new NoOpAuthorizationWebhookService(),
+                validator,
+                Config);
+
+            var context = new DefaultHttpContext();
+            context.Response.Body = new MemoryStream();
+            var scheme = new AuthenticationScheme(
+                TokenAuthenticationHandler.SchemeName, TokenAuthenticationHandler.SchemeName, typeof(TokenAuthenticationHandler));
+            return (handler, context, scheme);
+        }
+
+        [Fact]
+        public async Task ValidToken_Succeeds_WithSubjectAndScopeClaims()
+        {
+            var validator = new FakeValidator(OAuthValidationResult.Success("jwt", "user-9", "mcp:agent", "client-x"));
+            var (handler, context, scheme) = Create(validator);
+            context.Request.Headers["Authorization"] = "Bearer some.jwt.token";
+            context.Request.Path = new PathString("/mcp");
+            await handler.InitializeAsync(scheme, context);
+
+            var result = await handler.AuthenticateAsync();
+
+            result.Succeeded.ShouldBeTrue();
+            result.Principal!.HasClaim(TokenAuthenticationHandler.SubjectClaimType, "user-9").ShouldBeTrue();
+            result.Principal.HasClaim(TokenAuthenticationHandler.ScopeClaimType, "mcp:agent").ShouldBeTrue();
+            result.Principal.HasClaim(TokenAuthenticationHandler.ClientIdClaimType, "client-x").ShouldBeTrue();
+        }
+
+        [Fact]
+        public async Task InvalidToken_OnMcpPath_Fails()
+        {
+            var validator = new FakeValidator(OAuthValidationResult.Fail("jwt", "invalid signature"));
+            var (handler, context, scheme) = Create(validator);
+            context.Request.Headers["Authorization"] = "Bearer bad.jwt.token";
+            context.Request.Path = new PathString("/mcp");
+            await handler.InitializeAsync(scheme, context);
+
+            var result = await handler.AuthenticateAsync();
+
+            result.Succeeded.ShouldBeFalse();
+            result.None.ShouldBeFalse();
+        }
+
+        [Fact]
+        public async Task InvalidToken_OnHubPath_ReturnsNoResult()
+        {
+            var validator = new FakeValidator(OAuthValidationResult.Fail("jwt", "invalid signature"));
+            var (handler, context, scheme) = Create(validator);
+            context.Request.Headers["Authorization"] = "Bearer bad.jwt.token";
+            context.Request.Path = new PathString(Consts.Hub.RemoteApp);
+            await handler.InitializeAsync(scheme, context);
+
+            var result = await handler.AuthenticateAsync();
+
+            result.None.ShouldBeTrue();
+        }
+
+        [Fact]
+        public async Task NoToken_ReturnsNoResult()
+        {
+            var (handler, context, scheme) = Create(new FakeValidator(OAuthValidationResult.Success("jwt", "u", "mcp:agent")));
+            context.Request.Path = new PathString("/mcp");
+            await handler.InitializeAsync(scheme, context);
+
+            var result = await handler.AuthenticateAsync();
+
+            result.None.ShouldBeTrue();
+        }
+
+        [Fact]
+        public async Task Challenge_Emits401_WithAbsoluteResourceMetadata_AndScope()
+        {
+            var (handler, context, scheme) = Create(null);
+            await handler.InitializeAsync(scheme, context);
+
+            await handler.ChallengeAsync(null);
+
+            context.Response.StatusCode.ShouldBe(401);
+            var wwwAuth = context.Response.Headers["WWW-Authenticate"].ToString();
+            wwwAuth.ShouldContain("Bearer ");
+            wwwAuth.ShouldContain($"resource_metadata=\"{Config.ProtectedResourceMetadataUrl()}\"");
+            wwwAuth.ShouldContain("scope=\"mcp:agent\"");
+
+            // The resource_metadata URL must be ABSOLUTE (a real MCP client rejects relative URLs).
+            Config.ProtectedResourceMetadataUrl().ShouldStartWith("http://localhost:23471/.well-known/oauth-protected-resource");
+        }
+    }
+}

--- a/McpPlugin.Server/src/Auth/OAuth/AccessTokenValidator.cs
+++ b/McpPlugin.Server/src/Auth/OAuth/AccessTokenValidator.cs
@@ -1,0 +1,233 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace com.IvanMurzak.McpPlugin.Server.Auth.OAuth
+{
+    /// <summary>
+    /// Default <see cref="IOAuthTokenValidator"/> (mcp-authorize b2). Validates:
+    /// <list type="bullet">
+    ///   <item><b>ES256 JWTs</b> — header <c>alg</c> MUST be exactly <c>ES256</c> (this alone
+    ///         defeats the <c>alg:none</c> and HS256-with-the-public-key key-confusion attacks:
+    ///         no symmetric or "none" path is ever taken and no key material is loaded before the
+    ///         algorithm is confirmed); signature verified with the JWKS P-256 key resolved by
+    ///         <c>kid</c>; strict <c>iss</c>, strict per-resource <c>aud</c> (loopback-aliased),
+    ///         and <c>exp</c>/<c>nbf</c> with ±5 min skew.</item>
+    ///   <item><b>Opaque tokens</b> — routed to introspection (fail-closed).</item>
+    /// </list>
+    /// Every failure path returns <see cref="OAuthValidationResult.Fail"/>; nothing throws.
+    /// </summary>
+    public sealed class AccessTokenValidator : IOAuthTokenValidator
+    {
+        private const string RequiredAlgorithm = "ES256";
+        private const int P256SignatureLength = 64; // r(32) || s(32), IEEE P1363
+
+        private readonly OAuthResourceServerConfig _config;
+        private readonly IJwksKeyProvider _jwks;
+        private readonly IIntrospectionClient _introspection;
+        private readonly Func<DateTimeOffset> _now;
+        private readonly ILogger? _logger;
+
+        public AccessTokenValidator(
+            OAuthResourceServerConfig config,
+            IJwksKeyProvider jwks,
+            IIntrospectionClient introspection,
+            Func<DateTimeOffset>? now = null,
+            ILogger? logger = null)
+        {
+            _config = config ?? throw new ArgumentNullException(nameof(config));
+            _jwks = jwks ?? throw new ArgumentNullException(nameof(jwks));
+            _introspection = introspection ?? throw new ArgumentNullException(nameof(introspection));
+            _now = now ?? (() => DateTimeOffset.UtcNow);
+            _logger = logger;
+        }
+
+        public Task<OAuthValidationResult> ValidateAsync(string token, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrWhiteSpace(token))
+                return Task.FromResult(OAuthValidationResult.Fail("unknown", "empty token"));
+
+            return LooksLikeJwt(token, out var header, out var payload, out var signature)
+                ? ValidateJwtAsync(header, payload, signature, cancellationToken)
+                : ValidateOpaqueAsync(token, cancellationToken);
+        }
+
+        // A JWT is exactly three non-empty base64url segments whose header decodes to a JSON object
+        // carrying "alg". Anything else (e.g. an opaque `agd_pat_…`) is routed to introspection.
+        private static bool LooksLikeJwt(string token, out string header, out string payload, out string signature)
+        {
+            header = payload = signature = string.Empty;
+            var parts = token.Split('.');
+            if (parts.Length != 3 || parts[0].Length == 0 || parts[1].Length == 0 || parts[2].Length == 0)
+                return false;
+            if (!Base64Url.TryDecode(parts[0], out var headerBytes))
+                return false;
+            try
+            {
+                using var doc = JsonDocument.Parse(headerBytes);
+                if (doc.RootElement.ValueKind != JsonValueKind.Object
+                    || !doc.RootElement.TryGetProperty("alg", out _))
+                    return false;
+            }
+            catch (JsonException)
+            {
+                return false;
+            }
+
+            header = parts[0];
+            payload = parts[1];
+            signature = parts[2];
+            return true;
+        }
+
+        private async Task<OAuthValidationResult> ValidateJwtAsync(string headerSeg, string payloadSeg, string signatureSeg, CancellationToken cancellationToken)
+        {
+            // ---- Header: enforce ES256 BEFORE touching any key material (alg-confusion defense) --
+            if (!Base64Url.TryDecode(headerSeg, out var headerBytes))
+                return OAuthValidationResult.Fail("jwt", "malformed header");
+
+            string alg;
+            string? kid;
+            try
+            {
+                using var headerDoc = JsonDocument.Parse(headerBytes);
+                alg = GetString(headerDoc.RootElement, "alg") ?? string.Empty;
+                kid = GetString(headerDoc.RootElement, "kid");
+            }
+            catch (JsonException)
+            {
+                return OAuthValidationResult.Fail("jwt", "malformed header");
+            }
+
+            if (!string.Equals(alg, RequiredAlgorithm, StringComparison.Ordinal))
+                return OAuthValidationResult.Fail("jwt", $"unsupported alg '{alg}' (only ES256 accepted)");
+            if (string.IsNullOrEmpty(kid))
+                return OAuthValidationResult.Fail("jwt", "missing kid");
+
+            // ---- Signature: verify over the received header.payload with the JWKS P-256 key -------
+            if (!Base64Url.TryDecode(signatureSeg, out var signature) || signature.Length != P256SignatureLength)
+                return OAuthValidationResult.Fail("jwt", "malformed signature");
+
+            using var ecdsa = await _jwks.GetSigningKeyAsync(kid!, cancellationToken).ConfigureAwait(false);
+            if (ecdsa == null)
+                return OAuthValidationResult.Fail("jwt", "unknown signing key (kid)");
+
+            var signingInput = Encoding.ASCII.GetBytes(headerSeg + "." + payloadSeg);
+            bool signatureValid;
+            try
+            {
+                signatureValid = ecdsa.VerifyData(
+                    signingInput, signature, HashAlgorithmName.SHA256,
+                    DSASignatureFormat.IeeeP1363FixedFieldConcatenation);
+            }
+            catch (CryptographicException ex)
+            {
+                _logger?.LogWarning(ex, "ES256 signature verification threw; rejecting token.");
+                return OAuthValidationResult.Fail("jwt", "signature verification failed");
+            }
+
+            if (!signatureValid)
+                return OAuthValidationResult.Fail("jwt", "invalid signature");
+
+            // ---- Claims: iss / aud / exp / nbf ----------------------------------------------------
+            if (!Base64Url.TryDecode(payloadSeg, out var payloadBytes))
+                return OAuthValidationResult.Fail("jwt", "malformed payload");
+
+            try
+            {
+                using var payloadDoc = JsonDocument.Parse(payloadBytes);
+                var claims = payloadDoc.RootElement;
+
+                var iss = GetString(claims, "iss");
+                if (!string.Equals(iss, _config.Issuer, StringComparison.Ordinal))
+                    return OAuthValidationResult.Fail("jwt", "issuer mismatch");
+
+                if (!AudienceContainsResource(claims))
+                    return OAuthValidationResult.Fail("jwt", "audience mismatch");
+
+                var now = _now();
+
+                if (!TryGetUnixSeconds(claims, "exp", out var exp))
+                    return OAuthValidationResult.Fail("jwt", "missing exp");
+                if (now > exp + _config.ClockSkew)
+                    return OAuthValidationResult.Fail("jwt", "token expired");
+
+                if (TryGetUnixSeconds(claims, "nbf", out var nbf) && now < nbf - _config.ClockSkew)
+                    return OAuthValidationResult.Fail("jwt", "token not yet valid");
+
+                var sub = GetString(claims, "sub");
+                var scope = GetString(claims, "scope");
+                var clientId = GetString(claims, "client_id");
+                return OAuthValidationResult.Success("jwt", sub, scope, clientId);
+            }
+            catch (JsonException)
+            {
+                return OAuthValidationResult.Fail("jwt", "malformed payload");
+            }
+        }
+
+        private async Task<OAuthValidationResult> ValidateOpaqueAsync(string token, CancellationToken cancellationToken)
+        {
+            var result = await _introspection.IntrospectAsync(token, cancellationToken).ConfigureAwait(false);
+            if (!result.Active)
+                return OAuthValidationResult.Fail("opaque", "inactive token");
+
+            if (result.ExpiresAt is DateTimeOffset exp && _now() > exp + _config.ClockSkew)
+                return OAuthValidationResult.Fail("opaque", "token expired");
+
+            return OAuthValidationResult.Success("opaque", result.Subject, result.Scope);
+        }
+
+        private bool AudienceContainsResource(JsonElement claims)
+        {
+            if (!claims.TryGetProperty("aud", out var aud))
+                return false;
+
+            if (aud.ValueKind == JsonValueKind.String)
+                return UrlNormalization.ResourcesMatch(aud.GetString(), _config.ResourceUrl);
+
+            if (aud.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var entry in aud.EnumerateArray())
+                {
+                    if (entry.ValueKind == JsonValueKind.String
+                        && UrlNormalization.ResourcesMatch(entry.GetString(), _config.ResourceUrl))
+                        return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static string? GetString(JsonElement obj, string name)
+            => obj.TryGetProperty(name, out var prop) && prop.ValueKind == JsonValueKind.String
+                ? prop.GetString()
+                : null;
+
+        private static bool TryGetUnixSeconds(JsonElement obj, string name, out DateTimeOffset value)
+        {
+            value = default;
+            if (obj.TryGetProperty(name, out var prop) && prop.ValueKind == JsonValueKind.Number && prop.TryGetInt64(out var seconds))
+            {
+                value = DateTimeOffset.FromUnixTimeSeconds(seconds);
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/McpPlugin.Server/src/Auth/OAuth/Base64Url.cs
+++ b/McpPlugin.Server/src/Auth/OAuth/Base64Url.cs
@@ -1,0 +1,54 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+
+namespace com.IvanMurzak.McpPlugin.Server.Auth.OAuth
+{
+    /// <summary>
+    /// Base64url (RFC 4648 §5, no padding) decode used for JWS/JWT and JWK material. Hand-rolled to
+    /// keep the resource-server validation self-contained (no external identity-model dependency)
+    /// and portable across net8.0 / net9.0.
+    /// </summary>
+    public static class Base64Url
+    {
+        /// <summary>
+        /// Decode a base64url string to bytes. Returns <c>false</c> for any malformed input
+        /// (invalid characters, wrong length) rather than throwing — callers fail closed.
+        /// </summary>
+        public static bool TryDecode(string? input, out byte[] bytes)
+        {
+            bytes = Array.Empty<byte>();
+            if (input == null)
+                return false;
+
+            var s = input.Replace('-', '+').Replace('_', '/');
+            switch (s.Length % 4)
+            {
+                case 0: break;
+                case 2: s += "=="; break;
+                case 3: s += "="; break;
+                default: return false; // length % 4 == 1 is never valid base64
+            }
+
+            try
+            {
+                bytes = Convert.FromBase64String(s);
+                return true;
+            }
+            catch (FormatException)
+            {
+                bytes = Array.Empty<byte>();
+                return false;
+            }
+        }
+    }
+}

--- a/McpPlugin.Server/src/Auth/OAuth/IIntrospectionClient.cs
+++ b/McpPlugin.Server/src/Auth/OAuth/IIntrospectionClient.cs
@@ -1,0 +1,49 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace com.IvanMurzak.McpPlugin.Server.Auth.OAuth
+{
+    /// <summary>
+    /// Validates an opaque (non-JWT) token via OAuth 2.0 Token Introspection (RFC 7662) against the
+    /// authorization server (mcp-authorize b2). Results are cached briefly and the client fails
+    /// closed on any transport/parse error.
+    /// </summary>
+    public interface IIntrospectionClient
+    {
+        Task<IntrospectionResult> IntrospectAsync(string token, CancellationToken cancellationToken);
+    }
+
+    /// <summary>Posts the token to the introspection endpoint; returns the raw JSON body, or <c>null</c> on any transport/HTTP error.</summary>
+    public delegate Task<string?> IntrospectionPost(string token, CancellationToken cancellationToken);
+
+    /// <summary>Outcome of an introspection call. <see cref="Active"/> is <c>false</c> for inactive tokens AND fail-closed errors.</summary>
+    public sealed class IntrospectionResult
+    {
+        public bool Active { get; }
+        public string? Subject { get; }
+        public string? Scope { get; }
+        public DateTimeOffset? ExpiresAt { get; }
+
+        public IntrospectionResult(bool active, string? subject = null, string? scope = null, DateTimeOffset? expiresAt = null)
+        {
+            Active = active;
+            Subject = subject;
+            Scope = scope;
+            ExpiresAt = expiresAt;
+        }
+
+        public static IntrospectionResult Inactive { get; } = new IntrospectionResult(false);
+    }
+}

--- a/McpPlugin.Server/src/Auth/OAuth/IJwksDiskCache.cs
+++ b/McpPlugin.Server/src/Auth/OAuth/IJwksDiskCache.cs
@@ -1,0 +1,70 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.IO;
+
+namespace com.IvanMurzak.McpPlugin.Server.Auth.OAuth
+{
+    /// <summary>
+    /// Persists the fetched JWKS document (public keys only) for offline-grace validation
+    /// (mcp-authorize b2).
+    /// </summary>
+    public interface IJwksDiskCache
+    {
+        /// <summary>Read the cached JWKS JSON, or <c>null</c> when none is cached.</summary>
+        string? Read();
+
+        /// <summary>Persist the JWKS JSON.</summary>
+        void Write(string json);
+    }
+
+    /// <summary>
+    /// File-backed <see cref="IJwksDiskCache"/> co-located with the b1 machine credential store at
+    /// <c>~/.ai-game-dev/jwks-cache.json</c>. The path constants intentionally mirror the b1
+    /// primitive <c>McpPlugin.AgentConfig.MachineCredentialStore</c> (which lives in the client
+    /// library the server does not reference) so both sides share ONE on-disk cache location without
+    /// coupling the server package to the client library. JWKS holds only public keys, so it is
+    /// stored plaintext inside the user-only directory.
+    /// </summary>
+    public sealed class FileJwksDiskCache : IJwksDiskCache
+    {
+        // Mirror of MachineCredentialStore.DirectoryName / JwksCacheFileName (b1).
+        private const string DirectoryName = ".ai-game-dev";
+        private const string JwksCacheFileName = "jwks-cache.json";
+
+        private readonly string _path;
+
+        /// <summary>
+        /// Create a cache rooted at <paramref name="baseDirectory"/>, or at <c>~/.ai-game-dev</c>
+        /// when null. The override exists for tests.
+        /// </summary>
+        public FileJwksDiskCache(string? baseDirectory = null)
+        {
+            var dir = baseDirectory ?? Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                DirectoryName);
+            _path = Path.Combine(dir, JwksCacheFileName);
+        }
+
+        public string? Read() => File.Exists(_path) ? File.ReadAllText(_path) : null;
+
+        public void Write(string json)
+        {
+            if (json == null)
+                throw new ArgumentNullException(nameof(json));
+            var dir = Path.GetDirectoryName(_path);
+            if (!string.IsNullOrEmpty(dir))
+                Directory.CreateDirectory(dir!);
+            File.WriteAllText(_path, json);
+        }
+    }
+}

--- a/McpPlugin.Server/src/Auth/OAuth/IJwksKeyProvider.cs
+++ b/McpPlugin.Server/src/Auth/OAuth/IJwksKeyProvider.cs
@@ -1,0 +1,35 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace com.IvanMurzak.McpPlugin.Server.Auth.OAuth
+{
+    /// <summary>
+    /// Resolves an authorization-server signing key (by <c>kid</c>) to an <see cref="ECDsa"/>
+    /// public key for ES256 verification, backed by a disk-cached JWKS with offline grace and
+    /// rate-limited unknown-<c>kid</c> refetch (mcp-authorize b2).
+    /// </summary>
+    public interface IJwksKeyProvider
+    {
+        /// <summary>
+        /// Return a fresh <see cref="ECDsa"/> for the given <c>kid</c>, or <c>null</c> when the key
+        /// cannot be resolved (unknown kid after a rate-limited refetch, or no keys available while
+        /// offline with no cache). The caller owns and disposes the returned instance.
+        /// </summary>
+        Task<ECDsa?> GetSigningKeyAsync(string kid, CancellationToken cancellationToken);
+    }
+
+    /// <summary>Fetches the raw JWKS JSON document from the authorization server's <c>jwks_uri</c>.</summary>
+    public delegate Task<string?> JwksFetch(CancellationToken cancellationToken);
+}

--- a/McpPlugin.Server/src/Auth/OAuth/IOAuthTokenValidator.cs
+++ b/McpPlugin.Server/src/Auth/OAuth/IOAuthTokenValidator.cs
@@ -1,0 +1,55 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace com.IvanMurzak.McpPlugin.Server.Auth.OAuth
+{
+    /// <summary>
+    /// Validates a presented bearer token in OAuth resource-server mode (mcp-authorize b2): ES256
+    /// JWTs against the AS JWKS with strict <c>iss</c>/<c>aud</c>/<c>exp</c>, opaque tokens via
+    /// introspection. Always fails closed.
+    /// </summary>
+    public interface IOAuthTokenValidator
+    {
+        Task<OAuthValidationResult> ValidateAsync(string token, CancellationToken cancellationToken);
+    }
+
+    /// <summary>Outcome of resource-server token validation.</summary>
+    public sealed class OAuthValidationResult
+    {
+        public bool Succeeded { get; }
+        public string? FailureReason { get; }
+        public string? Subject { get; }
+        public string? Scope { get; }
+        public string? ClientId { get; }
+
+        /// <summary><c>"jwt"</c> or <c>"opaque"</c>.</summary>
+        public string TokenType { get; }
+
+        private OAuthValidationResult(bool succeeded, string? failureReason, string? subject, string? scope, string? clientId, string tokenType)
+        {
+            Succeeded = succeeded;
+            FailureReason = failureReason;
+            Subject = subject;
+            Scope = scope;
+            ClientId = clientId;
+            TokenType = tokenType;
+        }
+
+        public static OAuthValidationResult Success(string tokenType, string? subject, string? scope, string? clientId = null)
+            => new OAuthValidationResult(true, null, subject, scope, clientId, tokenType);
+
+        public static OAuthValidationResult Fail(string tokenType, string reason)
+            => new OAuthValidationResult(false, reason, null, null, null, tokenType);
+    }
+}

--- a/McpPlugin.Server/src/Auth/OAuth/IntrospectionClient.cs
+++ b/McpPlugin.Server/src/Auth/OAuth/IntrospectionClient.cs
@@ -37,6 +37,12 @@ namespace com.IvanMurzak.McpPlugin.Server.Auth.OAuth
 
         public static readonly TimeSpan DefaultCacheTtl = TimeSpan.FromSeconds(60);
 
+        // Hard bound on cached entries. Cache values are only useful for one TTL window, so this
+        // caps memory even under a flood of distinct opaque tokens (each token hashes to a unique
+        // key). Without it the dictionary would grow without bound (entries were only expired on
+        // read, never removed).
+        private const int MaxCacheEntries = 4096;
+
         public IntrospectionClient(
             IntrospectionPost post,
             Func<DateTimeOffset>? now = null,
@@ -77,8 +83,27 @@ namespace com.IvanMurzak.McpPlugin.Server.Auth.OAuth
             if (!TryParse(json, out var result))
                 return IntrospectionResult.Inactive; // malformed response, not cached
 
+            // Bound the cache: opportunistically drop expired entries when full, and if it is still
+            // full (extreme churn within one TTL window) skip caching this result — correctness is
+            // unaffected (the next request simply re-introspects).
+            if (_cache.Count >= MaxCacheEntries)
+            {
+                PruneExpired(now);
+                if (_cache.Count >= MaxCacheEntries)
+                    return result;
+            }
+
             _cache[key] = new CacheEntry(result, now);
             return result;
+        }
+
+        private void PruneExpired(DateTimeOffset now)
+        {
+            foreach (var kvp in _cache)
+            {
+                if (now - kvp.Value.CachedAt >= _cacheTtl)
+                    _cache.TryRemove(kvp.Key, out _);
+            }
         }
 
         private static bool TryParse(string json, out IntrospectionResult result)

--- a/McpPlugin.Server/src/Auth/OAuth/IntrospectionClient.cs
+++ b/McpPlugin.Server/src/Auth/OAuth/IntrospectionClient.cs
@@ -1,0 +1,137 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Collections.Concurrent;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace com.IvanMurzak.McpPlugin.Server.Auth.OAuth
+{
+    /// <summary>
+    /// Default <see cref="IIntrospectionClient"/> (mcp-authorize b2). Caches active/inactive
+    /// answers for <see cref="_cacheTtl"/> (60 s) keyed by a SHA-256 of the token (the raw token is
+    /// never used as a dictionary key), and fails closed: any transport/HTTP/parse error yields
+    /// <see cref="IntrospectionResult.Inactive"/> and is NOT cached, so a transient outage self-heals
+    /// on the next request.
+    /// </summary>
+    public sealed class IntrospectionClient : IIntrospectionClient
+    {
+        private readonly IntrospectionPost _post;
+        private readonly Func<DateTimeOffset> _now;
+        private readonly TimeSpan _cacheTtl;
+        private readonly ILogger? _logger;
+        private readonly ConcurrentDictionary<string, CacheEntry> _cache = new ConcurrentDictionary<string, CacheEntry>();
+
+        public static readonly TimeSpan DefaultCacheTtl = TimeSpan.FromSeconds(60);
+
+        public IntrospectionClient(
+            IntrospectionPost post,
+            Func<DateTimeOffset>? now = null,
+            TimeSpan? cacheTtl = null,
+            ILogger? logger = null)
+        {
+            _post = post ?? throw new ArgumentNullException(nameof(post));
+            _now = now ?? (() => DateTimeOffset.UtcNow);
+            _cacheTtl = cacheTtl ?? DefaultCacheTtl;
+            _logger = logger;
+        }
+
+        public async Task<IntrospectionResult> IntrospectAsync(string token, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(token))
+                return IntrospectionResult.Inactive;
+
+            var key = Hash(token);
+            var now = _now();
+
+            if (_cache.TryGetValue(key, out var entry) && now - entry.CachedAt < _cacheTtl)
+                return entry.Result;
+
+            string? json;
+            try
+            {
+                json = await _post(token, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (!(ex is OperationCanceledException))
+            {
+                _logger?.LogWarning(ex, "Token introspection failed; failing closed.");
+                return IntrospectionResult.Inactive; // fail closed, not cached
+            }
+
+            if (json == null)
+                return IntrospectionResult.Inactive; // transport/HTTP error, not cached
+
+            if (!TryParse(json, out var result))
+                return IntrospectionResult.Inactive; // malformed response, not cached
+
+            _cache[key] = new CacheEntry(result, now);
+            return result;
+        }
+
+        private static bool TryParse(string json, out IntrospectionResult result)
+        {
+            result = IntrospectionResult.Inactive;
+            try
+            {
+                using var doc = JsonDocument.Parse(json);
+                var root = doc.RootElement;
+                if (root.ValueKind != JsonValueKind.Object)
+                    return false;
+
+                var active = root.TryGetProperty("active", out var activeProp)
+                    && activeProp.ValueKind == JsonValueKind.True;
+
+                if (!active)
+                {
+                    result = IntrospectionResult.Inactive;
+                    return true;
+                }
+
+                string? sub = root.TryGetProperty("sub", out var subProp) && subProp.ValueKind == JsonValueKind.String
+                    ? subProp.GetString() : null;
+                string? scope = root.TryGetProperty("scope", out var scopeProp) && scopeProp.ValueKind == JsonValueKind.String
+                    ? scopeProp.GetString() : null;
+                DateTimeOffset? exp = root.TryGetProperty("exp", out var expProp) && expProp.ValueKind == JsonValueKind.Number
+                    && expProp.TryGetInt64(out var expUnix)
+                    ? DateTimeOffset.FromUnixTimeSeconds(expUnix) : (DateTimeOffset?)null;
+
+                result = new IntrospectionResult(true, sub, scope, exp);
+                return true;
+            }
+            catch (JsonException)
+            {
+                return false;
+            }
+        }
+
+        private static string Hash(string token)
+        {
+            var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(token));
+            return Convert.ToHexString(bytes);
+        }
+
+        private readonly struct CacheEntry
+        {
+            public IntrospectionResult Result { get; }
+            public DateTimeOffset CachedAt { get; }
+            public CacheEntry(IntrospectionResult result, DateTimeOffset cachedAt)
+            {
+                Result = result;
+                CachedAt = cachedAt;
+            }
+        }
+    }
+}

--- a/McpPlugin.Server/src/Auth/OAuth/JsonWebKeySet.cs
+++ b/McpPlugin.Server/src/Auth/OAuth/JsonWebKeySet.cs
@@ -1,0 +1,128 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Text.Json;
+
+namespace com.IvanMurzak.McpPlugin.Server.Auth.OAuth
+{
+    /// <summary>
+    /// Minimal JWKS (RFC 7517) reader for EC P-256 signing keys (mcp-authorize b2). Parses the
+    /// authorization server's <c>jwks.json</c> and resolves a <c>kid</c> to an <see cref="ECDsa"/>
+    /// public key for ES256 verification. Non-EC / non-P-256 keys are ignored — the RS accepts
+    /// ES256 only, so unsupported key types simply do not resolve (fail closed).
+    /// </summary>
+    public sealed class JsonWebKeySet
+    {
+        private readonly Dictionary<string, ECParameters> _keysByKid;
+
+        private JsonWebKeySet(Dictionary<string, ECParameters> keysByKid)
+        {
+            _keysByKid = keysByKid;
+        }
+
+        /// <summary>The set of <c>kid</c>s present in this key set.</summary>
+        public IReadOnlyCollection<string> KeyIds => _keysByKid.Keys;
+
+        /// <summary>True when a key with the given <c>kid</c> is present.</summary>
+        public bool ContainsKid(string kid) => _keysByKid.ContainsKey(kid);
+
+        /// <summary>
+        /// Create a fresh <see cref="ECDsa"/> for the given <c>kid</c>, or <c>null</c> when absent.
+        /// The caller owns the returned instance and should dispose it.
+        /// </summary>
+        public ECDsa? CreateEcdsa(string? kid)
+        {
+            if (kid == null || !_keysByKid.TryGetValue(kid, out var parameters))
+                return null;
+            return ECDsa.Create(parameters);
+        }
+
+        /// <summary>
+        /// Parse a JWKS document. Returns <c>false</c> (fail closed) for malformed JSON. A valid
+        /// document with zero usable EC/P-256 keys still returns <c>true</c> with an empty set.
+        /// </summary>
+        public static bool TryParse(string? json, out JsonWebKeySet keySet)
+        {
+            keySet = new JsonWebKeySet(new Dictionary<string, ECParameters>(StringComparer.Ordinal));
+            if (string.IsNullOrWhiteSpace(json))
+                return false;
+
+            try
+            {
+                using var doc = JsonDocument.Parse(json!);
+                if (!doc.RootElement.TryGetProperty("keys", out var keys) || keys.ValueKind != JsonValueKind.Array)
+                    return false;
+
+                var map = new Dictionary<string, ECParameters>(StringComparer.Ordinal);
+                foreach (var key in keys.EnumerateArray())
+                {
+                    if (!TryReadEcKey(key, out var kid, out var parameters))
+                        continue;
+                    map[kid] = parameters;
+                }
+
+                keySet = new JsonWebKeySet(map);
+                return true;
+            }
+            catch (JsonException)
+            {
+                keySet = new JsonWebKeySet(new Dictionary<string, ECParameters>(StringComparer.Ordinal));
+                return false;
+            }
+        }
+
+        private static bool TryReadEcKey(JsonElement key, out string kid, out ECParameters parameters)
+        {
+            kid = string.Empty;
+            parameters = default;
+
+            if (key.ValueKind != JsonValueKind.Object)
+                return false;
+
+            if (!TryGetString(key, "kty", out var kty) || kty != "EC")
+                return false;
+            if (!TryGetString(key, "crv", out var crv) || crv != "P-256")
+                return false;
+            if (!TryGetString(key, "kid", out var keyId) || string.IsNullOrEmpty(keyId))
+                return false;
+            if (!TryGetString(key, "x", out var x) || !Base64Url.TryDecode(x, out var xb))
+                return false;
+            if (!TryGetString(key, "y", out var y) || !Base64Url.TryDecode(y, out var yb))
+                return false;
+
+            // Reject a key advertised for anything other than signature verification.
+            if (TryGetString(key, "use", out var use) && use != "sig")
+                return false;
+
+            kid = keyId;
+            parameters = new ECParameters
+            {
+                Curve = ECCurve.NamedCurves.nistP256,
+                Q = new ECPoint { X = xb, Y = yb }
+            };
+            return true;
+        }
+
+        private static bool TryGetString(JsonElement obj, string name, out string value)
+        {
+            value = string.Empty;
+            if (obj.TryGetProperty(name, out var prop) && prop.ValueKind == JsonValueKind.String)
+            {
+                value = prop.GetString() ?? string.Empty;
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/McpPlugin.Server/src/Auth/OAuth/JsonWebKeySet.cs
+++ b/McpPlugin.Server/src/Auth/OAuth/JsonWebKeySet.cs
@@ -45,7 +45,16 @@ namespace com.IvanMurzak.McpPlugin.Server.Auth.OAuth
         {
             if (kid == null || !_keysByKid.TryGetValue(kid, out var parameters))
                 return null;
-            return ECDsa.Create(parameters);
+            try
+            {
+                return ECDsa.Create(parameters);
+            }
+            catch (Exception ex) when (ex is CryptographicException || ex is ArgumentException)
+            {
+                // Invalid key material (point not on the curve, bad coordinates) → fail closed as an
+                // unknown key rather than throwing out of the validator (the RS "never throws").
+                return null;
+            }
         }
 
         /// <summary>
@@ -99,6 +108,11 @@ namespace com.IvanMurzak.McpPlugin.Server.Auth.OAuth
             if (!TryGetString(key, "x", out var x) || !Base64Url.TryDecode(x, out var xb))
                 return false;
             if (!TryGetString(key, "y", out var y) || !Base64Url.TryDecode(y, out var yb))
+                return false;
+
+            // P-256 field elements are exactly 32 bytes; reject any mis-sized coordinate (fail closed)
+            // so a malformed JWK never reaches ECDsa.Create with an invalid point.
+            if (xb.Length != 32 || yb.Length != 32)
                 return false;
 
             // Reject a key advertised for anything other than signature verification.

--- a/McpPlugin.Server/src/Auth/OAuth/JwksKeyProvider.cs
+++ b/McpPlugin.Server/src/Auth/OAuth/JwksKeyProvider.cs
@@ -1,0 +1,155 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace com.IvanMurzak.McpPlugin.Server.Auth.OAuth
+{
+    /// <summary>
+    /// Default <see cref="IJwksKeyProvider"/> (mcp-authorize b2). Behavior:
+    /// <list type="bullet">
+    ///   <item><b>Disk cache</b> — the fetched JWKS is persisted via <see cref="IJwksDiskCache"/>,
+    ///         co-located with the b1 machine store at <c>~/.ai-game-dev/jwks-cache.json</c>.</item>
+    ///   <item><b>Offline grace</b> — when the network fetch fails, the last cached JWKS keeps
+    ///         validating tokens; validation only fails once there is neither a live nor a cached
+    ///         key set.</item>
+    ///   <item><b>Refresh</b> — the in-memory set is refreshed after <see cref="_refreshInterval"/>
+    ///         (24 h by default).</item>
+    ///   <item><b>Unknown-<c>kid</c> refetch</b> — a request for an unseen <c>kid</c> triggers a
+    ///         refetch, rate-limited to at most once per <see cref="_unknownKidMinRefetchInterval"/>
+    ///         so a bad/spoofed <c>kid</c> cannot be used to hammer the AS.</item>
+    /// </list>
+    /// A single <see cref="SemaphoreSlim"/> serializes network fetches to avoid a thundering herd.
+    /// </summary>
+    public sealed class JwksKeyProvider : IJwksKeyProvider
+    {
+        private readonly JwksFetch _fetch;
+        private readonly IJwksDiskCache _cache;
+        private readonly Func<DateTimeOffset> _now;
+        private readonly TimeSpan _refreshInterval;
+        private readonly TimeSpan _unknownKidMinRefetchInterval;
+        private readonly ILogger? _logger;
+        private readonly SemaphoreSlim _gate = new SemaphoreSlim(1, 1);
+
+        private JsonWebKeySet? _current;
+        private DateTimeOffset _loadedAt;
+        private DateTimeOffset _lastRefetchAttempt = DateTimeOffset.MinValue;
+
+        public static readonly TimeSpan DefaultRefreshInterval = TimeSpan.FromHours(24);
+        public static readonly TimeSpan DefaultUnknownKidMinRefetchInterval = TimeSpan.FromSeconds(60);
+
+        public JwksKeyProvider(
+            JwksFetch fetch,
+            IJwksDiskCache cache,
+            Func<DateTimeOffset>? now = null,
+            TimeSpan? refreshInterval = null,
+            TimeSpan? unknownKidMinRefetchInterval = null,
+            ILogger? logger = null)
+        {
+            _fetch = fetch ?? throw new ArgumentNullException(nameof(fetch));
+            _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+            _now = now ?? (() => DateTimeOffset.UtcNow);
+            _refreshInterval = refreshInterval ?? DefaultRefreshInterval;
+            _unknownKidMinRefetchInterval = unknownKidMinRefetchInterval ?? DefaultUnknownKidMinRefetchInterval;
+            _logger = logger;
+        }
+
+        public async Task<ECDsa?> GetSigningKeyAsync(string kid, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(kid))
+                return null;
+
+            await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                var now = _now();
+
+                // First use, or the in-memory set has aged past the refresh window.
+                if (_current == null || now - _loadedAt >= _refreshInterval)
+                    await RefreshAsync(now, cancellationToken).ConfigureAwait(false);
+
+                if (_current != null && _current.ContainsKid(kid))
+                    return _current.CreateEcdsa(kid);
+
+                // Unknown kid: rate-limited refetch — a rotated signing key that landed before the
+                // 24 h refresh should still be picked up, but a bogus kid must not be a DoS lever.
+                if (now - _lastRefetchAttempt >= _unknownKidMinRefetchInterval)
+                    await RefreshAsync(now, cancellationToken).ConfigureAwait(false);
+
+                return _current != null ? _current.CreateEcdsa(kid) : null;
+            }
+            finally
+            {
+                _gate.Release();
+            }
+        }
+
+        private async Task RefreshAsync(DateTimeOffset now, CancellationToken cancellationToken)
+        {
+            _lastRefetchAttempt = now;
+
+            string? json = null;
+            try
+            {
+                json = await _fetch(cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (!(ex is OperationCanceledException))
+            {
+                _logger?.LogWarning(ex, "JWKS fetch failed; falling back to the disk cache (offline grace).");
+            }
+
+            if (json != null && JsonWebKeySet.TryParse(json, out var fresh))
+            {
+                _current = fresh;
+                _loadedAt = now;
+                try
+                {
+                    _cache.Write(json);
+                }
+                catch (Exception ex)
+                {
+                    _logger?.LogWarning(ex, "Failed to persist the JWKS disk cache.");
+                }
+                return;
+            }
+
+            // Network path unavailable/invalid: keep any in-memory set; otherwise load the disk
+            // cache so a restarted, currently-offline RS can still validate tokens.
+            if (_current == null)
+            {
+                var cached = SafeReadCache();
+                if (cached != null && JsonWebKeySet.TryParse(cached, out var fromDisk))
+                {
+                    _current = fromDisk;
+                    _loadedAt = now;
+                    _logger?.LogInformation("Loaded JWKS from the disk cache (offline grace).");
+                }
+            }
+        }
+
+        private string? SafeReadCache()
+        {
+            try
+            {
+                return _cache.Read();
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning(ex, "Failed to read the JWKS disk cache.");
+                return null;
+            }
+        }
+    }
+}

--- a/McpPlugin.Server/src/Auth/OAuth/OAuthProtectedResourceMetadata.cs
+++ b/McpPlugin.Server/src/Auth/OAuth/OAuthProtectedResourceMetadata.cs
@@ -1,0 +1,34 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System.Collections.Generic;
+
+namespace com.IvanMurzak.McpPlugin.Server.Auth.OAuth
+{
+    /// <summary>
+    /// Builds the OAuth 2.0 Protected Resource Metadata document (RFC 9728) served in <c>oauth</c>
+    /// mode (mcp-authorize b2). Names the external authorization server so a spec-compliant MCP
+    /// client can run the discovery + authorize flow after a 401 challenge.
+    /// </summary>
+    public static class OAuthProtectedResourceMetadata
+    {
+        public static Dictionary<string, object> Build(OAuthResourceServerConfig config)
+        {
+            return new Dictionary<string, object>
+            {
+                ["resource"] = config.ResourceUrl,
+                ["authorization_servers"] = new[] { config.Issuer },
+                ["scopes_supported"] = new[] { OAuthResourceServerConfig.AgentScope },
+                ["bearer_methods_supported"] = new[] { "header" }
+            };
+        }
+    }
+}

--- a/McpPlugin.Server/src/Auth/OAuth/OAuthResourceServerConfig.cs
+++ b/McpPlugin.Server/src/Auth/OAuth/OAuthResourceServerConfig.cs
@@ -1,0 +1,81 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+
+namespace com.IvanMurzak.McpPlugin.Server.Auth.OAuth
+{
+    /// <summary>
+    /// Resolved OAuth resource-server configuration (mcp-authorize b2), built from
+    /// <c>--auth-issuer</c> (the AS) and <c>--public-url</c> (this RS's canonical resource id / the
+    /// value a token's <c>aud</c> must contain). Endpoints are derived from the issuer per the
+    /// well-known conventions (RFC 8414 JWKS, RFC 7662 introspection).
+    /// </summary>
+    public sealed class OAuthResourceServerConfig
+    {
+        /// <summary>Default MCP agent scope advertised in 401 challenges (see 08-security.md).</summary>
+        public const string AgentScope = "mcp:agent";
+
+        /// <summary>Default clock-skew tolerance for <c>exp</c>/<c>nbf</c> (±5 min).</summary>
+        public static readonly TimeSpan DefaultClockSkew = TimeSpan.FromMinutes(5);
+
+        /// <summary>Authorization server identity, pinned as the token <c>iss</c> (e.g. <c>https://ai-game.dev</c>).</summary>
+        public string Issuer { get; }
+
+        /// <summary>This RS's canonical resource id — the value a token's <c>aud</c> must contain (the <c>--public-url</c>).</summary>
+        public string ResourceUrl { get; }
+
+        public TimeSpan ClockSkew { get; }
+
+        /// <summary>The AS JWKS document URL (<c>{issuer}/.well-known/jwks.json</c>).</summary>
+        public string JwksUri { get; }
+
+        /// <summary>The AS token-introspection endpoint (<c>{issuer}/oauth/introspect</c>).</summary>
+        public string IntrospectionEndpoint { get; }
+
+        public OAuthResourceServerConfig(string issuer, string resourceUrl, TimeSpan? clockSkew = null)
+        {
+            if (string.IsNullOrWhiteSpace(issuer))
+                throw new ArgumentException("OAuth mode requires --auth-issuer (the authorization server URL).", nameof(issuer));
+            if (string.IsNullOrWhiteSpace(resourceUrl))
+                throw new ArgumentException("OAuth mode requires --public-url (this server's canonical resource id).", nameof(resourceUrl));
+
+            Issuer = issuer.Trim().TrimEnd('/');
+            ResourceUrl = resourceUrl.Trim();
+            ClockSkew = clockSkew ?? DefaultClockSkew;
+            JwksUri = $"{Issuer}/.well-known/jwks.json";
+            IntrospectionEndpoint = $"{Issuer}/oauth/introspect";
+        }
+
+        /// <summary>
+        /// The absolute Protected Resource Metadata URL (RFC 9728) for this resource, used as the
+        /// <c>resource_metadata</c> challenge parameter. The well-known segment is inserted between
+        /// authority and path (root-inserted) when the resource has a path (e.g.
+        /// <c>https://ai-game.dev/mcp</c> → <c>https://ai-game.dev/.well-known/oauth-protected-resource/mcp</c>);
+        /// a path-less resource simply appends it.
+        /// </summary>
+        public string ProtectedResourceMetadataUrl()
+        {
+            const string wellKnown = "/.well-known/oauth-protected-resource";
+            if (!Uri.TryCreate(ResourceUrl, UriKind.Absolute, out var uri))
+                return $"{ResourceUrl.TrimEnd('/')}{wellKnown}";
+
+            var authority = uri.GetLeftPart(UriPartial.Authority);
+            var path = uri.AbsolutePath;
+            if (path.Length > 1 && path.EndsWith("/", StringComparison.Ordinal))
+                path = path.TrimEnd('/');
+
+            return (string.IsNullOrEmpty(path) || path == "/")
+                ? $"{authority}{wellKnown}"
+                : $"{authority}{wellKnown}{path}";
+        }
+    }
+}

--- a/McpPlugin.Server/src/Auth/OAuth/UrlNormalization.cs
+++ b/McpPlugin.Server/src/Auth/OAuth/UrlNormalization.cs
@@ -1,0 +1,97 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Net;
+
+namespace com.IvanMurzak.McpPlugin.Server.Auth.OAuth
+{
+    /// <summary>
+    /// URL normalization helpers shared by strict-<c>aud</c> validation and Origin validation
+    /// (mcp-authorize b2). Loopback aliases (<c>localhost</c> / <c>127.0.0.1</c> / <c>::1</c>) are
+    /// normalized to a single canonical host so a token audienced to <c>http://localhost:23471</c>
+    /// matches an RS whose <c>--public-url</c> is <c>http://127.0.0.1:23471</c> and vice versa.
+    /// </summary>
+    public static class UrlNormalization
+    {
+        private const string CanonicalLoopbackHost = "localhost";
+
+        /// <summary>
+        /// True when <paramref name="host"/> is a loopback name/address
+        /// (<c>localhost</c>, <c>127.0.0.0/8</c>, or IPv6 <c>::1</c>).
+        /// </summary>
+        public static bool IsLoopbackHost(string? host)
+        {
+            if (string.IsNullOrEmpty(host))
+                return false;
+
+            var trimmed = host!.Trim().Trim('[', ']');
+            if (string.Equals(trimmed, CanonicalLoopbackHost, StringComparison.OrdinalIgnoreCase))
+                return true;
+
+            if (IPAddress.TryParse(trimmed, out var ip))
+                return IPAddress.IsLoopback(ip);
+
+            return false;
+        }
+
+        /// <summary>
+        /// Canonicalize a resource URI (the token <c>aud</c> / the RS <c>--public-url</c>) into a
+        /// comparable string: lowercased scheme, loopback-aliased + lowercased host, explicit port
+        /// (default ports normalized by <see cref="Uri"/>), and a trailing-slash-stripped path.
+        /// Returns <c>null</c> when the value is not an absolute URI.
+        /// </summary>
+        public static string? NormalizeResource(string? url)
+        {
+            if (string.IsNullOrWhiteSpace(url))
+                return null;
+
+            if (!Uri.TryCreate(url!.Trim(), UriKind.Absolute, out var uri))
+                return null;
+
+            var host = IsLoopbackHost(uri.Host) ? CanonicalLoopbackHost : uri.Host.ToLowerInvariant();
+            var path = uri.AbsolutePath;
+            if (path.Length > 1 && path.EndsWith("/", StringComparison.Ordinal))
+                path = path.TrimEnd('/');
+            if (path == "/")
+                path = string.Empty;
+
+            return $"{uri.Scheme.ToLowerInvariant()}://{host}:{uri.Port}{path}";
+        }
+
+        /// <summary>
+        /// Canonicalize an <c>Origin</c> header value into a comparable <c>scheme://host:port</c>
+        /// (no path) string, loopback-aliased. Returns <c>null</c> when the value is not a valid
+        /// absolute origin.
+        /// </summary>
+        public static string? NormalizeOrigin(string? origin)
+        {
+            if (string.IsNullOrWhiteSpace(origin))
+                return null;
+
+            if (!Uri.TryCreate(origin!.Trim(), UriKind.Absolute, out var uri))
+                return null;
+
+            var host = IsLoopbackHost(uri.Host) ? CanonicalLoopbackHost : uri.Host.ToLowerInvariant();
+            return $"{uri.Scheme.ToLowerInvariant()}://{host}:{uri.Port}";
+        }
+
+        /// <summary>
+        /// True when two resource identifiers are equal after normalization (loopback-aliased).
+        /// </summary>
+        public static bool ResourcesMatch(string? a, string? b)
+        {
+            var na = NormalizeResource(a);
+            var nb = NormalizeResource(b);
+            return na != null && nb != null && string.Equals(na, nb, StringComparison.Ordinal);
+        }
+    }
+}

--- a/McpPlugin.Server/src/Auth/TokenAuthenticationHandler.cs
+++ b/McpPlugin.Server/src/Auth/TokenAuthenticationHandler.cs
@@ -9,6 +9,7 @@
 */
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
 using System.Security.Cryptography;
@@ -16,6 +17,7 @@ using System.Text;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using com.IvanMurzak.McpPlugin.Common;
+using com.IvanMurzak.McpPlugin.Server.Auth.OAuth;
 using com.IvanMurzak.McpPlugin.Server.Webhooks.Services;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
@@ -28,23 +30,50 @@ namespace com.IvanMurzak.McpPlugin.Server.Auth
     {
         public const string SchemeName = "McpPluginToken";
         public const string TokenClaimType = "mcp_plugin_token";
+        public const string SubjectClaimType = "sub";
+        public const string ScopeClaimType = "scope";
+        public const string ClientIdClaimType = "client_id";
 
         readonly IAuthorizationWebhookService _authorizationWebhookService;
+        readonly IOAuthTokenValidator? _oauthValidator;
+        readonly OAuthResourceServerConfig? _oauthConfig;
 
         public TokenAuthenticationHandler(
             IOptionsMonitor<TokenAuthenticationOptions> options,
             ILoggerFactory logger,
             UrlEncoder encoder,
-            IAuthorizationWebhookService authorizationWebhookService)
+            IAuthorizationWebhookService authorizationWebhookService,
+            IOAuthTokenValidator? oauthValidator = null,
+            OAuthResourceServerConfig? oauthConfig = null)
             : base(options, logger, encoder)
         {
             _authorizationWebhookService = authorizationWebhookService ?? throw new ArgumentNullException(nameof(authorizationWebhookService));
+            _oauthValidator = oauthValidator;
+            _oauthConfig = oauthConfig;
         }
 
         protected override async Task HandleChallengeAsync(AuthenticationProperties properties)
         {
-            var baseUrl = $"{Request.Scheme}://{Request.Host}";
             Response.StatusCode = 401;
+
+            if (Options.OAuthMode && _oauthConfig != null)
+            {
+                // MCP OAuth resource-server challenge (RFC 9728): the client MUST be able to discover
+                // the authorization server from the ABSOLUTE resource_metadata URL, plus the scope.
+                var metadataUrl = _oauthConfig.ProtectedResourceMetadataUrl();
+                Response.Headers.WWWAuthenticate =
+                    $"Bearer resource_metadata=\"{metadataUrl}\", scope=\"{OAuthResourceServerConfig.AgentScope}\"";
+                await Response.WriteAsJsonAsync(new
+                {
+                    error = "invalid_token",
+                    error_description = "Authentication required. Discover the authorization server via the resource_metadata URL and present a Bearer access token.",
+                    resource_metadata = metadataUrl,
+                    scope = OAuthResourceServerConfig.AgentScope
+                });
+                return;
+            }
+
+            var baseUrl = $"{Request.Scheme}://{Request.Host}";
             Response.Headers.WWWAuthenticate = $"Bearer realm=\"MCP Plugin Server\", resource=\"{baseUrl}\"";
             await Response.WriteAsJsonAsync(new
             {
@@ -63,7 +92,67 @@ namespace com.IvanMurzak.McpPlugin.Server.Auth
             });
         }
 
-        protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            return Options.OAuthMode
+                ? HandleOAuthAuthenticateAsync()
+                : HandleLegacyAuthenticateAsync();
+        }
+
+        // ── OAuth resource-server path (mcp-authorize b2) ─────────────────────────────────────────
+        async Task<AuthenticateResult> HandleOAuthAuthenticateAsync()
+        {
+            if (!TryGetBearerToken(out var token))
+            {
+                // No/empty/non-Bearer credential. On the hub path stay silent (BaseHub does its own
+                // auth). Elsewhere NoResult lets the RequireAuthorization pipeline issue the 401
+                // resource_metadata challenge.
+                return AuthenticateResult.NoResult();
+            }
+
+            if (_oauthValidator == null)
+            {
+                Logger.LogError("OAuth mode is enabled but no token validator is configured.");
+                return IsHubPath() ? AuthenticateResult.NoResult() : AuthenticateResult.Fail("OAuth validator not configured.");
+            }
+
+            var validation = await _oauthValidator.ValidateAsync(token, Context.RequestAborted);
+            if (!validation.Succeeded)
+            {
+                if (!IsHubPath())
+                {
+                    Logger.LogWarning(
+                        "MCP OAuth auth rejected: {Reason}. RemoteIp: {RemoteIpAddress}, UserAgent: {UserAgent}, RequestPath: {RequestPath}, TokenFingerprint: {TokenFingerprint}",
+                        validation.FailureReason, GetClientIpAddress(), Request.Headers.UserAgent.ToString(),
+                        Request.Path.Value, FingerprintToken(token));
+                }
+                return IsHubPath()
+                    ? AuthenticateResult.NoResult()
+                    : AuthenticateResult.Fail($"Invalid token: {validation.FailureReason}");
+            }
+
+            // Optional enforcement channel (hosted account-status revocation). NoOp locally.
+            if (!await AuthorizeAiAgentAsync(token))
+                return AuthenticateResult.Fail("Authorization webhook rejected the connection.");
+
+            var claims = new List<Claim> { new Claim(TokenClaimType, token) };
+            if (!string.IsNullOrEmpty(validation.Subject))
+            {
+                claims.Add(new Claim(SubjectClaimType, validation.Subject!));
+                claims.Add(new Claim(ClaimTypes.NameIdentifier, validation.Subject!));
+            }
+            if (!string.IsNullOrEmpty(validation.Scope))
+                claims.Add(new Claim(ScopeClaimType, validation.Scope!));
+            if (!string.IsNullOrEmpty(validation.ClientId))
+                claims.Add(new Claim(ClientIdClaimType, validation.ClientId!));
+
+            var identity = new ClaimsIdentity(claims, SchemeName);
+            var principal = new ClaimsPrincipal(identity);
+            return AuthenticateResult.Success(new AuthenticationTicket(principal, SchemeName));
+        }
+
+        // ── Legacy token path (auth=required / none) — unchanged behavior ─────────────────────────
+        async Task<AuthenticateResult> HandleLegacyAuthenticateAsync()
         {
             // If no plugins have connected with tokens and no server token is configured,
             // allow anonymous access for backward compatibility
@@ -163,7 +252,7 @@ namespace com.IvanMurzak.McpPlugin.Server.Auth
             // source (issue #99). Returning NoResult on the hub path lets the connection
             // through silently while preserving the Fail+401 challenge on every other path
             // (which IS RequireAuthorization()-gated). The same hub-path-silencing rule is
-            // also applied to the empty-Bearer case above (line 76).
+            // also applied to the empty-Bearer case above.
             if (ticket == null)
             {
                 if (!IsHubPath())
@@ -185,9 +274,19 @@ namespace com.IvanMurzak.McpPlugin.Server.Auth
             return AuthenticateResult.Success(ticket);
         }
 
+        bool TryGetBearerToken(out string token)
+        {
+            token = string.Empty;
+            var authHeader = Request.Headers["Authorization"].ToString();
+            if (string.IsNullOrEmpty(authHeader) || !authHeader.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+                return false;
+            token = authHeader.Substring("Bearer ".Length).Trim();
+            return token.Length > 0;
+        }
+
         // True when the request targets the SignalR hub endpoint. Used to silence the
         // "[7] McpPluginToken was not authenticated" info log noise on hub probes — see
-        // the comment on the no-tier-matched branch in HandleAuthenticateAsync.
+        // the comment on the no-tier-matched branch in HandleLegacyAuthenticateAsync.
         bool IsHubPath()
         {
             var path = Request.Path.Value;
@@ -233,5 +332,11 @@ namespace com.IvanMurzak.McpPlugin.Server.Auth
     {
         public string? ServerToken { get; set; }
         public bool RequireToken { get; set; }
+
+        /// <summary>
+        /// When true, the handler runs the OAuth resource-server validation path (ES256/JWKS +
+        /// introspection) instead of the legacy token-equality path (mcp-authorize b2).
+        /// </summary>
+        public bool OAuthMode { get; set; }
     }
 }

--- a/McpPlugin.Server/src/Extension/ExtensionsMcpServerBuilder.cs
+++ b/McpPlugin.Server/src/Extension/ExtensionsMcpServerBuilder.cs
@@ -9,13 +9,18 @@
 */
 
 using System;
+using System.Collections.Generic;
+using System.Net.Http;
 using com.IvanMurzak.McpPlugin.Common;
 using com.IvanMurzak.McpPlugin.Common.Hub.Client;
 using com.IvanMurzak.McpPlugin.Common.Utils;
 using com.IvanMurzak.McpPlugin.Server.Auth;
+using com.IvanMurzak.McpPlugin.Server.Auth.OAuth;
+using com.IvanMurzak.McpPlugin.Server.Security;
 using com.IvanMurzak.McpPlugin.Server.Webhooks;
 using com.IvanMurzak.ReflectorNet;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace com.IvanMurzak.McpPlugin.Server
 {
@@ -90,6 +95,63 @@ namespace com.IvanMurzak.McpPlugin.Server
                         }
                     });
             mcpServerBuilder.Services.AddAuthorization();
+
+            // OAuth resource-server services (mcp-authorize b2) — registered only in oauth mode.
+            // The TokenAuthenticationHandler's optional IOAuthTokenValidator/OAuthResourceServerConfig
+            // ctor params resolve from these; in legacy modes they stay null (unchanged behavior).
+            if (dataArguments.Authorization == Consts.MCP.Server.AuthOption.oauth)
+            {
+                mcpServerBuilder.Services.AddHttpClient();
+
+                var oauthConfig = new OAuthResourceServerConfig(dataArguments.AuthIssuer!, dataArguments.PublicUrl!);
+                mcpServerBuilder.Services.AddSingleton(oauthConfig);
+                mcpServerBuilder.Services.AddSingleton<IJwksDiskCache>(_ => new FileJwksDiskCache());
+
+                mcpServerBuilder.Services.AddSingleton<IJwksKeyProvider>(sp =>
+                {
+                    var httpFactory = sp.GetRequiredService<IHttpClientFactory>();
+                    var cache = sp.GetRequiredService<IJwksDiskCache>();
+                    JwksFetch fetch = async ct =>
+                    {
+                        var client = httpFactory.CreateClient();
+                        client.Timeout = TimeSpan.FromSeconds(10);
+                        using var response = await client.GetAsync(oauthConfig.JwksUri, ct);
+                        if (!response.IsSuccessStatusCode)
+                            return null;
+                        return await response.Content.ReadAsStringAsync(ct);
+                    };
+                    return new JwksKeyProvider(fetch, cache, logger: sp.GetService<ILogger<JwksKeyProvider>>());
+                });
+
+                mcpServerBuilder.Services.AddSingleton<IIntrospectionClient>(sp =>
+                {
+                    var httpFactory = sp.GetRequiredService<IHttpClientFactory>();
+                    IntrospectionPost post = async (token, ct) =>
+                    {
+                        var client = httpFactory.CreateClient();
+                        client.Timeout = TimeSpan.FromSeconds(10);
+                        var body = new FormUrlEncodedContent(new[]
+                        {
+                            new KeyValuePair<string, string>("token", token)
+                        });
+                        using var response = await client.PostAsync(oauthConfig.IntrospectionEndpoint, body, ct);
+                        if (!response.IsSuccessStatusCode)
+                            return null;
+                        return await response.Content.ReadAsStringAsync(ct);
+                    };
+                    return new IntrospectionClient(post, logger: sp.GetService<ILogger<IntrospectionClient>>());
+                });
+
+                mcpServerBuilder.Services.AddSingleton<IOAuthTokenValidator>(sp => new AccessTokenValidator(
+                    sp.GetRequiredService<OAuthResourceServerConfig>(),
+                    sp.GetRequiredService<IJwksKeyProvider>(),
+                    sp.GetRequiredService<IIntrospectionClient>(),
+                    logger: sp.GetService<ILogger<AccessTokenValidator>>()));
+            }
+
+            // Origin validation options (mcp-authorize b2) — registered in ALL modes; consumed by
+            // OriginValidationMiddleware (wired in ExtensionsWebApplication.UseMcpPluginServer).
+            mcpServerBuilder.Services.AddSingleton(OriginValidationOptions.FromArguments(dataArguments));
 
             mcpServerBuilder.Services.AddRouting();
 

--- a/McpPlugin.Server/src/Extension/ExtensionsWebApplication.cs
+++ b/McpPlugin.Server/src/Extension/ExtensionsWebApplication.cs
@@ -39,6 +39,11 @@ namespace com.IvanMurzak.McpPlugin.Server
             forwardedHeadersOptions.KnownProxies.Clear();
             app.UseForwardedHeaders(forwardedHeadersOptions);
 
+            // Origin validation (MCP transport MUST — mcp-authorize b2): reject a present-but-non-
+            // allowed Origin with 403 on the MCP endpoint AND the SignalR negotiate path, in ALL
+            // auth modes (the DNS-rebinding defense; runs before routing/auth).
+            app.UseMiddleware<Security.OriginValidationMiddleware>();
+
             // Setup routing ----------------------------------------------------
             app.UseRouting();
 

--- a/McpPlugin.Server/src/Extension/ExtensionsWebHost.cs
+++ b/McpPlugin.Server/src/Extension/ExtensionsWebHost.cs
@@ -9,6 +9,7 @@
 */
 
 using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
 using Microsoft.AspNetCore.Hosting;
@@ -20,24 +21,71 @@ namespace com.IvanMurzak.McpPlugin.Server
     public static class ExtensionsWebHost
     {
         /// <summary>
-        /// Configures Kestrel to listen on the specified port using separate IPv4 and IPv6 bindings.
-        /// Avoids dual-stack sockets which cause SocketAddress size mismatch errors on macOS.
-        /// Falls back to IPv4-only when <see cref="Socket.OSSupportsIPv6"/> is false.
+        /// Configures Kestrel to listen on the specified port, bound to <b>loopback</b> by default
+        /// (decision D8, mcp-authorize b2). This is the 1-argument compatibility overload; it now
+        /// defaults to loopback-only just like <see cref="UseKestrelForMcpPlugin(IWebHostBuilder,int,string)"/>
+        /// with a null bind.
         /// </summary>
         public static IWebHostBuilder UseKestrelForMcpPlugin(this IWebHostBuilder webHost, int port)
+            => webHost.UseKestrelForMcpPlugin(port, bind: null);
+
+        /// <summary>
+        /// Resolve the bind argument into the concrete listen addresses. <c>null</c>/empty and the
+        /// <c>loopback</c>/<c>localhost</c> aliases yield loopback-only (D8 default). <c>any</c> (or
+        /// <c>0.0.0.0</c>/<c>::</c>) yields all-interfaces; any other value is parsed as a specific
+        /// <see cref="IPAddress"/>. IPv6 addresses are included only when the OS supports IPv6.
+        /// </summary>
+        public static IReadOnlyList<IPAddress> ResolveBindAddresses(string? bind)
+        {
+            var value = bind?.Trim();
+
+            if (string.IsNullOrEmpty(value)
+                || string.Equals(value, "loopback", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(value, "localhost", StringComparison.OrdinalIgnoreCase))
+            {
+                return WithOptionalIPv6(IPAddress.Loopback, IPAddress.IPv6Loopback);
+            }
+
+            if (string.Equals(value, "any", StringComparison.OrdinalIgnoreCase))
+                return WithOptionalIPv6(IPAddress.Any, IPAddress.IPv6Any);
+
+            if (!IPAddress.TryParse(value, out var parsed))
+                throw new ArgumentException($"Invalid --bind value '{bind}'. Use 'loopback', 'any', or a specific IP address.", nameof(bind));
+
+            if (parsed.AddressFamily == AddressFamily.InterNetworkV6 && !Socket.OSSupportsIPv6)
+                throw new ArgumentException($"--bind '{bind}' requests IPv6 but the OS does not support it.", nameof(bind));
+
+            return new[] { parsed };
+        }
+
+        private static IReadOnlyList<IPAddress> WithOptionalIPv6(IPAddress v4, IPAddress v6)
+        {
+            var list = new List<IPAddress> { v4 };
+            if (Socket.OSSupportsIPv6)
+                list.Add(v6);
+            return list;
+        }
+
+        /// <summary>
+        /// Configures Kestrel to listen on the specified port using separate IPv4 and IPv6 bindings
+        /// resolved from <paramref name="bind"/> (default loopback, D8). Avoids dual-stack sockets
+        /// which cause SocketAddress size mismatch errors on macOS. Falls back to IPv4-only when
+        /// <see cref="Socket.OSSupportsIPv6"/> is false.
+        /// </summary>
+        public static IWebHostBuilder UseKestrelForMcpPlugin(this IWebHostBuilder webHost, int port, string? bind)
         {
             if (webHost == null) throw new ArgumentNullException(nameof(webHost));
             if (port < 0 || port > 65535) throw new ArgumentOutOfRangeException(nameof(port), port, "Port must be between 0 and 65535.");
 
+            var addresses = ResolveBindAddresses(bind);
+
             return webHost
                 .UseKestrel(options =>
                 {
-                    // Bind IPv4 and IPv6 separately instead of using ListenAnyIP
+                    // Bind each resolved address separately instead of using ListenAnyIP
                     // which creates a dual-stack socket that fails on macOS.
-                    options.Listen(IPAddress.Any, port);
-
-                    if (Socket.OSSupportsIPv6)
-                        options.Listen(IPAddress.IPv6Any, port);
+                    foreach (var address in addresses)
+                        options.Listen(address, port);
                 })
                 .ConfigureServices(services =>
                 {

--- a/McpPlugin.Server/src/Hub/BaseHub.cs
+++ b/McpPlugin.Server/src/Hub/BaseHub.cs
@@ -47,7 +47,14 @@ namespace com.IvanMurzak.McpPlugin.Server
         public override async Task OnConnectedAsync()
         {
             var httpContext = Context.GetHttpContext();
-            var token = httpContext?.Request.Query["access_token"].FirstOrDefault();
+
+            // OAuth mode (mcp-authorize b2): the hub credential MUST arrive via the Authorization
+            // header only — the ?access_token= query param is NOT honored (it leaks into logs and
+            // referrers). Legacy modes keep the query fallback for backward compatibility.
+            string? token = _strategy.AuthOption == Consts.MCP.Server.AuthOption.oauth
+                ? null
+                : httpContext?.Request.Query["access_token"].FirstOrDefault();
+
             var remoteIpAddress = GetClientIpAddress(httpContext);
             var userAgent = httpContext?.Request.Headers.UserAgent.ToString() is { Length: > 0 } ua ? ua : null;
             var requestPath = httpContext?.Request.Path.Value;

--- a/McpPlugin.Server/src/Security/OriginPolicy.cs
+++ b/McpPlugin.Server/src/Security/OriginPolicy.cs
@@ -1,0 +1,76 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using com.IvanMurzak.McpPlugin.Server.Auth.OAuth;
+using Microsoft.AspNetCore.Http;
+
+namespace com.IvanMurzak.McpPlugin.Server.Security
+{
+    /// <summary>
+    /// Pure Origin-validation policy (mcp-authorize b2). Separated from the middleware so the
+    /// allow/deny and path-matching logic is unit-testable without an HTTP host.
+    /// </summary>
+    public static class OriginPolicy
+    {
+        /// <summary>
+        /// True when the request path is one the transport MUST guard: the MCP endpoints
+        /// (<c>/</c>, <c>/mcp</c>, <c>/mcp/*</c>) and the SignalR hub (incl. <c>/negotiate</c>).
+        /// Discovery paths (<c>/.well-known/*</c>, <c>/oauth/*</c>) are intentionally NOT guarded.
+        /// </summary>
+        public static bool IsGuardedPath(PathString path, string hubPath)
+        {
+            if (!path.HasValue)
+                return false;
+
+            var value = path.Value!;
+            if (value.StartsWith(hubPath, StringComparison.OrdinalIgnoreCase))
+                return true;
+
+            if (string.Equals(value, "/", StringComparison.Ordinal))
+                return true;
+            if (string.Equals(value, "/mcp", StringComparison.OrdinalIgnoreCase))
+                return true;
+            if (value.StartsWith("/mcp/", StringComparison.OrdinalIgnoreCase))
+                return true;
+
+            return false;
+        }
+
+        /// <summary>
+        /// True when the request may proceed: no <c>Origin</c> header (native client), a loopback
+        /// origin (when allowed), or an explicitly-allowed origin. A present-but-malformed or
+        /// present-but-non-allowed origin is rejected (fail closed).
+        /// </summary>
+        public static bool IsOriginAllowed(string? originHeader, OriginValidationOptions options)
+        {
+            if (string.IsNullOrEmpty(originHeader))
+                return true; // absent → allowed (native, non-browser MCP clients)
+
+            var normalized = UrlNormalization.NormalizeOrigin(originHeader);
+            if (normalized == null)
+                return false; // present but unparseable → reject
+
+            if (options.AllowLoopback
+                && Uri.TryCreate(originHeader!.Trim(), UriKind.Absolute, out var uri)
+                && UrlNormalization.IsLoopbackHost(uri.Host))
+                return true;
+
+            foreach (var allowed in options.AllowedOrigins)
+            {
+                if (string.Equals(allowed, normalized, StringComparison.Ordinal))
+                    return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/McpPlugin.Server/src/Security/OriginValidationMiddleware.cs
+++ b/McpPlugin.Server/src/Security/OriginValidationMiddleware.cs
@@ -1,0 +1,57 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace com.IvanMurzak.McpPlugin.Server.Security
+{
+    /// <summary>
+    /// Enforces Origin validation on the MCP endpoint and the SignalR hub (incl. negotiate) in ALL
+    /// auth modes (mcp-authorize b2). A guarded request carrying a present-but-non-allowed
+    /// <c>Origin</c> is rejected with <c>403</c> before it reaches routing/auth — the DNS-rebinding
+    /// defense for loopback servers (a loopback bind alone does not stop rebinding, since the
+    /// hostile request originates from the victim's own browser).
+    /// </summary>
+    public sealed class OriginValidationMiddleware
+    {
+        private readonly RequestDelegate _next;
+        private readonly OriginValidationOptions _options;
+
+        public OriginValidationMiddleware(RequestDelegate next, OriginValidationOptions options)
+        {
+            _next = next ?? throw new ArgumentNullException(nameof(next));
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+        }
+
+        public async Task InvokeAsync(HttpContext context)
+        {
+            if (OriginPolicy.IsGuardedPath(context.Request.Path, _options.HubPath))
+            {
+                var origin = context.Request.Headers["Origin"].ToString();
+                if (!OriginPolicy.IsOriginAllowed(origin, _options))
+                {
+                    context.Response.StatusCode = StatusCodes.Status403Forbidden;
+                    context.Response.ContentType = "application/json";
+                    await context.Response.WriteAsJsonAsync(new
+                    {
+                        error = "forbidden_origin",
+                        message = "The request Origin is not allowed."
+                    }).ConfigureAwait(false);
+                    return;
+                }
+            }
+
+            await _next(context).ConfigureAwait(false);
+        }
+    }
+}

--- a/McpPlugin.Server/src/Security/OriginValidationOptions.cs
+++ b/McpPlugin.Server/src/Security/OriginValidationOptions.cs
@@ -1,0 +1,63 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using com.IvanMurzak.McpPlugin.Common;
+using com.IvanMurzak.McpPlugin.Common.Utils;
+using com.IvanMurzak.McpPlugin.Server.Auth.OAuth;
+
+namespace com.IvanMurzak.McpPlugin.Server.Security
+{
+    /// <summary>
+    /// Configuration for Origin validation (mcp-authorize b2), the MCP-transport DNS-rebinding
+    /// defense applied in ALL auth modes. A request to the MCP endpoint or the SignalR hub carrying
+    /// a present-but-non-allowed <c>Origin</c> is rejected with <c>403</c>.
+    /// </summary>
+    public sealed class OriginValidationOptions
+    {
+        /// <summary>
+        /// Explicitly-allowed origins (normalized <c>scheme://host:port</c>). Loopback origins are
+        /// additionally allowed via <see cref="AllowLoopback"/>. Native (non-browser) MCP clients
+        /// send no <c>Origin</c> header and are always allowed.
+        /// </summary>
+        public IReadOnlyCollection<string> AllowedOrigins { get; }
+
+        /// <summary>When true (default), any loopback origin is allowed regardless of port.</summary>
+        public bool AllowLoopback { get; }
+
+        /// <summary>The SignalR hub base path to guard (e.g. <c>/hub/mcp-server</c>).</summary>
+        public string HubPath { get; }
+
+        public OriginValidationOptions(IReadOnlyCollection<string> allowedOrigins, bool allowLoopback = true, string? hubPath = null)
+        {
+            AllowedOrigins = allowedOrigins ?? Array.Empty<string>();
+            AllowLoopback = allowLoopback;
+            HubPath = hubPath ?? Consts.Hub.RemoteApp;
+        }
+
+        /// <summary>
+        /// Build from resolved arguments: the RS's own <c>--public-url</c> origin is allowed
+        /// (browsers hosted at the RS's own origin), and loopback is always allowed. This covers the
+        /// local RS (native clients + same-origin browser clients) and blocks cross-site (DNS
+        /// rebinding) origins in every mode.
+        /// </summary>
+        public static OriginValidationOptions FromArguments(DataArguments dataArguments)
+        {
+            var allowed = new HashSet<string>(StringComparer.Ordinal);
+            var publicOrigin = UrlNormalization.NormalizeOrigin(dataArguments.PublicUrl);
+            if (publicOrigin != null)
+                allowed.Add(publicOrigin);
+
+            return new OriginValidationOptions(allowed, allowLoopback: true);
+        }
+    }
+}

--- a/McpPlugin.Server/src/Strategy/McpStrategyFactory.cs
+++ b/McpPlugin.Server/src/Strategy/McpStrategyFactory.cs
@@ -26,9 +26,10 @@ namespace com.IvanMurzak.McpPlugin.Server.Strategy
             {
                 Consts.MCP.Server.AuthOption.none => new NoAuthMcpStrategy(),
                 Consts.MCP.Server.AuthOption.required => new RequiredAuthMcpStrategy(),
+                Consts.MCP.Server.AuthOption.oauth => new OAuthMcpStrategy(),
                 _ => throw new ArgumentException(
                     $"Unsupported auth option: {mode}. " +
-                    $"Supported auth options are: {Consts.MCP.Server.AuthOption.none}, {Consts.MCP.Server.AuthOption.required}")
+                    $"Supported auth options are: {Consts.MCP.Server.AuthOption.none}, {Consts.MCP.Server.AuthOption.required}, {Consts.MCP.Server.AuthOption.oauth}")
             };
         }
     }

--- a/McpPlugin.Server/src/Strategy/OAuthMcpStrategy.cs
+++ b/McpPlugin.Server/src/Strategy/OAuthMcpStrategy.cs
@@ -1,0 +1,81 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using com.IvanMurzak.McpPlugin.Common;
+using com.IvanMurzak.McpPlugin.Common.Model;
+using com.IvanMurzak.McpPlugin.Common.Utils;
+using com.IvanMurzak.McpPlugin.Server.Auth;
+using Microsoft.Extensions.Logging;
+
+namespace com.IvanMurzak.McpPlugin.Server.Strategy
+{
+    /// <summary>
+    /// OAuth resource-server connection strategy (mcp-authorize b2). Its responsibility in b2 is the
+    /// AUTH configuration: it flags the <see cref="TokenAuthenticationHandler"/> to run the OAuth
+    /// validation path (ES256/JWKS + introspection). The account+instance PAIRING plane (routing by
+    /// <c>sub</c>) arrives in b3; until then the interim routing/notification behavior is delegated
+    /// to the existing token-based <see cref="RequiredAuthMcpStrategy"/> so the server remains
+    /// functional. No routing test depends on this interim delegation.
+    /// </summary>
+    public sealed class OAuthMcpStrategy : IMcpConnectionStrategy
+    {
+        // Interim routing engine (token-based). Replaced by the account+instance registry in b3.
+        private readonly RequiredAuthMcpStrategy _routing = new RequiredAuthMcpStrategy();
+
+        public Consts.MCP.Server.AuthOption AuthOption
+            => Consts.MCP.Server.AuthOption.oauth;
+
+        public bool AllowMultipleConnections => true;
+
+        public void Validate(DataArguments dataArguments)
+        {
+            if (string.IsNullOrWhiteSpace(dataArguments.AuthIssuer))
+                throw new ArgumentException("auth=oauth mode requires --auth-issuer (the authorization server URL).");
+            if (string.IsNullOrWhiteSpace(dataArguments.PublicUrl))
+                throw new ArgumentException("auth=oauth mode requires --public-url (this server's canonical resource id).");
+        }
+
+        public void ConfigureAuthentication(TokenAuthenticationOptions options, DataArguments dataArguments)
+        {
+            // OAuth mode: the handler validates the presented token against the AS (JWKS +
+            // introspection). No pre-shared ServerToken; RequireToken must be true so the handler
+            // runs on the (RequireAuthorization-gated) MCP endpoint.
+            options.OAuthMode = true;
+            options.ServerToken = null;
+            options.RequireToken = true;
+        }
+
+        public void OnPluginConnected(Type hubType, string connectionId, string? token, ILogger logger, Action<string, string?> disconnectClient)
+            => _routing.OnPluginConnected(hubType, connectionId, token, logger, disconnectClient);
+
+        public void OnPluginDisconnected(Type hubType, string connectionId, ILogger logger)
+            => _routing.OnPluginDisconnected(hubType, connectionId, logger);
+
+        public string? ResolveConnectionId(string? token, int retryOffset)
+            => _routing.ResolveConnectionId(token, retryOffset);
+
+        public bool ShouldNotifySession(string pluginConnectionId, string sessionId)
+            => _routing.ShouldNotifySession(pluginConnectionId, sessionId);
+
+        public NotificationTarget ResolveNotificationTarget(string? routingToken)
+            => _routing.ResolveNotificationTarget(routingToken);
+
+        public McpClientData GetClientData(string? connectionId, IMcpSessionTracker sessionTracker)
+            => _routing.GetClientData(connectionId, sessionTracker);
+
+        public McpClientData[] GetAllClientData(string? connectionId, IMcpSessionTracker sessionTracker)
+            => _routing.GetAllClientData(connectionId, sessionTracker);
+
+        public McpServerData GetServerData(string? connectionId, IMcpSessionTracker sessionTracker)
+            => _routing.GetServerData(connectionId, sessionTracker);
+    }
+}

--- a/McpPlugin.Server/src/Transport/StreamableHttpTransportLayer.cs
+++ b/McpPlugin.Server/src/Transport/StreamableHttpTransportLayer.cs
@@ -124,11 +124,34 @@ namespace com.IvanMurzak.McpPlugin.Server.Transport
         public void ConfigureApp(WebApplication app, DataArguments dataArguments)
         {
             var logger = LogManager.GetCurrentClassLogger();
-            var requireAuth = dataArguments.Authorization == Consts.MCP.Server.AuthOption.required;
+            var mode = dataArguments.Authorization;
 
-            logger.Debug("Configuring HTTP transport endpoints. RequireAuth={requireAuth}", requireAuth);
+            logger.Debug("Configuring HTTP transport endpoints. Auth={mode}", mode);
 
-            if (requireAuth)
+            if (mode == Consts.MCP.Server.AuthOption.oauth)
+            {
+                // OAuth resource-server mode (mcp-authorize b2): serve ONLY Protected Resource
+                // Metadata (RFC 9728) pointing at the EXTERNAL authorization server. The RS never
+                // mints tokens, so no /oauth/register, /oauth/token, or AS-metadata are served here.
+                var oauthConfig = app.Services.GetService<Auth.OAuth.OAuthResourceServerConfig>();
+
+                app.MapGet("/.well-known/oauth-protected-resource", async (HttpContext ctx) =>
+                {
+                    if (oauthConfig == null)
+                    {
+                        await Results.StatusCode(500).ExecuteAsync(ctx);
+                        return;
+                    }
+                    // Public, non-secret metadata — CORS-open so browser-based MCP clients can read it.
+                    ctx.Response.Headers["Access-Control-Allow-Origin"] = "*";
+                    var document = Auth.OAuth.OAuthProtectedResourceMetadata.Build(oauthConfig);
+                    await Results.Json(document).ExecuteAsync(ctx);
+                }).AllowAnonymous();
+
+                app.MapMcp("/").RequireAuthorization();
+                app.MapMcp("/mcp").RequireAuthorization();
+            }
+            else if (mode == Consts.MCP.Server.AuthOption.required)
             {
                 // MCP: OAuth 2.0 Protected Resource Metadata (RFC 9728)
                 // Tells clients that this server is its own authorization server

--- a/McpPlugin.Server/src/Transport/StreamableHttpTransportLayer.cs
+++ b/McpPlugin.Server/src/Transport/StreamableHttpTransportLayer.cs
@@ -135,18 +135,34 @@ namespace com.IvanMurzak.McpPlugin.Server.Transport
                 // mints tokens, so no /oauth/register, /oauth/token, or AS-metadata are served here.
                 var oauthConfig = app.Services.GetService<Auth.OAuth.OAuthResourceServerConfig>();
 
-                app.MapGet("/.well-known/oauth-protected-resource", async (HttpContext ctx) =>
+                // Public, non-secret PRM (RFC 9728). Served at BOTH the bare well-known path AND —
+                // when --public-url carries a path (e.g. https://host/mcp) — the path-inserted URL
+                // the 401 challenge advertises (OAuthResourceServerConfig.ProtectedResourceMetadataUrl),
+                // so a spec-compliant client following the challenge does not 404 on a path-bearing
+                // resource. Shared handler avoids duplicating the body across both routes.
+                RequestDelegate servePrm = async ctx =>
                 {
                     if (oauthConfig == null)
                     {
                         await Results.StatusCode(500).ExecuteAsync(ctx);
                         return;
                     }
-                    // Public, non-secret metadata — CORS-open so browser-based MCP clients can read it.
+                    // CORS-open so browser-based MCP clients can read it.
                     ctx.Response.Headers["Access-Control-Allow-Origin"] = "*";
                     var document = Auth.OAuth.OAuthProtectedResourceMetadata.Build(oauthConfig);
                     await Results.Json(document).ExecuteAsync(ctx);
-                }).AllowAnonymous();
+                };
+
+                const string bareMetadataPath = "/.well-known/oauth-protected-resource";
+                app.MapGet(bareMetadataPath, servePrm).AllowAnonymous();
+
+                // Path-bearing resource → also serve at the challenge-advertised path-inserted URL.
+                if (oauthConfig != null
+                    && Uri.TryCreate(oauthConfig.ProtectedResourceMetadataUrl(), UriKind.Absolute, out var prmUri)
+                    && !string.Equals(prmUri.AbsolutePath, bareMetadataPath, StringComparison.Ordinal))
+                {
+                    app.MapGet(prmUri.AbsolutePath, servePrm).AllowAnonymous();
+                }
 
                 app.MapMcp("/").RequireAuthorization();
                 app.MapMcp("/mcp").RequireAuthorization();


### PR DESCRIPTION
## Summary
- Adds a new `oauth` auth mode (mcp-authorize task **b2**) that turns `McpPlugin.Server` into a pure OAuth 2.1 **resource server** — validating ES256 JWTs against the authorization server's JWKS and opaque tokens via introspection; it never mints tokens.
- `TokenAuthenticationHandler` oauth path: ES256/JWKS validation (disk cache, ±5 min skew, unknown-`kid` rate-limited refetch, offline grace, alg-confusion rejected — ES256 only), strict `iss` + strict per-resource `aud` vs `--public-url` (loopback aliases normalized), opaque → RFC 7662 introspection (60 s cache, fail-closed); 401 challenge carries an **absolute** `resource_metadata` URL + `scope`.
- `StreamableHttpTransportLayer`: serves Protected Resource Metadata (RFC 9728) in `oauth` mode (404 in `none`); Origin validation → **403 in ALL modes** (MCP endpoint + SignalR negotiate).
- New args/env: `--auth {none|oauth}`/`MCP_AUTH`, `--auth-issuer`/`MCP_AUTH_ISSUER`, `--public-url`/`MCP_PUBLIC_URL`, `--bind`/`MCP_BIND` (default flips to **loopback**, decision D8). Hub auth via the `Authorization` header only in `oauth` mode (no `?access_token=`).

Legacy shared-token deletion (b5) and the account+instance pairing plane (b3) are intentionally **out of scope** — this adds the resource-server surface alongside the existing `none`/`required` modes without removing the legacy surface.

## Test plan
- [x] Target-specific local tests passed (see profile test.md): full xUnit suite green on **net8.0 + net9.0** across `McpPlugin.Tests` + `McpPlugin.Server.Tests` (0 failures, 0 warnings).
- [x] Validation fuzz: expired / bad-iss / bad-aud / unknown-kid / alg-confusion (`alg:none`, HS256-signed-with-the-public-key) all rejected; skew edges covered.
- [x] Origin: 403 on present-but-non-allowed, pass on absent/allowed — in BOTH `none` AND `oauth`.
- [x] PRM content/absence per mode; 401 challenge format (absolute `resource_metadata` + `scope`); loopback bind default + `--bind` opt-out — verified via unit tests AND a live DemoWebApp smoke.

Closes #138