### PR TITLE
feat: server-native selection + enrollment tools + tools/list merge (mcp-authorize b4)

### DIFF
--- a/McpPlugin.Server.Tests/AgentActionableErrorsTests.cs
+++ b/McpPlugin.Server.Tests/AgentActionableErrorsTests.cs
@@ -1,0 +1,125 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+using com.IvanMurzak.McpPlugin.Server.Auth;
+using com.IvanMurzak.McpPlugin.Server.Strategy;
+using com.IvanMurzak.McpPlugin.Server.Tools;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.Server.Tests
+{
+    /// <summary>
+    /// The two agent-actionable no-instance error variants of design 04 step 5 (mcp-authorize b4):
+    /// pinned-no-match (project editor closed, other instances live) vs account-empty (nothing
+    /// connected). Verifies both the text builder and the strategy resolution → text path.
+    /// </summary>
+    [Collection("McpPlugin.Server")]
+    public class AgentActionableErrorsTests
+    {
+        const string HashA = "aabbccdd11223344556677889900aabbccddeeff00112233445566778899aabb";
+        const string PinA = "aabbccdd";
+        const string HashB = "99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa";
+        const string PinB = "99887766";
+
+        static PluginInstanceMetadata Meta(string instanceId, string engine = "unity", string project = "MyGame", string pathHash = HashA, string machine = "PC-1")
+            => new PluginInstanceMetadata(instanceId, engine, project, pathHash, machine);
+
+        static ConnectionIdentity Agent(string account) => new ConnectionIdentity(account, ConnectionIdentity.RoleAgent);
+
+        static IDisposable SessionContext(ConnectionIdentity? identity, string? pin = null, string? selected = null)
+        {
+            McpSessionTokenContext.CurrentIdentity = identity;
+            McpSessionTokenContext.CurrentProjectPin = pin;
+            McpSessionTokenContext.CurrentSelectedInstanceId = selected;
+            return new Reset();
+        }
+
+        sealed class Reset : IDisposable
+        {
+            public void Dispose()
+            {
+                McpSessionTokenContext.CurrentIdentity = null;
+                McpSessionTokenContext.CurrentProjectPin = null;
+                McpSessionTokenContext.CurrentSelectedInstanceId = null;
+            }
+        }
+
+        // ─────────────────────────────── Text builder ───────────────────────────────
+
+        [Fact]
+        public void AccountEmpty_Text_NamesEnrollAndCli()
+        {
+            AgentActionableErrors.AccountEmpty.ShouldContain("enroll_engine_plugin");
+            AgentActionableErrors.AccountEmpty.ShouldContain("unity-mcp-cli install-plugin --enroll");
+            AgentActionableErrors.AccountEmpty.ShouldContain("No game engine is connected");
+        }
+
+        [Fact]
+        public void PinnedNoMatch_Text_ListsOtherInstances_AndNeverSuggestsReinstall()
+        {
+            var registry = new AccountInstances();
+            registry.Register("acc-1", Meta("i-godot", engine: "godot", project: "OtherGame", pathHash: HashB, machine: "PC-2"), "conn-2");
+
+            var text = AgentActionableErrors.PinnedNoMatch(registry, "acc-1");
+
+            text.ShouldContain("not connected");
+            text.ShouldContain("Other connected instances:");
+            text.ShouldContain("godot:OtherGame on PC-2");
+            text.ShouldNotContain("install"); // never suggests re-installing
+        }
+
+        // ─────────────────────────── Strategy resolution → variant ───────────────────────────
+
+        [Fact]
+        public void ResolveCurrentSession_AccountEmpty_WhenNoInstances()
+        {
+            var strategy = new AccountMcpStrategy();
+            using (SessionContext(Agent("acc-1")))
+            {
+                var resolution = strategy.ResolveCurrentSession();
+                resolution.Kind.ShouldBe(InstanceResolutionKind.AccountEmpty);
+                AgentActionableErrors.ForResolution(resolution, strategy.Instances, "acc-1")
+                    .ShouldBe(AgentActionableErrors.AccountEmpty);
+            }
+        }
+
+        [Fact]
+        public void ResolveCurrentSession_PinnedNoMatch_WhenPinnedProjectEditorClosed()
+        {
+            var strategy = new AccountMcpStrategy();
+            // Account has a live instance for a DIFFERENT project than the session's pin.
+            strategy.Instances.Register("acc-1", Meta("i-other", engine: "unreal", project: "OtherGame", pathHash: HashB, machine: "PC-9"), "conn-9");
+
+            using (SessionContext(Agent("acc-1"), pin: PinA))
+            {
+                var resolution = strategy.ResolveCurrentSession();
+                resolution.Kind.ShouldBe(InstanceResolutionKind.NoMatchPinned);
+
+                var text = AgentActionableErrors.ForResolution(resolution, strategy.Instances, "acc-1");
+                text.ShouldContain("not connected");
+                text.ShouldContain("unreal:OtherGame on PC-9");
+            }
+        }
+
+        [Fact]
+        public void ForResolution_Resolved_FallsToAccountEmptyText_ButIsNotUsedByCallers()
+        {
+            // Defensive: a Resolved kind is never passed to the error builder in practice; assert it
+            // does not throw and yields the account-empty text as the harmless default.
+            var strategy = new AccountMcpStrategy();
+            var instance = strategy.Instances.Register("acc-1", Meta("i1"), "conn-1");
+            var resolution = InstanceResolution.Resolved(instance);
+            AgentActionableErrors.ForResolution(resolution, strategy.Instances, "acc-1")
+                .ShouldBe(AgentActionableErrors.AccountEmpty);
+        }
+    }
+}

--- a/McpPlugin.Server.Tests/EnrollmentClientTests.cs
+++ b/McpPlugin.Server.Tests/EnrollmentClientTests.cs
@@ -1,0 +1,101 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.Server.Tools;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.Server.Tests
+{
+    /// <summary>
+    /// Unit tests for the RS-side enrollment proxy (mcp-authorize b4, design 05 enroll/create) against
+    /// a MOCKED authorization server via the injected <see cref="EnrollCreatePost"/> delegate — no live
+    /// HttpClient. Real staging-AS e2e is deferred to the integration gates (b8).
+    /// </summary>
+    public class EnrollmentClientTests
+    {
+        const string PublicUrl = "https://ai-game.dev/mcp";
+
+        static EnrollmentClient WithResponse(string? json, System.Action<string, string, string>? capture = null)
+        {
+            EnrollCreatePost post = (bearer, engine, publicUrl, ct) =>
+            {
+                capture?.Invoke(bearer, engine, publicUrl);
+                return Task.FromResult(json);
+            };
+            return new EnrollmentClient(post, PublicUrl);
+        }
+
+        [Fact]
+        public async Task CreateAsync_ForwardsBearerEngineAndPublicUrl_ToTheAs()
+        {
+            string? seenBearer = null, seenEngine = null, seenPublicUrl = null;
+            var client = WithResponse("{\"enroll_code\":\"ABC123\"}",
+                (b, e, u) => { seenBearer = b; seenEngine = e; seenPublicUrl = u; });
+
+            await client.CreateAsync("godot", "jwt-or-pat-token", CancellationToken.None);
+
+            seenBearer.ShouldBe("jwt-or-pat-token");
+            seenEngine.ShouldBe("godot");
+            seenPublicUrl.ShouldBe(PublicUrl);
+        }
+
+        [Fact]
+        public async Task CreateAsync_ParsesEnrollCode_OnSuccess()
+        {
+            var result = await WithResponse("{\"enroll_code\":\"XYZ789\",\"expires_in\":300}")
+                .CreateAsync("unity", "token", CancellationToken.None);
+
+            result.Success.ShouldBeTrue();
+            result.EnrollCode.ShouldBe("XYZ789");
+            result.Error.ShouldBeNull();
+        }
+
+        [Fact]
+        public async Task CreateAsync_NullResponse_IsFailure()
+        {
+            var result = await WithResponse(null).CreateAsync("unity", "token", CancellationToken.None);
+            result.Success.ShouldBeFalse();
+            result.EnrollCode.ShouldBeNull();
+            result.Error.ShouldNotBeNull();
+        }
+
+        [Fact]
+        public async Task CreateAsync_MalformedJson_IsFailure()
+        {
+            var result = await WithResponse("not json").CreateAsync("unity", "token", CancellationToken.None);
+            result.Success.ShouldBeFalse();
+            result.Error.ShouldNotBeNull();
+        }
+
+        [Fact]
+        public async Task CreateAsync_MissingEnrollCode_IsFailure()
+        {
+            var result = await WithResponse("{\"something_else\":\"1\"}").CreateAsync("unity", "token", CancellationToken.None);
+            result.Success.ShouldBeFalse();
+            result.Error.ShouldNotBeNull();
+        }
+
+        [Fact]
+        public async Task CreateAsync_NoCredential_IsFailure_WithoutCallingTheAs()
+        {
+            var called = false;
+            EnrollCreatePost post = (b, e, u, ct) => { called = true; return Task.FromResult<string?>("{\"enroll_code\":\"x\"}"); };
+            var client = new EnrollmentClient(post, PublicUrl);
+
+            var result = await client.CreateAsync("unity", "", CancellationToken.None);
+
+            result.Success.ShouldBeFalse();
+            called.ShouldBeFalse();
+        }
+    }
+}

--- a/McpPlugin.Server.Tests/ServerNativeToolsTests.cs
+++ b/McpPlugin.Server.Tests/ServerNativeToolsTests.cs
@@ -1,0 +1,383 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.Common.Model;
+using com.IvanMurzak.McpPlugin.Server.Auth;
+using com.IvanMurzak.McpPlugin.Server.Strategy;
+using com.IvanMurzak.McpPlugin.Server.Tools;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.Server.Tests
+{
+    /// <summary>
+    /// Tests for the server-native selection + enrollment tools (mcp-authorize b4, design 04):
+    /// <c>list_engine_instances</c>, <c>select_engine_instance</c> (sticky, pin-narrowing),
+    /// <c>enroll_engine_plugin</c> (mocked AS). Also verifies the descriptors that
+    /// <see cref="ToolRouter"/> merges into <c>tools/list</c>.
+    /// </summary>
+    [Collection("McpPlugin.Server")]
+    public class ServerNativeToolsTests
+    {
+        const string Account = "acc-1";
+        const string Session = "session-1";
+        const string HashA = "aabbccdd11223344556677889900aabbccddeeff00112233445566778899aabb";
+        const string PinA = "aabbccdd";
+        const string HashB = "99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa";
+        const string PinB = "99887766";
+
+        sealed class Clock
+        {
+            public DateTimeOffset Now;
+            public Clock(DateTimeOffset start) => Now = start;
+            public void Advance(TimeSpan by) => Now += by;
+        }
+
+        sealed class FakeEnrollment : IEnrollmentClient
+        {
+            public EnrollmentResult Result = EnrollmentResult.Ok("CODE123");
+            public string? SeenEngine;
+            public string? SeenBearer;
+            public Task<EnrollmentResult> CreateAsync(string engine, string bearer, CancellationToken cancellationToken = default)
+            {
+                SeenEngine = engine;
+                SeenBearer = bearer;
+                return Task.FromResult(Result);
+            }
+        }
+
+        static PluginInstanceMetadata Meta(string instanceId, string engine = "unity", string project = "MyGame", string pathHash = HashA, string machine = "PC-1")
+            => new PluginInstanceMetadata(instanceId, engine, project, pathHash, machine);
+
+        static IReadOnlyDictionary<string, JsonElement> Args(params (string key, string value)[] kv)
+            => kv.ToDictionary(p => p.key, p => JsonSerializer.SerializeToElement(p.value));
+
+        static readonly IReadOnlyDictionary<string, JsonElement> NoArgs = new Dictionary<string, JsonElement>();
+
+        static SelectionToolContext Ctx(string? account = Account, string? session = Session, string? pin = null, string? bearer = "bearer-token")
+            => new SelectionToolContext(account, session, pin, bearer);
+
+        static string Text(ResponseCallTool r) => r.GetMessage() ?? string.Empty;
+
+        static (ServerNativeTools tools, AccountInstances registry, SessionSelectionStore selections, FakeEnrollment enroll, Clock clock) NewTools()
+        {
+            var clock = new Clock(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+            var registry = new AccountInstances(() => clock.Now);
+            var selections = new SessionSelectionStore();
+            var enroll = new FakeEnrollment();
+            var tools = new ServerNativeTools(registry, selections, enroll);
+            return (tools, registry, selections, enroll, clock);
+        }
+
+        // Reset the ambient AsyncLocal that HandleSelect writes for immediate-request effect.
+        sealed class Reset : IDisposable
+        {
+            public void Dispose() => McpSessionTokenContext.CurrentSelectedInstanceId = null;
+        }
+
+        // ─────────────────────────────── Descriptors (tools/list merge) ───────────────────────────────
+
+        [Fact]
+        public void Descriptors_AreTheThreeServerNativeTools_WithObjectSchema()
+        {
+            var (tools, _, _, _, _) = NewTools();
+            var names = tools.Descriptors.Select(t => t.Name).ToList();
+
+            names.ShouldContain(ServerNativeTools.ListInstances);
+            names.ShouldContain(ServerNativeTools.SelectInstance);
+            names.ShouldContain(ServerNativeTools.EnrollPlugin);
+            names.Count.ShouldBe(3);
+
+            foreach (var descriptor in tools.Descriptors)
+            {
+                descriptor.Description.ShouldNotBeNullOrEmpty();
+                descriptor.InputSchema.GetProperty("type").GetString().ShouldBe("object");
+            }
+        }
+
+        [Theory]
+        [InlineData("unity", "unity-mcp-cli")]
+        [InlineData("godot", "godot-cli")]
+        [InlineData("unreal", "unreal-mcp-cli")]
+        public void CliPackage_MapsEngineToPublishedCli(string engine, string expected)
+            => ServerNativeTools.CliPackage(engine).ShouldBe(expected);
+
+        [Fact]
+        public void IsServerNativeTool_RecognizesTheThreeNames()
+        {
+            ServerNativeTools.IsServerNativeTool(ServerNativeTools.ListInstances).ShouldBeTrue();
+            ServerNativeTools.IsServerNativeTool(ServerNativeTools.SelectInstance).ShouldBeTrue();
+            ServerNativeTools.IsServerNativeTool(ServerNativeTools.EnrollPlugin).ShouldBeTrue();
+            ServerNativeTools.IsServerNativeTool("some_plugin_tool").ShouldBeFalse();
+            ServerNativeTools.IsServerNativeTool(null).ShouldBeFalse();
+        }
+
+        // ─────────────────────────────── list_engine_instances ───────────────────────────────
+
+        [Fact]
+        public async Task List_EmptyAccount_ReturnsEnrollGuidance()
+        {
+            var (tools, _, _, _, _) = NewTools();
+            var response = await tools.HandleAsync(ServerNativeTools.ListInstances, NoArgs, Ctx());
+            response.Status.ShouldBe(ResponseStatus.Success);
+            Text(response).ShouldContain("enroll_engine_plugin");
+        }
+
+        [Fact]
+        public async Task List_ReturnsInstances_MarksSelected()
+        {
+            var (tools, registry, selections, _, _) = NewTools();
+            registry.Register(Account, Meta("inst-A", project: "GameA"), "conn-A");
+            registry.Register(Account, Meta("inst-B", project: "GameB", pathHash: HashB, machine: "PC-2"), "conn-B");
+            selections.Set(Session, "inst-B");
+
+            var response = await tools.HandleAsync(ServerNativeTools.ListInstances, NoArgs, Ctx());
+
+            response.Status.ShouldBe(ResponseStatus.Success);
+            var text = Text(response);
+            text.ShouldContain("inst-A");
+            text.ShouldContain("inst-B");
+            // The selected instance line carries the marker; the unselected one does not.
+            text.ShouldContain("inst-B");
+            text.Split('\n').Single(l => l.Contains("inst-B")).ShouldContain("(selected)");
+            text.Split('\n').Single(l => l.Contains("inst-A")).ShouldNotContain("(selected)");
+        }
+
+        [Fact]
+        public async Task List_IsAccountScoped()
+        {
+            var (tools, registry, _, _, _) = NewTools();
+            registry.Register("other-acc", Meta("inst-X"), "conn-X");
+
+            var response = await tools.HandleAsync(ServerNativeTools.ListInstances, NoArgs, Ctx());
+            Text(response).ShouldNotContain("inst-X");
+        }
+
+        // ─────────────────────────────── select_engine_instance ───────────────────────────────
+
+        [Fact]
+        public async Task Select_ByInstanceId_StoresSelection_AndSucceeds()
+        {
+            var (tools, registry, selections, _, _) = NewTools();
+            registry.Register(Account, Meta("inst-A"), "conn-A");
+
+            using (new Reset())
+            {
+                var response = await tools.HandleAsync(ServerNativeTools.SelectInstance, Args(("instance_id", "inst-A")), Ctx());
+
+                response.Status.ShouldBe(ResponseStatus.Success);
+                selections.Get(Session).ShouldBe("inst-A");
+                // Immediate within-request effect for routing.
+                McpSessionTokenContext.CurrentSelectedInstanceId.ShouldBe("inst-A");
+            }
+        }
+
+        [Fact]
+        public async Task Select_UnknownInstanceId_ReturnsError()
+        {
+            var (tools, registry, selections, _, _) = NewTools();
+            registry.Register(Account, Meta("inst-A"), "conn-A");
+
+            var response = await tools.HandleAsync(ServerNativeTools.SelectInstance, Args(("instance_id", "nope")), Ctx());
+
+            response.Status.ShouldBe(ResponseStatus.Error);
+            selections.Get(Session).ShouldBeNull();
+        }
+
+        [Fact]
+        public async Task Select_ByUniqueProjectName_Succeeds()
+        {
+            var (tools, registry, selections, _, _) = NewTools();
+            registry.Register(Account, Meta("inst-A", project: "Alpha"), "conn-A");
+            registry.Register(Account, Meta("inst-B", project: "Beta", pathHash: HashB, machine: "PC-2"), "conn-B");
+
+            var response = await tools.HandleAsync(ServerNativeTools.SelectInstance, Args(("project_name", "Beta")), Ctx());
+
+            response.Status.ShouldBe(ResponseStatus.Success);
+            selections.Get(Session).ShouldBe("inst-B");
+        }
+
+        [Fact]
+        public async Task Select_AmbiguousProjectName_ReturnsError()
+        {
+            var (tools, registry, _, _, clock) = NewTools();
+            registry.Register(Account, Meta("inst-A", project: "Same", machine: "PC-1"), "conn-A");
+            clock.Advance(TimeSpan.FromSeconds(1));
+            registry.Register(Account, Meta("inst-B", project: "Same", pathHash: HashB, machine: "PC-2"), "conn-B");
+
+            var response = await tools.HandleAsync(ServerNativeTools.SelectInstance, Args(("project_name", "Same")), Ctx());
+            response.Status.ShouldBe(ResponseStatus.Error);
+        }
+
+        [Fact]
+        public async Task Select_NoArguments_ReturnsError()
+        {
+            var (tools, registry, _, _, _) = NewTools();
+            registry.Register(Account, Meta("inst-A"), "conn-A");
+
+            var response = await tools.HandleAsync(ServerNativeTools.SelectInstance, NoArgs, Ctx());
+            response.Status.ShouldBe(ResponseStatus.Error);
+        }
+
+        [Fact]
+        public async Task Select_NoSessionId_ReturnsError()
+        {
+            var (tools, registry, _, _, _) = NewTools();
+            registry.Register(Account, Meta("inst-A"), "conn-A");
+
+            var response = await tools.HandleAsync(ServerNativeTools.SelectInstance, Args(("instance_id", "inst-A")), Ctx(session: null));
+            response.Status.ShouldBe(ResponseStatus.Error);
+        }
+
+        [Fact]
+        public async Task Select_PinnedSession_CannotSelectDifferentProject()
+        {
+            var (tools, registry, selections, _, _) = NewTools();
+            // Live instance is for HashB (project Beta); session is pinned to HashA (project Alpha).
+            registry.Register(Account, Meta("inst-B", project: "Beta", pathHash: HashB, machine: "PC-2"), "conn-B");
+
+            var response = await tools.HandleAsync(ServerNativeTools.SelectInstance, Args(("instance_id", "inst-B")), Ctx(pin: PinA));
+
+            response.Status.ShouldBe(ResponseStatus.Error);
+            selections.Get(Session).ShouldBeNull();
+        }
+
+        [Fact]
+        public async Task Select_PinnedSession_CanNarrowWithinPinnedProject()
+        {
+            var (tools, registry, selections, _, _) = NewTools();
+            // Two instances of the SAME pinned project (e.g. two editors) — selection may narrow.
+            registry.Register(Account, Meta("inst-A", machine: "PC-1"), "conn-A");
+            registry.Register(Account, Meta("inst-A2", machine: "PC-2"), "conn-A2");
+
+            using (new Reset())
+            {
+                var response = await tools.HandleAsync(ServerNativeTools.SelectInstance, Args(("instance_id", "inst-A2")), Ctx(pin: PinA));
+
+                response.Status.ShouldBe(ResponseStatus.Success);
+                selections.Get(Session).ShouldBe("inst-A2");
+            }
+        }
+
+        // ─────── Stickiness end-to-end: select persists across the store reload and beats MRU ───────
+
+        [Fact]
+        public async Task Select_Stickiness_SurvivesStoreReload_AndBeatsMru()
+        {
+            var (tools, registry, selections, _, clock) = NewTools();
+            // Two unpinned instances; inst-A is the most-recently-active (default MRU pick).
+            registry.Register(Account, Meta("inst-B", project: "GameB", pathHash: HashB, machine: "PC-B"), "conn-B");
+            clock.Advance(TimeSpan.FromSeconds(10));
+            registry.Register(Account, Meta("inst-A", project: "GameA", pathHash: HashA, machine: "PC-A"), "conn-A");
+
+            // Baseline: with no selection, resolution picks MRU inst-A.
+            registry.Resolve(Account, null, null).Instance!.InstanceId.ShouldBe("inst-A");
+
+            using (new Reset())
+            {
+                // Agent selects the NON-MRU instance-B in one request.
+                var select = await tools.HandleAsync(ServerNativeTools.SelectInstance, Args(("instance_id", "inst-B")), Ctx());
+                select.Status.ShouldBe(ResponseStatus.Success);
+            }
+
+            // Next request: the middleware reloads the stored selection into the ambient context.
+            var reloaded = selections.Get(Session);
+            reloaded.ShouldBe("inst-B");
+
+            // Routing now honors the sticky selection over MRU.
+            registry.Resolve(Account, null, reloaded).Instance!.InstanceId.ShouldBe("inst-B");
+        }
+
+        // ─────────────────────────────── enroll_engine_plugin ───────────────────────────────
+
+        [Fact]
+        public async Task Enroll_ValidEngine_ReturnsReadyToRunInstallCommand()
+        {
+            var (tools, _, _, enroll, _) = NewTools();
+            enroll.Result = EnrollmentResult.Ok("ONE-TIME-CODE");
+
+            var response = await tools.HandleAsync(ServerNativeTools.EnrollPlugin, Args(("engine", "godot")), Ctx());
+
+            response.Status.ShouldBe(ResponseStatus.Success);
+            Text(response).ShouldContain("npx godot-cli install-plugin --enroll ONE-TIME-CODE");
+            // The session credential was forwarded verbatim to the enroll proxy.
+            enroll.SeenBearer.ShouldBe("bearer-token");
+            enroll.SeenEngine.ShouldBe("godot");
+        }
+
+        [Theory]
+        [InlineData("unity", "unity-mcp-cli")]
+        [InlineData("godot", "godot-cli")]
+        [InlineData("unreal", "unreal-mcp-cli")]
+        public async Task Enroll_EmitsCorrectCliPerEngine(string engine, string cli)
+        {
+            var (tools, _, _, enroll, _) = NewTools();
+            enroll.Result = EnrollmentResult.Ok("C0DE");
+            var response = await tools.HandleAsync(ServerNativeTools.EnrollPlugin, Args(("engine", engine)), Ctx());
+            response.Status.ShouldBe(ResponseStatus.Success);
+            Text(response).ShouldContain($"npx {cli} install-plugin --enroll C0DE");
+        }
+
+        [Fact]
+        public async Task Enroll_InvalidEngine_ReturnsError()
+        {
+            var (tools, _, _, _, _) = NewTools();
+            var response = await tools.HandleAsync(ServerNativeTools.EnrollPlugin, Args(("engine", "cryengine")), Ctx());
+            response.Status.ShouldBe(ResponseStatus.Error);
+        }
+
+        [Fact]
+        public async Task Enroll_MissingEngine_ReturnsError()
+        {
+            var (tools, _, _, _, _) = NewTools();
+            var response = await tools.HandleAsync(ServerNativeTools.EnrollPlugin, NoArgs, Ctx());
+            response.Status.ShouldBe(ResponseStatus.Error);
+        }
+
+        [Fact]
+        public async Task Enroll_NoCredential_ReturnsError_WithoutCallingTheAs()
+        {
+            var (tools, _, _, enroll, _) = NewTools();
+            var response = await tools.HandleAsync(ServerNativeTools.EnrollPlugin, Args(("engine", "unity")), Ctx(bearer: null));
+
+            response.Status.ShouldBe(ResponseStatus.Error);
+            enroll.SeenEngine.ShouldBeNull(); // proxy not called
+        }
+
+        [Fact]
+        public async Task Enroll_AsFailure_SurfacesError()
+        {
+            var (tools, _, _, enroll, _) = NewTools();
+            enroll.Result = EnrollmentResult.Fail("The authorization server rejected the enrollment request.");
+
+            var response = await tools.HandleAsync(ServerNativeTools.EnrollPlugin, Args(("engine", "unity")), Ctx());
+
+            response.Status.ShouldBe(ResponseStatus.Error);
+            Text(response).ShouldContain("rejected");
+        }
+
+        [Fact]
+        public async Task Enroll_PatSession_ForwardsPatVerbatim()
+        {
+            var (tools, _, _, enroll, _) = NewTools();
+            // A PAT-authenticated agent session presents an opaque token; it is forwarded like a JWT.
+            var response = await tools.HandleAsync(ServerNativeTools.EnrollPlugin, Args(("engine", "unreal")), Ctx(bearer: "pat_opaque_value"));
+
+            response.Status.ShouldBe(ResponseStatus.Success);
+            enroll.SeenBearer.ShouldBe("pat_opaque_value");
+        }
+    }
+}

--- a/McpPlugin.Server.Tests/SessionSelectionStoreTests.cs
+++ b/McpPlugin.Server.Tests/SessionSelectionStoreTests.cs
@@ -1,0 +1,85 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+using com.IvanMurzak.McpPlugin.Server.Tools;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.Server.Tests
+{
+    /// <summary>
+    /// Unit tests for the per-MCP-session sticky-selection store (mcp-authorize b4, design 04 step 2):
+    /// set/replace/get/clear semantics and per-session isolation.
+    /// </summary>
+    public class SessionSelectionStoreTests
+    {
+        [Fact]
+        public void Set_Then_Get_ReturnsValue()
+        {
+            var store = new SessionSelectionStore();
+            store.Set("session-1", "inst-A");
+            store.Get("session-1").ShouldBe("inst-A");
+        }
+
+        [Fact]
+        public void Set_Replaces_PriorSelection()
+        {
+            var store = new SessionSelectionStore();
+            store.Set("session-1", "inst-A");
+            store.Set("session-1", "inst-B");
+            store.Get("session-1").ShouldBe("inst-B");
+        }
+
+        [Fact]
+        public void Get_UnknownSession_ReturnsNull()
+        {
+            var store = new SessionSelectionStore();
+            store.Get("nope").ShouldBeNull();
+        }
+
+        [Fact]
+        public void Sessions_AreIsolated()
+        {
+            var store = new SessionSelectionStore();
+            store.Set("session-1", "inst-A");
+            store.Set("session-2", "inst-B");
+            store.Get("session-1").ShouldBe("inst-A");
+            store.Get("session-2").ShouldBe("inst-B");
+        }
+
+        [Fact]
+        public void Clear_Removes_Selection()
+        {
+            var store = new SessionSelectionStore();
+            store.Set("session-1", "inst-A");
+            store.Clear("session-1");
+            store.Get("session-1").ShouldBeNull();
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void Get_NullOrEmpty_ReturnsNull(string? sessionId)
+        {
+            new SessionSelectionStore().Get(sessionId).ShouldBeNull();
+        }
+
+        [Theory]
+        [InlineData(null, "inst-A")]
+        [InlineData("", "inst-A")]
+        [InlineData("session-1", null)]
+        [InlineData("session-1", "")]
+        public void Set_RejectsEmptyArguments(string? sessionId, string? instanceId)
+        {
+            Should.Throw<ArgumentException>(() => new SessionSelectionStore().Set(sessionId!, instanceId!));
+        }
+    }
+}

--- a/McpPlugin.Server/src/Auth/McpSessionTokenContext.cs
+++ b/McpPlugin.Server/src/Auth/McpSessionTokenContext.cs
@@ -25,6 +25,7 @@ namespace com.IvanMurzak.McpPlugin.Server.Auth
         static readonly AsyncLocal<ConnectionIdentity?> _currentIdentity = new();
         static readonly AsyncLocal<string?> _currentProjectPin = new();
         static readonly AsyncLocal<string?> _currentSelectedInstanceId = new();
+        static readonly AsyncLocal<string?> _currentSessionId = new();
 
         public static string? CurrentToken
         {
@@ -62,6 +63,19 @@ namespace com.IvanMurzak.McpPlugin.Server.Auth
         {
             get => _currentSelectedInstanceId.Value;
             set => _currentSelectedInstanceId.Value = value;
+        }
+
+        /// <summary>
+        /// The MCP session id (the <c>Mcp-Session-Id</c> header value) for the in-flight request
+        /// (mcp-authorize b4). Captured by <see cref="McpSessionTokenMiddleware"/> and used as the
+        /// sticky-selection key by <c>select_engine_instance</c> (see
+        /// <see cref="Tools.ISessionSelectionStore"/>). Null on the initialize request (no id yet)
+        /// and for stdio (no HTTP context).
+        /// </summary>
+        public static string? CurrentSessionId
+        {
+            get => _currentSessionId.Value;
+            set => _currentSessionId.Value = value;
         }
 
         public static string? CurrentClientIp

--- a/McpPlugin.Server/src/Auth/McpSessionTokenMiddleware.cs
+++ b/McpPlugin.Server/src/Auth/McpSessionTokenMiddleware.cs
@@ -11,7 +11,9 @@
 using System;
 using System.Threading.Tasks;
 using com.IvanMurzak.McpPlugin.Common;
+using com.IvanMurzak.McpPlugin.Server.Tools;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace com.IvanMurzak.McpPlugin.Server.Auth
 {
@@ -30,6 +32,9 @@ namespace com.IvanMurzak.McpPlugin.Server.Auth
     /// </summary>
     public class McpSessionTokenMiddleware
     {
+        /// <summary>The MCP Streamable-HTTP session header (case-insensitive lookup).</summary>
+        public const string SessionIdHeader = "Mcp-Session-Id";
+
         private readonly RequestDelegate _next;
 
         public McpSessionTokenMiddleware(RequestDelegate next) => _next = next;
@@ -57,6 +62,15 @@ namespace com.IvanMurzak.McpPlugin.Server.Auth
 
             // Capture the project pin from the config URL's trailing /p/<pin> segment (design 04 D14).
             McpSessionTokenContext.CurrentProjectPin = TryExtractProjectPin(context.Request.Path.Value);
+
+            // Capture the MCP session id (mcp-authorize b4) and reload this session's sticky
+            // engine-instance selection so account routing honors it (design 04 step 2). The store is
+            // registered only in oauth mode — null in legacy/no-auth modes leaves selection untouched.
+            var sessionId = context.Request.Headers.TryGetValue(SessionIdHeader, out var sid) ? sid.ToString() : null;
+            McpSessionTokenContext.CurrentSessionId = string.IsNullOrEmpty(sessionId) ? null : sessionId;
+            var selectionStore = context.RequestServices?.GetService<ISessionSelectionStore>();
+            if (selectionStore != null)
+                McpSessionTokenContext.CurrentSelectedInstanceId = selectionStore.Get(sessionId);
 
             var remoteIp = context.Connection.RemoteIpAddress?.ToString();
             if (!string.IsNullOrEmpty(remoteIp))
@@ -87,6 +101,7 @@ namespace com.IvanMurzak.McpPlugin.Server.Auth
                 McpSessionTokenContext.CurrentIdentity = null;
                 McpSessionTokenContext.CurrentProjectPin = null;
                 McpSessionTokenContext.CurrentSelectedInstanceId = null;
+                McpSessionTokenContext.CurrentSessionId = null;
             }
         }
 

--- a/McpPlugin.Server/src/Extension/ExtensionsMcpServerBuilder.cs
+++ b/McpPlugin.Server/src/Extension/ExtensionsMcpServerBuilder.cs
@@ -11,12 +11,17 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
 using com.IvanMurzak.McpPlugin.Common;
 using com.IvanMurzak.McpPlugin.Common.Hub.Client;
 using com.IvanMurzak.McpPlugin.Common.Utils;
 using com.IvanMurzak.McpPlugin.Server.Auth;
 using com.IvanMurzak.McpPlugin.Server.Auth.OAuth;
 using com.IvanMurzak.McpPlugin.Server.Security;
+using com.IvanMurzak.McpPlugin.Server.Strategy;
+using com.IvanMurzak.McpPlugin.Server.Tools;
 using com.IvanMurzak.McpPlugin.Server.Webhooks;
 using com.IvanMurzak.ReflectorNet;
 using Microsoft.Extensions.DependencyInjection;
@@ -147,6 +152,49 @@ namespace com.IvanMurzak.McpPlugin.Server
                     sp.GetRequiredService<IJwksKeyProvider>(),
                     sp.GetRequiredService<IIntrospectionClient>(),
                     logger: sp.GetService<ILogger<AccessTokenValidator>>()));
+
+                // Server-native tools (mcp-authorize b4) — the account+instance selection + enrollment
+                // surface. Only meaningful in oauth mode (the pairing plane), so registered here.
+                mcpServerBuilder.Services.AddSingleton<ISessionSelectionStore, SessionSelectionStore>();
+
+                mcpServerBuilder.Services.AddSingleton<IEnrollmentClient>(sp =>
+                {
+                    var httpFactory = sp.GetRequiredService<IHttpClientFactory>();
+                    var config = sp.GetRequiredService<OAuthResourceServerConfig>();
+                    var enrollEndpoint = $"{config.Issuer.TrimEnd('/')}/api/auth/enroll/create";
+                    EnrollCreatePost post = async (bearer, engine, publicUrl, ct) =>
+                    {
+                        var client = httpFactory.CreateClient();
+                        client.Timeout = TimeSpan.FromSeconds(10);
+                        using var httpRequest = new HttpRequestMessage(HttpMethod.Post, enrollEndpoint);
+                        // Forward the session credential verbatim; NEVER log it.
+                        httpRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearer);
+                        var payload = JsonSerializer.Serialize(new Dictionary<string, string>
+                        {
+                            ["engine"] = engine,
+                            ["public_url"] = publicUrl
+                        });
+                        httpRequest.Content = new StringContent(payload, Encoding.UTF8, "application/json");
+                        using var httpResponse = await client.SendAsync(httpRequest, ct);
+                        if (!httpResponse.IsSuccessStatusCode)
+                            return null;
+                        return await httpResponse.Content.ReadAsStringAsync(ct);
+                    };
+                    return new EnrollmentClient(post, dataArguments.PublicUrl!, logger: sp.GetService<ILogger<EnrollmentClient>>());
+                });
+
+                mcpServerBuilder.Services.AddSingleton<ServerNativeTools>(sp =>
+                {
+                    // In oauth mode the resolved IMcpConnectionStrategy is always the AccountMcpStrategy,
+                    // whose registry backs the selection tools.
+                    var strategy = sp.GetRequiredService<IMcpConnectionStrategy>() as AccountMcpStrategy
+                        ?? throw new InvalidOperationException("ServerNativeTools requires the oauth AccountMcpStrategy.");
+                    return new ServerNativeTools(
+                        strategy.Instances,
+                        sp.GetRequiredService<ISessionSelectionStore>(),
+                        sp.GetRequiredService<IEnrollmentClient>(),
+                        logger: sp.GetService<ILogger<ServerNativeTools>>());
+                });
             }
 
             // Origin validation options (mcp-authorize b2) — registered in ALL modes; consumed by

--- a/McpPlugin.Server/src/Mcp/Tool/ToolRouter.Call.cs
+++ b/McpPlugin.Server/src/Mcp/Tool/ToolRouter.Call.cs
@@ -15,6 +15,9 @@ using System.Threading.Tasks;
 using com.IvanMurzak.McpPlugin.Common.Hub.Client;
 using com.IvanMurzak.McpPlugin.Common.Model;
 using com.IvanMurzak.McpPlugin.Common.Utils;
+using com.IvanMurzak.McpPlugin.Server.Auth;
+using com.IvanMurzak.McpPlugin.Server.Strategy;
+using com.IvanMurzak.McpPlugin.Server.Tools;
 using com.IvanMurzak.ReflectorNet;
 using Microsoft.Extensions.DependencyInjection;
 using ModelContextProtocol.Protocol;
@@ -47,6 +50,34 @@ namespace com.IvanMurzak.McpPlugin.Server
 
             var argumentsDict = request.Params.Arguments as IReadOnlyDictionary<string, JsonElement>
                 ?? new Dictionary<string, JsonElement>();
+
+            // Server-native tools (mcp-authorize b4) — the selection + enrollment surface handled by
+            // the RS itself, NEVER proxied to a plugin. Registered only in oauth mode; null otherwise
+            // (today's pure pass-through preserved). Checked BEFORE resolution so an engine-less agent
+            // can still call enroll_engine_plugin.
+            var nativeTools = request.Services.GetService<ServerNativeTools>();
+            if (nativeTools != null && ServerNativeTools.IsServerNativeTool(request.Params.Name))
+            {
+                var context = SelectionToolContext.FromCurrent();
+                var nativeResponse = await nativeTools.HandleAsync(request.Params.Name, argumentsDict, context, cancellationToken);
+                return nativeResponse.ToCallToolResult();
+            }
+
+            // oauth: when this agent session resolves to NO plugin instance, surface the design-04
+            // step-5 agent-actionable error (pinned-no-match vs account-empty) instead of the legacy
+            // 10x-retry → generic invoke failure. A Resolved session falls through to the proxy below
+            // (whose own retry loop still covers a transient mid-restart reconnect window).
+            if (nativeTools != null && request.Services.GetService<IMcpConnectionStrategy>() is AccountMcpStrategy accountStrategy)
+            {
+                var resolution = accountStrategy.ResolveCurrentSession();
+                if (resolution.Kind != InstanceResolutionKind.Resolved)
+                {
+                    var accountId = McpSessionTokenContext.CurrentIdentity?.AccountId;
+                    var actionable = AgentActionableErrors.ForResolution(resolution, accountStrategy.Instances, accountId);
+                    logger.Trace("Call '{0}': no instance resolved ({1}); returning agent-actionable error.", request.Params.Name, resolution.Kind);
+                    return new CallToolResult().SetError(actionable);
+                }
+            }
 
             var requestData = new RequestCallTool(request.Params.Name, argumentsDict);
             if (logger.IsTraceEnabled)

--- a/McpPlugin.Server/src/Mcp/Tool/ToolRouter.ListAll.cs
+++ b/McpPlugin.Server/src/Mcp/Tool/ToolRouter.ListAll.cs
@@ -15,6 +15,7 @@ using System.Threading.Tasks;
 using com.IvanMurzak.McpPlugin.Common.Hub.Client;
 using com.IvanMurzak.McpPlugin.Common.Model;
 using com.IvanMurzak.McpPlugin.Common.Utils;
+using com.IvanMurzak.McpPlugin.Server.Tools;
 using com.IvanMurzak.ReflectorNet;
 using Microsoft.Extensions.DependencyInjection;
 using ModelContextProtocol.Protocol;
@@ -35,6 +36,13 @@ namespace com.IvanMurzak.McpPlugin.Server
             if (request.Services == null)
                 return new ListToolsResult().SetError("[Error] 'request.Services' is null");
 
+            // Server-native tools (mcp-authorize b4) — the account+instance selection/enrollment
+            // surface served by the RS itself, merged alongside the paired plugin's tools (design 04).
+            // Registered only in oauth mode; null otherwise (leaving today's pure pass-through). They
+            // MUST appear even when NO plugin is connected so an engine-less agent can still call
+            // enroll_engine_plugin — hence they are merged into every return path below.
+            var nativeTools = request.Services.GetService<ServerNativeTools>()?.Descriptors;
+
             var clientToolHub = request.Services.GetRequiredService<IClientToolHub>();
             logger.Trace("ListAll Using ClientToolHub: {0}", clientToolHub.GetType().GetTypeShortName());
 
@@ -50,26 +58,26 @@ namespace com.IvanMurzak.McpPlugin.Server
             }
             catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
             {
-                logger.Warn("ListAll timed out after {0}s: MCP Plugin not yet connected. Returning empty tools list.", _listToolsTimeout.TotalSeconds);
-                return new ListToolsResult() { Tools = new List<Tool>() };
+                logger.Warn("ListAll timed out after {0}s: MCP Plugin not yet connected. Returning server-native tools only.", _listToolsTimeout.TotalSeconds);
+                return Merge(null, nativeTools);
             }
 
             if (response == null)
             {
-                logger.Warn("ListAll response is null. Returning empty tools list.");
-                return new ListToolsResult() { Tools = new List<Tool>() };
+                logger.Warn("ListAll response is null. Returning server-native tools only.");
+                return Merge(null, nativeTools);
             }
 
             if (response.Status == ResponseStatus.Error)
             {
-                logger.Warn("ListAll error (plugin may not be connected yet): {0}. Returning empty tools list.", response.Message);
-                return new ListToolsResult() { Tools = new List<Tool>() };
+                logger.Warn("ListAll error (plugin may not be connected yet): {0}. Returning server-native tools only.", response.Message);
+                return Merge(null, nativeTools);
             }
 
             if (response.Value == null)
             {
-                logger.Warn("ListAll response value is null. Returning empty tools list.");
-                return new ListToolsResult() { Tools = new List<Tool>() };
+                logger.Warn("ListAll response value is null. Returning server-native tools only.");
+                return Merge(null, nativeTools);
             }
 
             // Trusted internal clients (cli/desktop) opt in via the
@@ -77,15 +85,21 @@ namespace com.IvanMurzak.McpPlugin.Server
             // including `Enabled = false` tools tagged with `_meta.enabled = false`.
             // Every other caller continues to get the pre-existing filtered view.
             // See ExtensionsListMeta.SelectVisible for the predicate.
-            var result = new ListToolsResult()
-            {
-                Tools = response.Value.SelectVisible(x => x.Enabled, x => x.ToTool())
-            };
+            var result = Merge(response.Value.SelectVisible(x => x.Enabled, x => x.ToTool()), nativeTools);
 
             if (logger.IsTraceEnabled)
                 logger.Trace("ListAll, result: {0}", result.ToPrettyJson());
 
             return result;
+        }
+
+        /// <summary>Combines the plugin's tools with the server-native tools (either may be null/empty).</summary>
+        static ListToolsResult Merge(IList<Tool>? pluginTools, IReadOnlyList<Tool>? nativeTools)
+        {
+            var tools = pluginTools != null ? new List<Tool>(pluginTools) : new List<Tool>();
+            if (nativeTools != null && nativeTools.Count > 0)
+                tools.AddRange(nativeTools);
+            return new ListToolsResult() { Tools = tools };
         }
     }
 }

--- a/McpPlugin.Server/src/Strategy/AccountMcpStrategy.cs
+++ b/McpPlugin.Server/src/Strategy/AccountMcpStrategy.cs
@@ -104,19 +104,30 @@ namespace com.IvanMurzak.McpPlugin.Server.Strategy
             return instance;
         }
 
+        /// <summary>
+        /// Resolves the CURRENT agent session (from the ambient <see cref="McpSessionTokenContext"/>)
+        /// to a plugin instance, returning the full <see cref="InstanceResolution"/> so callers can
+        /// surface the design-04 step-5 agent-actionable error variants (pinned-no-match vs
+        /// account-empty). Fail-closed: no identity ⇒ <see cref="InstanceResolution.AccountEmpty"/>.
+        /// </summary>
+        public InstanceResolution ResolveCurrentSession()
+        {
+            var identity = McpSessionTokenContext.CurrentIdentity;
+            if (identity == null)
+                return InstanceResolution.AccountEmpty();
+
+            return _instances.Resolve(
+                identity.AccountId,
+                McpSessionTokenContext.CurrentProjectPin,
+                McpSessionTokenContext.CurrentSelectedInstanceId);
+        }
+
         public string? ResolveConnectionId(string? token, int retryOffset)
         {
             // Account routing reads the resolved session context (identity + pin + sticky), NOT the
             // raw token. Fail closed when there is no identity (e.g. stdio without a JWT): never fall
             // back to another account's instance.
-            var identity = McpSessionTokenContext.CurrentIdentity;
-            if (identity == null)
-                return null;
-
-            var resolution = _instances.Resolve(
-                identity.AccountId,
-                McpSessionTokenContext.CurrentProjectPin,
-                McpSessionTokenContext.CurrentSelectedInstanceId);
+            var resolution = ResolveCurrentSession();
 
             if (resolution.Kind != InstanceResolutionKind.Resolved || resolution.Instance == null)
                 return null;

--- a/McpPlugin.Server/src/Tools/AgentActionableErrors.cs
+++ b/McpPlugin.Server/src/Tools/AgentActionableErrors.cs
@@ -1,0 +1,58 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System.Linq;
+using com.IvanMurzak.McpPlugin.Server.Strategy;
+
+namespace com.IvanMurzak.McpPlugin.Server.Tools
+{
+    /// <summary>
+    /// Builds the two agent-actionable error texts of design 04 step 5, surfaced when an agent invokes
+    /// a plugin tool but no instance resolves. Replaces today's silent 10× retry → generic invoke
+    /// failure so agents can self-serve recovery. Both variants are PAT-session aware (the credential
+    /// kind does not change the guidance — the enroll flow accepts either JWT or PAT).
+    /// </summary>
+    public static class AgentActionableErrors
+    {
+        /// <summary>
+        /// The <c>enroll_engine_plugin</c>-first recovery text for an account with NO live instances
+        /// (design 04 step 5, second variant). Uses unity as the illustrative CLI and names
+        /// <c>enroll_engine_plugin</c> for the godot/unreal path.
+        /// </summary>
+        public const string AccountEmpty =
+            "No game engine is connected for your account. To set up: run " +
+            "'npx unity-mcp-cli install-plugin --enroll <code>' in the project folder " +
+            "(also for godot/unreal via enroll_engine_plugin), then open the project in the editor.";
+
+        /// <summary>
+        /// The text for a pinned session whose project's editor is closed while the account HAS other
+        /// live instances (design 04 step 5, first variant). Lists the other connected instances and
+        /// never suggests re-installing.
+        /// </summary>
+        public static string PinnedNoMatch(AccountInstances instances, string? accountId)
+        {
+            var others = instances.GetInstances(accountId);
+            var list = others.Count == 0
+                ? "(none)"
+                : string.Join(", ", others.Select(i => $"{i.Engine}:{i.ProjectName} on {i.MachineName}"));
+            return "The engine for this project is not connected — open the project in your editor. " +
+                   $"Other connected instances: {list}.";
+        }
+
+        /// <summary>Maps an unresolved <see cref="InstanceResolution"/> to its agent-actionable text.</summary>
+        public static string ForResolution(InstanceResolution resolution, AccountInstances instances, string? accountId)
+        {
+            return resolution.Kind == InstanceResolutionKind.NoMatchPinned
+                ? PinnedNoMatch(instances, accountId)
+                : AccountEmpty;
+        }
+    }
+}

--- a/McpPlugin.Server/src/Tools/EnrollmentClient.cs
+++ b/McpPlugin.Server/src/Tools/EnrollmentClient.cs
@@ -1,0 +1,124 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace com.IvanMurzak.McpPlugin.Server.Tools
+{
+    /// <summary>Outcome of proxying an enrollment-create to the authorization server (design 05).</summary>
+    public readonly struct EnrollmentResult
+    {
+        public bool Success { get; }
+
+        /// <summary>The one-time enrollment code when <see cref="Success"/>; else null.</summary>
+        public string? EnrollCode { get; }
+
+        /// <summary>An agent-facing failure reason when not <see cref="Success"/>; else null. Never carries the credential.</summary>
+        public string? Error { get; }
+
+        EnrollmentResult(bool success, string? enrollCode, string? error)
+        {
+            Success = success;
+            EnrollCode = enrollCode;
+            Error = error;
+        }
+
+        public static EnrollmentResult Ok(string enrollCode) => new EnrollmentResult(true, enrollCode, null);
+        public static EnrollmentResult Fail(string error) => new EnrollmentResult(false, null, error);
+    }
+
+    /// <summary>
+    /// POSTs the enroll/create request to the authorization server with (bearer, engine, publicUrl)
+    /// and returns the raw JSON response body, or null on transport/HTTP failure. Mirrors the b2
+    /// <c>JwksFetch</c>/<c>IntrospectionPost</c> delegate seam so tests inject a fake without a live
+    /// <c>HttpClient</c> (design 05 <c>POST /api/auth/enroll/create</c>).
+    /// </summary>
+    public delegate Task<string?> EnrollCreatePost(string bearer, string engine, string publicUrl, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// The RS-side enrollment proxy (mcp-authorize b4, design 04 <c>enroll_engine_plugin</c> + design
+    /// 05 enrollment endpoints). Forwards the agent session's bearer credential (JWT or introspected
+    /// <c>mcp:agent</c> PAT — both accepted at enroll/create) plus THIS RS's public URL to the AS, and
+    /// returns the minted one-time code. <b>Never logs the credential.</b>
+    /// </summary>
+    public interface IEnrollmentClient
+    {
+        Task<EnrollmentResult> CreateAsync(string engine, string bearer, CancellationToken cancellationToken = default);
+    }
+
+    /// <inheritdoc cref="IEnrollmentClient"/>
+    public sealed class EnrollmentClient : IEnrollmentClient
+    {
+        readonly EnrollCreatePost _post;
+        readonly string _publicUrl;
+        readonly ILogger? _logger;
+
+        /// <param name="post">The transport delegate that performs the authenticated POST to the AS.</param>
+        /// <param name="publicUrl">This RS's canonical public URL (<c>MCP_PUBLIC_URL</c>); embedded in the minted code.</param>
+        public EnrollmentClient(EnrollCreatePost post, string publicUrl, ILogger? logger = null)
+        {
+            _post = post ?? throw new ArgumentNullException(nameof(post));
+            if (string.IsNullOrWhiteSpace(publicUrl))
+                throw new ArgumentException("publicUrl must be non-empty.", nameof(publicUrl));
+            _publicUrl = publicUrl;
+            _logger = logger;
+        }
+
+        public async Task<EnrollmentResult> CreateAsync(string engine, string bearer, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrEmpty(engine))
+                return EnrollmentResult.Fail("An engine (unity|godot|unreal) is required to enroll.");
+            if (string.IsNullOrEmpty(bearer))
+                return EnrollmentResult.Fail("No session credential is available to enroll with.");
+
+            string? json;
+            try
+            {
+                json = await _post(bearer, engine, _publicUrl, cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                // Log the failure WITHOUT the credential (never include `bearer` in any log).
+                _logger?.LogWarning(ex, "Enrollment create request to the authorization server failed for engine {engine}.", engine);
+                return EnrollmentResult.Fail("Could not reach the authorization server to create an enrollment code. Try again shortly.");
+            }
+
+            if (string.IsNullOrEmpty(json))
+                return EnrollmentResult.Fail("The authorization server rejected the enrollment request.");
+
+            try
+            {
+                using var doc = JsonDocument.Parse(json!);
+                if (doc.RootElement.ValueKind == JsonValueKind.Object
+                    && doc.RootElement.TryGetProperty("enroll_code", out var codeEl)
+                    && codeEl.ValueKind == JsonValueKind.String)
+                {
+                    var code = codeEl.GetString();
+                    if (!string.IsNullOrEmpty(code))
+                        return EnrollmentResult.Ok(code!);
+                }
+                return EnrollmentResult.Fail("The authorization server response did not contain an enrollment code.");
+            }
+            catch (JsonException)
+            {
+                return EnrollmentResult.Fail("The authorization server returned a malformed response.");
+            }
+        }
+    }
+}

--- a/McpPlugin.Server/src/Tools/SelectionToolContext.cs
+++ b/McpPlugin.Server/src/Tools/SelectionToolContext.cs
@@ -1,0 +1,52 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using com.IvanMurzak.McpPlugin.Server.Auth;
+
+namespace com.IvanMurzak.McpPlugin.Server.Tools
+{
+    /// <summary>
+    /// The per-request session facts a server-native tool needs (mcp-authorize b4). Materialized from
+    /// the ambient <see cref="McpSessionTokenContext"/> at call time by <see cref="FromCurrent"/>, or
+    /// built explicitly in tests. Kept as a plain value so the tool logic is unit-testable without the
+    /// AsyncLocal request context.
+    /// </summary>
+    public readonly struct SelectionToolContext
+    {
+        /// <summary>The account routing key (JWT <c>sub</c> / introspected PAT owner). Null when unauthenticated.</summary>
+        public string? AccountId { get; }
+
+        /// <summary>The MCP session id (<c>Mcp-Session-Id</c>) — the sticky-selection key. Null on the initialize request / stdio.</summary>
+        public string? SessionId { get; }
+
+        /// <summary>The session's strict project pin (design 04 D14), or null when unpinned.</summary>
+        public string? ProjectPin { get; }
+
+        /// <summary>The raw bearer credential (JWT or PAT) forwarded verbatim to the AS on enroll. Never logged.</summary>
+        public string? Bearer { get; }
+
+        public SelectionToolContext(string? accountId, string? sessionId, string? projectPin, string? bearer)
+        {
+            AccountId = accountId;
+            SessionId = sessionId;
+            ProjectPin = projectPin;
+            Bearer = bearer;
+        }
+
+        /// <summary>Snapshot the current request's ambient session context.</summary>
+        public static SelectionToolContext FromCurrent()
+            => new SelectionToolContext(
+                McpSessionTokenContext.CurrentIdentity?.AccountId,
+                McpSessionTokenContext.CurrentSessionId,
+                McpSessionTokenContext.CurrentProjectPin,
+                McpSessionTokenContext.CurrentToken);
+    }
+}

--- a/McpPlugin.Server/src/Tools/ServerNativeTools.cs
+++ b/McpPlugin.Server/src/Tools/ServerNativeTools.cs
@@ -1,0 +1,211 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.Common.Model;
+using com.IvanMurzak.McpPlugin.Server.Auth;
+using com.IvanMurzak.McpPlugin.Server.Strategy;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Protocol;
+
+namespace com.IvanMurzak.McpPlugin.Server.Tools
+{
+    /// <summary>
+    /// The server-native MCP tools of the account+instance pairing plane (mcp-authorize b4, design 04
+    /// "Built-in selection tools"): <c>list_engine_instances</c>, <c>select_engine_instance</c>,
+    /// <c>enroll_engine_plugin</c>. These are served by the RS itself (NOT proxied to a plugin) and are
+    /// merged into <c>tools/list</c> alongside the paired plugin's tools by <see cref="ToolRouter"/>.
+    /// Registered only in <c>oauth</c> mode (there is no account/instance concept in none/required).
+    /// </summary>
+    public sealed class ServerNativeTools
+    {
+        public const string ListInstances = "list_engine_instances";
+        public const string SelectInstance = "select_engine_instance";
+        public const string EnrollPlugin = "enroll_engine_plugin";
+
+        static readonly IReadOnlyList<Tool> _descriptors = BuildDescriptors();
+
+        readonly AccountInstances _instances;
+        readonly ISessionSelectionStore _selections;
+        readonly IEnrollmentClient _enrollment;
+        readonly ILogger? _logger;
+
+        public ServerNativeTools(AccountInstances instances, ISessionSelectionStore selections, IEnrollmentClient enrollment, ILogger<ServerNativeTools>? logger = null)
+        {
+            _instances = instances ?? throw new ArgumentNullException(nameof(instances));
+            _selections = selections ?? throw new ArgumentNullException(nameof(selections));
+            _enrollment = enrollment ?? throw new ArgumentNullException(nameof(enrollment));
+            _logger = logger;
+        }
+
+        /// <summary>The MCP tool descriptors merged into <c>tools/list</c> (design 04).</summary>
+        public IReadOnlyList<Tool> Descriptors => _descriptors;
+
+        /// <summary>True when <paramref name="name"/> is one of the server-native tool names.</summary>
+        public static bool IsServerNativeTool(string? name)
+            => name == ListInstances || name == SelectInstance || name == EnrollPlugin;
+
+        /// <summary>Dispatches a server-native tool call. The caller guarantees <see cref="IsServerNativeTool"/>.</summary>
+        public Task<ResponseCallTool> HandleAsync(string name, IReadOnlyDictionary<string, JsonElement> arguments, SelectionToolContext context, CancellationToken cancellationToken = default)
+        {
+            arguments ??= new Dictionary<string, JsonElement>();
+            switch (name)
+            {
+                case ListInstances:
+                    return Task.FromResult(HandleList(context));
+                case SelectInstance:
+                    return Task.FromResult(HandleSelect(arguments, context));
+                case EnrollPlugin:
+                    return HandleEnrollAsync(arguments, context, cancellationToken);
+                default:
+                    return Task.FromResult(ResponseCallTool.Error($"'{name}' is not a server-native tool."));
+            }
+        }
+
+        // ─────────────────────────────── list_engine_instances ───────────────────────────────
+        ResponseCallTool HandleList(SelectionToolContext context)
+        {
+            var instances = _instances.GetInstances(context.AccountId);
+            if (instances.Count == 0)
+                return ResponseCallTool.Success("No engine instances are connected for your account. Use enroll_engine_plugin to set one up.");
+
+            var selected = _selections.Get(context.SessionId);
+            var lines = instances
+                .OrderByDescending(i => i.LastActiveAt)
+                .Select(i =>
+                {
+                    var mark = string.Equals(i.InstanceId, selected, StringComparison.Ordinal) ? " (selected)" : string.Empty;
+                    return $"- {i.InstanceId}: {i.Engine}:{i.ProjectName} on {i.MachineName}; " +
+                           $"connected {i.ConnectedAt:u}, last active {i.LastActiveAt:u}{mark}";
+                });
+
+            return ResponseCallTool.Success("Connected engine instances for your account:\n" + string.Join("\n", lines));
+        }
+
+        // ─────────────────────────────── select_engine_instance ──────────────────────────────
+        ResponseCallTool HandleSelect(IReadOnlyDictionary<string, JsonElement> arguments, SelectionToolContext context)
+        {
+            if (string.IsNullOrEmpty(context.SessionId))
+                return ResponseCallTool.Error("Cannot set a selection without an active MCP session.");
+
+            var instances = _instances.GetInstances(context.AccountId);
+            if (instances.Count == 0)
+                return ResponseCallTool.Error("No engine instances are connected for your account. Use enroll_engine_plugin to set one up.");
+
+            var instanceId = GetStringArg(arguments, "instance_id");
+            var projectName = GetStringArg(arguments, "project_name");
+
+            PluginInstance? target;
+            if (!string.IsNullOrEmpty(instanceId))
+            {
+                target = instances.FirstOrDefault(i => string.Equals(i.InstanceId, instanceId, StringComparison.Ordinal));
+                if (target == null)
+                    return ResponseCallTool.Error($"No connected instance has id '{instanceId}'. Use list_engine_instances to see valid ids.");
+            }
+            else if (!string.IsNullOrEmpty(projectName))
+            {
+                var matches = instances.Where(i => string.Equals(i.ProjectName, projectName, StringComparison.OrdinalIgnoreCase)).ToList();
+                if (matches.Count == 0)
+                    return ResponseCallTool.Error($"No connected instance is for project '{projectName}'. Use list_engine_instances to see connected projects.");
+                if (matches.Count > 1)
+                    return ResponseCallTool.Error($"Multiple instances match project '{projectName}'; pass instance_id instead (see list_engine_instances).");
+                target = matches[0];
+            }
+            else
+            {
+                return ResponseCallTool.Error("Provide 'instance_id' (preferred) or a unique 'project_name'.");
+            }
+
+            // A sticky selection may narrow a pin but NEVER override it to a different project (design 04 step 2).
+            if (!string.IsNullOrEmpty(context.ProjectPin) && !target.MatchesPin(context.ProjectPin))
+                return ResponseCallTool.Error("This session is pinned to a project; you can only select an instance of the pinned project.");
+
+            _selections.Set(context.SessionId!, target.InstanceId);
+            // Take effect within this request too (routing reads the ambient AsyncLocal).
+            McpSessionTokenContext.CurrentSelectedInstanceId = target.InstanceId;
+
+            return ResponseCallTool.Success($"Selected {target.Engine}:{target.ProjectName} ({target.InstanceId}) for this session.");
+        }
+
+        // ─────────────────────────────── enroll_engine_plugin ────────────────────────────────
+        async Task<ResponseCallTool> HandleEnrollAsync(IReadOnlyDictionary<string, JsonElement> arguments, SelectionToolContext context, CancellationToken cancellationToken)
+        {
+            var engine = (GetStringArg(arguments, "engine") ?? string.Empty).Trim().ToLowerInvariant();
+            if (engine != "unity" && engine != "godot" && engine != "unreal")
+                return ResponseCallTool.Error("Argument 'engine' is required and must be one of: unity, godot, unreal.");
+
+            if (string.IsNullOrEmpty(context.Bearer))
+                return ResponseCallTool.Error("No session credential is available to enroll with. Sign in first.");
+
+            var result = await _enrollment.CreateAsync(engine, context.Bearer!, cancellationToken);
+            if (!result.Success || string.IsNullOrEmpty(result.EnrollCode))
+                return ResponseCallTool.Error(result.Error ?? "Enrollment failed.");
+
+            var command = $"npx {CliPackage(engine)} install-plugin --enroll {result.EnrollCode}";
+            return ResponseCallTool.Success(
+                $"Run this in your {engine} project folder, then open the project in the editor:\n\n{command}");
+        }
+
+        /// <summary>Maps an engine to its published CLI npm package (design 04 step 5 / workspace CLIs).</summary>
+        public static string CliPackage(string engine) => engine switch
+        {
+            "unity" => "unity-mcp-cli",
+            "godot" => "godot-cli",
+            "unreal" => "unreal-mcp-cli",
+            _ => $"{engine}-mcp-cli"
+        };
+
+        static string? GetStringArg(IReadOnlyDictionary<string, JsonElement> arguments, string key)
+        {
+            if (arguments != null && arguments.TryGetValue(key, out var el) && el.ValueKind == JsonValueKind.String)
+            {
+                var value = el.GetString();
+                return string.IsNullOrWhiteSpace(value) ? null : value;
+            }
+            return null;
+        }
+
+        static IReadOnlyList<Tool> BuildDescriptors()
+        {
+            return new List<Tool>
+            {
+                new Tool
+                {
+                    Name = ListInstances,
+                    Description = "List the live game-engine instances connected for your account (engine, project, machine, connected/last-active), and which one this session has selected.",
+                    InputSchema = Schema("{\"type\":\"object\",\"properties\":{},\"additionalProperties\":false}"),
+                    Annotations = new ToolAnnotations { Title = "List engine instances", ReadOnlyHint = true, OpenWorldHint = false }
+                },
+                new Tool
+                {
+                    Name = SelectInstance,
+                    Description = "Set the sticky engine instance for this MCP session. Provide instance_id (preferred) or a unique project_name. May narrow a project pin but never overrides it to another project.",
+                    InputSchema = Schema("{\"type\":\"object\",\"properties\":{\"instance_id\":{\"type\":\"string\",\"description\":\"The instance id from list_engine_instances.\"},\"project_name\":{\"type\":\"string\",\"description\":\"A unique project name (alternative to instance_id).\"}},\"additionalProperties\":false}"),
+                    Annotations = new ToolAnnotations { Title = "Select engine instance", ReadOnlyHint = false, OpenWorldHint = false }
+                },
+                new Tool
+                {
+                    Name = EnrollPlugin,
+                    Description = "Start connecting a new game engine to your account. Returns a ready-to-run 'npx <engine>-cli install-plugin --enroll <code>' command to run in the project folder.",
+                    InputSchema = Schema("{\"type\":\"object\",\"properties\":{\"engine\":{\"type\":\"string\",\"enum\":[\"unity\",\"godot\",\"unreal\"],\"description\":\"The engine to enroll.\"}},\"required\":[\"engine\"],\"additionalProperties\":false}"),
+                    Annotations = new ToolAnnotations { Title = "Enroll engine plugin", ReadOnlyHint = false, OpenWorldHint = true }
+                }
+            };
+        }
+
+        static JsonElement Schema(string json) => JsonSerializer.Deserialize<JsonElement>(json);
+    }
+}

--- a/McpPlugin.Server/src/Tools/SessionSelectionStore.cs
+++ b/McpPlugin.Server/src/Tools/SessionSelectionStore.cs
@@ -1,0 +1,70 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Collections.Concurrent;
+
+namespace com.IvanMurzak.McpPlugin.Server.Tools
+{
+    /// <summary>
+    /// Per-MCP-session sticky engine-instance selection (mcp-authorize b4, design doc 04 step 2).
+    /// Keyed by the MCP session id (the <c>Mcp-Session-Id</c> header). <c>select_engine_instance</c>
+    /// writes here; the request pipeline reloads the value into
+    /// <see cref="Auth.McpSessionTokenContext.CurrentSelectedInstanceId"/> on each subsequent request
+    /// so routing honors the selection. Selection is per-SESSION, NOT per-account — two agent
+    /// sessions of the same account may independently select different instances (design 04
+    /// multi-tenancy semantics). A selection may narrow a pin but never override it to another
+    /// project (enforced by <c>select_engine_instance</c> before writing here).
+    /// </summary>
+    public interface ISessionSelectionStore
+    {
+        /// <summary>The instance id sticky-selected for <paramref name="sessionId"/>, or null when none.</summary>
+        string? Get(string? sessionId);
+
+        /// <summary>Record (or replace) the sticky selection for <paramref name="sessionId"/>.</summary>
+        void Set(string sessionId, string instanceId);
+
+        /// <summary>Drop the selection for <paramref name="sessionId"/> (e.g. on session end).</summary>
+        void Clear(string? sessionId);
+    }
+
+    /// <summary>
+    /// In-memory <see cref="ISessionSelectionStore"/>. Registered as a singleton only in <c>oauth</c>
+    /// mode (the account+instance pairing plane); the map is small (one entry per live agent session)
+    /// and entries are dropped on <see cref="Clear"/>.
+    /// </summary>
+    public sealed class SessionSelectionStore : ISessionSelectionStore
+    {
+        readonly ConcurrentDictionary<string, string> _selections = new ConcurrentDictionary<string, string>(StringComparer.Ordinal);
+
+        public string? Get(string? sessionId)
+        {
+            if (string.IsNullOrEmpty(sessionId))
+                return null;
+            return _selections.TryGetValue(sessionId!, out var instanceId) ? instanceId : null;
+        }
+
+        public void Set(string sessionId, string instanceId)
+        {
+            if (string.IsNullOrEmpty(sessionId))
+                throw new ArgumentException("sessionId must be non-empty.", nameof(sessionId));
+            if (string.IsNullOrEmpty(instanceId))
+                throw new ArgumentException("instanceId must be non-empty.", nameof(instanceId));
+            _selections[sessionId] = instanceId;
+        }
+
+        public void Clear(string? sessionId)
+        {
+            if (!string.IsNullOrEmpty(sessionId))
+                _selections.TryRemove(sessionId!, out _);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds the agent-facing selection + enrollment surface of the mcp-authorize **b4** / design-04 account+instance pairing plane (`oauth` mode), built on the b1+b2+b3 base (`ProjectIdentity`/cred store, RS auth, `AccountInstances` registry + resolution).
- **Three server-native MCP tools** served by the RS itself (never proxied): `list_engine_instances`; `select_engine_instance` (sticky per MCP session via `Mcp-Session-Id`; may narrow but never override a strict project pin); `enroll_engine_plugin` (proxies the session credential — JWT or PAT — to the ai-game.dev AS enroll/create with this RS's public URL, returns the ready-to-run `npx <engine>-cli install-plugin --enroll <code>`).
- **tools/list merge plumbing** in `ToolRouter.ListAll` (previously a pure pass-through): server-native tools appear alongside the paired plugin's tools, and stay visible even when no plugin is connected so an engine-less agent can still enroll.
- **Agent-actionable no-instance errors** (design 04 step 5) surfaced from `ToolRouter.Call` — pinned-no-match (lists other live instances, never suggests re-install) vs account-empty (names `enroll_engine_plugin` + the CLI) — replacing the silent 10×-retry → generic invoke failure. PAT-session aware.
- Sticky selection persists in a per-session `SessionSelectionStore`, reloaded into the ambient routing context by the session middleware (keyed by `Mcp-Session-Id`).

New services registered only in `oauth` mode: `ISessionSelectionStore`, `IEnrollmentClient`, `ServerNativeTools`.

## Scope / deferral

- Scope is **b4 only**: deleting `RequiredAuthMcpStrategy` / flipping `McpStrategyFactory` is **b5** (not done here).
- The **AS enroll/create endpoint (Group A / a4) is not built yet**, so the RS-side enroll proxy + tools/list merge are implemented and unit-tested against a **MOCKED/contract-stubbed AS** (per the design 03/05 enroll contract). Real one-time-code **end-to-end against a staging AS is deferred to the later integration gates (b8)** — the DoD item for this task is the mocked-AS proxy round-trip + returned install command. The enroll proxy forwards the session credential only to the configured AS public URL and never logs it.

## Test plan

- [x] Target-specific local tests passed: `dotnet build --no-restore --configuration Release` + `dotnet test --no-build --configuration Release` — **494** McpPlugin.Server.Tests + **630** McpPlugin.Tests, 0 failures across `net8.0` + `net9.0`.
- New unit tests: `ServerNativeToolsTests` (descriptors/list/select-stickiness/enroll-mocked-AS), `SessionSelectionStoreTests`, `EnrollmentClientTests` (mocked AS), `AgentActionableErrorsTests` (both error variants).

Closes #142