### PR TITLE
feat(auth): credential-free project-pinned config writers (mcp-authorize b6)

### DIFF
--- a/McpPlugin.Tests/AgentConfig/AiAgentConfiguratorTests.cs
+++ b/McpPlugin.Tests/AgentConfig/AiAgentConfiguratorTests.cs
@@ -81,7 +81,7 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
         }
 
         [Fact]
-        public void Codex_IsTomlBased_AndAuthInjectsEnvVar()
+        public void Codex_IsTomlBased_AndAdvancedPatInjectsEnvVar_ButDefaultPathDoesNot()
         {
             var root = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
             Directory.CreateDirectory(root);
@@ -93,9 +93,16 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
                     "http://localhost:50000/mcp", token: "secret",
                     authOption: Consts.MCP.Server.AuthOption.required);
 
-                var http = c.GetHttpConfig(settings);
-                http.ShouldBeOfType<TomlAiAgentConfig>();
-                http.ExpectedFileContent.ShouldContain("bearer_token_env_var");
+                // Default (OAuth) path: credential-free — no env-var indirection, no token value.
+                var oauth = c.GetHttpConfig(settings);
+                oauth.ShouldBeOfType<TomlAiAgentConfig>();
+                oauth.ExpectedFileContent.ShouldNotContain("bearer_token_env_var");
+                oauth.ExpectedFileContent.ShouldNotContain("secret");
+
+                // Advanced PAT path: env-var indirection is written; the token VALUE stays out of the file.
+                var pat = c.GetHttpConfig(settings, credentialMode: HttpCredentialMode.AccessToken);
+                pat.ExpectedFileContent.ShouldContain("bearer_token_env_var");
+                pat.ExpectedFileContent.ShouldNotContain("secret");
             }
             finally
             {

--- a/McpPlugin.Tests/AgentConfig/ConfigWritersB6Tests.cs
+++ b/McpPlugin.Tests/AgentConfig/ConfigWritersB6Tests.cs
@@ -1,0 +1,395 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json.Nodes;
+using com.IvanMurzak.McpPlugin.AgentConfig.Impl;
+using com.IvanMurzak.McpPlugin.Common;
+using Microsoft.Extensions.Logging;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
+{
+    using TransportMethod = Consts.MCP.Server.TransportMethod;
+
+    /// <summary>
+    /// mcp-authorize b6 — config writers flipped to the credential-free, project-pinned shape
+    /// (design 03/06). Covers the four Definition-of-Done items: (1) per-configurator snapshot of
+    /// the new shapes for all 16 configurators + dedup/upsert regression; (2) marker-override
+    /// propagation into the written port; (3) the security assertion that NO credential can reach a
+    /// project-scoped config file on the default path; plus the <c>SupportsOAuth</c> flag and the
+    /// advanced-PAT escape hatch (explicit opt-in, env-var/user-scope preference, project-file warning).
+    /// </summary>
+    public class ConfigWritersB6Tests
+    {
+        // A token value distinctive enough that a substring assertion cannot false-match.
+        private const string PatValue = "S3CR3T-PAT-VALUE";
+
+        private static AgentConfiguratorSettings Settings(
+            string root,
+            string? token = null,
+            ConnectionMode connectionMode = ConnectionMode.Local,
+            Consts.MCP.Server.AuthOption authOption = Consts.MCP.Server.AuthOption.none,
+            string host = "http://localhost:50000/mcp") => new(
+                operatingSystem: OperatingSystemKind.Windows,
+                projectRootPath: root,
+                executableFullPath: "C:/Tools/ai-game-developer-mcp-server.exe",
+                port: 50000,
+                timeoutMs: 30000,
+                host: host,
+                token: token,
+                connectionMode: connectionMode,
+                authOption: authOption);
+
+        private static string NewTempDir()
+        {
+            var root = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(root);
+            return root;
+        }
+
+        private static IEnumerable<AiAgentConfigurator> RealConfigurators()
+            => AiAgentConfiguratorRegistry.All.Where(c => c is not CustomConfigurator);
+
+        private static bool IsUnderRoot(string configPath, string root)
+        {
+            static string Norm(string p) => p.Replace('\\', '/').TrimEnd('/');
+            return Norm(configPath).StartsWith(Norm(root) + "/", StringComparison.OrdinalIgnoreCase);
+        }
+
+        // ---- DoD 1: SupportsOAuth flag (default true across the registry). ----
+
+        [Fact]
+        public void AllConfigurators_DefaultToSupportsOAuth()
+        {
+            foreach (var c in AiAgentConfiguratorRegistry.All)
+                c.SupportsOAuth.ShouldBeTrue($"{c.AgentId} should default SupportsOAuth=true");
+        }
+
+        // ---- DoD 1: per-configurator snapshot of the new default (OAuth) shapes — credential-free + pinned. ----
+
+        [Fact]
+        public void AllConfigurators_DefaultHttp_AreCredentialFree_AndProjectPinned()
+        {
+            var root = NewTempDir();
+            try
+            {
+                // A token + authorization=required is the pre-b6 "would have injected a Bearer header"
+                // condition; the default path must strip it regardless.
+                var settings = Settings(root, token: PatValue, authOption: Consts.MCP.Server.AuthOption.required);
+                foreach (var c in RealConfigurators())
+                {
+                    var content = c.GetHttpConfig(settings).ExpectedFileContent;
+
+                    content.ShouldContain($"/p/{settings.ProjectPin}", customMessage: $"{c.AgentId} HTTP must carry the pin path segment");
+                    content.ShouldNotContain(PatValue, customMessage: $"{c.AgentId} HTTP must not embed the token value");
+                    content.ShouldNotContain("Bearer", customMessage: $"{c.AgentId} HTTP must not embed a Bearer header");
+                    content.ShouldNotContain("bearer_token_env_var", customMessage: $"{c.AgentId} HTTP must not carry the PAT env-var indirection on the default path");
+                }
+            }
+            finally { Directory.Delete(root, recursive: true); }
+        }
+
+        [Fact]
+        public void AllConfigurators_DefaultStdio_AreCredentialFree_AndProjectPinned()
+        {
+            var root = NewTempDir();
+            try
+            {
+                var settings = Settings(root, token: PatValue, authOption: Consts.MCP.Server.AuthOption.required);
+                foreach (var c in RealConfigurators())
+                {
+                    var content = c.GetStdioConfig(settings).ExpectedFileContent;
+
+                    content.ShouldContain($"{Consts.MCP.Server.Args.Project}={settings.ProjectPin}", customMessage: $"{c.AgentId} stdio must carry project=<pin>");
+                    content.ShouldContain($"{Consts.MCP.Server.Args.Port}={settings.ResolvedPort}", customMessage: $"{c.AgentId} stdio must carry the ProjectIdentity port");
+                    content.ShouldNotContain($"{Consts.MCP.Server.Args.Authorization}=", customMessage: $"{c.AgentId} stdio must not carry an authorization arg on the default path");
+                    content.ShouldNotContain($"{Consts.MCP.Server.Args.Token}=", customMessage: $"{c.AgentId} stdio must not carry a token arg on the default path");
+                    content.ShouldNotContain(PatValue, customMessage: $"{c.AgentId} stdio must not embed the token value");
+                }
+            }
+            finally { Directory.Delete(root, recursive: true); }
+        }
+
+        [Fact]
+        public void Custom_DefaultHttpSnippet_IsCredentialFree_AndProjectPinned()
+        {
+            var root = NewTempDir();
+            try
+            {
+                var c = new CustomConfigurator();
+                var settings = Settings(root, token: PatValue, authOption: Consts.MCP.Server.AuthOption.required);
+                var snippet = c.Describe(settings, TransportMethod.streamableHttp).Sections
+                    .SelectMany(s => s.Items)
+                    .Select(i => i.Text ?? string.Empty)
+                    .First(t => t.Contains("mcpServers"));
+
+                snippet.ShouldContain($"/p/{settings.ProjectPin}");
+                snippet.ShouldNotContain(PatValue);
+                snippet.ShouldNotContain("Bearer");
+            }
+            finally { Directory.Delete(root, recursive: true); }
+        }
+
+        [Fact]
+        public void ClaudeCode_NewShapes_ExactContent()
+        {
+            var root = NewTempDir();
+            try
+            {
+                var c = new ClaudeCodeConfigurator();
+                var settings = Settings(root);
+                var pin = settings.ProjectPin;
+                var port = settings.ResolvedPort;
+
+                var stdio = c.GetStdioConfig(settings).ExpectedFileContent;
+                stdio.ShouldContain($"\"{Consts.MCP.Server.Args.Port}={port}\"");
+                stdio.ShouldContain($"\"{Consts.MCP.Server.Args.PluginTimeout}=30000\"");
+                stdio.ShouldContain($"\"{Consts.MCP.Server.Args.ClientTransportMethod}=stdio\"");
+                stdio.ShouldContain($"\"{Consts.MCP.Server.Args.Project}={pin}\"");
+                stdio.ShouldNotContain("\"type\"");
+                stdio.ShouldNotContain("\"url\"");
+
+                var http = c.GetHttpConfig(settings).ExpectedFileContent;
+                http.ShouldContain($"\"url\": \"http://localhost:{port}/mcp/p/{pin}\"");
+                http.ShouldContain("\"type\": \"http\"");
+                http.ShouldNotContain("\"headers\"");
+            }
+            finally { Directory.Delete(root, recursive: true); }
+        }
+
+        [Fact]
+        public void GlobalConfigurators_AreExplicitlyProjectPinned()
+        {
+            // Design 06 D14: the three inherently-global configurators still carry the project pin,
+            // so even a globally-configured client talks to exactly one chosen project.
+            var root = NewTempDir();
+            try
+            {
+                var settings = Settings(root);
+                foreach (var id in new[] { "claude-desktop", "antigravity", "cline" })
+                {
+                    var c = AiAgentConfiguratorRegistry.GetByAgentId(id)!;
+                    c.GetHttpConfig(settings).ExpectedFileContent.ShouldContain($"/p/{settings.ProjectPin}", customMessage: $"{id} HTTP must be pinned");
+                    c.GetStdioConfig(settings).ExpectedFileContent.ShouldContain($"{Consts.MCP.Server.Args.Project}={settings.ProjectPin}", customMessage: $"{id} stdio must be pinned");
+                }
+            }
+            finally { Directory.Delete(root, recursive: true); }
+        }
+
+        // ---- DoD 1: dedup / upsert regression on the new pinned shape. ----
+
+        [Fact]
+        public void Configure_IsIdempotentUpsert_KeepsSingleEntry()
+        {
+            var root = NewTempDir();
+            try
+            {
+                var c = new ClaudeCodeConfigurator();
+                var settings = Settings(root);
+
+                c.GetHttpConfig(settings).Configure().ShouldBeTrue();
+                c.GetHttpConfig(settings).Configure().ShouldBeTrue(); // re-configure = upsert
+                c.IsConfigured(settings, TransportMethod.streamableHttp).ShouldBeTrue();
+
+                var servers = ReadServers(c.GetHttpConfig(settings).ConfigPath, "mcpServers");
+                servers.Count.ShouldBe(1);
+                servers.Single().Key.ShouldBe(AiAgentConfig.DefaultMcpServerName);
+            }
+            finally { Directory.Delete(root, recursive: true); }
+        }
+
+        [Fact]
+        public void Configure_DedupsSameServerUnderADifferentName()
+        {
+            var root = NewTempDir();
+            try
+            {
+                var c = new ClaudeCodeConfigurator();
+                var settings = Settings(root);
+                var pinnedUrl = settings.PinnedHttpUrl;
+                var configPath = Path.Combine(root, ".mcp.json");
+
+                // Pre-existing entry under a DIFFERENT name but the same (identity) url.
+                File.WriteAllText(configPath,
+                    $"{{ \"mcpServers\": {{ \"legacy-name\": {{ \"type\": \"http\", \"url\": \"{pinnedUrl}\" }} }} }}");
+
+                c.GetHttpConfig(settings).Configure().ShouldBeTrue();
+
+                var servers = ReadServers(configPath, "mcpServers");
+                servers.ContainsKey(AiAgentConfig.DefaultMcpServerName).ShouldBeTrue();
+                servers.ContainsKey("legacy-name").ShouldBeFalse();
+            }
+            finally { Directory.Delete(root, recursive: true); }
+        }
+
+        // ---- DoD 2: marker portOverride propagates into the written config port. ----
+
+        [Fact]
+        public void MarkerPortOverride_PropagatesToWrittenPort_StdioAndHttp()
+        {
+            var root = NewTempDir();
+            try
+            {
+                const int overridePort = 27777;
+                new ProjectMarker { PortOverride = overridePort }.Write(root);
+
+                var settings = Settings(root);
+                settings.ResolvedPort.ShouldBe(overridePort);
+                settings.Identity.PortIsOverridden.ShouldBeTrue();
+
+                var c = new ClaudeCodeConfigurator();
+                c.GetStdioConfig(settings).ExpectedFileContent.ShouldContain($"{Consts.MCP.Server.Args.Port}={overridePort}");
+                c.GetHttpConfig(settings).ExpectedFileContent.ShouldContain($"localhost:{overridePort}/");
+            }
+            finally { Directory.Delete(root, recursive: true); }
+        }
+
+        [Fact]
+        public void NoMarker_UsesDeterministicDerivedPort()
+        {
+            var root = NewTempDir();
+            try
+            {
+                var settings = Settings(root);
+                settings.Identity.PortIsOverridden.ShouldBeFalse();
+                settings.ResolvedPort.ShouldBe(ProjectIdentity.DerivePort(root));
+                settings.ResolvedPort.ShouldBeInRange(ProjectIdentity.MinPort, ProjectIdentity.MaxPort);
+            }
+            finally { Directory.Delete(root, recursive: true); }
+        }
+
+        // ---- DoD 3: NO credential can reach a project-scoped config FILE on the default path. ----
+
+        [Fact]
+        public void DefaultPath_WritesNoCredentialIntoAnyProjectScopedFile()
+        {
+            var root = NewTempDir();
+            try
+            {
+                // Strongest condition: a token is present AND auth is "required" — pre-b6 this wrote a
+                // credential into the project file for every project-scoped configurator.
+                var settings = Settings(root, token: PatValue, authOption: Consts.MCP.Server.AuthOption.required);
+                var assertedAtLeastOne = false;
+
+                foreach (var c in RealConfigurators())
+                {
+                    foreach (var transport in new[] { TransportMethod.stdio, TransportMethod.streamableHttp })
+                    {
+                        var config = transport == TransportMethod.stdio
+                            ? c.GetStdioConfig(settings)
+                            : c.GetHttpConfig(settings);
+
+                        // Only touch disk for project-scoped configs (never pollute a global user path).
+                        if (!IsUnderRoot(config.ConfigPath, root))
+                            continue;
+
+                        config.Configure().ShouldBeTrue($"{c.AgentId}/{transport} should configure");
+                        var onDisk = File.ReadAllText(config.ConfigPath);
+
+                        onDisk.ShouldNotContain(PatValue, customMessage: $"{c.AgentId}/{transport} leaked the token value into a project file");
+                        onDisk.ShouldNotContain("Bearer", customMessage: $"{c.AgentId}/{transport} leaked a Bearer header into a project file");
+                        onDisk.ShouldNotContain($"{Consts.MCP.Server.Args.Token}=", customMessage: $"{c.AgentId}/{transport} leaked a token arg into a project file");
+                        assertedAtLeastOne = true;
+                    }
+                }
+
+                assertedAtLeastOne.ShouldBeTrue("expected at least one project-scoped configurator to be asserted on disk");
+            }
+            finally { Directory.Delete(root, recursive: true); }
+        }
+
+        // ---- Advanced PAT escape hatch: explicit opt-in, env-var/user-scope preference, project-file warning. ----
+
+        [Fact]
+        public void AdvancedPat_WritesBearerHeader_AndWarnsForProjectScopedFile()
+        {
+            var root = NewTempDir();
+            try
+            {
+                var c = new ClaudeCodeConfigurator(); // project-scoped .mcp.json
+                var settings = Settings(root, token: PatValue);
+                var logger = new CapturingLogger();
+
+                var config = c.GetHttpConfig(settings, logger, HttpCredentialMode.AccessToken);
+
+                config.ExpectedFileContent.ShouldContain($"Bearer {PatValue}");
+                logger.Warnings.ShouldContain(m => m.Contains("project-scoped"));
+            }
+            finally { Directory.Delete(root, recursive: true); }
+        }
+
+        [Fact]
+        public void AdvancedPat_GlobalConfig_WritesHeader_ButDoesNotWarn()
+        {
+            var root = NewTempDir();
+            try
+            {
+                var c = new ClaudeDesktopConfigurator(); // global per-OS path
+                var settings = Settings(root, token: PatValue);
+                var logger = new CapturingLogger();
+
+                var config = c.GetHttpConfig(settings, logger, HttpCredentialMode.AccessToken);
+
+                config.ExpectedFileContent.ShouldContain($"Bearer {PatValue}");
+                logger.Warnings.ShouldBeEmpty(); // user-scope placement — the preferred PAT location.
+            }
+            finally { Directory.Delete(root, recursive: true); }
+        }
+
+        [Fact]
+        public void AdvancedPat_Codex_UsesEnvVar_KeepsTokenOutOfFile_NoWarning()
+        {
+            var root = NewTempDir();
+            try
+            {
+                var c = new CodexConfigurator(); // project-scoped .codex/config.toml
+                var settings = Settings(root, token: PatValue);
+                var logger = new CapturingLogger();
+
+                var config = c.GetHttpConfig(settings, logger, HttpCredentialMode.AccessToken);
+
+                config.ExpectedFileContent.ShouldContain("bearer_token_env_var");
+                config.ExpectedFileContent.ShouldNotContain(PatValue); // env-var indirection keeps the secret out of the file
+                logger.Warnings.ShouldBeEmpty();
+            }
+            finally { Directory.Delete(root, recursive: true); }
+        }
+
+        // --- helpers ---
+
+        private static Dictionary<string, JsonNode?> ReadServers(string configPath, string bodyKey)
+        {
+            var root = JsonNode.Parse(File.ReadAllText(configPath))!.AsObject();
+            var body = root[bodyKey]!.AsObject();
+            return body.ToDictionary(kv => kv.Key, kv => kv.Value);
+        }
+
+        private sealed class CapturingLogger : ILogger
+        {
+            private readonly List<(LogLevel Level, string Message)> _entries = new();
+            public IEnumerable<string> Warnings => _entries.Where(e => e.Level == LogLevel.Warning).Select(e => e.Message);
+
+            public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+            public bool IsEnabled(LogLevel logLevel) => true;
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+                => _entries.Add((logLevel, formatter(state, exception)));
+
+            private sealed class NullScope : IDisposable
+            {
+                public static readonly NullScope Instance = new();
+                public void Dispose() { }
+            }
+        }
+    }
+}

--- a/McpPlugin/src/AgentConfig/AgentConfigBuilders.cs
+++ b/McpPlugin/src/AgentConfig/AgentConfigBuilders.cs
@@ -23,13 +23,18 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
     /// </summary>
     internal static class AgentConfigBuilders
     {
-        /// <summary>The standard stdio arg array (port, plugin-timeout, client-transport, authorization).</summary>
+        /// <summary>
+        /// The standard stdio arg array (mcp-authorize b6, design 06): the ProjectIdentity-derived
+        /// per-project <c>port=</c> (marker <c>portOverride</c> wins), plugin-timeout, client-transport,
+        /// and the <c>project=&lt;pin&gt;</c> routing arg. NO auth args — stdio spawns in <c>none</c> mode
+        /// on the default path (the credential-free / anonymous local flow).
+        /// </summary>
         public static JsonArray StdioArgs(AgentConfiguratorSettings s) => new()
         {
-            $"{Args.Port}={s.Port}",
+            $"{Args.Port}={s.ResolvedPort}",
             $"{Args.PluginTimeout}={s.TimeoutMs}",
             $"{Args.ClientTransportMethod}={TransportMethod.stdio}",
-            $"{Args.Authorization}={s.AuthOption}"
+            $"{Args.Project}={s.ProjectPin}"
         };
 
         /// <summary>
@@ -72,7 +77,7 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
         {
             var config = new JsonAiAgentConfig(name, configPath, bodyPath, logger)
                 .SetProperty("type", JsonValue.Create(type)!, requiredForConfiguration: true)
-                .SetProperty("url", JsonValue.Create(settings.Host)!, requiredForConfiguration: true, comparison: ValueComparisonMode.Url)
+                .SetProperty("url", JsonValue.Create(settings.PinnedHttpUrl)!, requiredForConfiguration: true, comparison: ValueComparisonMode.Url)
                 .SetPropertyToRemove("command")
                 .SetPropertyToRemove("args");
             if (disabled.HasValue)

--- a/McpPlugin/src/AgentConfig/AgentConfiguratorSettings.cs
+++ b/McpPlugin/src/AgentConfig/AgentConfiguratorSettings.cs
@@ -9,6 +9,7 @@
 */
 
 #nullable enable
+using System;
 using System.Runtime.InteropServices;
 using com.IvanMurzak.McpPlugin.Common;
 
@@ -192,5 +193,56 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
 
         /// <summary>Convenience: <see cref="OperatingSystem"/> is <see cref="OperatingSystemKind.Windows"/>.</summary>
         public bool IsWindows => OperatingSystem == OperatingSystemKind.Windows;
+
+        // --- mcp-authorize b6: project-pinned, marker-aware identity resolution (design 03/06). ---
+        // Every config writer consults the same ProjectIdentity + project marker so the routing pin
+        // and the per-project local port can never silently diverge between the plugin and a
+        // terminal-written config. Resolved lazily and cached (a marker read is file I/O, and the
+        // identity is stable for the settings' <see cref="ProjectRootPath"/>).
+        private ProjectIdentity? _identity;
+
+        /// <summary>
+        /// The project's <see cref="ProjectIdentity"/> — routing pin plus the resolved local port
+        /// (the project marker's <c>portOverride</c> wins, else the deterministic hash-derived port).
+        /// Read once from the marker at <see cref="ProjectRootPath"/> and cached.
+        /// </summary>
+        public ProjectIdentity Identity => _identity ??= ProjectIdentity.Derive(ProjectRootPath, ProjectMarker.Read(ProjectRootPath));
+
+        /// <summary>The routing pin (first 8 hex chars of the ProjectIdentity SHA-256). Non-secret, safe to commit.</summary>
+        public string ProjectPin => Identity.Pin;
+
+        /// <summary>
+        /// The resolved per-project local port: the project marker's <c>portOverride</c> when set,
+        /// otherwise the deterministic hash-derived port. This is the port written into configs
+        /// (stdio <c>port=</c> arg and the loopback HTTP URL), NOT the raw engine-supplied
+        /// <see cref="Port"/> — b6 single-sources the local port from <see cref="ProjectIdentity"/>.
+        /// </summary>
+        public int ResolvedPort => Identity.Port;
+
+        /// <summary>
+        /// The HTTP <c>url</c> written into configs on the default (credential-free) path: the base
+        /// <see cref="Host"/> with the <c>/p/&lt;pin&gt;</c> routing path segment appended, and — for a
+        /// loopback URL in <see cref="ConnectionMode.Local"/> — the port rewritten to
+        /// <see cref="ResolvedPort"/>. The pin rides as a path segment (not a query param) so a lost
+        /// pin 404s loudly instead of silently degrading to unpinned routing (design 03 Flow F).
+        /// </summary>
+        public string PinnedHttpUrl => BuildPinnedHttpUrl();
+
+        private string BuildPinnedHttpUrl()
+        {
+            var pin = ProjectPin;
+            if (Uri.TryCreate(Host, UriKind.Absolute, out var uri))
+            {
+                // Only the per-project LOCAL loopback port is rewritten from ProjectIdentity; a hosted
+                // (or non-loopback) target keeps its authority verbatim (default ports stay implicit).
+                var authority = ConnectionMode == ConnectionMode.Local && uri.IsLoopback
+                    ? $"{uri.Scheme}://{uri.Host}:{ResolvedPort}"
+                    : uri.GetLeftPart(UriPartial.Authority);
+                var basePath = uri.AbsolutePath.TrimEnd('/');
+                return $"{authority}{basePath}/p/{pin}{uri.Query}";
+            }
+            // Non-absolute host (defensive): append the pin segment without a port rewrite.
+            return $"{Host.TrimEnd('/')}/p/{pin}";
+        }
     }
 }

--- a/McpPlugin/src/AgentConfig/AiAgentConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/AiAgentConfigurator.cs
@@ -9,12 +9,28 @@
 */
 
 #nullable enable
+using System;
 using System.Collections.Generic;
 using System.IO;
 using Microsoft.Extensions.Logging;
 
 namespace com.IvanMurzak.McpPlugin.AgentConfig
 {
+    /// <summary>
+    /// How a credential is written into an HTTP MCP config (mcp-authorize b6). The default is
+    /// <see cref="Oauth"/>: the config carries no credential at all — the client performs native
+    /// MCP OAuth against the server URL (design 03 Flow A). <see cref="AccessToken"/> is the
+    /// advanced PAT escape hatch (Flow C) written ONLY on explicit request, preferring env-var /
+    /// user-scope placement; writing it into a project-scoped file emits a warning.
+    /// </summary>
+    public enum HttpCredentialMode
+    {
+        /// <summary>Default: no credential written; the client authorizes natively via OAuth.</summary>
+        Oauth,
+        /// <summary>Advanced PAT path: write the legacy bearer/header shape (explicit opt-in only).</summary>
+        AccessToken
+    }
+
     /// <summary>
     /// Engine-agnostic base for an AI-agent configurator. Each subclass knows one agent's
     /// config-file location(s) and the stdio/http server-entry shape; it produces
@@ -63,6 +79,16 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
         public abstract string? IconName { get; }
 
         /// <summary>
+        /// Whether this agent can complete native MCP OAuth against the server URL (design 03 Flow A).
+        /// Default <c>true</c> — the credential-free config is written and the client's own authorize
+        /// flow completes the loop. The few clients that cannot do MCP OAuth override this to
+        /// <c>false</c>, which is the signal for the engine UI to offer the "Advanced: use access
+        /// token" (PAT) path (<see cref="HttpCredentialMode.AccessToken"/>, design 03 Flow C). The
+        /// flag never changes what the DEFAULT path writes — that path is always credential-free.
+        /// </summary>
+        public virtual bool SupportsOAuth => true;
+
+        /// <summary>
         /// Builds the STDIO transport config for the given settings. Override per agent.
         /// Authorization is applied by <see cref="GetStdioConfig"/>; subclasses build the base entry only.
         /// </summary>
@@ -75,7 +101,9 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
         protected abstract AiAgentConfig CreateHttpConfig(AgentConfiguratorSettings settings, ILogger? logger);
 
         /// <summary>
-        /// Returns the STDIO config with STDIO authorization applied, ready to <c>Configure()</c> / inspect.
+        /// Returns the STDIO config, ready to <c>Configure()</c> / inspect. Always credential-free
+        /// (mcp-authorize b6): stdio spawns in <c>none</c> mode (design 03 Flow D), so any stray
+        /// <c>token=</c> arg is stripped and no credential is ever written for the stdio transport.
         /// </summary>
         public AiAgentConfig GetStdioConfig(AgentConfiguratorSettings settings, ILogger? logger = null)
         {
@@ -85,30 +113,93 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
         }
 
         /// <summary>
-        /// Returns the HTTP config with HTTP authorization applied, ready to <c>Configure()</c> / inspect.
+        /// Returns the HTTP config, ready to <c>Configure()</c> / inspect. On the default
+        /// <see cref="HttpCredentialMode.Oauth"/> path the config is credential-free — the client
+        /// authorizes natively against the pinned server URL (design 03 Flow A). Passing
+        /// <see cref="HttpCredentialMode.AccessToken"/> is the explicit advanced PAT path (Flow C):
+        /// it writes the legacy bearer shape and, when that credential would land in a
+        /// project-scoped file, emits a warning (prefer env-var / user-scope placement).
         /// </summary>
-        public AiAgentConfig GetHttpConfig(AgentConfiguratorSettings settings, ILogger? logger = null)
+        public AiAgentConfig GetHttpConfig(
+            AgentConfiguratorSettings settings,
+            ILogger? logger = null,
+            HttpCredentialMode credentialMode = HttpCredentialMode.Oauth)
         {
             var config = CreateHttpConfig(settings, logger);
-            ApplyHttpAuthorization(config, settings);
+            ApplyHttpAuthorization(config, settings, credentialMode);
+            WarnIfCredentialWouldLandInProjectFile(config, settings, credentialMode, logger);
             return config;
         }
 
         /// <summary>
-        /// Applies STDIO authorization to a config. Override for agent-specific token handling.
+        /// Applies STDIO authorization to a config. The default path is unconditionally
+        /// credential-free — this strips any existing <c>token=</c> arg (and HTTP-only
+        /// <c>headers</c>). Override only for agents whose stdio credential handling is not
+        /// args-based (e.g. Open Code, which builds a single <c>command</c> array).
         /// </summary>
         protected virtual void ApplyStdioAuthorization(AiAgentConfig config, AgentConfiguratorSettings settings)
         {
-            config.ApplyStdioAuthorization(settings.IsStdioAuthRequired, settings.Token);
+            config.ApplyStdioAuthorization(isRequired: false, token: null);
         }
 
         /// <summary>
-        /// Applies HTTP authorization to a config. Override for agent-specific token handling
-        /// (e.g. Codex's bearer-token env-var indirection).
+        /// Applies HTTP authorization to a config for the requested <paramref name="credentialMode"/>.
+        /// <see cref="HttpCredentialMode.Oauth"/> (default) strips any credential; only
+        /// <see cref="HttpCredentialMode.AccessToken"/> injects the legacy bearer shape, and only
+        /// when a token is present. Override for agent-specific token placement (e.g. Codex's
+        /// bearer-token env-var indirection, which keeps the secret out of the file entirely).
         /// </summary>
-        protected virtual void ApplyHttpAuthorization(AiAgentConfig config, AgentConfiguratorSettings settings)
+        protected virtual void ApplyHttpAuthorization(
+            AiAgentConfig config,
+            AgentConfiguratorSettings settings,
+            HttpCredentialMode credentialMode)
         {
-            config.ApplyHttpAuthorization(settings.IsHttpAuthRequired, settings.Token);
+            var writeToken = credentialMode == HttpCredentialMode.AccessToken && !string.IsNullOrEmpty(settings.Token);
+            config.ApplyHttpAuthorization(writeToken, settings.Token);
+        }
+
+        /// <summary>
+        /// Warns when the advanced PAT path would write the raw token VALUE into a config file that
+        /// lives under the project root (VCS-visible). Detected generically: the credential is
+        /// considered "in the file" when the built <see cref="AiAgentConfig.ExpectedFileContent"/>
+        /// contains the token value — so an env-var indirection (Codex) that keeps the secret out of
+        /// the file never trips it, and neither does a user-global config path.
+        /// </summary>
+        private static void WarnIfCredentialWouldLandInProjectFile(
+            AiAgentConfig config,
+            AgentConfiguratorSettings settings,
+            HttpCredentialMode credentialMode,
+            ILogger? logger)
+        {
+            if (credentialMode != HttpCredentialMode.AccessToken || string.IsNullOrEmpty(settings.Token))
+                return;
+
+            if (!config.ExpectedFileContent.Contains(settings.Token!, StringComparison.Ordinal))
+                return; // credential is not in the file (e.g. env-var placement) — nothing to warn about.
+
+            if (!IsProjectScopedPath(config.ConfigPath, settings.ProjectRootPath))
+                return; // user-global config path — the preferred placement for a PAT.
+
+            logger?.LogWarning(
+                "Writing an access token into project-scoped config file '{ConfigPath}' — it is under the project root and may be committed to version control. Prefer an env-var or user-scope placement for the access token.",
+                config.ConfigPath);
+        }
+
+        /// <summary>
+        /// True when <paramref name="configPath"/> resolves to a location under
+        /// <paramref name="projectRoot"/> (separator- and case-insensitive). Used to decide whether a
+        /// PAT write would land in a VCS-visible project file.
+        /// </summary>
+        internal static bool IsProjectScopedPath(string? configPath, string? projectRoot)
+        {
+            if (string.IsNullOrEmpty(configPath) || string.IsNullOrEmpty(projectRoot))
+                return false;
+
+            static string Norm(string p) => p.Replace('\\', '/').TrimEnd('/');
+            var root = Norm(projectRoot!);
+            var path = Norm(configPath!);
+            return path.Equals(root, StringComparison.OrdinalIgnoreCase)
+                || path.StartsWith(root + "/", StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>

--- a/McpPlugin/src/AgentConfig/Impl/AntigravityConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/Impl/AntigravityConfigurator.cs
@@ -47,7 +47,7 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Impl
             => new JsonAiAgentConfig(AgentName, GlobalConfigPath(settings), bodyPath: "mcpServers", logger: logger)
                 .AddIdentityKey("serverUrl")
                 .SetProperty("disabled", JsonValue.Create(false)!, requiredForConfiguration: true)
-                .SetProperty("serverUrl", JsonValue.Create(settings.Host)!, requiredForConfiguration: true, comparison: ValueComparisonMode.Url)
+                .SetProperty("serverUrl", JsonValue.Create(settings.PinnedHttpUrl)!, requiredForConfiguration: true, comparison: ValueComparisonMode.Url)
                 .SetPropertyToRemove("command")
                 .SetPropertyToRemove("args")
                 .SetPropertyToRemove("url")

--- a/McpPlugin/src/AgentConfig/Impl/ClineConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/Impl/ClineConfigurator.cs
@@ -56,7 +56,7 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Impl
         protected override AiAgentConfig CreateHttpConfig(AgentConfiguratorSettings settings, ILogger? logger)
             => new JsonAiAgentConfig(AgentName, GlobalConfigPath(settings), bodyPath: DefaultBodyPath, logger: logger)
                 .SetProperty("type", JsonValue.Create($"{TransportMethod.streamableHttp}")!, requiredForConfiguration: true)
-                .SetProperty("url", JsonValue.Create(settings.Host)!, requiredForConfiguration: true, comparison: ValueComparisonMode.Url)
+                .SetProperty("url", JsonValue.Create(settings.PinnedHttpUrl)!, requiredForConfiguration: true, comparison: ValueComparisonMode.Url)
                 .SetPropertyToRemove("command")
                 .SetPropertyToRemove("args");
 

--- a/McpPlugin/src/AgentConfig/Impl/CodexConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/Impl/CodexConfigurator.cs
@@ -40,10 +40,10 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Impl
                 .SetProperty("command", settings.ExecutableFullPath.Replace('\\', '/'), requiredForConfiguration: true, comparison: ValueComparisonMode.Path)
                 .SetProperty("args", new[]
                 {
-                    $"{Args.Port}={settings.Port}",
+                    $"{Args.Port}={settings.ResolvedPort}",
                     $"{Args.PluginTimeout}={settings.TimeoutMs}",
                     $"{Args.ClientTransportMethod}={TransportMethod.stdio}",
-                    $"{Args.Authorization}={settings.AuthOption}"
+                    $"{Args.Project}={settings.ProjectPin}"
                 }, requiredForConfiguration: true)
                 .SetProperty("tool_timeout_sec", 300, requiredForConfiguration: false)
                 .SetPropertyToRemove("url")
@@ -53,21 +53,24 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Impl
         protected override AiAgentConfig CreateHttpConfig(AgentConfiguratorSettings settings, ILogger? logger)
             => new TomlAiAgentConfig(AgentName, LocalConfigPath(settings), bodyPath: "mcp_servers", logger: logger)
                 .SetProperty("enabled", true, requiredForConfiguration: true)
-                .SetProperty("url", settings.Host, requiredForConfiguration: true, comparison: ValueComparisonMode.Url)
+                .SetProperty("url", settings.PinnedHttpUrl, requiredForConfiguration: true, comparison: ValueComparisonMode.Url)
                 .SetProperty("tool_timeout_sec", 300, requiredForConfiguration: false)
                 .SetProperty("startup_timeout_sec", 30, requiredForConfiguration: false)
                 .SetPropertyToRemove("command")
                 .SetPropertyToRemove("args")
                 .SetPropertyToRemove("type");
 
-        protected override void ApplyHttpAuthorization(AiAgentConfig config, AgentConfiguratorSettings settings)
+        protected override void ApplyHttpAuthorization(AiAgentConfig config, AgentConfiguratorSettings settings, HttpCredentialMode credentialMode)
         {
-            base.ApplyHttpAuthorization(config, settings);
+            base.ApplyHttpAuthorization(config, settings, credentialMode);
 
             var tomlConfig = config as TomlAiAgentConfig
                 ?? throw new InvalidCastException($"Expected TomlAiAgentConfig for Codex HTTP configuration but got {config.GetType().Name}");
 
-            if (settings.IsHttpAuthRequired && !string.IsNullOrEmpty(settings.Token))
+            // Advanced PAT path only (mcp-authorize b6): Codex reads the token from the
+            // GAME_DEV_AUTH_TOKEN env var, so the secret never lands in the config file (the
+            // preferred placement). The default OAuth path writes neither the indirection nor a token.
+            if (credentialMode == HttpCredentialMode.AccessToken && !string.IsNullOrEmpty(settings.Token))
                 tomlConfig.SetProperty(EnvVarNameBearerToken, EnvVarNameAuthToken, requiredForConfiguration: true);
             else
                 tomlConfig.SetPropertyToRemove(EnvVarNameBearerToken);

--- a/McpPlugin/src/AgentConfig/Impl/CustomConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/Impl/CustomConfigurator.cs
@@ -86,8 +86,9 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Impl
                 items.Add(ConfigurationItem.ReadOnlyField(DockerCommands.Run(settings)));
 
                 items.Add(ConfigurationItem.Description("3. Copy paste the json into your MCP Client to configure it."));
+                // mcp-authorize b6: credential-free, project-pinned URL (no token in the snippet).
                 items.Add(ConfigurationItem.ReadOnlyField(
-                    $"{{\"mcpServers\":{{\"{AiAgentConfig.DefaultMcpServerName}\":{{\"type\":\"http\",\"url\":\"{settings.Host}\"}}}}}}"));
+                    $"{{\"mcpServers\":{{\"{AiAgentConfig.DefaultMcpServerName}\":{{\"type\":\"http\",\"url\":\"{settings.PinnedHttpUrl}\"}}}}}}"));
 
                 items.Add(ConfigurationItem.Description("4. (Optional) Stop and remove the MCP server using Docker when you are done."));
                 items.Add(ConfigurationItem.ReadOnlyField(DockerCommands.Stop(settings)));

--- a/McpPlugin/src/AgentConfig/Impl/OpenCodeConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/Impl/OpenCodeConfigurator.cs
@@ -34,16 +34,16 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Impl
 
         protected override AiAgentConfig CreateStdioConfig(AgentConfiguratorSettings settings, ILogger? logger)
         {
+            // mcp-authorize b6: credential-free, pinned stdio command array — ProjectIdentity port
+            // (marker override wins) + project=<pin>, no auth args (spawns in `none` mode, Flow D).
             var commandArray = new JsonArray
             {
                 settings.ExecutableFullPath.Replace('\\', '/'),
-                $"{Args.Port}={settings.Port}",
+                $"{Args.Port}={settings.ResolvedPort}",
                 $"{Args.PluginTimeout}={settings.TimeoutMs}",
                 $"{Args.ClientTransportMethod}={TransportMethod.stdio}",
-                $"{Args.Authorization}={settings.AuthOption}"
+                $"{Args.Project}={settings.ProjectPin}"
             };
-            if (settings.IsStdioAuthRequired && !string.IsNullOrEmpty(settings.Token))
-                commandArray.Add($"{Args.Token}={settings.Token}");
 
             return new JsonAiAgentConfig(AgentName, LocalConfigPath(settings), bodyPath: "mcp", logger: logger)
                 .SetProperty("type", JsonValue.Create("local")!, requiredForConfiguration: true)
@@ -57,15 +57,16 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Impl
             => new JsonAiAgentConfig(AgentName, LocalConfigPath(settings), bodyPath: "mcp", logger: logger)
                 .SetProperty("type", JsonValue.Create("remote")!, requiredForConfiguration: true)
                 .SetProperty("enabled", JsonValue.Create(true)!, requiredForConfiguration: true)
-                .SetProperty("url", JsonValue.Create(settings.Host)!, requiredForConfiguration: true, comparison: ValueComparisonMode.Url)
+                .SetProperty("url", JsonValue.Create(settings.PinnedHttpUrl)!, requiredForConfiguration: true, comparison: ValueComparisonMode.Url)
                 .SetPropertyToRemove("command")
                 .SetPropertyToRemove("args");
 
-        // OpenCode embeds the token in the command array (not the args), so the base
-        // args-based STDIO authorization injection does not apply.
+        // OpenCode uses a single `command` array (not a separate `args` array), so the base
+        // args-based STDIO stripping does not apply. The command array is credential-free by
+        // construction (mcp-authorize b6), so there is nothing to strip.
         protected override void ApplyStdioAuthorization(AiAgentConfig config, AgentConfiguratorSettings settings)
         {
-            // no-op: token is handled inline in CreateStdioConfig's command array.
+            // no-op: CreateStdioConfig's command array carries no credential.
         }
 
         protected override IReadOnlyList<ConfigurationSection> BuildSections(

--- a/McpPlugin/src/AgentConfig/Impl/RiderConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/Impl/RiderConfigurator.cs
@@ -45,7 +45,7 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Impl
                 .SetProperty("enabled", JsonValue.Create(true)!, requiredForConfiguration: true)
                 .SetPropertyToRemove("disabled")
                 .SetProperty("type", JsonValue.Create("http")!, requiredForConfiguration: true)
-                .SetProperty("url", JsonValue.Create(settings.Host)!, requiredForConfiguration: true, comparison: ValueComparisonMode.Url)
+                .SetProperty("url", JsonValue.Create(settings.PinnedHttpUrl)!, requiredForConfiguration: true, comparison: ValueComparisonMode.Url)
                 .SetPropertyToRemove("command")
                 .SetPropertyToRemove("args");
 


### PR DESCRIPTION
## Summary
- Flip the 16 AI-client configurators (`McpPlugin/src/AgentConfig/*`) to the **credential-free, project-pinned** shape (design 03/06): default HTTP = `type`+`url` with a `/p/<pin>` path segment + the ProjectIdentity port (marker `portOverride` wins); default STDIO = derived `port=` + `project=<pin>`, no auth args. Removed the Bearer-header / `token=` / `bearer_token_env_var` injection from the default path.
- Added a `SupportsOAuth` capability flag (default `true`) and an explicit `HttpCredentialMode.AccessToken` PAT escape hatch — writes the legacy header shape only on request, prefers env-var/user-scope placement, and warns when a credential would land in a project-scoped file (Codex keeps the token in `GAME_DEV_AUTH_TOKEN`, never in the file).
- Every writer consults the project marker; the three global configurators (Claude Desktop, Antigravity, Cline) stay explicitly project-pinned.

## Test plan
- [x] Per-configurator credential-free + pinned snapshot tests for all 16 configurators; dedup/upsert regression.
- [x] Marker-override propagation test (`portOverride` → written config port).
- [x] Assertion test: no credential reaches a project-scoped file on the default path (on-disk).
- [x] Target-specific local tests passed (see profile test.md): xUnit green — `McpPlugin.Tests` 644/644, `McpPlugin.Server.Tests` 434/434 across net8.0 + net9.0.

Closes #146