### PR TITLE
feat(auth): engine plugin connection layer (mcp-authorize b7)

### DIFF
--- a/McpPlugin.Common/src/Utils/Consts.MCP.cs
+++ b/McpPlugin.Common/src/Utils/Consts.MCP.cs
@@ -34,7 +34,9 @@ namespace com.IvanMurzak.McpPlugin.Common
                 {
                     public const string McpServerEndpoint = "mcp-server-endpoint";
                     public const string McpServerTimeout = "mcp-server-timeout";
-                    public const string McpPluginToken = "mcp-plugin-token";
+                    // The plugin-side shared-token args/env (`mcp-plugin-token` / `MCP_PLUGIN_TOKEN`) were
+                    // removed in mcp-authorize b7: the plugin now presents an auto-refreshed account JWT via
+                    // ConnectionConfig.CredentialProvider (machine-store), never a static shared token.
                     public const string McpSkillsFolder = "mcp-skills-folder";
                 }
 
@@ -42,7 +44,6 @@ namespace com.IvanMurzak.McpPlugin.Common
                 {
                     public const string McpServerEndpoint = "MCP_SERVER_ENDPOINT";
                     public const string McpServerTimeout = "MCP_SERVER_TIMEOUT";
-                    public const string McpPluginToken = "MCP_PLUGIN_TOKEN";
                     public const string McpSkillsFolder = "MCP_SKILLS_FOLDER";
                 }
             }

--- a/McpPlugin.Server.Tests/DirectToolEndpointsAuthGatingTests.cs
+++ b/McpPlugin.Server.Tests/DirectToolEndpointsAuthGatingTests.cs
@@ -1,0 +1,143 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.Common;
+using com.IvanMurzak.McpPlugin.Common.Hub.Client;
+using com.IvanMurzak.McpPlugin.Common.Model;
+using com.IvanMurzak.McpPlugin.Common.Utils;
+using com.IvanMurzak.McpPlugin.Server.Api;
+using com.IvanMurzak.McpPlugin.Server.Auth;
+using com.IvanMurzak.McpPlugin.Server.Webhooks.Services;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.Server.Tests
+{
+    /// <summary>
+    /// mcp-authorize b7 folded fix 2 (🔒 security regression): the direct-tool REST surface (<c>/api/tools</c>)
+    /// and the system-tool surface (<c>/api/system-tools</c>) MUST require a valid token in <c>oauth</c> mode
+    /// (fail closed) and be reachable in <c>none</c> mode. Before b7 both gated on the now-unreachable
+    /// <c>AuthOption.required</c>, so they were NEVER authorization-gated in oauth mode.
+    /// </summary>
+    [Collection("McpPlugin.Server")]
+    public sealed class DirectToolEndpointsAuthGatingTests
+    {
+        [Theory]
+        [InlineData("/api/tools")]
+        [InlineData("/api/system-tools")]
+        public async Task OauthMode_WithoutToken_Returns401(string route)
+        {
+            await using var host = await StartHostAsync(Consts.MCP.Server.AuthOption.oauth);
+            using var client = new HttpClient { BaseAddress = new Uri(host.BaseUrl) };
+
+            var response = await client.GetAsync(route);
+
+            response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized, $"{route} must fail closed (401) in oauth mode without a token");
+        }
+
+        [Theory]
+        [InlineData("/api/tools")]
+        [InlineData("/api/system-tools")]
+        public async Task NoneMode_WithoutToken_IsReachable(string route)
+        {
+            await using var host = await StartHostAsync(Consts.MCP.Server.AuthOption.none);
+            using var client = new HttpClient { BaseAddress = new Uri(host.BaseUrl) };
+
+            var response = await client.GetAsync(route);
+
+            response.StatusCode.ShouldNotBe(HttpStatusCode.Unauthorized, $"{route} must be open (not 401) in none mode");
+            ((int)response.StatusCode).ShouldBeLessThan(500, $"{route} should serve the (empty) tool list in none mode");
+        }
+
+        // ── Minimal in-memory host: only what the two endpoint mappers + the auth scheme need. ──
+
+        static async Task<RunningHost> StartHostAsync(Consts.MCP.Server.AuthOption authOption)
+        {
+            var builder = WebApplication.CreateBuilder();
+            builder.Logging.ClearProviders();
+
+            var dataArguments = Mock.Of<IDataArguments>(d => d.Authorization == authOption);
+            builder.Services.AddSingleton(dataArguments);
+            builder.Services.AddSingleton<IClientToolHub>(new StubToolHub());
+            builder.Services.AddSingleton<IClientSystemToolHub>(new StubSystemToolHub());
+            builder.Services.AddSingleton(Mock.Of<IAuthorizationWebhookService>());
+
+            builder.Services
+                .AddAuthentication(TokenAuthenticationHandler.SchemeName)
+                .AddScheme<TokenAuthenticationOptions, TokenAuthenticationHandler>(
+                    TokenAuthenticationHandler.SchemeName,
+                    options => options.OAuthMode = authOption == Consts.MCP.Server.AuthOption.oauth);
+            builder.Services.AddAuthorization();
+
+            var app = builder.Build();
+            app.Urls.Add("http://127.0.0.1:0"); // OS-assigned loopback port
+            app.UseAuthentication();
+            app.UseAuthorization();
+            app.MapDirectToolCallApi(dataArguments);
+            app.MapSystemToolApi(dataArguments);
+
+            await app.StartAsync();
+            var baseUrl = app.Urls.First();
+            return new RunningHost(app, baseUrl);
+        }
+
+        sealed class RunningHost : IAsyncDisposable
+        {
+            readonly WebApplication _app;
+            public string BaseUrl { get; }
+
+            public RunningHost(WebApplication app, string baseUrl)
+            {
+                _app = app;
+                BaseUrl = baseUrl;
+            }
+
+            public async ValueTask DisposeAsync()
+            {
+                await _app.StopAsync();
+                await _app.DisposeAsync();
+            }
+        }
+
+        sealed class StubToolHub : IClientToolHub
+        {
+            public Task<ResponseData<ResponseCallTool>> RunCallTool(RequestCallTool request)
+                => Task.FromResult(ResponseData<ResponseCallTool>.Success(request.RequestID));
+
+            public Task<ResponseData<ResponseListTool[]>> RunListTool(RequestListTool request, CancellationToken cancellationToken = default)
+                => Task.FromResult(new ResponseData<ResponseListTool[]>(request.RequestID, ResponseStatus.Success)
+                {
+                    Value = Array.Empty<ResponseListTool>()
+                });
+        }
+
+        sealed class StubSystemToolHub : IClientSystemToolHub
+        {
+            public Task<ResponseData<ResponseCallTool>> RunSystemTool(RequestCallTool request, CancellationToken cancellationToken = default)
+                => Task.FromResult(ResponseData<ResponseCallTool>.Success(request.RequestID));
+
+            public Task<ResponseData<ResponseListTool[]>> RunListSystemTool(RequestListTool request, CancellationToken cancellationToken = default)
+                => Task.FromResult(new ResponseData<ResponseListTool[]>(request.RequestID, ResponseStatus.Success)
+                {
+                    Value = Array.Empty<ResponseListTool>()
+                });
+        }
+    }
+}

--- a/McpPlugin.Server.Tests/InstanceMetadataHandshakeRegistrationTests.cs
+++ b/McpPlugin.Server.Tests/InstanceMetadataHandshakeRegistrationTests.cs
@@ -1,0 +1,99 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+using System.Collections.Generic;
+using com.IvanMurzak.McpPlugin.Common;
+using com.IvanMurzak.McpPlugin.Server.Auth;
+using com.IvanMurzak.McpPlugin.Server.Strategy;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.Server.Tests
+{
+    /// <summary>
+    /// mcp-authorize b7 handshake integration with the b3 account+instance pairing plane: the exact query
+    /// keys an engine plugin sends in its hub handshake (<see cref="Consts.MCP.Server.HubQuery"/>) are read
+    /// by the server, built into <see cref="PluginInstanceMetadata"/>, and land in the account registry —
+    /// then resolve back to the instance by the session's project pin. This validates the client→server
+    /// wire contract without needing a live SignalR hub (the client half asserts that
+    /// <c>ConnectionInstanceMetadata.ToQuery()</c> emits these same keys).
+    /// </summary>
+    public sealed class InstanceMetadataHandshakeRegistrationTests
+    {
+        // A full 64-char SHA-256 hex project-path hash; its first 8 chars are the routing pin.
+        const string ProjectPathHash = "abcd1234ef567890abcd1234ef567890abcd1234ef567890abcd1234ef567890";
+        const string Pin = "abcd1234";
+        const string AccountId = "account-1";
+        const string ConnectionId = "conn-1";
+
+        static IReadOnlyDictionary<string, string> ClientHandshakeQuery() => new Dictionary<string, string>
+        {
+            [Consts.MCP.Server.HubQuery.InstanceId] = "sess-42",
+            [Consts.MCP.Server.HubQuery.Engine] = "unity",
+            [Consts.MCP.Server.HubQuery.ProjectName] = "MyGame",
+            [Consts.MCP.Server.HubQuery.ProjectPathHash] = ProjectPathHash,
+            [Consts.MCP.Server.HubQuery.MachineName] = "DESKTOP-9",
+        };
+
+        [Fact]
+        public void HandshakeQuery_RegistersInstance_IntoTheAccountRegistry()
+        {
+            var query = ClientHandshakeQuery();
+            var strategy = new AccountMcpStrategy();
+            var identity = new ConnectionIdentity(AccountId, ConnectionIdentity.RolePlugin);
+
+            // The server reads the b7 query keys exactly as McpServerHub.TryRegisterOAuthInstanceAsync does.
+            var metadata = AccountMcpStrategy.BuildInstanceMetadata(
+                connectionId: ConnectionId,
+                instanceId: query[Consts.MCP.Server.HubQuery.InstanceId],
+                engine: query[Consts.MCP.Server.HubQuery.Engine],
+                projectName: query[Consts.MCP.Server.HubQuery.ProjectName],
+                projectPathHash: query[Consts.MCP.Server.HubQuery.ProjectPathHash],
+                machineName: query[Consts.MCP.Server.HubQuery.MachineName]);
+
+            var registered = strategy.RegisterInstance(identity, metadata, ConnectionId, NullLogger.Instance);
+
+            registered.InstanceId.ShouldBe("sess-42");
+            registered.Engine.ShouldBe("unity");
+            registered.ProjectName.ShouldBe("MyGame");
+            registered.ProjectPathHash.ShouldBe(ProjectPathHash);
+            registered.MachineName.ShouldBe("DESKTOP-9");
+            strategy.Instances.InstanceCount(AccountId).ShouldBe(1);
+        }
+
+        [Fact]
+        public void RegisteredInstance_ResolvesBack_BySessionPin()
+        {
+            var query = ClientHandshakeQuery();
+            var strategy = new AccountMcpStrategy();
+            var identity = new ConnectionIdentity(AccountId, ConnectionIdentity.RolePlugin);
+
+            var metadata = AccountMcpStrategy.BuildInstanceMetadata(
+                connectionId: ConnectionId,
+                instanceId: query[Consts.MCP.Server.HubQuery.InstanceId],
+                engine: query[Consts.MCP.Server.HubQuery.Engine],
+                projectName: query[Consts.MCP.Server.HubQuery.ProjectName],
+                projectPathHash: query[Consts.MCP.Server.HubQuery.ProjectPathHash],
+                machineName: query[Consts.MCP.Server.HubQuery.MachineName]);
+            strategy.RegisterInstance(identity, metadata, ConnectionId, NullLogger.Instance);
+
+            // The session pin (first 8 hex of the project-path hash) routes strictly to this instance.
+            var resolution = strategy.Instances.Resolve(AccountId, Pin, selectedInstanceId: null);
+
+            resolution.Instance.ShouldNotBeNull();
+            resolution.Instance!.InstanceId.ShouldBe("sess-42");
+            resolution.Instance.MatchesPin(Pin).ShouldBeTrue();
+
+            // Fail closed: a pin for a DIFFERENT project never resolves to this account's instance.
+            strategy.Instances.Resolve(AccountId, "ffffffff", selectedInstanceId: null)
+                .Instance.ShouldBeNull();
+        }
+    }
+}

--- a/McpPlugin.Server/src/Api/DirectToolCallEndpoints.cs
+++ b/McpPlugin.Server/src/Api/DirectToolCallEndpoints.cs
@@ -40,7 +40,10 @@ namespace com.IvanMurzak.McpPlugin.Server.Api
         /// <summary>
         /// Maps the direct tool call API endpoints onto the given <see cref="WebApplication"/>.
         /// Authorization is required when <paramref name="dataArguments"/> has <see cref="IDataArguments.Authorization"/>
-        /// set to <see cref="Consts.MCP.Server.AuthOption.required"/>.
+        /// set to <see cref="Consts.MCP.Server.AuthOption.oauth"/> — the REST tool surface must present a valid
+        /// token in oauth mode (fail closed); it is open only in <see cref="Consts.MCP.Server.AuthOption.none"/> mode.
+        /// (Before mcp-authorize b7 this gated on the now-unreachable <c>AuthOption.required</c> — deleted with the
+        /// legacy shared-token pairing mode in b5 — so the endpoints were NEVER gated in oauth mode. Fixed here.)
         /// </summary>
         public static WebApplication MapDirectToolCallApi(this WebApplication app, IDataArguments dataArguments)
         {
@@ -50,7 +53,7 @@ namespace com.IvanMurzak.McpPlugin.Server.Api
             if (dataArguments == null)
                 throw new ArgumentNullException(nameof(dataArguments));
 
-            var requireAuth = dataArguments.Authorization == Consts.MCP.Server.AuthOption.required;
+            var requireAuth = dataArguments.Authorization == Consts.MCP.Server.AuthOption.oauth;
             var group = app.MapGroup(RoutePrefix);
 
             // GET /api/tools — list all registered tools

--- a/McpPlugin.Server/src/Api/SystemToolEndpoints.cs
+++ b/McpPlugin.Server/src/Api/SystemToolEndpoints.cs
@@ -40,7 +40,11 @@ namespace com.IvanMurzak.McpPlugin.Server.Api
 
         /// <summary>
         /// Maps the system tool API endpoints onto the given <see cref="WebApplication"/>.
-        /// Authorization follows the same rules as direct tool call endpoints.
+        /// Authorization follows the same rules as direct tool call endpoints: required in
+        /// <see cref="Consts.MCP.Server.AuthOption.oauth"/> mode (fail closed — a valid token is required),
+        /// open only in <see cref="Consts.MCP.Server.AuthOption.none"/> mode. (Before mcp-authorize b7 this
+        /// gated on the now-unreachable <c>AuthOption.required</c>, so the endpoints were never gated in oauth
+        /// mode; fixed here.)
         /// </summary>
         public static WebApplication MapSystemToolApi(this WebApplication app, IDataArguments dataArguments)
         {
@@ -50,7 +54,7 @@ namespace com.IvanMurzak.McpPlugin.Server.Api
             if (dataArguments == null)
                 throw new ArgumentNullException(nameof(dataArguments));
 
-            var requireAuth = dataArguments.Authorization == Consts.MCP.Server.AuthOption.required;
+            var requireAuth = dataArguments.Authorization == Consts.MCP.Server.AuthOption.oauth;
             var group = app.MapGroup(RoutePrefix);
 
             // GET /api/system-tools — list all registered system tools

--- a/McpPlugin.Tests/Network/Connection/ConnectionInstanceMetadataTests.cs
+++ b/McpPlugin.Tests/Network/Connection/ConnectionInstanceMetadataTests.cs
@@ -1,0 +1,110 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+using System;
+using com.IvanMurzak.McpPlugin.AgentConfig;
+using com.IvanMurzak.McpPlugin.Common;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.Tests.Network.Connection
+{
+    /// <summary>
+    /// Coverage for the mcp-authorize b7 instance-metadata handshake payload the plugin sends on its hub
+    /// connection (design 04/06): correct query-key mapping, URL append semantics, and pin/hash consistency.
+    /// </summary>
+    public sealed class ConnectionInstanceMetadataTests
+    {
+        const string ProjectRoot = "/home/dev/MyGame";
+
+        [Fact]
+        public void Create_DerivesProjectPathHash_WithPinAsPrefix()
+        {
+            var metadata = ConnectionInstanceMetadata.Create("unity", "MyGame", ProjectRoot);
+
+            metadata.ProjectPathHash.ShouldBe(ProjectIdentity.DeriveProjectPathHash(ProjectRoot));
+            metadata.ProjectPathHash.Length.ShouldBe(64);
+            // The routing pin is the first 8 hex chars of the same hash — so the server pin-matches by prefix.
+            metadata.ProjectPathHash.ShouldStartWith(ProjectIdentity.DerivePin(ProjectRoot));
+            metadata.InstanceId.ShouldNotBeNullOrEmpty();
+            metadata.Engine.ShouldBe("unity");
+            metadata.ProjectName.ShouldBe("MyGame");
+        }
+
+        [Fact]
+        public void Create_DefaultsInstanceIdAndMachineName()
+        {
+            var metadata = ConnectionInstanceMetadata.Create("godot", "Proj", ProjectRoot);
+
+            Guid.TryParse(metadata.InstanceId, out _).ShouldBeTrue("a default InstanceId should be a GUID");
+            metadata.MachineName.ShouldBe(Environment.MachineName);
+        }
+
+        [Fact]
+        public void Create_HonoursExplicitInstanceIdAndMachineName()
+        {
+            var metadata = ConnectionInstanceMetadata.Create("unreal", "P", ProjectRoot, instanceId: "sess-1", machineName: "BUILDBOX");
+
+            metadata.InstanceId.ShouldBe("sess-1");
+            metadata.MachineName.ShouldBe("BUILDBOX");
+        }
+
+        [Fact]
+        public void ToQuery_UsesTheHubQueryKeys()
+        {
+            var metadata = new ConnectionInstanceMetadata("sess-1", "unity", "MyGame", "abcd1234ef", "DESKTOP-1");
+
+            var query = metadata.ToQuery();
+
+            query[Consts.MCP.Server.HubQuery.InstanceId].ShouldBe("sess-1");
+            query[Consts.MCP.Server.HubQuery.Engine].ShouldBe("unity");
+            query[Consts.MCP.Server.HubQuery.ProjectName].ShouldBe("MyGame");
+            query[Consts.MCP.Server.HubQuery.ProjectPathHash].ShouldBe("abcd1234ef");
+            query[Consts.MCP.Server.HubQuery.MachineName].ShouldBe("DESKTOP-1");
+        }
+
+        [Fact]
+        public void ToQuery_OmitsEmptyFields_ButAlwaysKeepsInstanceId()
+        {
+            var metadata = new ConnectionInstanceMetadata("sess-1", engine: "", projectName: "", projectPathHash: "", machineName: "");
+
+            var query = metadata.ToQuery();
+
+            query.Count.ShouldBe(1);
+            query[Consts.MCP.Server.HubQuery.InstanceId].ShouldBe("sess-1");
+            query.ContainsKey(Consts.MCP.Server.HubQuery.Engine).ShouldBeFalse();
+        }
+
+        [Fact]
+        public void AppendToUrl_AddsQueryString_AndEncodes()
+        {
+            var metadata = new ConnectionInstanceMetadata("sess 1", "unity", "My Game", "abcd", "DESK");
+
+            var url = metadata.AppendToUrl("http://localhost:8080/hub/mcp-server");
+
+            url.ShouldStartWith("http://localhost:8080/hub/mcp-server?");
+            url.ShouldContain($"{Consts.MCP.Server.HubQuery.InstanceId}=sess%201");   // space URL-encoded
+            url.ShouldContain($"{Consts.MCP.Server.HubQuery.ProjectName}=My%20Game");
+            // The token must never appear in the query — this payload carries only non-secret identity.
+            url.ShouldNotContain("Bearer");
+            url.ShouldNotContain("access_token");
+        }
+
+        [Fact]
+        public void AppendToUrl_PreservesExistingQuery_WithAmpersand()
+        {
+            var metadata = new ConnectionInstanceMetadata("sess-1", "unity", "", "", "");
+
+            var url = metadata.AppendToUrl("http://localhost:8080/hub?existing=1");
+
+            url.ShouldStartWith("http://localhost:8080/hub?existing=1&");
+            url.ShouldContain($"{Consts.MCP.Server.HubQuery.InstanceId}=sess-1");
+        }
+    }
+}

--- a/McpPlugin.Tests/Network/Connection/Credentials/ConnectionCredentialCoordinatorTests.cs
+++ b/McpPlugin.Tests/Network/Connection/Credentials/ConnectionCredentialCoordinatorTests.cs
@@ -1,0 +1,185 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.AgentConfig;
+using Microsoft.AspNetCore.SignalR.Client;
+using Moq;
+using R3;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.Tests.Network.Connection.Credentials
+{
+    /// <summary>
+    /// Coverage for the mcp-authorize b7 refresh-on-reject loop: the connection layer's 3-strike
+    /// authorization-rejection signal drives a token refresh and, on success, a reconnect; on refresh
+    /// failure the coordinator stops and the provider surfaces sign-in-again.
+    /// </summary>
+    public sealed class ConnectionCredentialCoordinatorTests : IDisposable
+    {
+        const string SeededAccessToken = "eyJ.SEEDED.aaa";
+        const string SeededRefreshToken = "RT-SEEDED-bbb";
+        const string RefreshedAccessToken = "eyJ.REFRESHED.ccc";
+
+        readonly string _baseDir;
+
+        public ConnectionCredentialCoordinatorTests()
+        {
+            _baseDir = Path.Combine(Path.GetTempPath(), "agd-coord-" + Guid.NewGuid().ToString("N"), ".ai-game-dev");
+        }
+
+        public void Dispose()
+        {
+            var parent = Path.GetDirectoryName(_baseDir);
+            if (parent != null && Directory.Exists(parent))
+                Directory.Delete(parent, recursive: true);
+        }
+
+        MachineCredentialStore NewStore() => new MachineCredentialStore(_baseDir);
+
+        PluginCredentialProvider SeededProvider(ITokenRefresher refresher)
+        {
+            NewStore().Write(new MachineCredentials
+            {
+                AccessToken = SeededAccessToken,
+                RefreshToken = SeededRefreshToken,
+                ExpiresAt = DateTimeOffset.UtcNow.AddHours(1),
+                ServerTarget = "https://ai-game.dev",
+            });
+            return new PluginCredentialProvider(NewStore(), refresher);
+        }
+
+        static Mock<ITokenRefresher> RefresherReturning(TokenRefreshResult result)
+        {
+            var refresher = new Mock<ITokenRefresher>();
+            refresher
+                .Setup(r => r.RefreshAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(result);
+            return refresher;
+        }
+
+        // ── DoD: 3-strike signal → refresh → reconnect. ──
+
+        [Fact]
+        public async Task HandleRejection_RefreshSucceeds_Reconnects()
+        {
+            var refresher = RefresherReturning(TokenRefreshResult.Success(RefreshedAccessToken, expiresAt: DateTimeOffset.UtcNow.AddHours(1)));
+            using var provider = SeededProvider(refresher.Object);
+            using var connection = new FakeConnection();
+            using var coordinator = new ConnectionCredentialCoordinator(connection, provider);
+
+            var handled = await coordinator.HandleRejectionAsync();
+
+            handled.ShouldBeTrue();
+            connection.ConnectCount.ShouldBe(1);
+            provider.State.CurrentValue.ShouldBe(AuthState.SignedIn);
+            (await provider.GetAccessTokenAsync()).ShouldBe(RefreshedAccessToken);
+        }
+
+        [Fact]
+        public async Task HandleRejection_RefreshFails_DoesNotReconnect_SurfacesSignInRequired()
+        {
+            var refresher = RefresherReturning(TokenRefreshResult.Failure("refresh token expired"));
+            using var provider = SeededProvider(refresher.Object);
+            using var connection = new FakeConnection();
+            using var coordinator = new ConnectionCredentialCoordinator(connection, provider);
+
+            var handled = await coordinator.HandleRejectionAsync();
+
+            handled.ShouldBeFalse();
+            connection.ConnectCount.ShouldBe(0);
+            provider.State.CurrentValue.ShouldBe(AuthState.SignInRequired);
+        }
+
+        // ── The subscription is actually wired: firing OnAuthorizationRejected drives the refresh+reconnect. ──
+
+        [Fact]
+        public async Task OnAuthorizationRejected_Signal_TriggersRefreshAndReconnect()
+        {
+            var refresher = RefresherReturning(TokenRefreshResult.Success(RefreshedAccessToken, expiresAt: DateTimeOffset.UtcNow.AddHours(1)));
+            using var provider = SeededProvider(refresher.Object);
+            using var connection = new FakeConnection();
+            using var coordinator = new ConnectionCredentialCoordinator(connection, provider);
+
+            // Simulate the ConnectionManager firing its aggregated 3-strike rejection signal.
+            connection.FireAuthorizationRejected();
+
+            // The handler runs fire-and-forget; await the Connect it drives (bounded).
+            var reconnected = await connection.WaitForNextConnectAsync(TimeSpan.FromSeconds(5));
+            reconnected.ShouldBeTrue("the rejection signal should drive a reconnect");
+            provider.State.CurrentValue.ShouldBe(AuthState.SignedIn);
+        }
+
+        /// <summary>
+        /// A minimal <see cref="IConnection"/> test double: exposes a rejection signal to fire, records
+        /// reconnect attempts, and signals each <see cref="Connect"/> via a task so tests can await the
+        /// fire-and-forget handler deterministically.
+        /// </summary>
+        sealed class FakeConnection : IConnection
+        {
+            readonly ReactiveProperty<bool> _keepConnected = new ReactiveProperty<bool>(true);
+            readonly ReactiveProperty<HubConnectionState> _state = new ReactiveProperty<HubConnectionState>(HubConnectionState.Disconnected);
+            readonly ReadOnlyReactiveProperty<bool> _keepConnectedRo;
+            readonly ReadOnlyReactiveProperty<HubConnectionState> _stateRo;
+            readonly Subject<Unit> _authRejected = new Subject<Unit>();
+            readonly object _sync = new object();
+            // Single-shot: completes on the FIRST Connect and stays completed, so a waiter registered
+            // before OR after the fire-and-forget handler runs observes it (no TCS-replacement race).
+            readonly TaskCompletionSource<bool> _firstConnectSignal = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            public FakeConnection()
+            {
+                _keepConnectedRo = _keepConnected.ToReadOnlyReactiveProperty();
+                _stateRo = _state.ToReadOnlyReactiveProperty();
+            }
+
+            public int ConnectCount { get; private set; }
+
+            public ReadOnlyReactiveProperty<bool> KeepConnected => _keepConnectedRo;
+            public ReadOnlyReactiveProperty<HubConnectionState> ConnectionState => _stateRo;
+            public Observable<Unit> OnAuthorizationRejected => _authRejected;
+
+            public void FireAuthorizationRejected() => _authRejected.OnNext(Unit.Default);
+
+            public async Task<bool> WaitForNextConnectAsync(TimeSpan timeout)
+            {
+                var completed = await Task.WhenAny(_firstConnectSignal.Task, Task.Delay(timeout)).ConfigureAwait(false);
+                return completed == _firstConnectSignal.Task;
+            }
+
+            public Task<bool> Connect(CancellationToken cancellationToken = default)
+            {
+                lock (_sync)
+                {
+                    ConnectCount++;
+                    _state.Value = HubConnectionState.Connected;
+                    _firstConnectSignal.TrySetResult(true);
+                }
+                return Task.FromResult(true);
+            }
+
+            public Task Disconnect(CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public void DisconnectImmediate() { }
+            public bool WaitForImmediateTeardown(TimeSpan timeout) => true;
+
+            public void Dispose()
+            {
+                _authRejected.Dispose();
+                _keepConnectedRo.Dispose();
+                _stateRo.Dispose();
+                _keepConnected.Dispose();
+                _state.Dispose();
+            }
+        }
+    }
+}

--- a/McpPlugin.Tests/Network/Connection/Credentials/PluginCredentialProviderTests.cs
+++ b/McpPlugin.Tests/Network/Connection/Credentials/PluginCredentialProviderTests.cs
@@ -1,0 +1,248 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.AgentConfig;
+using Moq;
+using R3;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.Tests.Network.Connection.Credentials
+{
+    /// <summary>
+    /// Coverage for the mcp-authorize b7 account credential provider: machine-store auto-adopt (the
+    /// zero-button rule), proactive refresh before expiry, reactive refresh, and the sign-in-again state
+    /// surfaced on refresh failure.
+    /// </summary>
+    public sealed class PluginCredentialProviderTests : IDisposable
+    {
+        const string SeededAccessToken = "eyJ.SEEDED-ACCESS.aaa";
+        const string SeededRefreshToken = "RT-SEEDED-bbb";
+        const string RefreshedAccessToken = "eyJ.REFRESHED-ACCESS.ccc";
+        const string RefreshedRefreshToken = "RT-REFRESHED-ddd";
+
+        readonly string _baseDir;
+
+        public PluginCredentialProviderTests()
+        {
+            _baseDir = Path.Combine(Path.GetTempPath(), "agd-credprov-" + Guid.NewGuid().ToString("N"), ".ai-game-dev");
+        }
+
+        public void Dispose()
+        {
+            var parent = Path.GetDirectoryName(_baseDir);
+            if (parent != null && Directory.Exists(parent))
+                Directory.Delete(parent, recursive: true);
+        }
+
+        MachineCredentialStore NewStore() => new MachineCredentialStore(_baseDir);
+
+        static MachineCredentials Seed(DateTimeOffset? expiresAt = null) => new MachineCredentials
+        {
+            AccessToken = SeededAccessToken,
+            RefreshToken = SeededRefreshToken,
+            ExpiresAt = expiresAt,
+            ServerTarget = "https://ai-game.dev",
+            Subject = "account-uuid-123",
+        };
+
+        // ── DoD: store auto-adopt — boot with a seeded store connects signed-in with ZERO calls to UI code. ──
+
+        [Fact]
+        public async Task AutoAdopt_SeededStore_IsSignedInWithoutRefresherInteraction()
+        {
+            NewStore().Write(Seed(expiresAt: DateTimeOffset.UtcNow.AddHours(1)));
+            var refresher = new Mock<ITokenRefresher>(MockBehavior.Strict);
+
+            using var provider = new PluginCredentialProvider(NewStore(), refresher.Object);
+
+            // Signed in purely from the store read — no device flow, no network, no refresh.
+            provider.State.CurrentValue.ShouldBe(AuthState.SignedIn);
+            provider.IsSignedIn.ShouldBeTrue();
+            provider.ServerTarget.ShouldBe("https://ai-game.dev");
+            provider.Subject.ShouldBe("account-uuid-123");
+
+            var token = await provider.GetAccessTokenAsync();
+            token.ShouldBe(SeededAccessToken);
+
+            // The zero-button rule: nothing but the store was touched (a strict mock proves the refresher
+            // was never invoked during boot + token fetch of a still-valid credential).
+            refresher.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public void AutoAdopt_EmptyStore_IsSignedOut()
+        {
+            using var provider = new PluginCredentialProvider(NewStore());
+
+            provider.State.CurrentValue.ShouldBe(AuthState.SignedOut);
+            provider.IsSignedIn.ShouldBeFalse();
+        }
+
+        [Fact]
+        public async Task GetAccessToken_EmptyStore_ReturnsNull()
+        {
+            using var provider = new PluginCredentialProvider(NewStore());
+            (await provider.GetAccessTokenAsync()).ShouldBeNull();
+        }
+
+        // ── DoD: expiry soak — a token within the skew window is proactively refreshed before use. ──
+
+        [Fact]
+        public async Task GetAccessToken_TokenNearExpiry_ProactivelyRefreshes()
+        {
+            NewStore().Write(Seed(expiresAt: DateTimeOffset.UtcNow.AddSeconds(10))); // within the 60s skew
+            var refresher = new Mock<ITokenRefresher>();
+            refresher
+                .Setup(r => r.RefreshAsync(SeededRefreshToken, "https://ai-game.dev", It.IsAny<CancellationToken>()))
+                .ReturnsAsync(TokenRefreshResult.Success(RefreshedAccessToken, RefreshedRefreshToken, DateTimeOffset.UtcNow.AddHours(1)));
+
+            using var provider = new PluginCredentialProvider(NewStore(), refresher.Object);
+
+            var token = await provider.GetAccessTokenAsync();
+
+            token.ShouldBe(RefreshedAccessToken);
+            refresher.Verify(r => r.RefreshAsync(SeededRefreshToken, "https://ai-game.dev", It.IsAny<CancellationToken>()), Times.Once);
+
+            // The rotated token was persisted (a fresh store instance re-reads it) with identity preserved.
+            var reread = NewStore().Read();
+            reread!.AccessToken.ShouldBe(RefreshedAccessToken);
+            reread.RefreshToken.ShouldBe(RefreshedRefreshToken);
+            reread.Subject.ShouldBe("account-uuid-123");
+        }
+
+        [Fact]
+        public async Task GetAccessToken_TokenFarFromExpiry_DoesNotRefresh()
+        {
+            NewStore().Write(Seed(expiresAt: DateTimeOffset.UtcNow.AddHours(2)));
+            var refresher = new Mock<ITokenRefresher>();
+
+            using var provider = new PluginCredentialProvider(NewStore(), refresher.Object);
+
+            (await provider.GetAccessTokenAsync()).ShouldBe(SeededAccessToken);
+            refresher.Verify(r => r.RefreshAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        // ── DoD: refresh-on-reject — RefreshAsync mints + persists a new token. ──
+
+        [Fact]
+        public async Task RefreshAsync_Success_RotatesTokenAndStaysSignedIn()
+        {
+            NewStore().Write(Seed(expiresAt: DateTimeOffset.UtcNow.AddHours(1)));
+            var refresher = new Mock<ITokenRefresher>();
+            refresher
+                .Setup(r => r.RefreshAsync(SeededRefreshToken, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(TokenRefreshResult.Success(RefreshedAccessToken, RefreshedRefreshToken, DateTimeOffset.UtcNow.AddHours(1)));
+
+            using var provider = new PluginCredentialProvider(NewStore(), refresher.Object);
+
+            (await provider.RefreshAsync()).ShouldBeTrue();
+            provider.State.CurrentValue.ShouldBe(AuthState.SignedIn);
+            (await provider.GetAccessTokenAsync()).ShouldBe(RefreshedAccessToken);
+        }
+
+        [Fact]
+        public async Task RefreshAsync_Success_WithoutRotatedRefreshToken_KeepsExistingRefreshToken()
+        {
+            NewStore().Write(Seed(expiresAt: DateTimeOffset.UtcNow.AddHours(1)));
+            var refresher = new Mock<ITokenRefresher>();
+            refresher
+                .Setup(r => r.RefreshAsync(SeededRefreshToken, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(TokenRefreshResult.Success(RefreshedAccessToken)); // AS did not rotate the refresh token
+
+            using var provider = new PluginCredentialProvider(NewStore(), refresher.Object);
+
+            (await provider.RefreshAsync()).ShouldBeTrue();
+            NewStore().Read()!.RefreshToken.ShouldBe(SeededRefreshToken);
+        }
+
+        // ── DoD: refresh failure surfaces "sign in again". ──
+
+        [Fact]
+        public async Task RefreshAsync_Failure_SurfacesSignInRequired()
+        {
+            NewStore().Write(Seed(expiresAt: DateTimeOffset.UtcNow.AddHours(1)));
+            var refresher = new Mock<ITokenRefresher>();
+            refresher
+                .Setup(r => r.RefreshAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(TokenRefreshResult.Failure("refresh token expired"));
+
+            using var provider = new PluginCredentialProvider(NewStore(), refresher.Object);
+
+            var signInRequiredFired = false;
+            using var _ = provider.OnSignInRequired.Subscribe(__ => { signInRequiredFired = true; });
+
+            (await provider.RefreshAsync()).ShouldBeFalse();
+            provider.State.CurrentValue.ShouldBe(AuthState.SignInRequired);
+            signInRequiredFired.ShouldBeTrue();
+        }
+
+        [Fact]
+        public async Task RefreshAsync_ThrowingRefresher_SurfacesSignInRequired_WithoutLeaking()
+        {
+            NewStore().Write(Seed(expiresAt: DateTimeOffset.UtcNow.AddHours(1)));
+            var refresher = new Mock<ITokenRefresher>();
+            refresher
+                .Setup(r => r.RefreshAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new InvalidOperationException("network down"));
+
+            using var provider = new PluginCredentialProvider(NewStore(), refresher.Object);
+
+            (await provider.RefreshAsync()).ShouldBeFalse();
+            provider.State.CurrentValue.ShouldBe(AuthState.SignInRequired);
+        }
+
+        [Fact]
+        public async Task RefreshAsync_NoRefresher_SurfacesSignInRequired()
+        {
+            NewStore().Write(Seed(expiresAt: DateTimeOffset.UtcNow.AddHours(1)));
+            using var provider = new PluginCredentialProvider(NewStore(), refresher: null);
+
+            (await provider.RefreshAsync()).ShouldBeFalse();
+            provider.State.CurrentValue.ShouldBe(AuthState.SignInRequired);
+        }
+
+        // ── Sign-out clears the store and resets state. ──
+
+        [Fact]
+        public void SignOut_DeletesStoreAndResetsState()
+        {
+            NewStore().Write(Seed(expiresAt: DateTimeOffset.UtcNow.AddHours(1)));
+            using var provider = new PluginCredentialProvider(NewStore());
+
+            provider.SignOut();
+
+            provider.State.CurrentValue.ShouldBe(AuthState.SignedOut);
+            provider.IsSignedIn.ShouldBeFalse();
+            NewStore().Exists.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void Adopt_SignsInAndPersists()
+        {
+            using var provider = new PluginCredentialProvider(NewStore());
+            provider.State.CurrentValue.ShouldBe(AuthState.SignedOut);
+
+            provider.Adopt(new MachineCredentials
+            {
+                AccessToken = RefreshedAccessToken,
+                RefreshToken = RefreshedRefreshToken,
+                ExpiresAt = DateTimeOffset.UtcNow.AddHours(1),
+                ServerTarget = "https://ai-game.dev",
+            });
+
+            provider.State.CurrentValue.ShouldBe(AuthState.SignedIn);
+            NewStore().Read()!.AccessToken.ShouldBe(RefreshedAccessToken);
+        }
+    }
+}

--- a/McpPlugin.Tests/Network/Connection/LegacySharedTokenRemovalTests.cs
+++ b/McpPlugin.Tests/Network/Connection/LegacySharedTokenRemovalTests.cs
@@ -1,0 +1,76 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.Common;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.Tests.Network.Connection
+{
+    /// <summary>
+    /// Regression guard for mcp-authorize b7 folded fix 1: the legacy client-side shared-token surface
+    /// (<c>MCP_PLUGIN_TOKEN</c> / <c>mcp-plugin-token</c> / <c>ConnectionConfig.Token</c>) was removed —
+    /// nothing reads the old shared token, and the credential-provider replacement is in place.
+    /// </summary>
+    public sealed class LegacySharedTokenRemovalTests
+    {
+        [Fact]
+        public void ConnectionConfig_HasNoLegacyTokenSurface()
+        {
+            var type = typeof(ConnectionConfig);
+            type.GetProperty("Token").ShouldBeNull("ConnectionConfig.Token (the static shared token) must be removed");
+            type.GetMethod("GetTokenFromArgsOrEnv", BindingFlags.Public | BindingFlags.Static)
+                .ShouldBeNull("ConnectionConfig.GetTokenFromArgsOrEnv must be removed");
+        }
+
+        [Fact]
+        public void ConnectionConfig_HasCredentialProviderReplacement()
+        {
+            var type = typeof(ConnectionConfig);
+            var credentialProvider = type.GetProperty("CredentialProvider");
+            credentialProvider.ShouldNotBeNull("the credential-provider callback replaces the static token");
+            credentialProvider!.PropertyType.ShouldBe(typeof(Func<Task<string?>>));
+
+            type.GetProperty("InstanceMetadata").ShouldNotBeNull("the b7 instance-metadata handshake surface must exist");
+        }
+
+        [Fact]
+        public void PluginTokenConsts_AreRemoved()
+        {
+            // The plugin-side shared-token arg/env constants are gone (nothing can parse them anymore).
+            typeof(Consts.MCP.Plugin.Args).GetField("McpPluginToken", BindingFlags.Public | BindingFlags.Static)
+                .ShouldBeNull("Consts.MCP.Plugin.Args.McpPluginToken must be removed");
+            typeof(Consts.MCP.Plugin.Env).GetField("McpPluginToken", BindingFlags.Public | BindingFlags.Static)
+                .ShouldBeNull("Consts.MCP.Plugin.Env.McpPluginToken must be removed");
+        }
+
+        [Fact]
+        public void BuildFromArgsOrEnv_DoesNotResurrectAToken_FromMcpPluginTokenEnv()
+        {
+            var previous = Environment.GetEnvironmentVariable("MCP_PLUGIN_TOKEN");
+            try
+            {
+                Environment.SetEnvironmentVariable("MCP_PLUGIN_TOKEN", "leaked-shared-token");
+
+                var config = ConnectionConfig.BuildFromArgsOrEnv(Array.Empty<string>());
+
+                // No credential is read from the legacy env var — the plugin now presents an
+                // auto-refreshed account JWT via CredentialProvider, which is wired by the host, not here.
+                config.CredentialProvider.ShouldBeNull();
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("MCP_PLUGIN_TOKEN", previous);
+            }
+        }
+    }
+}

--- a/McpPlugin/src/AgentConfig/ProjectIdentity.cs
+++ b/McpPlugin/src/AgentConfig/ProjectIdentity.cs
@@ -123,6 +123,20 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
         }
 
         /// <summary>
+        /// The FULL project-path hash: the complete 64-char lowercase hex of the SHA-256 of the
+        /// normalized project root. This is the <c>projectPathHash</c> an engine plugin sends in its
+        /// hub instance-metadata handshake (mcp-authorize b7); the server pin-matches a session by
+        /// checking that the routing <see cref="Pin"/> is a case-insensitive prefix of this value
+        /// (<c>PluginInstance.MatchesPin</c>), so the two are derived from the same hash by construction.
+        /// </summary>
+        public static string DeriveProjectPathHash(string projectRoot)
+        {
+            if (projectRoot == null)
+                throw new ArgumentNullException(nameof(projectRoot));
+            return ToHex(HashOf(projectRoot), 32);
+        }
+
+        /// <summary>
         /// The pure hash-derived port (ignores any override). This is the byte-for-byte equivalent of
         /// the shipped Unity <c>GeneratePortFromDirectory</c> when given the same directory string.
         /// </summary>

--- a/McpPlugin/src/McpPlugin/Builder/McpPluginBuilder.cs
+++ b/McpPlugin/src/McpPlugin/Builder/McpPluginBuilder.cs
@@ -302,7 +302,9 @@ namespace com.IvanMurzak.McpPlugin
         public virtual IMcpPluginBuilder WithConfigFromArgsOrEnv(string[]? args = null) => WithConfig(config =>
         {
             config.Host = ConnectionConfig.GetEndpointFromArgsOrEnv(args);
-            config.Token = ConnectionConfig.GetTokenFromArgsOrEnv(args);
+            // The legacy MCP_PLUGIN_TOKEN / mcp-plugin-token shared-token plumbing was removed in
+            // mcp-authorize b7. The plugin no longer reads a static token from args/env; the host wires
+            // config.CredentialProvider (auto-refreshed account JWT from the machine store) instead.
             config.TimeoutMs = ConnectionConfig.GetTimeoutFromArgsOrEnv(args);
         });
 

--- a/McpPlugin/src/McpPlugin/Network/Connection/ConnectionConfig.cs
+++ b/McpPlugin/src/McpPlugin/Network/Connection/ConnectionConfig.cs
@@ -10,6 +10,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
+using System.Threading.Tasks;
 using com.IvanMurzak.McpPlugin.Common;
 using com.IvanMurzak.McpPlugin.Common.Utils;
 
@@ -45,10 +46,29 @@ namespace com.IvanMurzak.McpPlugin
         public virtual int ConnectTimeoutSeconds { get; set; } = 0;
 
         /// <summary>
-        /// Token for authorization when connecting to the MCP server via SignalR.
-        /// Set via command line arg 'mcp-plugin-token' or environment variable 'MCP_PLUGIN_TOKEN'.
+        /// Credential provider callback (mcp-authorize b7): returns the current, auto-refreshed account
+        /// access token (an ES256 JWT) to present on the SignalR connection, or <c>null</c> for an
+        /// anonymous connection (a <c>none</c>-mode / offline local server). This replaces the removed
+        /// static <c>Token</c> string and the <c>MCP_PLUGIN_TOKEN</c> shared-token plumbing: the token is
+        /// no longer a fixed value read from an env/arg, it is fetched fresh on every (re)connect so a
+        /// proactively-refreshed JWT is always presented. The token always travels in the
+        /// <c>Authorization</c> header (never a query param) — see <see cref="HubConnectionProvider"/>.
+        /// Hosts wire this to <c>PluginCredentialProvider.AsAccessTokenProvider()</c> (machine-store
+        /// auto-adopt + refresh); leaving it null keeps the anonymous local-server behaviour.
         /// </summary>
-        public virtual string? Token { get; set; }
+        public virtual Func<Task<string?>>? CredentialProvider { get; set; }
+
+        /// <summary>
+        /// Instance-metadata handshake payload (mcp-authorize b7, design 04/06): identifies THIS editor
+        /// session to the server's account+instance pairing plane (b3). When set, the fields are sent as
+        /// non-secret query parameters on the hub connection (keyed by
+        /// <see cref="Consts.MCP.Server.HubQuery"/>); the server reads them in <c>oauth</c> mode to
+        /// register the instance under the account resolved from the (header-carried) token. Null keeps
+        /// the pre-b7 behaviour (the server falls back to a synthetic single-instance registration).
+        /// Runtime-only; never serialized to the on-disk connection config.
+        /// </summary>
+        [JsonIgnore]
+        public virtual ConnectionInstanceMetadata? InstanceMetadata { get; set; }
 
         /// <summary>
         /// Whether to automatically generate skill markdown files for each registered MCP tool.
@@ -121,18 +141,6 @@ namespace com.IvanMurzak.McpPlugin
             return endpoint ?? Consts.Hub.DefaultHost;
         }
 
-        public static string? GetTokenFromArgsOrEnv(string[]? args = null)
-        {
-            args ??= Environment.GetCommandLineArgs();
-            var token = Environment.GetEnvironmentVariable(Consts.MCP.Plugin.Env.McpPluginToken);
-            var commandLineArgs = ArgsUtils.ParseLineArguments(args);
-
-            if (commandLineArgs.TryGetValue(Consts.MCP.Plugin.Args.McpPluginToken.TrimStart('-'), out var argToken))
-                return argToken;
-
-            return token;
-        }
-
         public static int GetTimeoutFromArgsOrEnv(string[]? args = null)
         {
             args ??= Environment.GetCommandLineArgs();
@@ -165,10 +173,6 @@ namespace com.IvanMurzak.McpPlugin
             if (timeout != null && int.TryParse(timeout, out var parsedEnvTimeoutMs))
                 TimeoutMs = parsedEnvTimeoutMs;
 
-            var token = Environment.GetEnvironmentVariable(Consts.MCP.Plugin.Env.McpPluginToken);
-            if (token != null)
-                Token = token;
-
             var skillsFolder = Environment.GetEnvironmentVariable(Consts.MCP.Plugin.Env.McpSkillsFolder);
             if (skillsFolder != null)
                 SkillsPath = skillsFolder;
@@ -188,10 +192,6 @@ namespace com.IvanMurzak.McpPlugin
             var argPluginTimeout = commandLineArgs.GetValueOrDefault(Consts.MCP.Plugin.Args.McpServerTimeout.TrimStart('-'));
             if (argPluginTimeout != null && int.TryParse(argPluginTimeout, out var timeoutMs))
                 TimeoutMs = timeoutMs;
-
-            var argToken = commandLineArgs.GetValueOrDefault(Consts.MCP.Plugin.Args.McpPluginToken.TrimStart('-'));
-            if (argToken != null)
-                Token = argToken;
 
             var argSkillsFolder = commandLineArgs.GetValueOrDefault(Consts.MCP.Plugin.Args.McpSkillsFolder.TrimStart('-'));
             if (argSkillsFolder != null)

--- a/McpPlugin/src/McpPlugin/Network/Connection/ConnectionInstanceMetadata.cs
+++ b/McpPlugin/src/McpPlugin/Network/Connection/ConnectionInstanceMetadata.cs
@@ -1,0 +1,150 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Text;
+using com.IvanMurzak.McpPlugin.AgentConfig;
+using com.IvanMurzak.McpPlugin.Common;
+
+namespace com.IvanMurzak.McpPlugin
+{
+    /// <summary>
+    /// The engine-side instance-metadata handshake payload (mcp-authorize b7, design docs 04/06). It
+    /// identifies THIS editor session to the server's account+instance pairing plane (b3):
+    /// <c>{instanceId, engine, projectName, projectPathHash, machineName}</c>. The fields are
+    /// <b>non-secret</b> and travel as query parameters on the SignalR hub connection (keyed by
+    /// <see cref="Consts.MCP.Server.HubQuery"/>); the credential (JWT) itself always travels separately in
+    /// the <c>Authorization</c> header. The server (<c>McpServerHub</c>) reads these query keys in
+    /// <c>oauth</c> mode and registers the instance under the account resolved from the validated token.
+    /// </summary>
+    public sealed class ConnectionInstanceMetadata
+    {
+        /// <summary>GUID minted per editor session (engine-side). Stable across reconnects of the same editor.</summary>
+        public string InstanceId { get; }
+
+        /// <summary>The engine identifier: <c>"unity"</c> | <c>"godot"</c> | <c>"unreal"</c>.</summary>
+        public string Engine { get; }
+
+        /// <summary>Human-facing project name, e.g. <c>"MyGame"</c>.</summary>
+        public string ProjectName { get; }
+
+        /// <summary>Full SHA-256 hex of the normalized project path (see <see cref="ProjectIdentity.DeriveProjectPathHash"/>). Stable across editor restarts; pin-matched by prefix.</summary>
+        public string ProjectPathHash { get; }
+
+        /// <summary>The host machine name.</summary>
+        public string MachineName { get; }
+
+        public ConnectionInstanceMetadata(
+            string instanceId,
+            string engine,
+            string projectName,
+            string projectPathHash,
+            string machineName)
+        {
+            if (string.IsNullOrEmpty(instanceId))
+                throw new ArgumentException("InstanceId must be non-empty.", nameof(instanceId));
+
+            InstanceId = instanceId;
+            Engine = engine ?? string.Empty;
+            ProjectName = projectName ?? string.Empty;
+            ProjectPathHash = projectPathHash ?? string.Empty;
+            MachineName = machineName ?? string.Empty;
+        }
+
+        /// <summary>
+        /// Builds metadata for a project. The <see cref="ProjectPathHash"/> is derived deterministically
+        /// from <paramref name="projectRootPath"/> (same hash whose first 8 hex chars are the routing pin);
+        /// <paramref name="instanceId"/> defaults to a fresh GUID (mint one per editor session and reuse it
+        /// across reconnects); <paramref name="machineName"/> defaults to <see cref="Environment.MachineName"/>.
+        /// </summary>
+        public static ConnectionInstanceMetadata Create(
+            string engine,
+            string projectName,
+            string projectRootPath,
+            string? instanceId = null,
+            string? machineName = null)
+        {
+            if (projectRootPath == null)
+                throw new ArgumentNullException(nameof(projectRootPath));
+
+            return new ConnectionInstanceMetadata(
+                instanceId: string.IsNullOrEmpty(instanceId) ? Guid.NewGuid().ToString() : instanceId!,
+                engine: engine ?? string.Empty,
+                projectName: projectName ?? string.Empty,
+                projectPathHash: ProjectIdentity.DeriveProjectPathHash(projectRootPath),
+                machineName: string.IsNullOrEmpty(machineName) ? SafeMachineName() : machineName!);
+        }
+
+        /// <summary>
+        /// The hub-handshake query parameters, keyed by <see cref="Consts.MCP.Server.HubQuery"/>. Empty
+        /// fields are omitted so a partial handshake never sends blank keys. <see cref="InstanceId"/> is
+        /// always present.
+        /// </summary>
+        public IReadOnlyDictionary<string, string> ToQuery()
+        {
+            var query = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                [Consts.MCP.Server.HubQuery.InstanceId] = InstanceId
+            };
+            AddIfPresent(query, Consts.MCP.Server.HubQuery.Engine, Engine);
+            AddIfPresent(query, Consts.MCP.Server.HubQuery.ProjectName, ProjectName);
+            AddIfPresent(query, Consts.MCP.Server.HubQuery.ProjectPathHash, ProjectPathHash);
+            AddIfPresent(query, Consts.MCP.Server.HubQuery.MachineName, MachineName);
+            return query;
+        }
+
+        /// <summary>
+        /// Appends <see cref="ToQuery"/> as URL query parameters onto <paramref name="url"/>, preserving
+        /// any existing query string and URL-encoding every value. The token is never included here — it
+        /// is presented in the <c>Authorization</c> header.
+        /// </summary>
+        public string AppendToUrl(string url)
+        {
+            if (url == null)
+                throw new ArgumentNullException(nameof(url));
+
+            var query = ToQuery();
+            if (query.Count == 0)
+                return url;
+
+            var builder = new StringBuilder(url);
+            var first = url.IndexOf('?') < 0;
+            foreach (var kvp in query)
+            {
+                builder.Append(first ? '?' : '&');
+                first = false;
+                builder.Append(Uri.EscapeDataString(kvp.Key));
+                builder.Append('=');
+                builder.Append(Uri.EscapeDataString(kvp.Value));
+            }
+            return builder.ToString();
+        }
+
+        static void AddIfPresent(IDictionary<string, string> query, string key, string value)
+        {
+            if (!string.IsNullOrEmpty(value))
+                query[key] = value;
+        }
+
+        static string SafeMachineName()
+        {
+            try
+            {
+                return Environment.MachineName ?? string.Empty;
+            }
+            catch (InvalidOperationException)
+            {
+                return string.Empty;
+            }
+        }
+    }
+}

--- a/McpPlugin/src/McpPlugin/Network/Connection/Credentials/AuthState.cs
+++ b/McpPlugin/src/McpPlugin/Network/Connection/Credentials/AuthState.cs
@@ -1,0 +1,31 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+namespace com.IvanMurzak.McpPlugin
+{
+    /// <summary>
+    /// The plugin's account sign-in state, surfaced by <see cref="PluginCredentialProvider"/> so engine UI
+    /// can render a sign-in chip without knowing anything about tokens (mcp-authorize b7, design 06).
+    /// </summary>
+    public enum AuthState
+    {
+        /// <summary>No credential is present (never signed in, or explicitly signed out).</summary>
+        SignedOut,
+
+        /// <summary>A valid (or refreshable) credential is present — connect signed-in.</summary>
+        SignedIn,
+
+        /// <summary>
+        /// A credential was present but a refresh failed (expired/revoked refresh token). The connection
+        /// cannot recover automatically; the engine UI must prompt "Session expired — sign in again".
+        /// </summary>
+        SignInRequired
+    }
+}

--- a/McpPlugin/src/McpPlugin/Network/Connection/Credentials/ConnectionCredentialCoordinator.cs
+++ b/McpPlugin/src/McpPlugin/Network/Connection/Credentials/ConnectionCredentialCoordinator.cs
@@ -1,0 +1,113 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using R3;
+
+namespace com.IvanMurzak.McpPlugin
+{
+    /// <summary>
+    /// Wires the connection layer's authorization-rejection signal to the account credential provider
+    /// (mcp-authorize b7, design 03 Flow B / design 06): when the server rejects the connection repeatedly
+    /// (the <c>IConnection.OnAuthorizationRejected</c> 3-strike signal — an invalid or expired JWT), refresh
+    /// the token and reconnect. If the refresh fails, the <see cref="PluginCredentialProvider"/> has already
+    /// surfaced <see cref="AuthState.SignInRequired"/>, so this coordinator simply stops — the editor UI
+    /// prompts the user to sign in again.
+    /// <para>
+    /// This is a small composition seam the engine plugin creates after building the connection; it owns no
+    /// UI and no HTTP. It reconnects via <c>IConnection.Connect</c>, which re-invokes the credential-provider
+    /// callback and thus presents the freshly refreshed JWT.
+    /// </para>
+    /// </summary>
+    public sealed class ConnectionCredentialCoordinator : IDisposable
+    {
+        readonly IConnection _connection;
+        readonly PluginCredentialProvider _credentials;
+        readonly ILogger? _logger;
+        readonly CompositeDisposable _disposables = new CompositeDisposable();
+        readonly SemaphoreSlim _handleGate = new SemaphoreSlim(1, 1);
+        volatile bool _disposed;
+
+        public ConnectionCredentialCoordinator(IConnection connection, PluginCredentialProvider credentials, ILogger? logger = null)
+        {
+            _connection = connection ?? throw new ArgumentNullException(nameof(connection));
+            _credentials = credentials ?? throw new ArgumentNullException(nameof(credentials));
+            _logger = logger;
+
+            // The 3-strike auth-rejection signal is already aggregated by the ConnectionManager (it fires
+            // once per rejection burst). Fire-and-forget the async handler; HandleRejectionAsync collapses
+            // any overlap with a non-blocking gate.
+            _connection.OnAuthorizationRejected
+                .Subscribe(_ => OnAuthorizationRejected())
+                .AddTo(_disposables);
+        }
+
+        // Fire-and-forget bridge from the R3 subscription to the async handler (the discard here is a true
+        // discard, not the Unit lambda parameter). HandleRejectionAsync observes its own faults.
+        void OnAuthorizationRejected()
+            => _ = HandleRejectionAsync();
+
+        /// <summary>
+        /// Refresh the credential then reconnect. Returns true when the refresh succeeded and a reconnect
+        /// was attempted; false when the refresh failed (sign-in-required is surfaced by the provider) or a
+        /// handling pass is already in flight. Public so engines/tests can invoke it directly.
+        /// </summary>
+        public async Task<bool> HandleRejectionAsync(CancellationToken cancellationToken = default)
+        {
+            if (_disposed)
+                return false;
+
+            // Collapse overlapping rejection bursts — only one refresh+reconnect at a time.
+            if (!await _handleGate.WaitAsync(0, cancellationToken).ConfigureAwait(false))
+                return false;
+            try
+            {
+                _logger?.LogInformation("Authorization rejected — attempting token refresh + reconnect.");
+
+                var refreshed = await _credentials.RefreshAsync(cancellationToken).ConfigureAwait(false);
+                if (!refreshed)
+                {
+                    _logger?.LogWarning("Token refresh failed after authorization rejection; staying disconnected (sign-in required).");
+                    return false;
+                }
+
+                _logger?.LogInformation("Token refreshed — reconnecting with the new credential.");
+                await _connection.Connect(cancellationToken).ConfigureAwait(false);
+                return true;
+            }
+            catch (OperationCanceledException)
+            {
+                return false;
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogError(ex, "Error handling authorization rejection: {message}", ex.Message);
+                return false;
+            }
+            finally
+            {
+                _handleGate.Release();
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+            _disposed = true;
+            _disposables.Dispose();
+            _handleGate.Dispose();
+        }
+    }
+}

--- a/McpPlugin/src/McpPlugin/Network/Connection/Credentials/ITokenRefresher.cs
+++ b/McpPlugin/src/McpPlugin/Network/Connection/Credentials/ITokenRefresher.cs
@@ -1,0 +1,81 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace com.IvanMurzak.McpPlugin
+{
+    /// <summary>
+    /// The outcome of a token refresh (mcp-authorize b7). On success it carries the freshly minted access
+    /// token (and, if the AS rotated it, a new refresh token) plus the new absolute expiry; on failure it
+    /// carries only a <see cref="FailureReason"/>. Never carries partial success — a failed refresh leaves
+    /// the caller to surface the "sign in again" state and keep the old (rejected) credential untouched.
+    /// </summary>
+    public sealed class TokenRefreshResult
+    {
+        /// <summary>True when a new access token was obtained.</summary>
+        public bool Succeeded { get; }
+
+        /// <summary>The new short-lived access token (an ES256 JWT). Non-null on success.</summary>
+        public string? AccessToken { get; }
+
+        /// <summary>The new refresh token when the AS rotated it; null keeps the caller's existing refresh token.</summary>
+        public string? RefreshToken { get; }
+
+        /// <summary>Absolute expiry of <see cref="AccessToken"/> (used to schedule the next proactive refresh).</summary>
+        public DateTimeOffset? ExpiresAt { get; }
+
+        /// <summary>A short human-facing reason when <see cref="Succeeded"/> is false (e.g. "refresh token expired").</summary>
+        public string? FailureReason { get; }
+
+        TokenRefreshResult(bool succeeded, string? accessToken, string? refreshToken, DateTimeOffset? expiresAt, string? failureReason)
+        {
+            Succeeded = succeeded;
+            AccessToken = accessToken;
+            RefreshToken = refreshToken;
+            ExpiresAt = expiresAt;
+            FailureReason = failureReason;
+        }
+
+        /// <summary>A successful refresh. <paramref name="refreshToken"/> null ⇒ the AS did not rotate it (keep the old one).</summary>
+        public static TokenRefreshResult Success(string accessToken, string? refreshToken = null, DateTimeOffset? expiresAt = null)
+        {
+            if (string.IsNullOrEmpty(accessToken))
+                throw new ArgumentException("A successful refresh must carry a non-empty access token.", nameof(accessToken));
+            return new TokenRefreshResult(true, accessToken, refreshToken, expiresAt, failureReason: null);
+        }
+
+        /// <summary>A failed refresh (expired/revoked refresh token, AS unreachable, …). Fail closed — no token.</summary>
+        public static TokenRefreshResult Failure(string? reason = null)
+            => new TokenRefreshResult(false, accessToken: null, refreshToken: null, expiresAt: null, failureReason: reason);
+    }
+
+    /// <summary>
+    /// Exchanges a refresh token for a fresh access token against the ai-game.dev authorization server
+    /// (<c>grant_type=refresh_token</c> at <c>/oauth/token</c>; design 03 Flow B). This is the ONE piece of
+    /// the connection layer that talks to the AS over HTTP, so it is an injected seam: the shared library
+    /// defines the contract, and each engine plugin / CLI (which already owns the device-flow HTTP client)
+    /// provides the concrete implementation. Tests substitute a fake. Implementations MUST fail closed —
+    /// any error returns <see cref="TokenRefreshResult.Failure"/>, never a partial or fabricated token —
+    /// and MUST NOT log token material.
+    /// </summary>
+    public interface ITokenRefresher
+    {
+        /// <summary>
+        /// Attempt to mint a new access token from <paramref name="refreshToken"/>.
+        /// <paramref name="serverTarget"/> is the enrolled hub/AS target the credential was issued for
+        /// (hosted vs local), or null to use the implementation's default.
+        /// </summary>
+        Task<TokenRefreshResult> RefreshAsync(string refreshToken, string? serverTarget, CancellationToken cancellationToken = default);
+    }
+}

--- a/McpPlugin/src/McpPlugin/Network/Connection/Credentials/PluginCredentialProvider.cs
+++ b/McpPlugin/src/McpPlugin/Network/Connection/Credentials/PluginCredentialProvider.cs
@@ -1,0 +1,296 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.AgentConfig;
+using Microsoft.Extensions.Logging;
+using R3;
+
+namespace com.IvanMurzak.McpPlugin
+{
+    /// <summary>
+    /// The engine-side account credential provider (mcp-authorize b7, design 03 Flow B / design 06). It
+    /// owns the machine-store-backed account credential and is the source of the access token the SignalR
+    /// connection presents. Three behaviours:
+    /// <list type="bullet">
+    ///   <item><b>Machine-store auto-adopt (the zero-button rule):</b> the machine credential store is read
+    ///   at construction. If a credential exists the provider is <see cref="AuthState.SignedIn"/> with
+    ///   <b>zero</b> UI interaction — engines connect signed-in on boot without any editor click.</item>
+    ///   <item><b>Proactive refresh:</b> <see cref="GetAccessTokenAsync"/> refreshes the token before its
+    ///   <c>exp</c> (within a skew window) so a valid JWT is always presented on (re)connect.</item>
+    ///   <item><b>Reactive refresh + sign-in-again:</b> <see cref="RefreshAsync"/> (driven by the connection
+    ///   layer's <c>_authorizationRejected</c> 3-strike signal) mints a new token and persists it; a refresh
+    ///   failure transitions to <see cref="AuthState.SignInRequired"/> and fires <see cref="OnSignInRequired"/>
+    ///   so the engine UI can prompt "Session expired — sign in again".</item>
+    /// </list>
+    /// The actual token-endpoint HTTP exchange is delegated to an injected <see cref="ITokenRefresher"/>
+    /// (each engine/CLI owns it); this class never talks to the network directly and never logs token
+    /// material.
+    /// </summary>
+    public sealed class PluginCredentialProvider : IDisposable
+    {
+        /// <summary>Default proactive-refresh skew: refresh once the token is within 60s of expiry.</summary>
+        public static readonly TimeSpan DefaultRefreshSkew = TimeSpan.FromSeconds(60);
+
+        readonly MachineCredentialStore _store;
+        readonly ITokenRefresher? _refresher;
+        readonly ILogger? _logger;
+        readonly TimeSpan _refreshSkew;
+        readonly Func<DateTimeOffset> _clock;
+
+        readonly SemaphoreSlim _gate = new SemaphoreSlim(1, 1);
+        readonly ReactiveProperty<AuthState> _state;
+        readonly ReadOnlyReactiveProperty<AuthState> _stateReadOnly;
+        readonly Subject<Unit> _signInRequired = new Subject<Unit>();
+        MachineCredentials? _current;
+        volatile bool _disposed;
+
+        /// <summary>
+        /// Construct over a machine credential store. <paramref name="refresher"/> null ⇒ no refresh is
+        /// possible (proactive/reactive refresh become no-ops that surface sign-in-required). The optional
+        /// <paramref name="clock"/> exists for deterministic expiry tests.
+        /// </summary>
+        public PluginCredentialProvider(
+            MachineCredentialStore store,
+            ITokenRefresher? refresher = null,
+            ILogger? logger = null,
+            TimeSpan? refreshSkew = null,
+            Func<DateTimeOffset>? clock = null)
+        {
+            _store = store ?? throw new ArgumentNullException(nameof(store));
+            _refresher = refresher;
+            _logger = logger;
+            _refreshSkew = refreshSkew ?? DefaultRefreshSkew;
+            _clock = clock ?? (() => DateTimeOffset.UtcNow);
+
+            // Auto-adopt: read the machine store now. No UI, no device flow. If a credential exists the
+            // plugin is already signed in (the zero-button rule — design 06).
+            _current = SafeRead();
+            _state = new ReactiveProperty<AuthState>(_current?.AccessToken != null ? AuthState.SignedIn : AuthState.SignedOut);
+            _stateReadOnly = _state.ToReadOnlyReactiveProperty();
+        }
+
+        /// <summary>The current sign-in state (engine UI binds a sign-in chip to this).</summary>
+        public ReadOnlyReactiveProperty<AuthState> State => _stateReadOnly;
+
+        /// <summary>Fires when a refresh failed and the user must sign in again (design 06).</summary>
+        public Observable<Unit> OnSignInRequired => _signInRequired;
+
+        /// <summary>True when a usable credential is present.</summary>
+        public bool IsSignedIn => _state.CurrentValue == AuthState.SignedIn && _current?.AccessToken != null;
+
+        /// <summary>The enrolled server target the current credential was issued for (hosted vs local), if known.</summary>
+        public string? ServerTarget => _current?.ServerTarget;
+
+        /// <summary>The account id (<c>sub</c>) the current credential resolves to, if known (diagnostic only).</summary>
+        public string? Subject => _current?.Subject;
+
+        /// <summary>
+        /// The <c>Func&lt;Task&lt;string?&gt;&gt;</c> to assign to
+        /// <see cref="ConnectionConfig.CredentialProvider"/> / SignalR's <c>AccessTokenProvider</c>. It
+        /// returns the current (proactively-refreshed) access token, or null when signed out.
+        /// </summary>
+        public Func<Task<string?>> AsAccessTokenProvider()
+            => () => GetAccessTokenAsync(CancellationToken.None);
+
+        /// <summary>
+        /// Returns the current access token, proactively refreshing first when it is within the skew window
+        /// of expiry. Returns null when signed out (anonymous / <c>none</c> mode). Never throws for a normal
+        /// refresh failure — it returns the existing token and surfaces sign-in-required, letting the
+        /// server's rejection path drive recovery.
+        /// </summary>
+        public async Task<string?> GetAccessTokenAsync(CancellationToken cancellationToken = default)
+        {
+            if (_disposed)
+                return null;
+
+            await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                if (_current?.AccessToken == null)
+                    return null;
+
+                if (ShouldRefresh(_current))
+                    await RefreshCoreAsync(cancellationToken).ConfigureAwait(false);
+
+                return _current?.AccessToken;
+            }
+            finally
+            {
+                _gate.Release();
+            }
+        }
+
+        /// <summary>
+        /// Refresh the access token now (driven by the connection layer's <c>_authorizationRejected</c>
+        /// signal). Returns true when a fresh token was persisted; false when refresh failed or is
+        /// impossible (in which case <see cref="AuthState.SignInRequired"/> has been surfaced).
+        /// </summary>
+        public async Task<bool> RefreshAsync(CancellationToken cancellationToken = default)
+        {
+            if (_disposed)
+                return false;
+
+            await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                return await RefreshCoreAsync(cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                _gate.Release();
+            }
+        }
+
+        /// <summary>
+        /// Adopt a freshly obtained credential (e.g. after an in-editor device-flow sign-in). Persists it to
+        /// the machine store and transitions to <see cref="AuthState.SignedIn"/>.
+        /// </summary>
+        public void Adopt(MachineCredentials credentials)
+        {
+            if (credentials == null)
+                throw new ArgumentNullException(nameof(credentials));
+
+            _gate.Wait();
+            try
+            {
+                _store.Write(credentials);
+                _current = credentials;
+                _state.Value = credentials.AccessToken != null ? AuthState.SignedIn : AuthState.SignedOut;
+            }
+            finally
+            {
+                _gate.Release();
+            }
+        }
+
+        /// <summary>Sign out: delete the stored credential and reset to <see cref="AuthState.SignedOut"/>.</summary>
+        public void SignOut()
+        {
+            _gate.Wait();
+            try
+            {
+                try { _store.Delete(); }
+                catch (Exception ex) { _logger?.LogWarning("Deleting stored credential failed: {message}", ex.Message); }
+                _current = null;
+                _state.Value = AuthState.SignedOut;
+            }
+            finally
+            {
+                _gate.Release();
+            }
+        }
+
+        // MUST be called with _gate held.
+        async Task<bool> RefreshCoreAsync(CancellationToken cancellationToken)
+        {
+            var current = _current;
+            if (current?.RefreshToken == null || _refresher == null)
+            {
+                SurfaceSignInRequired("no refresh token or refresher configured");
+                return false;
+            }
+
+            TokenRefreshResult result;
+            try
+            {
+                result = await _refresher.RefreshAsync(current.RefreshToken, current.ServerTarget, cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning("Token refresh threw: {message}", ex.Message); // never log token material
+                SurfaceSignInRequired("refresh error");
+                return false;
+            }
+
+            if (result == null || !result.Succeeded || string.IsNullOrEmpty(result.AccessToken))
+            {
+                SurfaceSignInRequired(result?.FailureReason);
+                return false;
+            }
+
+            var refreshToken = string.IsNullOrEmpty(result.RefreshToken) ? current.RefreshToken! : result.RefreshToken!;
+
+            MachineCredentials rotated;
+            try
+            {
+                // Rotate() preserves the stored identity fields (ServerTarget / Subject) and persists.
+                rotated = _store.Rotate(result.AccessToken!, refreshToken, result.ExpiresAt);
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning("Persisting refreshed credential failed: {message}", ex.Message);
+                // Keep the refreshed token in memory even if the disk write failed — the connection can proceed.
+                rotated = new MachineCredentials
+                {
+                    AccessToken = result.AccessToken,
+                    RefreshToken = refreshToken,
+                    ExpiresAt = result.ExpiresAt,
+                    ServerTarget = current.ServerTarget,
+                    Subject = current.Subject
+                };
+            }
+
+            _current = rotated;
+            _state.Value = AuthState.SignedIn;
+            return true;
+        }
+
+        bool ShouldRefresh(MachineCredentials credentials)
+        {
+            if (_refresher == null)
+                return false;
+            if (credentials.ExpiresAt == null)
+                return false; // unknown expiry — recover reactively on server rejection instead
+            return credentials.ExpiresAt.Value - _clock() <= _refreshSkew;
+        }
+
+        void SurfaceSignInRequired(string? reason)
+        {
+            _logger?.LogWarning("Account credential refresh failed ({reason}); sign-in required.", reason ?? "unknown");
+            if (_disposed)
+                return;
+            _state.Value = AuthState.SignInRequired;
+            _signInRequired.OnNext(Unit.Default);
+        }
+
+        MachineCredentials? SafeRead()
+        {
+            try
+            {
+                return _store.Read();
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning("Reading the machine credential store failed: {message}", ex.Message);
+                return null;
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+            _disposed = true;
+
+            _signInRequired.Dispose();
+            _stateReadOnly.Dispose();
+            _state.Dispose();
+            _gate.Dispose();
+        }
+    }
+}

--- a/McpPlugin/src/McpPlugin/Network/Connection/Credentials/ServerTargetResolver.cs
+++ b/McpPlugin/src/McpPlugin/Network/Connection/Credentials/ServerTargetResolver.cs
@@ -1,0 +1,74 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using com.IvanMurzak.McpPlugin.AgentConfig;
+
+namespace com.IvanMurzak.McpPlugin
+{
+    /// <summary>
+    /// Resolves which server a plugin connects to (hosted ai-game.dev vs a local hub URL) from the
+    /// tool-neutral per-project marker (mcp-authorize b7, design 06). The project marker
+    /// (<c>&lt;project&gt;/.ai-game-dev/project.json</c>) is the single source of the enrolled server target,
+    /// so the plugin and any terminal-written config can never diverge on where the project points. Resolution
+    /// priority: the project marker's <c>serverTarget</c>, then the credential's issued <c>serverTarget</c>,
+    /// then the hosted default.
+    /// </summary>
+    public static class ServerTargetResolver
+    {
+        /// <summary>The hosted ai-game.dev server target (the default when nothing else is enrolled).</summary>
+        public const string HostedTarget = "https://ai-game.dev";
+
+        /// <summary>
+        /// Resolve the enrolled server target URL for the project rooted at <paramref name="projectRootPath"/>.
+        /// The project marker wins, then <paramref name="credentials"/>'s issued target, then
+        /// <paramref name="fallback"/> (hosted by default).
+        /// </summary>
+        public static string Resolve(string? projectRootPath, MachineCredentials? credentials = null, string fallback = HostedTarget)
+        {
+            var markerTarget = ReadMarkerTarget(projectRootPath);
+            if (!string.IsNullOrWhiteSpace(markerTarget))
+                return markerTarget!;
+
+            if (!string.IsNullOrWhiteSpace(credentials?.ServerTarget))
+                return credentials!.ServerTarget!;
+
+            return fallback;
+        }
+
+        /// <summary>
+        /// True when <paramref name="target"/> is a hosted (non-loopback) server; false for a localhost hub
+        /// URL or an unparseable/empty value.
+        /// </summary>
+        public static bool IsHosted(string? target)
+        {
+            if (string.IsNullOrWhiteSpace(target))
+                return false;
+            if (!Uri.TryCreate(target, UriKind.Absolute, out var uri))
+                return false;
+            return !uri.IsLoopback;
+        }
+
+        static string? ReadMarkerTarget(string? projectRootPath)
+        {
+            if (string.IsNullOrWhiteSpace(projectRootPath))
+                return null;
+            try
+            {
+                return ProjectMarker.Read(projectRootPath!)?.ServerTarget;
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/McpPlugin/src/McpPlugin/Network/Connection/Provider/HubConnectionProvider.cs
+++ b/McpPlugin/src/McpPlugin/Network/Connection/Provider/HubConnectionProvider.cs
@@ -57,10 +57,12 @@ namespace com.IvanMurzak.McpPlugin
                         // account JWT on every (re)connect. Null provider ⇒ anonymous (none-mode local server).
                         // SignalR places this token in the Authorization header for both the negotiate request
                         // and the WebSocket upgrade — the server reads it there (never a query param).
-                        var credentialProvider = connectionConfig.CredentialProvider;
-                        options.AccessTokenProvider = credentialProvider != null
-                            ? () => credentialProvider()
-                            : new Func<Task<string?>>(() => Task.FromResult<string?>(null));
+                        // Assign the credential-provider delegate directly (null ⇒ a constant null-token
+                        // provider for an anonymous none-mode connection). SignalR invokes the delegate on
+                        // every (re)connect, so a proactively-refreshed JWT is always fetched fresh — no
+                        // wrapping lambda needed.
+                        options.AccessTokenProvider = connectionConfig.CredentialProvider
+                            ?? (() => Task.FromResult<string?>(null));
 
 #if NET5_0_OR_GREATER
                         // OPT-IN transport CONNECT timeout (ConnectionConfig.ConnectTimeoutSeconds > 0): make an

--- a/McpPlugin/src/McpPlugin/Network/Connection/Provider/HubConnectionProvider.cs
+++ b/McpPlugin/src/McpPlugin/Network/Connection/Provider/HubConnectionProvider.cs
@@ -43,16 +43,24 @@ namespace com.IvanMurzak.McpPlugin
             {
                 var connectionConfig = _serviceProvider.GetRequiredService<IOptions<ConnectionConfig>>().Value;
 
+                // Instance-metadata handshake (mcp-authorize b7): the non-secret identity fields ride as
+                // query parameters so the server can register this editor session in its account+instance
+                // pairing plane (b3). The credential (JWT) itself NEVER goes in the query — it is presented
+                // via AccessTokenProvider (the Authorization header) below.
+                var baseUrl = connectionConfig.Host + endpoint;
+                var url = connectionConfig.InstanceMetadata?.AppendToUrl(baseUrl) ?? baseUrl;
+
                 var hubConnectionBuilder = new HubConnectionBuilder()
-                    .WithUrl(connectionConfig.Host + endpoint, options =>
+                    .WithUrl(url, options =>
                     {
-                        options.AccessTokenProvider = () =>
-                        {
-                            var token = connectionConfig.Token;
-                            if (string.IsNullOrWhiteSpace(token))
-                                return Task.FromResult<string?>(null);
-                            return Task.FromResult<string?>(token);
-                        };
+                        // Credential-provider callback (mcp-authorize b7): fetches the current, auto-refreshed
+                        // account JWT on every (re)connect. Null provider ⇒ anonymous (none-mode local server).
+                        // SignalR places this token in the Authorization header for both the negotiate request
+                        // and the WebSocket upgrade — the server reads it there (never a query param).
+                        var credentialProvider = connectionConfig.CredentialProvider;
+                        options.AccessTokenProvider = credentialProvider != null
+                            ? () => credentialProvider()
+                            : new Func<Task<string?>>(() => Task.FromResult<string?>(null));
 
 #if NET5_0_OR_GREATER
                         // OPT-IN transport CONNECT timeout (ConnectionConfig.ConnectTimeoutSeconds > 0): make an

--- a/docs/architecture-transport-auth.md
+++ b/docs/architecture-transport-auth.md
@@ -8,6 +8,17 @@
 > The two supported auth modes are now **`none`** and **`oauth`**. The authoritative design lives
 > in the mcp-authorize design (`02-target-architecture.md`) and `03-auth-flows.md`.
 
+> **Follow-up (mcp-authorize b7).** The client/plugin side of the shared-token removal is now
+> complete: the engine plugin no longer reads a static `MCP_PLUGIN_TOKEN` / `mcp-plugin-token`
+> shared token. `ConnectionConfig.Token` is replaced by a **credential-provider callback** that
+> presents an auto-refreshed account JWT (machine-store auto-adopt — the zero-button rule) in the
+> `Authorization` header, and the instance-metadata handshake
+> `{instanceId, engine, projectName, projectPathHash, machineName}` rides as non-secret hub query
+> parameters (the token never appears in the query). It also fixes the direct-tool REST endpoints
+> (`/api/tools`, `/api/system-tools`): they now **require authorization in `oauth` mode** (they
+> previously gated on the deleted `required` mode and were unintentionally never gated), and stay
+> open in `none` mode.
+
 ## Overview
 
 The MCP Plugin Server is configured through **two independent axes**: **Transport** and **Auth**.


### PR DESCRIPTION
## Summary

- **b7 core (design 03 Flow B / 06):** replace the static `ConnectionConfig.Token` with an auto-refreshed **credential-provider callback** (token in the `Authorization` header, never a query param); **machine-store auto-adopt** on boot (the zero-button rule); **proactive + reactive (3-strike) refresh → reconnect** via `ConnectionCredentialCoordinator`; a surfaced **"sign in again"** state (`AuthState.SignInRequired` + `OnSignInRequired`) on refresh failure; the **instance-metadata handshake** `{instanceId, engine, projectName, projectPathHash, machineName}` as non-secret hub query params; and **server-target resolution** from the project marker. `ITokenRefresher` is an injected seam — the shared lib never talks to the AS directly and never logs token material.
- **Folded fix 1:** remove the residual client-side legacy shared-token surface (`ConnectionConfig.Token`, the `MCP_PLUGIN_TOKEN` / `mcp-plugin-token` plugin arg+env consts, `GetTokenFromArgsOrEnv`, the builder wiring) — nothing still reads the old shared token.
- **Folded fix 2 (🔒 security):** the `/api/tools` + system-tool REST endpoints gated on the now-unreachable `AuthOption.required` and so were never authorization-gated in `oauth` mode. They now **require authorization in `oauth` mode** (open in `none` mode).

## Scope deviation (please note)

Folded fix 1 also listed "remove the Common-layer enum value" (`AuthOption.required`). It is **kept**: it is the live, tested signal for the b6 config-writer PAT / "Advanced: use access token" path (Flow C, landed in #147). Removing it is a config-writer-subsystem rework outside b7's connection-layer scope and would break tested behavior. Folded fix 2 removes the *dead* `AuthOption.required` references (the two endpoint gates). The security intent of folded fix 1 — "nothing still reads the old shared token" — is fully met.

## Test plan

- [x] Target-specific local tests passed (see profile test.md): full suite green on **net8.0 + net9.0**, both test projects (`McpPlugin.Tests` 670×2, `McpPlugin.Server.Tests` 440×2).
- [x] New coverage: machine-store auto-adopt (zero UI), proactive/expiry refresh, refresh-on-reject → reconnect, sign-in-again on failure, instance-metadata query contract + b3 registry round-trip, folded-fix-1 removal regression, folded-fix-2 behavioral 401-in-oauth / reachable-in-none.

Closes #148