### PR TITLE
Map MCP tool errors to HTTP statuses

### DIFF
--- a/McpPlugin.Common/src/Data/Response/ResponseData.cs
+++ b/McpPlugin.Common/src/Data/Response/ResponseData.cs
@@ -33,9 +33,11 @@ namespace com.IvanMurzak.McpPlugin.Common.Model
         {
             Message = message
         };
-        public static new ResponseData<T> Error(string requestId, string? message = null) => new ResponseData<T>(requestId, ResponseStatus.Error)
+        public static new ResponseData<T> Error(string requestId, string? message = null, ResponseErrorKind errorKind = ResponseErrorKind.None, int? httpStatusCode = null) => new ResponseData<T>(requestId, ResponseStatus.Error)
         {
-            Message = message
+            Message = message,
+            ErrorKind = errorKind,
+            HttpStatusCode = httpStatusCode
         };
         public static new ResponseData<T> Processing(string requestId, string? message = null) => new ResponseData<T>(requestId, ResponseStatus.Processing)
         {
@@ -48,6 +50,8 @@ namespace com.IvanMurzak.McpPlugin.Common.Model
         public string RequestID { get; set; } = string.Empty;
         public ResponseStatus Status { get; set; }
         public string? Message { get; set; }
+        public ResponseErrorKind ErrorKind { get; set; } = ResponseErrorKind.None;
+        public int? HttpStatusCode { get; set; }
 
         public ResponseData() { }
         public ResponseData(string requestId, ResponseStatus status)
@@ -66,9 +70,11 @@ namespace com.IvanMurzak.McpPlugin.Common.Model
         {
             Message = message
         };
-        public static ResponseData Error(string requestId, string? message = null) => new ResponseData(requestId, ResponseStatus.Error)
+        public static ResponseData Error(string requestId, string? message = null, ResponseErrorKind errorKind = ResponseErrorKind.None, int? httpStatusCode = null) => new ResponseData(requestId, ResponseStatus.Error)
         {
-            Message = message
+            Message = message,
+            ErrorKind = errorKind,
+            HttpStatusCode = httpStatusCode
         };
         public static ResponseData Processing(string requestId, string? message = null) => new ResponseData(requestId, ResponseStatus.Processing)
         {

--- a/McpPlugin.Common/src/Data/Response/ResponseErrorKind.cs
+++ b/McpPlugin.Common/src/Data/Response/ResponseErrorKind.cs
@@ -1,0 +1,23 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+namespace com.IvanMurzak.McpPlugin.Common.Model
+{
+    public enum ResponseErrorKind
+    {
+        None,
+        BadRequest,
+        NotFound,
+        Conflict,
+        Timeout,
+        Unavailable,
+        Internal
+    }
+}

--- a/McpPlugin.Common/src/Data/Response/Tool/Call/ResponseCallTool.Static.cs
+++ b/McpPlugin.Common/src/Data/Response/Tool/Call/ResponseCallTool.Static.cs
@@ -22,7 +22,7 @@ namespace com.IvanMurzak.McpPlugin.Common.Model
             return Error($"[Error] {exception?.Message}\n{exception?.StackTrace}", errorKind, httpStatusCode);
         }
 
-        public static ResponseCallTool Error(string? message = null, ResponseErrorKind errorKind = ResponseErrorKind.BadRequest, int? httpStatusCode = null)
+        public static ResponseCallTool Error(string? message = null, ResponseErrorKind errorKind = ResponseErrorKind.Internal, int? httpStatusCode = null)
         {
             return new ResponseCallTool(
                 status: ResponseStatus.Error,
@@ -61,7 +61,7 @@ namespace com.IvanMurzak.McpPlugin.Common.Model
                 status: ResponseStatus.Success);
         }
 
-        public static ResponseCallTool ErrorStructured(JsonNode? structuredContent, ResponseErrorKind errorKind = ResponseErrorKind.BadRequest, int? httpStatusCode = null)
+        public static ResponseCallTool ErrorStructured(JsonNode? structuredContent, ResponseErrorKind errorKind = ResponseErrorKind.Internal, int? httpStatusCode = null)
         {
             return new ResponseCallTool(
                 structuredContent: structuredContent,

--- a/McpPlugin.Common/src/Data/Response/Tool/Call/ResponseCallTool.Static.cs
+++ b/McpPlugin.Common/src/Data/Response/Tool/Call/ResponseCallTool.Static.cs
@@ -17,12 +17,12 @@ namespace com.IvanMurzak.McpPlugin.Common.Model
 {
     public partial class ResponseCallTool : IRequestID
     {
-        public static ResponseCallTool Error(Exception exception)
+        public static ResponseCallTool Error(Exception exception, ResponseErrorKind errorKind = ResponseErrorKind.Internal, int? httpStatusCode = null)
         {
-            return Error($"[Error] {exception?.Message}\n{exception?.StackTrace}");
+            return Error($"[Error] {exception?.Message}\n{exception?.StackTrace}", errorKind, httpStatusCode);
         }
 
-        public static ResponseCallTool Error(string? message = null)
+        public static ResponseCallTool Error(string? message = null, ResponseErrorKind errorKind = ResponseErrorKind.BadRequest, int? httpStatusCode = null)
         {
             return new ResponseCallTool(
                 status: ResponseStatus.Error,
@@ -34,7 +34,9 @@ namespace com.IvanMurzak.McpPlugin.Common.Model
                         Text = message,
                         MimeType = Consts.MimeType.TextPlain
                     }
-                });
+                },
+                errorKind: errorKind,
+                httpStatusCode: httpStatusCode);
         }
 
         public static ResponseCallTool Success(string? message = null)
@@ -59,11 +61,13 @@ namespace com.IvanMurzak.McpPlugin.Common.Model
                 status: ResponseStatus.Success);
         }
 
-        public static ResponseCallTool ErrorStructured(JsonNode? structuredContent)
+        public static ResponseCallTool ErrorStructured(JsonNode? structuredContent, ResponseErrorKind errorKind = ResponseErrorKind.BadRequest, int? httpStatusCode = null)
         {
             return new ResponseCallTool(
                 structuredContent: structuredContent,
-                status: ResponseStatus.Error);
+                status: ResponseStatus.Error,
+                errorKind: errorKind,
+                httpStatusCode: httpStatusCode);
         }
 
         public static ResponseCallTool Processing(string? message = null)

--- a/McpPlugin.Common/src/Data/Response/Tool/Call/ResponseCallTool.cs
+++ b/McpPlugin.Common/src/Data/Response/Tool/Call/ResponseCallTool.cs
@@ -21,32 +21,42 @@ namespace com.IvanMurzak.McpPlugin.Common.Model
         public virtual ResponseStatus Status { get; set; } = ResponseStatus.Error;
         public virtual List<ContentBlock> Content { get; set; } = new List<ContentBlock>();
         public virtual JsonNode? StructuredContent { get; set; } = null;
+        public ResponseErrorKind ErrorKind { get; set; } = ResponseErrorKind.None;
+        public int? HttpStatusCode { get; set; }
 
         public ResponseCallTool() { }
-        public ResponseCallTool(ResponseStatus status, List<ContentBlock> content) : this(
+        public ResponseCallTool(ResponseStatus status, List<ContentBlock> content, ResponseErrorKind errorKind = ResponseErrorKind.None, int? httpStatusCode = null) : this(
             requestId: string.Empty,
             status: status,
-            content: content)
+            content: content,
+            errorKind: errorKind,
+            httpStatusCode: httpStatusCode)
         {
             // none
         }
-        public ResponseCallTool(string requestId, ResponseStatus status, List<ContentBlock> content)
+        public ResponseCallTool(string requestId, ResponseStatus status, List<ContentBlock> content, ResponseErrorKind errorKind = ResponseErrorKind.None, int? httpStatusCode = null)
         {
             RequestID = requestId;
             Status = status;
             Content = content;
+            ErrorKind = errorKind;
+            HttpStatusCode = httpStatusCode;
         }
-        public ResponseCallTool(JsonNode? structuredContent, ResponseStatus status) : this(
+        public ResponseCallTool(JsonNode? structuredContent, ResponseStatus status, ResponseErrorKind errorKind = ResponseErrorKind.None, int? httpStatusCode = null) : this(
             requestId: string.Empty,
             structuredContent: structuredContent,
-            status: status)
+            status: status,
+            errorKind: errorKind,
+            httpStatusCode: httpStatusCode)
         {
             // none
         }
-        public ResponseCallTool(string requestId, JsonNode? structuredContent, ResponseStatus status)
+        public ResponseCallTool(string requestId, JsonNode? structuredContent, ResponseStatus status, ResponseErrorKind errorKind = ResponseErrorKind.None, int? httpStatusCode = null)
         {
             RequestID = requestId;
             Status = status;
+            ErrorKind = errorKind;
+            HttpStatusCode = httpStatusCode;
             StructuredContent = new JsonObject()
             {
                 [JsonSchema.Result] = structuredContent

--- a/McpPlugin.Common/src/Data/Response/Tool/Call/ResponseCallToolExtensions.cs
+++ b/McpPlugin.Common/src/Data/Response/Tool/Call/ResponseCallToolExtensions.cs
@@ -30,7 +30,7 @@ namespace com.IvanMurzak.McpPlugin.Common.Model
         public static ResponseData<ResponseCallTool> Pack(this ResponseCallTool target, string requestId, string? message = null)
         {
             if (target.Status == ResponseStatus.Error)
-                return ResponseData<ResponseCallTool>.Error(requestId, message ?? target.GetMessage() ?? "Tool execution error.")
+                return ResponseData<ResponseCallTool>.Error(requestId, message ?? target.GetMessage() ?? "Tool execution error.", target.ErrorKind, target.HttpStatusCode)
                     .SetData(target);
             else if (target.Status == ResponseStatus.Success)
                 return ResponseData<ResponseCallTool>.Success(requestId, message ?? target.GetMessage() ?? "Tool executed successfully.")

--- a/McpPlugin.Server.Tests/DirectToolEndpointErrorStatusTests.cs
+++ b/McpPlugin.Server.Tests/DirectToolEndpointErrorStatusTests.cs
@@ -1,0 +1,194 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.Common;
+using com.IvanMurzak.McpPlugin.Common.Hub.Client;
+using com.IvanMurzak.McpPlugin.Common.Model;
+using com.IvanMurzak.McpPlugin.Common.Utils;
+using com.IvanMurzak.McpPlugin.Server.Api;
+using com.IvanMurzak.McpPlugin.Server.Webhooks.Services;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.Server.Tests
+{
+    [Collection("McpPlugin.Server")]
+    public sealed class DirectToolEndpointErrorStatusTests
+    {
+        [Theory]
+        [InlineData(ResponseErrorKind.BadRequest, HttpStatusCode.BadRequest)]
+        [InlineData(ResponseErrorKind.NotFound, HttpStatusCode.NotFound)]
+        [InlineData(ResponseErrorKind.Conflict, HttpStatusCode.Conflict)]
+        [InlineData(ResponseErrorKind.Unavailable, HttpStatusCode.ServiceUnavailable)]
+        [InlineData(ResponseErrorKind.Timeout, HttpStatusCode.GatewayTimeout)]
+        [InlineData(ResponseErrorKind.Internal, HttpStatusCode.InternalServerError)]
+        public async Task ToolCall_MapsErrorKindToHttpStatus(ResponseErrorKind errorKind, HttpStatusCode expectedStatus)
+        {
+            var toolResponse = ResponseData<ResponseCallTool>.Error("request-1", "mapped error", errorKind)
+                .SetData(ResponseCallTool.Error("mapped error", errorKind));
+            await using var host = await StartHostAsync(toolResponse: toolResponse);
+            using var client = new HttpClient { BaseAddress = new Uri(host.BaseUrl) };
+
+            var response = await PostJsonAsync(client, "/api/tools/test");
+
+            response.StatusCode.ShouldBe(expectedStatus);
+        }
+
+        [Fact]
+        public async Task ToolCall_ExplicitHttpStatusOverridesErrorKind()
+        {
+            var toolResponse = ResponseData<ResponseCallTool>.Error("request-1", "legal restriction", ResponseErrorKind.BadRequest, 451)
+                .SetData(ResponseCallTool.Error("legal restriction", ResponseErrorKind.BadRequest, 451));
+            await using var host = await StartHostAsync(toolResponse: toolResponse);
+            using var client = new HttpClient { BaseAddress = new Uri(host.BaseUrl) };
+
+            var response = await PostJsonAsync(client, "/api/tools/test");
+
+            response.StatusCode.ShouldBe((HttpStatusCode)451);
+        }
+
+        [Fact]
+        public async Task ToolCall_NullHubResponse_ReturnsBadGateway()
+        {
+            await using var host = await StartHostAsync(toolHubReturnsNull: true);
+            using var client = new HttpClient { BaseAddress = new Uri(host.BaseUrl) };
+
+            var response = await PostJsonAsync(client, "/api/tools/test");
+
+            response.StatusCode.ShouldBe(HttpStatusCode.BadGateway);
+        }
+
+        [Theory]
+        [InlineData(ResponseErrorKind.BadRequest, HttpStatusCode.BadRequest)]
+        [InlineData(ResponseErrorKind.NotFound, HttpStatusCode.NotFound)]
+        [InlineData(ResponseErrorKind.Conflict, HttpStatusCode.Conflict)]
+        [InlineData(ResponseErrorKind.Unavailable, HttpStatusCode.ServiceUnavailable)]
+        [InlineData(ResponseErrorKind.Timeout, HttpStatusCode.GatewayTimeout)]
+        [InlineData(ResponseErrorKind.Internal, HttpStatusCode.InternalServerError)]
+        public async Task SystemToolCall_MapsErrorKindToHttpStatus(ResponseErrorKind errorKind, HttpStatusCode expectedStatus)
+        {
+            var toolResponse = ResponseData<ResponseCallTool>.Error("request-1", "mapped error", errorKind)
+                .SetData(ResponseCallTool.Error("mapped error", errorKind));
+            await using var host = await StartHostAsync(systemToolResponse: toolResponse);
+            using var client = new HttpClient { BaseAddress = new Uri(host.BaseUrl) };
+
+            var response = await PostJsonAsync(client, "/api/system-tools/test");
+
+            response.StatusCode.ShouldBe(expectedStatus);
+        }
+
+        [Fact]
+        public async Task SystemToolCall_NullHubResponse_ReturnsBadGateway()
+        {
+            await using var host = await StartHostAsync(systemToolHubReturnsNull: true);
+            using var client = new HttpClient { BaseAddress = new Uri(host.BaseUrl) };
+
+            var response = await PostJsonAsync(client, "/api/system-tools/test");
+
+            response.StatusCode.ShouldBe(HttpStatusCode.BadGateway);
+        }
+
+        static Task<HttpResponseMessage> PostJsonAsync(HttpClient client, string route)
+            => client.PostAsync(route, new StringContent("{}", Encoding.UTF8, "application/json"));
+
+        static async Task<RunningHost> StartHostAsync(
+            ResponseData<ResponseCallTool>? toolResponse = null,
+            ResponseData<ResponseCallTool>? systemToolResponse = null,
+            bool toolHubReturnsNull = false,
+            bool systemToolHubReturnsNull = false)
+        {
+            var builder = WebApplication.CreateBuilder();
+            builder.Logging.ClearProviders();
+
+            var dataArguments = Mock.Of<IDataArguments>(d => d.Authorization == Consts.MCP.Server.AuthOption.none);
+            builder.Services.AddSingleton(dataArguments);
+            builder.Services.AddSingleton<IClientToolHub>(new StubToolHub(toolResponse, toolHubReturnsNull));
+            builder.Services.AddSingleton<IClientSystemToolHub>(new StubSystemToolHub(systemToolResponse, systemToolHubReturnsNull));
+            builder.Services.AddSingleton(Mock.Of<IAuthorizationWebhookService>());
+
+            var app = builder.Build();
+            app.Urls.Add("http://127.0.0.1:0");
+            app.MapDirectToolCallApi(dataArguments);
+            app.MapSystemToolApi(dataArguments);
+
+            await app.StartAsync();
+            return new RunningHost(app, app.Urls.First());
+        }
+
+        sealed class RunningHost : IAsyncDisposable
+        {
+            readonly WebApplication _app;
+            public string BaseUrl { get; }
+
+            public RunningHost(WebApplication app, string baseUrl)
+            {
+                _app = app;
+                BaseUrl = baseUrl;
+            }
+
+            public async ValueTask DisposeAsync()
+            {
+                await _app.StopAsync();
+                await _app.DisposeAsync();
+            }
+        }
+
+        sealed class StubToolHub : IClientToolHub
+        {
+            readonly ResponseData<ResponseCallTool>? _toolResponse;
+
+            public StubToolHub(ResponseData<ResponseCallTool>? toolResponse, bool returnsNull)
+            {
+                _toolResponse = returnsNull
+                    ? null
+                    : toolResponse ?? ResponseData<ResponseCallTool>.Success("request-1")
+                        .SetData(ResponseCallTool.Success("ok"));
+            }
+
+            public Task<ResponseData<ResponseCallTool>> RunCallTool(RequestCallTool request)
+                => Task.FromResult(_toolResponse!);
+
+            public Task<ResponseData<ResponseListTool[]>> RunListTool(RequestListTool request, CancellationToken cancellationToken = default)
+                => Task.FromResult(ResponseData<ResponseListTool[]>.Success(request.RequestID)
+                    .SetData(Array.Empty<ResponseListTool>()));
+        }
+
+        sealed class StubSystemToolHub : IClientSystemToolHub
+        {
+            readonly ResponseData<ResponseCallTool>? _toolResponse;
+
+            public StubSystemToolHub(ResponseData<ResponseCallTool>? toolResponse, bool returnsNull)
+            {
+                _toolResponse = returnsNull
+                    ? null
+                    : toolResponse ?? ResponseData<ResponseCallTool>.Success("request-1")
+                        .SetData(ResponseCallTool.Success("ok"));
+            }
+
+            public Task<ResponseData<ResponseCallTool>> RunSystemTool(RequestCallTool request, CancellationToken cancellationToken = default)
+                => Task.FromResult(_toolResponse!);
+
+            public Task<ResponseData<ResponseListTool[]>> RunListSystemTool(RequestListTool request, CancellationToken cancellationToken = default)
+                => Task.FromResult(ResponseData<ResponseListTool[]>.Success(request.RequestID)
+                    .SetData(Array.Empty<ResponseListTool>()));
+        }
+    }
+}

--- a/McpPlugin.Server/src/Api/DirectHttpErrorMapper.cs
+++ b/McpPlugin.Server/src/Api/DirectHttpErrorMapper.cs
@@ -1,0 +1,34 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+using com.IvanMurzak.McpPlugin.Common.Model;
+
+namespace com.IvanMurzak.McpPlugin.Server.Api
+{
+    static class DirectHttpErrorMapper
+    {
+        public static int GetStatusCode(ResponseData response, int fallbackStatusCode)
+        {
+            if (response.HttpStatusCode is >= 400 and <= 599)
+                return response.HttpStatusCode.Value;
+
+            return response.ErrorKind switch
+            {
+                ResponseErrorKind.BadRequest => 400,
+                ResponseErrorKind.NotFound => 404,
+                ResponseErrorKind.Conflict => 409,
+                ResponseErrorKind.Unavailable => 503,
+                ResponseErrorKind.Timeout => 504,
+                ResponseErrorKind.Internal => 500,
+                _ => fallbackStatusCode
+            };
+        }
+    }
+}

--- a/McpPlugin.Server/src/Api/DirectToolCallEndpoints.cs
+++ b/McpPlugin.Server/src/Api/DirectToolCallEndpoints.cs
@@ -82,14 +82,14 @@ namespace com.IvanMurzak.McpPlugin.Server.Api
 
             if (response == null)
             {
-                context.Response.StatusCode = 500;
+                context.Response.StatusCode = 502;
                 await context.Response.WriteAsJsonAsync(new { error = "Tool hub returned a null response." });
                 return;
             }
 
             if (response.Status == ResponseStatus.Error)
             {
-                context.Response.StatusCode = 500;
+                context.Response.StatusCode = DirectHttpErrorMapper.GetStatusCode(response, 500);
                 await context.Response.WriteAsJsonAsync(new { error = response.Message ?? "Failed to list tools." });
                 return;
             }
@@ -240,14 +240,14 @@ namespace com.IvanMurzak.McpPlugin.Server.Api
 
             if (response == null)
             {
-                context.Response.StatusCode = 500;
+                context.Response.StatusCode = 502;
                 await context.Response.WriteAsJsonAsync(new { error = "Tool hub returned a null response." });
                 return;
             }
 
             if (response.Status == ResponseStatus.Error)
             {
-                context.Response.StatusCode = 500;
+                context.Response.StatusCode = DirectHttpErrorMapper.GetStatusCode(response, 400);
                 await context.Response.WriteAsJsonAsync(new { error = response.Message ?? $"Tool '{name}' returned an error." });
                 return;
             }

--- a/McpPlugin.Server/src/Api/SystemToolEndpoints.cs
+++ b/McpPlugin.Server/src/Api/SystemToolEndpoints.cs
@@ -83,14 +83,14 @@ namespace com.IvanMurzak.McpPlugin.Server.Api
 
             if (response == null)
             {
-                context.Response.StatusCode = 500;
+                context.Response.StatusCode = 502;
                 await context.Response.WriteAsJsonAsync(new { error = "System tool hub returned a null response." });
                 return;
             }
 
             if (response.Status == ResponseStatus.Error)
             {
-                context.Response.StatusCode = 500;
+                context.Response.StatusCode = DirectHttpErrorMapper.GetStatusCode(response, 500);
                 await context.Response.WriteAsJsonAsync(new { error = response.Message ?? "Failed to list system tools." });
                 return;
             }
@@ -239,14 +239,14 @@ namespace com.IvanMurzak.McpPlugin.Server.Api
 
             if (response == null)
             {
-                context.Response.StatusCode = 500;
+                context.Response.StatusCode = 502;
                 await context.Response.WriteAsJsonAsync(new { error = "System tool hub returned a null response." });
                 return;
             }
 
             if (response.Status == ResponseStatus.Error)
             {
-                context.Response.StatusCode = 500;
+                context.Response.StatusCode = DirectHttpErrorMapper.GetStatusCode(response, 400);
                 await context.Response.WriteAsJsonAsync(new { error = response.Message ?? $"System tool '{name}' returned an error." });
                 return;
             }

--- a/McpPlugin.Server/src/Client/ClientUtils.cs
+++ b/McpPlugin.Server/src/Client/ClientUtils.cs
@@ -158,10 +158,10 @@ namespace com.IvanMurzak.McpPlugin.Server
             where THub : Hub
         {
             if (hubContext == null)
-                return ResponseData<TResponse>.Error(request.RequestID, $"'{nameof(hubContext)}' is null.").Log(logger);
+                return ResponseData<TResponse>.Error(request.RequestID, $"'{nameof(hubContext)}' is null.", ResponseErrorKind.Internal).Log(logger);
 
             if (string.IsNullOrEmpty(methodName))
-                return ResponseData<TResponse>.Error(request.RequestID, $"'{nameof(methodName)}' is null.").Log(logger);
+                return ResponseData<TResponse>.Error(request.RequestID, $"'{nameof(methodName)}' is null.", ResponseErrorKind.Internal).Log(logger);
 
             try
             {
@@ -172,6 +172,8 @@ namespace com.IvanMurzak.McpPlugin.Server
                 }
 
                 var retryCount = 0;
+                var sawClient = false;
+                var sawTimeout = false;
                 while (retryCount < maxRetries)
                 {
                     retryCount++;
@@ -187,6 +189,7 @@ namespace com.IvanMurzak.McpPlugin.Server
                         await Task.Delay(1000, cancellationToken); // Wait before retrying
                         continue;
                     }
+                    sawClient = true;
 
                     if (logger.IsEnabled(LogLevel.Trace))
                     {
@@ -201,7 +204,7 @@ namespace com.IvanMurzak.McpPlugin.Server
                         {
                             var result = await invokeTask;
                             if (result == null)
-                                return ResponseData<TResponse>.Error(request.RequestID, $"Invoke '{request}' returned null result.")
+                                return ResponseData<TResponse>.Error(request.RequestID, $"Invoke '{request}' returned null result.", ResponseErrorKind.Internal)
                                     .Log(logger);
 
                             LastSuccessfulClients[typeof(McpServerHub)] = connectionId!;
@@ -217,17 +220,21 @@ namespace com.IvanMurzak.McpPlugin.Server
                     }
 
                     // Timeout occurred
+                    sawTimeout = true;
                     logger.LogWarning($"Invoke '{methodName}': Timeout: Client '{connectionId}' did not respond in {dataArguments.PluginTimeoutMs} ms. Removing from ConnectedClients.");
                     // RemoveCurrentClient(client);
                     await Task.Delay(retryDelayMs, cancellationToken); // Wait before retrying
                     // Restart the loop to try again with a new client
                 }
-                return ResponseData<TResponse>.Error(request.RequestID, $"Invoke '{methodName}': Failed to invoke '{request}' after {retryCount} retries.")
+                var errorKind = sawTimeout
+                    ? ResponseErrorKind.Timeout
+                    : sawClient ? ResponseErrorKind.Internal : ResponseErrorKind.Unavailable;
+                return ResponseData<TResponse>.Error(request.RequestID, $"Invoke '{methodName}': Failed to invoke '{request}' after {retryCount} retries.", errorKind)
                     .Log(logger);
             }
             catch (Exception ex)
             {
-                return ResponseData<TResponse>.Error(request.RequestID, $"Invoke '{methodName}': Failed to invoke '{request}'. Exception: {ex}")
+                return ResponseData<TResponse>.Error(request.RequestID, $"Invoke '{methodName}': Failed to invoke '{request}'. Exception: {ex}", ResponseErrorKind.Internal)
                     .Log(logger, ex: ex);
             }
         }

--- a/McpPlugin.Server/src/Client/RemoteSystemToolRunner.cs
+++ b/McpPlugin.Server/src/Client/RemoteSystemToolRunner.cs
@@ -69,7 +69,15 @@ namespace com.IvanMurzak.McpPlugin.Server
                         token: McpSessionTokenContext.CurrentToken,
                         cancellationToken: cancellationToken);
 
-                    return responseData.Value ?? ResponseCallTool.Error("Response data is null");
+                    if (responseData.Status == ResponseStatus.Error)
+                    {
+                        var errorKind = responseData.ErrorKind == ResponseErrorKind.None
+                            ? ResponseErrorKind.Internal
+                            : responseData.ErrorKind;
+                        return ResponseCallTool.Error(responseData.Message ?? "System tool invocation failed", errorKind, responseData.HttpStatusCode);
+                    }
+
+                    return responseData.Value ?? ResponseCallTool.Error("Response data is null", ResponseErrorKind.Internal);
                 },
                 TimeSpan.FromMinutes(5),
                 cancellationToken);
@@ -93,7 +101,7 @@ namespace com.IvanMurzak.McpPlugin.Server
                 cancellationToken: cancellationToken);
 
             if (response.Status == ResponseStatus.Error)
-                return ResponseData<ResponseListTool[]>.Error(request.RequestID, response.Message ?? "Got an error during listing system tools");
+                return ResponseData<ResponseListTool[]>.Error(request.RequestID, response.Message ?? "Got an error during listing system tools", response.ErrorKind, response.HttpStatusCode);
 
             return response;
         }

--- a/McpPlugin.Server/src/Client/RemoteToolRunner.cs
+++ b/McpPlugin.Server/src/Client/RemoteToolRunner.cs
@@ -64,7 +64,15 @@ namespace com.IvanMurzak.McpPlugin.Server
                         token: McpSessionTokenContext.CurrentToken,
                         cancellationToken: cancellationToken);
 
-                    return responseData.Value ?? ResponseCallTool.Error("Response data is null");
+                    if (responseData.Status == ResponseStatus.Error)
+                    {
+                        var errorKind = responseData.ErrorKind == ResponseErrorKind.None
+                            ? ResponseErrorKind.Internal
+                            : responseData.ErrorKind;
+                        return ResponseCallTool.Error(responseData.Message ?? "Tool invocation failed", errorKind, responseData.HttpStatusCode);
+                    }
+
+                    return responseData.Value ?? ResponseCallTool.Error("Response data is null", ResponseErrorKind.Internal);
                 },
                 TimeSpan.FromMinutes(5),
                 cancellationToken);
@@ -90,7 +98,7 @@ namespace com.IvanMurzak.McpPlugin.Server
                 cancellationToken: cancellationToken);
 
             if (response.Status == ResponseStatus.Error)
-                return ResponseData<ResponseListTool[]>.Error(request.RequestID, response.Message ?? "Got an error during listing tools");
+                return ResponseData<ResponseListTool[]>.Error(request.RequestID, response.Message ?? "Got an error during listing tools", response.ErrorKind, response.HttpStatusCode);
 
             return response;
         }

--- a/McpPlugin.Server/src/Client/RequestTrackingService.cs
+++ b/McpPlugin.Server/src/Client/RequestTrackingService.cs
@@ -175,7 +175,7 @@ namespace com.IvanMurzak.McpPlugin.Server
                 }
                 catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                 {
-                    return ResponseCallTool.Error("Request was canceled").SetRequestID(RequestId);
+                    return ResponseCallTool.Error("Request was canceled", ResponseErrorKind.Timeout).SetRequestID(RequestId);
                 }
                 catch (OperationCanceledException) when (TimeoutCts.Token.IsCancellationRequested)
                 {

--- a/McpPlugin.Server/src/Client/RequestTrackingService.cs
+++ b/McpPlugin.Server/src/Client/RequestTrackingService.cs
@@ -149,7 +149,7 @@ namespace com.IvanMurzak.McpPlugin.Server
                     {
                         IsCompleted = true;
                         _completionSource.TrySetResult(
-                            ResponseCallTool.Error($"Request {RequestId} timed out after {timeout}").SetRequestID(RequestId));
+                            ResponseCallTool.Error($"Request {RequestId} timed out after {timeout}", ResponseErrorKind.Timeout).SetRequestID(RequestId));
                     }
                 });
             }
@@ -179,7 +179,7 @@ namespace com.IvanMurzak.McpPlugin.Server
                 }
                 catch (OperationCanceledException) when (TimeoutCts.Token.IsCancellationRequested)
                 {
-                    return ResponseCallTool.Error("Request timed out").SetRequestID(RequestId);
+                    return ResponseCallTool.Error("Request timed out", ResponseErrorKind.Timeout).SetRequestID(RequestId);
                 }
             }
 

--- a/McpPlugin.Server/src/Tools/ServerNativeTools.cs
+++ b/McpPlugin.Server/src/Tools/ServerNativeTools.cs
@@ -71,7 +71,7 @@ namespace com.IvanMurzak.McpPlugin.Server.Tools
                 case EnrollPlugin:
                     return HandleEnrollAsync(arguments, context, cancellationToken);
                 default:
-                    return Task.FromResult(ResponseCallTool.Error($"'{name}' is not a server-native tool."));
+                    return Task.FromResult(ResponseCallTool.Error($"'{name}' is not a server-native tool.", ResponseErrorKind.NotFound));
             }
         }
 
@@ -99,11 +99,11 @@ namespace com.IvanMurzak.McpPlugin.Server.Tools
         ResponseCallTool HandleSelect(IReadOnlyDictionary<string, JsonElement> arguments, SelectionToolContext context)
         {
             if (string.IsNullOrEmpty(context.SessionId))
-                return ResponseCallTool.Error("Cannot set a selection without an active MCP session.");
+                return ResponseCallTool.Error("Cannot set a selection without an active MCP session.", ResponseErrorKind.BadRequest);
 
             var instances = _instances.GetInstances(context.AccountId);
             if (instances.Count == 0)
-                return ResponseCallTool.Error("No engine instances are connected for your account. Use enroll_engine_plugin to set one up.");
+                return ResponseCallTool.Error("No engine instances are connected for your account. Use enroll_engine_plugin to set one up.", ResponseErrorKind.Unavailable);
 
             var instanceId = GetStringArg(arguments, "instance_id");
             var projectName = GetStringArg(arguments, "project_name");
@@ -113,25 +113,25 @@ namespace com.IvanMurzak.McpPlugin.Server.Tools
             {
                 target = instances.FirstOrDefault(i => string.Equals(i.InstanceId, instanceId, StringComparison.Ordinal));
                 if (target == null)
-                    return ResponseCallTool.Error($"No connected instance has id '{instanceId}'. Use list_engine_instances to see valid ids.");
+                    return ResponseCallTool.Error($"No connected instance has id '{instanceId}'. Use list_engine_instances to see valid ids.", ResponseErrorKind.NotFound);
             }
             else if (!string.IsNullOrEmpty(projectName))
             {
                 var matches = instances.Where(i => string.Equals(i.ProjectName, projectName, StringComparison.OrdinalIgnoreCase)).ToList();
                 if (matches.Count == 0)
-                    return ResponseCallTool.Error($"No connected instance is for project '{projectName}'. Use list_engine_instances to see connected projects.");
+                    return ResponseCallTool.Error($"No connected instance is for project '{projectName}'. Use list_engine_instances to see connected projects.", ResponseErrorKind.NotFound);
                 if (matches.Count > 1)
-                    return ResponseCallTool.Error($"Multiple instances match project '{projectName}'; pass instance_id instead (see list_engine_instances).");
+                    return ResponseCallTool.Error($"Multiple instances match project '{projectName}'; pass instance_id instead (see list_engine_instances).", ResponseErrorKind.Conflict);
                 target = matches[0];
             }
             else
             {
-                return ResponseCallTool.Error("Provide 'instance_id' (preferred) or a unique 'project_name'.");
+                return ResponseCallTool.Error("Provide 'instance_id' (preferred) or a unique 'project_name'.", ResponseErrorKind.BadRequest);
             }
 
             // A sticky selection may narrow a pin but NEVER override it to a different project (design 04 step 2).
             if (!string.IsNullOrEmpty(context.ProjectPin) && !target.MatchesPin(context.ProjectPin))
-                return ResponseCallTool.Error("This session is pinned to a project; you can only select an instance of the pinned project.");
+                return ResponseCallTool.Error("This session is pinned to a project; you can only select an instance of the pinned project.", ResponseErrorKind.Conflict);
 
             _selections.Set(context.SessionId!, target.InstanceId);
             // Take effect within this request too (routing reads the ambient AsyncLocal).
@@ -145,14 +145,14 @@ namespace com.IvanMurzak.McpPlugin.Server.Tools
         {
             var engine = (GetStringArg(arguments, "engine") ?? string.Empty).Trim().ToLowerInvariant();
             if (engine != "unity" && engine != "godot" && engine != "unreal")
-                return ResponseCallTool.Error("Argument 'engine' is required and must be one of: unity, godot, unreal.");
+                return ResponseCallTool.Error("Argument 'engine' is required and must be one of: unity, godot, unreal.", ResponseErrorKind.BadRequest);
 
             if (string.IsNullOrEmpty(context.Bearer))
-                return ResponseCallTool.Error("No session credential is available to enroll with. Sign in first.");
+                return ResponseCallTool.Error("No session credential is available to enroll with. Sign in first.", ResponseErrorKind.BadRequest);
 
             var result = await _enrollment.CreateAsync(engine, context.Bearer!, cancellationToken);
             if (!result.Success || string.IsNullOrEmpty(result.EnrollCode))
-                return ResponseCallTool.Error(result.Error ?? "Enrollment failed.");
+                return ResponseCallTool.Error(result.Error ?? "Enrollment failed.", ResponseErrorKind.Unavailable);
 
             var command = $"npx {CliPackage(engine)} install-plugin --enroll {result.EnrollCode}";
             return ResponseCallTool.Success(

--- a/McpPlugin.Tests/Data/ResponseCallToolErrorMetadataTests.cs
+++ b/McpPlugin.Tests/Data/ResponseCallToolErrorMetadataTests.cs
@@ -1,0 +1,83 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+using System.Text.Json.Nodes;
+using com.IvanMurzak.McpPlugin.Common.Model;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.Tests.Data
+{
+    public class ResponseCallToolErrorMetadataTests
+    {
+        [Fact]
+        public void Error_WithMessage_DefaultsToBadRequest()
+        {
+            var response = ResponseCallTool.Error("Invalid input.");
+
+            response.Status.ShouldBe(ResponseStatus.Error);
+            response.ErrorKind.ShouldBe(ResponseErrorKind.BadRequest);
+            response.HttpStatusCode.ShouldBeNull();
+        }
+
+        [Fact]
+        public void Error_WithException_DefaultsToInternal()
+        {
+            var response = ResponseCallTool.Error(new InvalidOperationException("boom"));
+
+            response.Status.ShouldBe(ResponseStatus.Error);
+            response.ErrorKind.ShouldBe(ResponseErrorKind.Internal);
+            response.HttpStatusCode.ShouldBeNull();
+        }
+
+        [Fact]
+        public void Error_WithExplicitKindAndStatus_PreservesMetadata()
+        {
+            var response = ResponseCallTool.Error(
+                "Request timed out.",
+                ResponseErrorKind.Timeout,
+                504);
+
+            response.ErrorKind.ShouldBe(ResponseErrorKind.Timeout);
+            response.HttpStatusCode.ShouldBe(504);
+        }
+
+        [Fact]
+        public void ErrorStructured_WithExplicitKindAndStatus_PreservesMetadata()
+        {
+            var structured = new JsonObject { ["message"] = "missing" };
+
+            var response = ResponseCallTool.ErrorStructured(
+                structured,
+                ResponseErrorKind.NotFound,
+                404);
+
+            response.ErrorKind.ShouldBe(ResponseErrorKind.NotFound);
+            response.HttpStatusCode.ShouldBe(404);
+        }
+
+        [Fact]
+        public void Pack_CopiesErrorMetadataToResponseData()
+        {
+            var toolResponse = ResponseCallTool.Error(
+                "Current state does not allow this operation.",
+                ResponseErrorKind.Conflict,
+                409);
+
+            var packed = toolResponse.Pack("request-1");
+
+            packed.Status.ShouldBe(ResponseStatus.Error);
+            packed.ErrorKind.ShouldBe(ResponseErrorKind.Conflict);
+            packed.HttpStatusCode.ShouldBe(409);
+            packed.Value.ShouldBeSameAs(toolResponse);
+        }
+    }
+}

--- a/McpPlugin.Tests/Data/ResponseCallToolErrorMetadataTests.cs
+++ b/McpPlugin.Tests/Data/ResponseCallToolErrorMetadataTests.cs
@@ -19,9 +19,19 @@ namespace com.IvanMurzak.McpPlugin.Tests.Data
     public class ResponseCallToolErrorMetadataTests
     {
         [Fact]
-        public void Error_WithMessage_DefaultsToBadRequest()
+        public void Error_WithMessage_DefaultsToInternal()
         {
             var response = ResponseCallTool.Error("Invalid input.");
+
+            response.Status.ShouldBe(ResponseStatus.Error);
+            response.ErrorKind.ShouldBe(ResponseErrorKind.Internal);
+            response.HttpStatusCode.ShouldBeNull();
+        }
+
+        [Fact]
+        public void Error_WithExplicitBadRequest_PreservesBadRequest()
+        {
+            var response = ResponseCallTool.Error("Invalid input.", ResponseErrorKind.BadRequest);
 
             response.Status.ShouldBe(ResponseStatus.Error);
             response.ErrorKind.ShouldBe(ResponseErrorKind.BadRequest);

--- a/McpPlugin.Tests/Mcp/ToolErrorClassificationTests.cs
+++ b/McpPlugin.Tests/Mcp/ToolErrorClassificationTests.cs
@@ -1,0 +1,158 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.Common.Model;
+using com.IvanMurzak.ReflectorNet;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.Tests.Mcp
+{
+    [Collection("McpPlugin")]
+    public class ToolErrorClassificationTests
+    {
+        [Fact]
+        public async Task RunCallTool_NullRequest_IsBadRequest()
+        {
+            var manager = ToolManager();
+
+            var response = await manager.RunCallTool(null!);
+
+            response.Status.ShouldBe(ResponseStatus.Error);
+            response.ErrorKind.ShouldBe(ResponseErrorKind.BadRequest);
+        }
+
+        [Fact]
+        public async Task RunCallTool_MissingName_IsBadRequest()
+        {
+            var manager = ToolManager();
+
+            var response = await manager.RunCallTool(new RequestCallTool("request-1", "", EmptyArgs));
+
+            response.Status.ShouldBe(ResponseStatus.Error);
+            response.ErrorKind.ShouldBe(ResponseErrorKind.BadRequest);
+        }
+
+        [Fact]
+        public async Task RunCallTool_UnknownTool_IsNotFound()
+        {
+            var manager = ToolManager();
+
+            var response = await manager.RunCallTool(new RequestCallTool("request-1", "missing", EmptyArgs));
+
+            response.Status.ShouldBe(ResponseStatus.Error);
+            response.ErrorKind.ShouldBe(ResponseErrorKind.NotFound);
+        }
+
+        [Theory]
+        [MemberData(nameof(ExceptionCases))]
+        public async Task RunCallTool_ClassifiesExceptions(Exception exception, ResponseErrorKind expected)
+        {
+            var manager = ToolManager(new ThrowingTool(exception));
+
+            var response = await manager.RunCallTool(new RequestCallTool("request-1", ThrowingTool.ToolName, EmptyArgs));
+
+            response.Status.ShouldBe(ResponseStatus.Error);
+            response.ErrorKind.ShouldBe(expected);
+        }
+
+        [Fact]
+        public async Task RunSystemTool_UnknownTool_IsNotFound()
+        {
+            var manager = SystemToolManager();
+
+            var response = await manager.RunSystemTool(new RequestCallTool("request-1", "missing", EmptyArgs));
+
+            response.Status.ShouldBe(ResponseStatus.Error);
+            response.ErrorKind.ShouldBe(ResponseErrorKind.NotFound);
+        }
+
+        [Theory]
+        [MemberData(nameof(ExceptionCases))]
+        public async Task RunSystemTool_ClassifiesExceptions(Exception exception, ResponseErrorKind expected)
+        {
+            var manager = SystemToolManager(new ThrowingTool(exception));
+
+            var response = await manager.RunSystemTool(new RequestCallTool("request-1", ThrowingTool.ToolName, EmptyArgs));
+
+            response.Status.ShouldBe(ResponseStatus.Error);
+            response.ErrorKind.ShouldBe(expected);
+        }
+
+        public static IEnumerable<object[]> ExceptionCases()
+        {
+            yield return new object[] { new ArgumentException("bad arg"), ResponseErrorKind.BadRequest };
+            yield return new object[] { new FormatException("bad format"), ResponseErrorKind.BadRequest };
+            yield return new object[] { new JsonException("bad json"), ResponseErrorKind.BadRequest };
+            yield return new object[] { new FileNotFoundException("missing file"), ResponseErrorKind.NotFound };
+            yield return new object[] { new DirectoryNotFoundException("missing directory"), ResponseErrorKind.NotFound };
+            yield return new object[] { new KeyNotFoundException("missing key"), ResponseErrorKind.NotFound };
+            yield return new object[] { new InvalidOperationException("bad state"), ResponseErrorKind.Conflict };
+            yield return new object[] { new TimeoutException("too slow"), ResponseErrorKind.Timeout };
+            yield return new object[] { new ApplicationException("bug"), ResponseErrorKind.Internal };
+        }
+
+        static readonly IReadOnlyDictionary<string, JsonElement> EmptyArgs = new Dictionary<string, JsonElement>();
+
+        static McpToolManager ToolManager(IRunTool? tool = null)
+        {
+            var tools = new ToolRunnerCollection(new Reflector(), NullLogger.Instance);
+            if (tool != null)
+                tools[tool.Name] = tool;
+
+            return new McpToolManager(NullLogger<McpToolManager>.Instance, new Reflector(), tools);
+        }
+
+        static McpSystemToolManager SystemToolManager(IRunTool? tool = null)
+        {
+            var tools = new SystemToolRunnerCollection(new Reflector(), NullLogger.Instance);
+            if (tool != null)
+                tools[tool.Name] = tool;
+
+            return new McpSystemToolManager(NullLogger<McpSystemToolManager>.Instance, tools);
+        }
+
+        sealed class ThrowingTool : IRunTool
+        {
+            public const string ToolName = "throwing";
+            readonly Exception _exception;
+
+            public ThrowingTool(Exception exception)
+            {
+                _exception = exception;
+            }
+
+            public string Name => ToolName;
+            public string? Title => "Throwing";
+            public string? Description => "Throws for tests";
+            public string? SkillDescription => null;
+            public string? SkillBody => null;
+            public JsonNode? InputSchema => JsonNode.Parse("{}");
+            public JsonNode? OutputSchema => JsonNode.Parse("{}");
+            public bool Enabled { get; set; } = true;
+            public bool? ReadOnlyHint => null;
+            public bool? DestructiveHint => null;
+            public bool? IdempotentHint => null;
+            public bool? OpenWorldHint => null;
+            public int TokenCount => 0;
+
+            public Task<ResponseCallTool> Run(string requestId, IReadOnlyDictionary<string, JsonElement>? namedParameters, CancellationToken cancellationToken = default)
+                => Task.FromException<ResponseCallTool>(_exception);
+        }
+    }
+}

--- a/McpPlugin.Tests/Mcp/ToolErrorClassificationTests.cs
+++ b/McpPlugin.Tests/Mcp/ToolErrorClassificationTests.cs
@@ -20,6 +20,7 @@ using com.IvanMurzak.ReflectorNet;
 using Microsoft.Extensions.Logging.Abstractions;
 using Shouldly;
 using Xunit;
+using Version = com.IvanMurzak.McpPlugin.Common.Version;
 
 namespace com.IvanMurzak.McpPlugin.Tests.Mcp
 {
@@ -69,6 +70,22 @@ namespace com.IvanMurzak.McpPlugin.Tests.Mcp
 
             response.Status.ShouldBe(ResponseStatus.Error);
             response.ErrorKind.ShouldBe(expected);
+        }
+
+        [Fact]
+        public async Task RunCallTool_ReflectedToolExecutionFailure_IsInternal()
+        {
+            var reflector = new Reflector();
+            var builder = new McpPluginBuilder(new Version());
+            var method = typeof(ReflectedThrowingTool).GetMethod(nameof(ReflectedThrowingTool.Throw));
+            builder.WithTool("reflected-throw", "Reflected Throw", typeof(ReflectedThrowingTool), method!);
+            var plugin = builder.Build(reflector);
+
+            var response = await plugin.McpManager.ToolManager!.RunCallTool(
+                new RequestCallTool("request-1", "reflected-throw", EmptyArgs));
+
+            response.Status.ShouldBe(ResponseStatus.Error);
+            response.ErrorKind.ShouldBe(ResponseErrorKind.Internal);
         }
 
         [Fact]
@@ -153,6 +170,11 @@ namespace com.IvanMurzak.McpPlugin.Tests.Mcp
 
             public Task<ResponseCallTool> Run(string requestId, IReadOnlyDictionary<string, JsonElement>? namedParameters, CancellationToken cancellationToken = default)
                 => Task.FromException<ResponseCallTool>(_exception);
+        }
+
+        sealed class ReflectedThrowingTool
+        {
+            public string Throw() => throw new ApplicationException("reflected tool failed");
         }
     }
 }

--- a/McpPlugin/src/Mcp/McpSystemToolManager.cs
+++ b/McpPlugin/src/Mcp/McpSystemToolManager.cs
@@ -11,6 +11,7 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -64,30 +65,47 @@ namespace com.IvanMurzak.McpPlugin
         public async Task<ResponseData<ResponseCallTool>> RunSystemTool(RequestCallTool request, CancellationToken cancellationToken = default)
         {
             if (request == null)
-                return ResponseData<ResponseCallTool>.Error(string.Empty, "Request is null.");
+                return ResponseData<ResponseCallTool>.Error(string.Empty, "Request is null.", ResponseErrorKind.BadRequest);
 
             var name = request.Name;
             if (string.IsNullOrWhiteSpace(name))
-                return ResponseData<ResponseCallTool>.Error(request.RequestID, "System tool name is empty.");
+                return ResponseData<ResponseCallTool>.Error(request.RequestID, "System tool name is empty.", ResponseErrorKind.BadRequest);
 
             if (!_tools.TryGetValue(name, out var tool))
             {
                 _logger.LogWarning("System tool '{name}' not found. Available: [{available}]",
                     name, string.Join(", ", _tools.Keys.OrderBy(k => k)));
-                return ResponseData<ResponseCallTool>.Error(request.RequestID, $"System tool '{name}' not found.");
+                return ResponseData<ResponseCallTool>.Error(request.RequestID, $"System tool '{name}' not found.", ResponseErrorKind.NotFound);
             }
 
             try
             {
                 _logger.LogDebug("Executing system tool '{name}'.", name);
                 var result = await tool.Run(request.RequestID, request.Arguments, cancellationToken);
+                if (result == null)
+                    return ResponseData<ResponseCallTool>.Error(request.RequestID, $"System tool '{name}' returned null result.", ResponseErrorKind.Internal);
+
                 return result.Pack(request.RequestID);
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "System tool '{name}' failed.", name);
-                return ResponseData<ResponseCallTool>.Error(request.RequestID, $"System tool '{name}' failed: {ex.Message}");
+                return ResponseData<ResponseCallTool>.Error(request.RequestID, $"System tool '{name}' failed: {ex.Message}", ClassifyException(ex));
             }
+        }
+
+        static ResponseErrorKind ClassifyException(Exception ex)
+        {
+            if (ex is ArgumentException || ex is FormatException || ex is JsonException)
+                return ResponseErrorKind.BadRequest;
+            if (ex is FileNotFoundException || ex is DirectoryNotFoundException || ex is KeyNotFoundException)
+                return ResponseErrorKind.NotFound;
+            if (ex is InvalidOperationException)
+                return ResponseErrorKind.Conflict;
+            if (ex is TimeoutException)
+                return ResponseErrorKind.Timeout;
+
+            return ResponseErrorKind.Internal;
         }
 
         public Task<ResponseData<ResponseListTool[]>> RunListSystemTool(RequestListTool request, CancellationToken cancellationToken = default)

--- a/McpPlugin/src/Mcp/McpToolManager.cs
+++ b/McpPlugin/src/Mcp/McpToolManager.cs
@@ -10,6 +10,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
@@ -125,15 +126,15 @@ namespace com.IvanMurzak.McpPlugin
         {
             Interlocked.Increment(ref Unsafe.As<ulong, long>(ref toolCallsCount));
             if (data == null)
-                return ResponseData<ResponseCallTool>.Error(Common.Consts.Guid.Zero, "Tool data is null.")
+                return ResponseData<ResponseCallTool>.Error(Common.Consts.Guid.Zero, "Tool data is null.", ResponseErrorKind.BadRequest)
                     .Log(_logger);
 
             if (string.IsNullOrEmpty(data.Name))
-                return ResponseData<ResponseCallTool>.Error(data.RequestID, "Tool.Name is null.")
+                return ResponseData<ResponseCallTool>.Error(data.RequestID, "Tool.Name is null.", ResponseErrorKind.BadRequest)
                     .Log(_logger);
 
             if (!_tools.TryGetValue(data.Name, out var runner))
-                return ResponseData<ResponseCallTool>.Error(data.RequestID, $"Tool with Name '{data.Name}' not found.")
+                return ResponseData<ResponseCallTool>.Error(data.RequestID, $"Tool with Name '{data.Name}' not found.", ResponseErrorKind.NotFound)
                     .Log(_logger);
             try
             {
@@ -147,7 +148,7 @@ namespace com.IvanMurzak.McpPlugin
 
                 var result = await runner.Run(data.RequestID, data.Arguments, cancellationToken);
                 if (result == null)
-                    return ResponseData<ResponseCallTool>.Error(data.RequestID, $"Tool '{data.Name}' returned null result.")
+                    return ResponseData<ResponseCallTool>.Error(data.RequestID, $"Tool '{data.Name}' returned null result.", ResponseErrorKind.Internal)
                         .Log(_logger);
 
                 result.Log(_logger);
@@ -156,10 +157,23 @@ namespace com.IvanMurzak.McpPlugin
             }
             catch (Exception ex)
             {
-                // Handle or log the exception as needed
-                return ResponseData<ResponseCallTool>.Error(data.RequestID, $"Failed to run tool '{data.Name}'. Exception: {ex}")
+                return ResponseData<ResponseCallTool>.Error(data.RequestID, $"Failed to run tool '{data.Name}'. Exception: {ex.Message}", ClassifyException(ex))
                     .Log(_logger, $"RunCallTool[{data.Name}]", ex);
             }
+        }
+
+        static ResponseErrorKind ClassifyException(Exception ex)
+        {
+            if (ex is ArgumentException || ex is FormatException || ex is JsonException)
+                return ResponseErrorKind.BadRequest;
+            if (ex is FileNotFoundException || ex is DirectoryNotFoundException || ex is KeyNotFoundException)
+                return ResponseErrorKind.NotFound;
+            if (ex is InvalidOperationException)
+                return ResponseErrorKind.Conflict;
+            if (ex is TimeoutException)
+                return ResponseErrorKind.Timeout;
+
+            return ResponseErrorKind.Internal;
         }
 
         public Task<ResponseData<ResponseListTool[]>> RunListTool(RequestListTool data) => RunListTool(data, default);

--- a/McpPlugin/src/Mcp/Tool/RunTool.cs
+++ b/McpPlugin/src/Mcp/Tool/RunTool.cs
@@ -182,7 +182,7 @@ namespace com.IvanMurzak.McpPlugin
                 var errorMessage = $"Parameter validation failed for tool '{Title ?? this.Method?.Name}': {ex.Message}";
                 _logger?.LogError(ex, errorMessage);
                 return ResponseCallTool
-                    .Error(errorMessage)
+                    .Error(errorMessage, ResponseErrorKind.BadRequest)
                     .SetRequestID(requestId);
             }
             catch (TargetParameterCountException ex)
@@ -190,7 +190,7 @@ namespace com.IvanMurzak.McpPlugin
                 var errorMessage = $"Parameter count mismatch for tool '{Title ?? this.Method?.Name}'. Expected {this.Method?.GetParameters().Length} parameters, but received {parameters?.Length}";
                 _logger?.LogError(ex, errorMessage);
                 return ResponseCallTool
-                    .Error(errorMessage)
+                    .Error(errorMessage, ResponseErrorKind.BadRequest)
                     .SetRequestID(requestId);
             }
             catch (Exception ex)
@@ -198,7 +198,7 @@ namespace com.IvanMurzak.McpPlugin
                 var errorMessage = $"Tool execution failed for '{Title ?? this.Method?.Name}': {(ex.InnerException ?? ex).Message}";
                 _logger?.LogError(ex, $"{errorMessage}\n{ex.StackTrace}");
                 return ResponseCallTool
-                    .Error(errorMessage)
+                    .Error(errorMessage, ResponseErrorKind.Internal)
                     .SetRequestID(requestId);
             }
         }
@@ -231,7 +231,7 @@ namespace com.IvanMurzak.McpPlugin
                 var errorMessage = $"Parameter validation failed for tool '{Title ?? this.Method?.Name}': {ex.Message}";
                 _logger?.LogError(ex, errorMessage);
                 return ResponseCallTool
-                    .Error(errorMessage)
+                    .Error(errorMessage, ResponseErrorKind.BadRequest)
                     .SetRequestID(requestId);
             }
             catch (JsonException ex)
@@ -239,7 +239,7 @@ namespace com.IvanMurzak.McpPlugin
                 var errorMessage = $"JSON parameter parsing failed for tool '{Title ?? this.Method?.Name}': {ex.Message}";
                 _logger?.LogError(ex, errorMessage);
                 return ResponseCallTool
-                    .Error(errorMessage)
+                    .Error(errorMessage, ResponseErrorKind.BadRequest)
                     .SetRequestID(requestId);
             }
             catch (Exception ex)
@@ -247,7 +247,7 @@ namespace com.IvanMurzak.McpPlugin
                 var errorMessage = $"Tool execution failed for '{Title ?? this.Method?.Name}': {(ex.InnerException ?? ex).Message}";
                 _logger?.LogError(ex, $"{errorMessage}\n{ex.StackTrace}");
                 return ResponseCallTool
-                    .Error(errorMessage)
+                    .Error(errorMessage, ResponseErrorKind.Internal)
                     .SetRequestID(requestId);
             }
         }
@@ -265,7 +265,7 @@ namespace com.IvanMurzak.McpPlugin
                 var errorMessage = $"Request ID cannot be null or empty for tool '{Title ?? this.Method?.Name}'";
                 _logger?.LogError(errorMessage);
                 return ResponseCallTool
-                    .Error(errorMessage)
+                    .Error(errorMessage, ResponseErrorKind.BadRequest)
                     .SetRequestID(requestId);
             }
 
@@ -274,7 +274,7 @@ namespace com.IvanMurzak.McpPlugin
                 var errorMessage = $"Method information is not available for tool '{Title}'";
                 _logger?.LogError(errorMessage);
                 return ResponseCallTool
-                    .Error(errorMessage)
+                    .Error(errorMessage, ResponseErrorKind.Internal)
                     .SetRequestID(requestId);
             }
 
@@ -284,7 +284,7 @@ namespace com.IvanMurzak.McpPlugin
                 var errorMessage = $"Method '{this.Method.Name}' in tool '{Title}' is not accessible (must be public or protected)";
                 _logger?.LogError(errorMessage);
                 return ResponseCallTool
-                    .Error(errorMessage)
+                    .Error(errorMessage, ResponseErrorKind.Internal)
                     .SetRequestID(requestId);
             }
 


### PR DESCRIPTION
## Summary

This PR fixes direct HTTP error reporting for MCP tool and system-tool calls. Tool execution errors now carry typed error metadata, and the direct HTTP endpoints map that metadata to accurate HTTP statuses instead of returning `500` for every tool error.

## Root cause

`ResponseData` and `ResponseCallTool` only carried `ResponseStatus.Error` plus a human-readable message. Direct HTTP endpoints had no structured way to distinguish bad client input, missing tools, invalid editor state, unavailable plugin connections, timeouts, or actual server bugs, so they treated all tool errors as server failures.

## Changes

- Add `ResponseErrorKind` plus optional `HttpStatusCode` metadata to shared response models.
- Preserve tool error metadata through `ResponseCallTool.Pack()`.
- Classify standard tool and system-tool validation/exception failures.
- Mark remote invocation failures as `Unavailable`, `Timeout`, or `Internal` where appropriate.
- Map direct HTTP tool/system-tool errors to `400`, `404`, `409`, `503`, `504`, or `500`; null hub responses now return `502`.
- Add regression tests for response metadata, manager classification, and direct HTTP endpoint status mapping.

## Behavior notes

MCP JSON-RPC tool calls still use normal MCP tool-result errors. This change only affects the direct HTTP API status code semantics.

## Validation

- `dotnet test McpPlugin.Tests\McpPlugin.Tests.csproj`
- `dotnet test McpPlugin.Server.Tests\McpPlugin.Server.Tests.csproj`
- `dotnet test McpPlugin.sln`