### PR TITLE
chore(release): McpPlugin 7.0.0-preview.1 — major prerelease

### DIFF
--- a/McpPlugin.Common/McpPlugin.Common.csproj
+++ b/McpPlugin.Common/McpPlugin.Common.csproj
@@ -11,7 +11,7 @@
     <!-- NuGet Package Information -->
     <IsPackable>true</IsPackable>
     <PackageId>com.IvanMurzak.McpPlugin.Common</PackageId>
-    <Version>6.11.1</Version>
+    <Version>7.0.0-preview.1</Version>
     <Authors>Ivan Murzak</Authors>
     <Company>Ivan Murzak</Company>
     <Copyright>Copyright © Ivan Murzak 2025</Copyright>

--- a/McpPlugin.Common/src/Utils/Consts.cs
+++ b/McpPlugin.Common/src/Utils/Consts.cs
@@ -12,7 +12,7 @@ namespace com.IvanMurzak.McpPlugin.Common
     public static partial class Consts
     {
         public const string ApiVersion = "2.0.0";
-        public const string PluginVersion = "6.11.1";
+        public const string PluginVersion = "7.0.0-preview.1";
 
         public static class Guid
         {

--- a/McpPlugin.Server/McpPlugin.Server.csproj
+++ b/McpPlugin.Server/McpPlugin.Server.csproj
@@ -11,7 +11,7 @@
     <!-- NuGet Package Information -->
     <IsPackable>true</IsPackable>
     <PackageId>com.IvanMurzak.McpPlugin.Server</PackageId>
-    <Version>6.11.1</Version>
+    <Version>7.0.0-preview.1</Version>
     <Authors>Ivan Murzak</Authors>
     <Company>Ivan Murzak</Company>
     <Copyright>Copyright © Ivan Murzak 2025</Copyright>

--- a/McpPlugin.Server/server.json
+++ b/McpPlugin.Server/server.json
@@ -8,13 +8,13 @@
     "source": "github",
     "subfolder": "McpPlugin.Server"
   },
-  "version": "6.11.1",
+  "version": "7.0.0-preview.1",
   "packages": [
     {
       "registry_type": "oci",
       "registry_base_url": "https://docker.io",
       "identifier": "ivanmurzakdev/mcp-plugin-server",
-      "version": "6.11.1",
+      "version": "7.0.0-preview.1",
       "transport": {
         "type": "stdio"
       },

--- a/McpPlugin/McpPlugin.csproj
+++ b/McpPlugin/McpPlugin.csproj
@@ -15,7 +15,7 @@
     <!-- NuGet Package Information -->
     <IsPackable>true</IsPackable>
     <PackageId>com.IvanMurzak.McpPlugin</PackageId>
-    <Version>6.11.1</Version>
+    <Version>7.0.0-preview.1</Version>
     <Authors>Ivan Murzak</Authors>
     <Company>Ivan Murzak</Company>
     <Copyright>Copyright © Ivan Murzak 2025</Copyright>


### PR DESCRIPTION
## McpPlugin 7.0 — major prerelease (mcp-authorize Phase 2)

Bumps all three packages (`McpPlugin`, `McpPlugin.Common`, `McpPlugin.Server`) 6.11.1 → **7.0.0-preview.1**.

This is the breaking 6.x → 7.0 major delivered by the mcp-authorize design (b1–b8, already merged to `main`): OAuth 2.1 resource-server auth (JWKS/ES256 validation, strict aud, Origin 403), account+instance pairing plane, legacy shared-token/DCR removal, stdio contention contract.

**Published as a PRERELEASE deliberately.** NuGet prereleases are opt-in, so no not-yet-migrated consumer resolves to it accidentally. c1 (GameDev-MCP-Server 9.0) and the engine plugins (Unity/Godot/Unreal) will pin `7.0.0-preview.1` explicitly during their migration; stable `7.0.0` ships once every consumer is migrated. No consumer cascade is run from this PR.

Merging triggers `release.yml` → GitHub Release/tag `7.0.0-preview.1` → NuGet publish of all three packages.

🤖 Part of the mcp-authorize design (unblocks c1 + all engine tasks).