### PR TITLE
chore(release): promote McpPlugin 7.0.0-preview.1 -> 7.0.0 stable

### DIFF
--- a/McpPlugin.Common/McpPlugin.Common.csproj
+++ b/McpPlugin.Common/McpPlugin.Common.csproj
@@ -11,7 +11,7 @@
     <!-- NuGet Package Information -->
     <IsPackable>true</IsPackable>
     <PackageId>com.IvanMurzak.McpPlugin.Common</PackageId>
-    <Version>7.0.0-preview.1</Version>
+    <Version>7.0.0</Version>
     <Authors>Ivan Murzak</Authors>
     <Company>Ivan Murzak</Company>
     <Copyright>Copyright © Ivan Murzak 2025</Copyright>

--- a/McpPlugin.Common/src/Utils/Consts.cs
+++ b/McpPlugin.Common/src/Utils/Consts.cs
@@ -12,7 +12,7 @@ namespace com.IvanMurzak.McpPlugin.Common
     public static partial class Consts
     {
         public const string ApiVersion = "2.0.0";
-        public const string PluginVersion = "7.0.0-preview.1";
+        public const string PluginVersion = "7.0.0";
 
         public static class Guid
         {

--- a/McpPlugin.Server/McpPlugin.Server.csproj
+++ b/McpPlugin.Server/McpPlugin.Server.csproj
@@ -11,7 +11,7 @@
     <!-- NuGet Package Information -->
     <IsPackable>true</IsPackable>
     <PackageId>com.IvanMurzak.McpPlugin.Server</PackageId>
-    <Version>7.0.0-preview.1</Version>
+    <Version>7.0.0</Version>
     <Authors>Ivan Murzak</Authors>
     <Company>Ivan Murzak</Company>
     <Copyright>Copyright © Ivan Murzak 2025</Copyright>

--- a/McpPlugin.Server/server.json
+++ b/McpPlugin.Server/server.json
@@ -8,13 +8,13 @@
     "source": "github",
     "subfolder": "McpPlugin.Server"
   },
-  "version": "7.0.0-preview.1",
+  "version": "7.0.0",
   "packages": [
     {
       "registry_type": "oci",
       "registry_base_url": "https://docker.io",
       "identifier": "ivanmurzakdev/mcp-plugin-server",
-      "version": "7.0.0-preview.1",
+      "version": "7.0.0",
       "transport": {
         "type": "stdio"
       },

--- a/McpPlugin/McpPlugin.csproj
+++ b/McpPlugin/McpPlugin.csproj
@@ -15,7 +15,7 @@
     <!-- NuGet Package Information -->
     <IsPackable>true</IsPackable>
     <PackageId>com.IvanMurzak.McpPlugin</PackageId>
-    <Version>7.0.0-preview.1</Version>
+    <Version>7.0.0</Version>
     <Authors>Ivan Murzak</Authors>
     <Company>Ivan Murzak</Company>
     <Copyright>Copyright © Ivan Murzak 2025</Copyright>


### PR DESCRIPTION
## Promote McpPlugin 7.0 to STABLE (`7.0.0-preview.1` → `7.0.0`)

First step of the mcp-authorize Phase-4 release sequence. The 7.0 major has lived on NuGet as
`7.0.0-preview.1` (b8) to unblock the 9.0 server + engine work without a stable public-dep commitment.
Local pre-release verification is complete (client auth chain verified end-to-end), so promote to
**stable 7.0.0** — the 3 engine plugins will then ship depending on a stable McpPlugin, not a prerelease.

### Change
Version-only bump (6 occurrences, 5 files): `McpPlugin` / `McpPlugin.Common` / `McpPlugin.Server` csproj
`<Version>`, `server.json` (2×), and `Consts.PluginVersion`. No code changes.

> Note: the repo's `bump-version.ps1` and the release pipeline both read the version with a `[\d.]+`
> regex that can't match a `-preview.N` suffix, so this prerelease→stable promotion is a deliberate
> hand-edit (they'd otherwise report "no matches" / "not strictly greater").

### No cascade here
The 3 engine plugins (Unity/Godot/Unreal) are re-pinned `7.0.0-preview.1` → `7.0.0` in the **next**
step (Phase-4 engine releases), so this PR intentionally does NOT bump any consumer.

### On merge
`release.yml` (push→main) creates GitHub release **v7.0.0** (`prerelease: false`) → `deploy.yml`
(release `released`) publishes the 3 packages to NuGet via OIDC Trusted Publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
