### PR TITLE
feat(auth): offline local `token` auth strategy + constant-time gate (mcp-authorize g6)

### DIFF
--- a/McpPlugin.Common/src/Utils/Consts.MCP.cs
+++ b/McpPlugin.Common/src/Utils/Consts.MCP.cs
@@ -202,6 +202,13 @@ namespace com.IvanMurzak.McpPlugin.Common
                 {
                     unknown,
                     none,
+
+                    /// <summary>
+                    /// Legacy shared-token pairing mode name (mcp-authorize b5 removed its dedicated
+                    /// strategy). RETAINED so an un-migrated <c>authorization=required</c> config does
+                    /// not silently downgrade to anonymous: the server's <c>McpStrategyFactory</c>
+                    /// aliases <c>required</c> onto the offline <see cref="token"/> strategy (mcp-authorize g6).
+                    /// </summary>
                     required,
 
                     /// <summary>
@@ -210,7 +217,17 @@ namespace com.IvanMurzak.McpPlugin.Common
                     /// introspection; it never mints tokens. Selected via <c>--auth oauth</c> /
                     /// <c>MCP_AUTH=oauth</c>.
                     /// </summary>
-                    oauth
+                    oauth,
+
+                    /// <summary>
+                    /// Offline shared-secret mode (mcp-authorize g6). A loopback single-project server
+                    /// gates BOTH the SignalR plugin connection and the streamableHttp MCP endpoint on a
+                    /// single static bearer secret (<c>--token</c> / <c>MCP_PLUGIN_TOKEN</c>), validated
+                    /// with a constant-time compare. No authorization server / egress required — the
+                    /// offline counterpart of <see cref="oauth"/>. Selected via <c>--auth token</c> /
+                    /// <c>MCP_AUTH=token</c>.
+                    /// </summary>
+                    token
                 }
 
                 /// <summary>

--- a/McpPlugin.Server.Tests/DirectToolEndpointsAuthGatingTests.cs
+++ b/McpPlugin.Server.Tests/DirectToolEndpointsAuthGatingTests.cs
@@ -31,14 +31,17 @@ using Xunit;
 namespace com.IvanMurzak.McpPlugin.Server.Tests
 {
     /// <summary>
-    /// mcp-authorize b7 folded fix 2 (🔒 security regression): the direct-tool REST surface (<c>/api/tools</c>)
-    /// and the system-tool surface (<c>/api/system-tools</c>) MUST require a valid token in <c>oauth</c> mode
-    /// (fail closed) and be reachable in <c>none</c> mode. Before b7 both gated on the now-unreachable
-    /// <c>AuthOption.required</c>, so they were NEVER authorization-gated in oauth mode.
+    /// 🔒 The direct-tool REST surface (<c>/api/tools</c>) and the system-tool surface (<c>/api/system-tools</c>)
+    /// can EXECUTE tools, so they MUST fail closed in every credential-bearing mode — <c>oauth</c>, the offline
+    /// <c>token</c> (mcp-authorize g6), and the deprecated <c>required</c> alias — and be reachable only in
+    /// <c>none</c> mode. b7 closed the oauth gap (both once gated on the now-unreachable <c>required</c>); g6
+    /// closes the token-mode gap so the REST surface is never an unauthenticated bypass of the endpoint's token gate.
     /// </summary>
     [Collection("McpPlugin.Server")]
     public sealed class DirectToolEndpointsAuthGatingTests
     {
+        const string Secret = "rest-gate-secret";
+
         [Theory]
         [InlineData("/api/tools")]
         [InlineData("/api/system-tools")]
@@ -50,6 +53,49 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
             var response = await client.GetAsync(route);
 
             response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized, $"{route} must fail closed (401) in oauth mode without a token");
+        }
+
+        [Theory]
+        [InlineData("/api/tools")]
+        [InlineData("/api/system-tools")]
+        public async Task TokenMode_WithoutToken_Returns401(string route)
+        {
+            await using var host = await StartHostAsync(Consts.MCP.Server.AuthOption.token);
+            using var client = new HttpClient { BaseAddress = new Uri(host.BaseUrl) };
+
+            var response = await client.GetAsync(route);
+
+            response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized, $"{route} must fail closed (401) in token mode without a token");
+        }
+
+        [Theory]
+        [InlineData("/api/tools")]
+        [InlineData("/api/system-tools")]
+        public async Task RequiredAliasMode_WithoutToken_Returns401(string route)
+        {
+            // The deprecated `required` alias resolves to token-gated behavior — it must gate the REST surface too.
+            await using var host = await StartHostAsync(Consts.MCP.Server.AuthOption.required);
+            using var client = new HttpClient { BaseAddress = new Uri(host.BaseUrl) };
+
+            var response = await client.GetAsync(route);
+
+            response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized, $"{route} must fail closed (401) in the required-alias mode without a token");
+        }
+
+        [Theory]
+        [InlineData("/api/tools")]
+        [InlineData("/api/system-tools")]
+        public async Task TokenMode_WithValidToken_IsReachable(string route)
+        {
+            await using var host = await StartHostAsync(Consts.MCP.Server.AuthOption.token);
+            using var client = new HttpClient { BaseAddress = new Uri(host.BaseUrl) };
+            var request = new HttpRequestMessage(HttpMethod.Get, route);
+            request.Headers.TryAddWithoutValidation("Authorization", $"Bearer {Secret}");
+
+            var response = await client.SendAsync(request);
+
+            response.StatusCode.ShouldNotBe(HttpStatusCode.Unauthorized, $"{route} must be reachable with the correct token");
+            ((int)response.StatusCode).ShouldBeLessThan(500, $"{route} should serve the (empty) tool list with a valid token");
         }
 
         [Theory]
@@ -79,11 +125,20 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
             builder.Services.AddSingleton<IClientSystemToolHub>(new StubSystemToolHub());
             builder.Services.AddSingleton(Mock.Of<IAuthorizationWebhookService>());
 
+            var localTokenMode = authOption == Consts.MCP.Server.AuthOption.token
+                || authOption == Consts.MCP.Server.AuthOption.required;
+
             builder.Services
                 .AddAuthentication(TokenAuthenticationHandler.SchemeName)
                 .AddScheme<TokenAuthenticationOptions, TokenAuthenticationHandler>(
                     TokenAuthenticationHandler.SchemeName,
-                    options => options.OAuthMode = authOption == Consts.MCP.Server.AuthOption.oauth);
+                    options =>
+                    {
+                        options.OAuthMode = authOption == Consts.MCP.Server.AuthOption.oauth;
+                        options.LocalTokenMode = localTokenMode;
+                        if (localTokenMode)
+                            options.LocalToken = Secret;
+                    });
             builder.Services.AddAuthorization();
 
             var app = builder.Build();

--- a/McpPlugin.Server.Tests/LocalTokenMcpStrategyTests.cs
+++ b/McpPlugin.Server.Tests/LocalTokenMcpStrategyTests.cs
@@ -1,0 +1,200 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using com.IvanMurzak.McpPlugin.Common;
+using com.IvanMurzak.McpPlugin.Common.Model;
+using com.IvanMurzak.McpPlugin.Common.Utils;
+using com.IvanMurzak.McpPlugin.Server.Auth;
+using com.IvanMurzak.McpPlugin.Server.Strategy;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.Server.Tests
+{
+    /// <summary>
+    /// The offline <c>token</c> auth strategy (mcp-authorize g6): single-connection, broadcast routing
+    /// like <see cref="NoAuthMcpStrategy"/>, but gated at the hub on a single static secret with a
+    /// constant-time compare.
+    /// </summary>
+    [Collection("McpPlugin.Server")]
+    public class LocalTokenMcpStrategyTests
+    {
+        const string Secret = "s3cr3t-shared-token-value";
+
+        static LocalTokenMcpStrategy NewConfiguredStrategy(string token = Secret)
+        {
+            var strategy = new LocalTokenMcpStrategy();
+            strategy.Validate(new DataArguments(new[] { $"token={token}" }));
+            return strategy;
+        }
+
+        [Fact]
+        public void AuthOption_ReturnsToken()
+        {
+            new LocalTokenMcpStrategy().AuthOption.ShouldBe(Consts.MCP.Server.AuthOption.token);
+        }
+
+        [Fact]
+        public void AllowMultipleConnections_ReturnsFalse()
+        {
+            new LocalTokenMcpStrategy().AllowMultipleConnections.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void Validate_WithoutToken_Throws()
+        {
+            var strategy = new LocalTokenMcpStrategy();
+            Should.Throw<ArgumentException>(() => strategy.Validate(new DataArguments(new string[0])));
+        }
+
+        [Fact]
+        public void Validate_WithToken_DoesNotThrow()
+        {
+            var strategy = new LocalTokenMcpStrategy();
+            Should.NotThrow(() => strategy.Validate(new DataArguments(new[] { $"token={Secret}" })));
+        }
+
+        [Fact]
+        public void Validate_NonLoopbackBind_WarnsButDoesNotThrow()
+        {
+            // Owner ruling: a non-loopback bind is WARNED (LAN cleartext-token caveat) but ALLOWED.
+            var strategy = new LocalTokenMcpStrategy();
+            Should.NotThrow(() => strategy.Validate(new DataArguments(new[] { $"token={Secret}", "bind=any" })));
+        }
+
+        [Fact]
+        public void ConfigureAuthentication_EnablesLocalTokenMode_WithSecret()
+        {
+            var strategy = new LocalTokenMcpStrategy();
+            var options = new TokenAuthenticationOptions();
+
+            strategy.ConfigureAuthentication(options, new DataArguments(new[] { $"token={Secret}" }));
+
+            options.OAuthMode.ShouldBeFalse();
+            options.LocalTokenMode.ShouldBeTrue();
+            options.LocalToken.ShouldBe(Secret);
+        }
+
+        [Fact]
+        public void OnPluginConnected_WithoutToken_DisconnectsCaller()
+        {
+            var strategy = NewConfiguredStrategy();
+            var logger = new Mock<ILogger>().Object;
+            var connectionId = "conn-token-notoken";
+            var disconnected = new List<string>();
+
+            strategy.OnPluginConnected(typeof(McpServerHub), connectionId, null, logger,
+                (id, _) => disconnected.Add(id));
+
+            disconnected.ShouldContain(connectionId);
+            ClientUtils.GetAllConnectionIds(typeof(McpServerHub)).ShouldNotContain(connectionId);
+        }
+
+        [Fact]
+        public void OnPluginConnected_WithWrongToken_DisconnectsCaller()
+        {
+            var strategy = NewConfiguredStrategy();
+            var logger = new Mock<ILogger>().Object;
+            var connectionId = "conn-token-wrong";
+            var disconnected = new List<string>();
+
+            strategy.OnPluginConnected(typeof(McpServerHub), connectionId, "not-the-secret", logger,
+                (id, _) => disconnected.Add(id));
+
+            disconnected.ShouldContain(connectionId);
+            ClientUtils.GetAllConnectionIds(typeof(McpServerHub)).ShouldNotContain(connectionId);
+        }
+
+        [Fact]
+        public void OnPluginConnected_WithMatchingToken_RegistersAndEnforcesSingleConnection()
+        {
+            var strategy = NewConfiguredStrategy();
+            var logger = new Mock<ILogger>().Object;
+            var existingId = "conn-token-existing";
+            var newId = "conn-token-new";
+            var disconnected = new List<string>();
+
+            ClientUtils.AddClient(typeof(McpServerHub), existingId, logger, Secret);
+
+            try
+            {
+                strategy.OnPluginConnected(typeof(McpServerHub), newId, Secret, logger,
+                    (id, _) => disconnected.Add(id));
+
+                ClientUtils.GetAllConnectionIds(typeof(McpServerHub)).ShouldContain(newId);
+                // Single-connection invariant: the previous plugin is disconnected + removed.
+                disconnected.ShouldContain(existingId);
+                ClientUtils.GetAllConnectionIds(typeof(McpServerHub)).ShouldNotContain(existingId);
+            }
+            finally
+            {
+                ClientUtils.RemoveClient(typeof(McpServerHub), existingId, logger);
+                ClientUtils.RemoveClient(typeof(McpServerHub), newId, logger);
+            }
+        }
+
+        [Fact]
+        public void OnPluginDisconnected_RemovesClient()
+        {
+            var strategy = NewConfiguredStrategy();
+            var logger = new Mock<ILogger>().Object;
+            var connectionId = "conn-token-remove";
+            ClientUtils.AddClient(typeof(McpServerHub), connectionId, logger, Secret);
+
+            strategy.OnPluginDisconnected(typeof(McpServerHub), connectionId, logger);
+
+            ClientUtils.GetAllConnectionIds(typeof(McpServerHub)).ShouldNotContain(connectionId);
+        }
+
+        [Fact]
+        public void ShouldNotifySession_AlwaysReturnsTrue()
+        {
+            var strategy = NewConfiguredStrategy();
+            strategy.ShouldNotifySession("any-connection", "any-session").ShouldBeTrue();
+        }
+
+        [Fact]
+        public void ResolveNotificationTarget_AlwaysBroadcasts()
+        {
+            var strategy = NewConfiguredStrategy();
+            foreach (var probe in new[] { (string?)null, "", "any-token" })
+                strategy.ResolveNotificationTarget(probe).Kind.ShouldBe(NotificationTarget.TargetKind.Broadcast);
+        }
+
+        [Fact]
+        public void GetClientData_DelegatesToSessionTracker()
+        {
+            var strategy = NewConfiguredStrategy();
+            var tracker = new Mock<IMcpSessionTracker>();
+            var expected = new McpClientData { IsConnected = true, ClientName = "test" };
+            tracker.Setup(t => t.GetClientData()).Returns(expected);
+
+            strategy.GetClientData("any-connection", tracker.Object).ShouldBeSameAs(expected);
+            tracker.Verify(t => t.GetClientData(), Times.Once);
+        }
+
+        [Fact]
+        public void GetServerData_DelegatesToSessionTracker()
+        {
+            var strategy = NewConfiguredStrategy();
+            var tracker = new Mock<IMcpSessionTracker>();
+            var expected = new McpServerData { IsAiAgentConnected = true };
+            tracker.Setup(t => t.GetServerData()).Returns(expected);
+
+            strategy.GetServerData("any-connection", tracker.Object).ShouldBeSameAs(expected);
+            tracker.Verify(t => t.GetServerData(), Times.Once);
+        }
+    }
+}

--- a/McpPlugin.Server.Tests/McpStrategyFactoryTests.cs
+++ b/McpPlugin.Server.Tests/McpStrategyFactoryTests.cs
@@ -43,15 +43,26 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
         }
 
         [Fact]
-        public void Create_Required_ThrowsArgumentException()
+        public void Create_Token_ReturnsLocalTokenMcpStrategy()
         {
-            // mcp-authorize b5: the legacy shared-token pairing mode is deleted. The factory now
-            // switches ONLY on {none, oauth}; `required` fails closed with an explicit error
-            // (no silent downgrade to `none`).
-            Action act = () => _factory.Create(Consts.MCP.Server.AuthOption.required);
+            // mcp-authorize g6: the offline shared-secret mode.
+            var strategy = _factory.Create(Consts.MCP.Server.AuthOption.token);
 
-            Should.Throw<ArgumentException>(act)
-                .Message.ShouldContain("Unsupported auth option");
+            strategy.ShouldBeOfType<LocalTokenMcpStrategy>();
+            strategy.AuthOption.ShouldBe(Consts.MCP.Server.AuthOption.token);
+        }
+
+        [Fact]
+        public void Create_Required_AliasesOntoLocalTokenMcpStrategy()
+        {
+            // mcp-authorize g6 back-compat: the deprecated `required` alias must NOT throw (that would
+            // crash an un-migrated binary) and must NOT downgrade to anonymous — it maps onto the same
+            // token-gated strategy so old `authorization=required` configs keep working token-gated.
+            var strategy = _factory.Create(Consts.MCP.Server.AuthOption.required);
+
+            strategy.ShouldBeOfType<LocalTokenMcpStrategy>();
+            // The resolved strategy reports the target-state `token` option, not the legacy alias name.
+            strategy.AuthOption.ShouldBe(Consts.MCP.Server.AuthOption.token);
         }
 
         [Fact]

--- a/McpPlugin.Server.Tests/TokenAuthenticationHandlerLocalTokenTests.cs
+++ b/McpPlugin.Server.Tests/TokenAuthenticationHandlerLocalTokenTests.cs
@@ -1,0 +1,161 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System.IO;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.Common;
+using com.IvanMurzak.McpPlugin.Server.Auth;
+using com.IvanMurzak.McpPlugin.Server.Webhooks.Services;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.Server.Tests
+{
+    /// <summary>
+    /// The offline <c>token</c> mode's HTTP-endpoint gate (mcp-authorize g6): the presented Bearer is
+    /// compared against the configured secret in constant time; the hub path stays silent (BaseHub does
+    /// its own auth); a missing credential yields the non-OAuth <c>Bearer realm</c> 401 challenge.
+    /// </summary>
+    [Collection("McpPlugin.Server")]
+    public class TokenAuthenticationHandlerLocalTokenTests
+    {
+        const string Secret = "the-shared-local-secret";
+
+        static (TokenAuthenticationHandler Handler, DefaultHttpContext Context, AuthenticationScheme Scheme) Create(
+            string? configuredSecret)
+        {
+            var options = new TokenAuthenticationOptions { LocalTokenMode = true, LocalToken = configuredSecret };
+            var monitor = new Mock<IOptionsMonitor<TokenAuthenticationOptions>>();
+            monitor.Setup(x => x.CurrentValue).Returns(options);
+            monitor.Setup(x => x.Get(TokenAuthenticationHandler.SchemeName)).Returns(options);
+
+            var loggerFactory = new Mock<ILoggerFactory>();
+            loggerFactory.Setup(x => x.CreateLogger(It.IsAny<string>())).Returns(new Mock<ILogger>().Object);
+
+            var handler = new TokenAuthenticationHandler(
+                monitor.Object,
+                loggerFactory.Object,
+                System.Text.Encodings.Web.UrlEncoder.Default,
+                new NoOpAuthorizationWebhookService());
+
+            var context = new DefaultHttpContext();
+            context.Response.Body = new MemoryStream();
+            var scheme = new AuthenticationScheme(
+                TokenAuthenticationHandler.SchemeName, TokenAuthenticationHandler.SchemeName, typeof(TokenAuthenticationHandler));
+            return (handler, context, scheme);
+        }
+
+        [Fact]
+        public async Task ValidToken_OnMcpPath_Succeeds_WithTokenClaim()
+        {
+            var (handler, context, scheme) = Create(Secret);
+            context.Request.Headers["Authorization"] = $"Bearer {Secret}";
+            context.Request.Path = new PathString("/mcp");
+            await handler.InitializeAsync(scheme, context);
+
+            var result = await handler.AuthenticateAsync();
+
+            result.Succeeded.ShouldBeTrue();
+            result.Principal!.HasClaim(TokenAuthenticationHandler.TokenClaimType, Secret).ShouldBeTrue();
+        }
+
+        [Fact]
+        public async Task InvalidToken_OnMcpPath_Fails()
+        {
+            var (handler, context, scheme) = Create(Secret);
+            context.Request.Headers["Authorization"] = "Bearer wrong-secret";
+            context.Request.Path = new PathString("/mcp");
+            await handler.InitializeAsync(scheme, context);
+
+            var result = await handler.AuthenticateAsync();
+
+            result.Succeeded.ShouldBeFalse();
+            result.None.ShouldBeFalse();
+        }
+
+        [Fact]
+        public async Task InvalidToken_OnHubPath_ReturnsNoResult()
+        {
+            var (handler, context, scheme) = Create(Secret);
+            context.Request.Headers["Authorization"] = "Bearer wrong-secret";
+            context.Request.Path = new PathString(Consts.Hub.RemoteApp);
+            await handler.InitializeAsync(scheme, context);
+
+            var result = await handler.AuthenticateAsync();
+
+            result.None.ShouldBeTrue();
+        }
+
+        [Fact]
+        public async Task NoToken_OnMcpPath_ReturnsNoResult()
+        {
+            // NoResult lets the RequireAuthorization pipeline issue the 401 challenge.
+            var (handler, context, scheme) = Create(Secret);
+            context.Request.Path = new PathString("/mcp");
+            await handler.InitializeAsync(scheme, context);
+
+            var result = await handler.AuthenticateAsync();
+
+            result.None.ShouldBeTrue();
+        }
+
+        [Fact]
+        public async Task EmptyConfiguredSecret_RejectsAnyPresentedToken()
+        {
+            // Defensive: the strategy's Validate forbids an empty secret at boot, but the handler must
+            // still fail closed if one ever reaches it — an empty expected never matches.
+            var (handler, context, scheme) = Create(configuredSecret: "");
+            context.Request.Headers["Authorization"] = "Bearer anything";
+            context.Request.Path = new PathString("/mcp");
+            await handler.InitializeAsync(scheme, context);
+
+            var result = await handler.AuthenticateAsync();
+
+            result.Succeeded.ShouldBeFalse();
+        }
+
+        [Fact]
+        public async Task PrefixSharingToken_Fails_ConstantTimeCompare()
+        {
+            // A token that shares a long prefix with the secret must still be rejected — proves the
+            // compare is over the full fixed-length digest, not an early-exit prefix match.
+            var (handler, context, scheme) = Create(Secret);
+            context.Request.Headers["Authorization"] = $"Bearer {Secret}-extra";
+            context.Request.Path = new PathString("/mcp");
+            await handler.InitializeAsync(scheme, context);
+
+            var result = await handler.AuthenticateAsync();
+
+            result.Succeeded.ShouldBeFalse();
+        }
+
+        [Fact]
+        public async Task Challenge_Emits401_WithBearerRealm()
+        {
+            var (handler, context, scheme) = Create(Secret);
+            context.Request.Path = new PathString("/mcp");
+            await handler.InitializeAsync(scheme, context);
+
+            await handler.ChallengeAsync(null);
+
+            context.Response.StatusCode.ShouldBe(401);
+            var wwwAuth = context.Response.Headers["WWW-Authenticate"].ToString();
+            wwwAuth.ShouldContain("Bearer realm=\"MCP Plugin Server\"");
+            // Token mode advertises NO resource_metadata (there is no authorization server to discover).
+            wwwAuth.ShouldNotContain("resource_metadata");
+        }
+    }
+}

--- a/McpPlugin.Server.Tests/TokenComparisonTests.cs
+++ b/McpPlugin.Server.Tests/TokenComparisonTests.cs
@@ -1,0 +1,52 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using com.IvanMurzak.McpPlugin.Server.Auth;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.Server.Tests
+{
+    /// <summary>
+    /// The offline <c>token</c> mode's constant-time secret comparison (mcp-authorize g6). Asserts
+    /// correctness across the cases a timing-leaky <c>string.Equals</c> would distinguish by early exit:
+    /// prefix-sharing values and different-length values both fail, matching values succeed.
+    /// </summary>
+    public class TokenComparisonTests
+    {
+        [Fact]
+        public void Equal_Tokens_Match()
+        {
+            TokenComparison.FixedTimeEquals("shared-secret-abc", "shared-secret-abc").ShouldBeTrue();
+        }
+
+        [Theory]
+        [InlineData("shared-secret-abc", "shared-secret-abd")] // differ in last char
+        [InlineData("shared-secret-abc", "shared-secret-abc-longer")] // shared prefix, different length
+        [InlineData("shared-secret-abc", "x")] // shorter, no shared prefix
+        [InlineData("shared-secret-abc", "Shared-Secret-Abc")] // case differs (case-sensitive)
+        public void Mismatched_Tokens_DoNotMatch(string presented, string expected)
+        {
+            TokenComparison.FixedTimeEquals(presented, expected).ShouldBeFalse();
+        }
+
+        [Theory]
+        [InlineData(null, "secret")]
+        [InlineData("secret", null)]
+        [InlineData("", "secret")]
+        [InlineData("secret", "")]
+        [InlineData(null, null)]
+        public void NullOrEmpty_Operand_NeverMatches(string? presented, string? expected)
+        {
+            TokenComparison.FixedTimeEquals(presented, expected).ShouldBeFalse();
+        }
+    }
+}

--- a/McpPlugin.Server.Tests/TokenModeTransportGatingTests.cs
+++ b/McpPlugin.Server.Tests/TokenModeTransportGatingTests.cs
@@ -1,0 +1,144 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.Common;
+using com.IvanMurzak.McpPlugin.Common.Utils;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.Server.Tests
+{
+    /// <summary>
+    /// End-to-end proof that offline <c>token</c> mode (mcp-authorize g6) both VALIDATES and ENFORCES
+    /// the shared secret. Drives a REAL loopback host through the full production wiring
+    /// (<c>WithMcpServer</c> → <c>WithMcpPluginServer</c> → <c>UseMcpPluginServer</c>): an anonymous /
+    /// wrong-token request is rejected with 401 (the endpoint is <c>RequireAuthorization</c>-gated —
+    /// without the gate the token would be validated but never enforced), while the correct Bearer
+    /// establishes an MCP session. No RFC 9728 resource-metadata is served in token mode.
+    /// </summary>
+    [Collection("McpPlugin.Server")]
+    public sealed class TokenModeTransportGatingTests
+    {
+        const string Secret = "gating-test-shared-secret";
+
+        [Fact]
+        public async Task TokenMode_NoBearer_Returns401()
+        {
+            await using var host = await StartHostAsync();
+            using var client = NewClient(host);
+
+            using var resp = await client.SendAsync(InitializeRequest("/mcp", bearer: null), HttpCompletionOption.ResponseHeadersRead);
+            resp.StatusCode.ShouldBe(HttpStatusCode.Unauthorized, "token mode must gate /mcp (401), not serve it anonymously");
+        }
+
+        [Fact]
+        public async Task TokenMode_WrongBearer_Returns401()
+        {
+            await using var host = await StartHostAsync();
+            using var client = NewClient(host);
+
+            using var resp = await client.SendAsync(InitializeRequest("/mcp", bearer: "not-the-secret"), HttpCompletionOption.ResponseHeadersRead);
+            resp.StatusCode.ShouldBe(HttpStatusCode.Unauthorized, "a wrong token must be rejected");
+        }
+
+        [Fact]
+        public async Task TokenMode_CorrectBearer_EstablishesSession()
+        {
+            await using var host = await StartHostAsync();
+            using var client = NewClient(host);
+
+            using var resp = await client.SendAsync(InitializeRequest("/mcp", bearer: Secret), HttpCompletionOption.ResponseHeadersRead);
+            resp.StatusCode.ShouldBe(HttpStatusCode.OK, "the correct token must reach the MCP handler");
+            resp.Headers.Contains("Mcp-Session-Id").ShouldBeTrue("a valid session must be established");
+        }
+
+        [Fact]
+        public async Task TokenMode_ServesNoResourceMetadata()
+        {
+            await using var host = await StartHostAsync();
+            using var client = NewClient(host);
+
+            using var resp = await client.GetAsync("/.well-known/oauth-protected-resource");
+            resp.StatusCode.ShouldBe(HttpStatusCode.NotFound, "token mode has no authorization server to advertise");
+        }
+
+        // ───────────────── helpers ─────────────────
+
+        static HttpClient NewClient(RunningHost host)
+            => new HttpClient { BaseAddress = new Uri(host.BaseUrl), Timeout = TimeSpan.FromSeconds(30) };
+
+        static HttpRequestMessage InitializeRequest(string path, string? bearer)
+        {
+            var req = new HttpRequestMessage(HttpMethod.Post, path);
+            req.Headers.TryAddWithoutValidation("Accept", "application/json, text/event-stream");
+            if (!string.IsNullOrEmpty(bearer))
+                req.Headers.TryAddWithoutValidation("Authorization", $"Bearer {bearer}");
+            req.Content = new StringContent(
+                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{" +
+                "\"protocolVersion\":\"2025-06-18\",\"capabilities\":{}," +
+                "\"clientInfo\":{\"name\":\"token-gating-test\",\"version\":\"1.0.0\"}}}",
+                Encoding.UTF8, "application/json");
+            return req;
+        }
+
+        static async Task<RunningHost> StartHostAsync()
+        {
+            var dataArguments = new DataArguments(new[] { "client-transport=streamableHttp", "auth=token", $"token={Secret}" });
+
+            var builder = WebApplication.CreateBuilder();
+            builder.Logging.ClearProviders();
+            builder.Services
+                .WithMcpServer(dataArguments)
+                .WithMcpPluginServer(dataArguments);
+
+            var app = builder.Build();
+            app.Urls.Add("http://127.0.0.1:0"); // OS-assigned loopback port
+            app.UseMcpPluginServer(dataArguments);
+
+            await app.StartAsync();
+
+            var address = app.Services
+                .GetRequiredService<IServer>()
+                .Features.Get<IServerAddressesFeature>()!
+                .Addresses.First();
+            return new RunningHost(app, address);
+        }
+
+        sealed class RunningHost : IAsyncDisposable
+        {
+            readonly WebApplication _app;
+            public string BaseUrl { get; }
+
+            public RunningHost(WebApplication app, string baseUrl)
+            {
+                _app = app;
+                BaseUrl = baseUrl;
+            }
+
+            public async ValueTask DisposeAsync()
+            {
+                await _app.StopAsync();
+                await _app.DisposeAsync();
+            }
+        }
+    }
+}

--- a/McpPlugin.Server/src/Api/AuthGating.cs
+++ b/McpPlugin.Server/src/Api/AuthGating.cs
@@ -1,0 +1,33 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using com.IvanMurzak.McpPlugin.Common;
+
+namespace com.IvanMurzak.McpPlugin.Server.Api
+{
+    /// <summary>
+    /// Shared auth-gating predicate for the REST tool surfaces (<c>/api/tools</c>, <c>/api/system-tools</c>).
+    /// Keeps the direct-tool and system-tool endpoint mappers in lockstep so a credential-bearing mode can
+    /// never leave one gated and the other open.
+    /// </summary>
+    internal static class AuthGating
+    {
+        /// <summary>
+        /// True when the REST tool surface must be <c>RequireAuthorization</c>-gated: every credential-bearing
+        /// mode — <c>oauth</c>, the offline <c>token</c> (mcp-authorize g6), and the deprecated <c>required</c>
+        /// alias. Only <c>none</c> (and the never-configured <c>unknown</c>) leaves it open (fail closed).
+        /// </summary>
+        public static bool RequiresAuthorization(Consts.MCP.Server.AuthOption mode)
+            => mode == Consts.MCP.Server.AuthOption.oauth
+            || mode == Consts.MCP.Server.AuthOption.token
+            || mode == Consts.MCP.Server.AuthOption.required;
+    }
+}

--- a/McpPlugin.Server/src/Api/DirectToolCallEndpoints.cs
+++ b/McpPlugin.Server/src/Api/DirectToolCallEndpoints.cs
@@ -39,11 +39,12 @@ namespace com.IvanMurzak.McpPlugin.Server.Api
 
         /// <summary>
         /// Maps the direct tool call API endpoints onto the given <see cref="WebApplication"/>.
-        /// Authorization is required when <paramref name="dataArguments"/> has <see cref="IDataArguments.Authorization"/>
-        /// set to <see cref="Consts.MCP.Server.AuthOption.oauth"/> — the REST tool surface must present a valid
-        /// token in oauth mode (fail closed); it is open only in <see cref="Consts.MCP.Server.AuthOption.none"/> mode.
-        /// (Before mcp-authorize b7 this gated on the now-unreachable <c>AuthOption.required</c> — deleted with the
-        /// legacy shared-token pairing mode in b5 — so the endpoints were NEVER gated in oauth mode. Fixed here.)
+        /// Authorization is required in every credential-bearing mode — <see cref="Consts.MCP.Server.AuthOption.oauth"/>,
+        /// the offline <see cref="Consts.MCP.Server.AuthOption.token"/> (mcp-authorize g6), and the deprecated
+        /// <see cref="Consts.MCP.Server.AuthOption.required"/> alias — so the REST tool surface (which can EXECUTE
+        /// tools) is never an unauthenticated bypass of the endpoint's credential gate (fail closed). It is open only
+        /// in <see cref="Consts.MCP.Server.AuthOption.none"/> mode. (Before mcp-authorize b7 this gated on the then-unreachable
+        /// <c>required</c> value, so it was never gated in oauth mode; g6 additionally closes the token-mode gap.)
         /// </summary>
         public static WebApplication MapDirectToolCallApi(this WebApplication app, IDataArguments dataArguments)
         {
@@ -53,7 +54,7 @@ namespace com.IvanMurzak.McpPlugin.Server.Api
             if (dataArguments == null)
                 throw new ArgumentNullException(nameof(dataArguments));
 
-            var requireAuth = dataArguments.Authorization == Consts.MCP.Server.AuthOption.oauth;
+            var requireAuth = AuthGating.RequiresAuthorization(dataArguments.Authorization);
             var group = app.MapGroup(RoutePrefix);
 
             // GET /api/tools — list all registered tools

--- a/McpPlugin.Server/src/Api/SystemToolEndpoints.cs
+++ b/McpPlugin.Server/src/Api/SystemToolEndpoints.cs
@@ -40,11 +40,12 @@ namespace com.IvanMurzak.McpPlugin.Server.Api
 
         /// <summary>
         /// Maps the system tool API endpoints onto the given <see cref="WebApplication"/>.
-        /// Authorization follows the same rules as direct tool call endpoints: required in
-        /// <see cref="Consts.MCP.Server.AuthOption.oauth"/> mode (fail closed — a valid token is required),
-        /// open only in <see cref="Consts.MCP.Server.AuthOption.none"/> mode. (Before mcp-authorize b7 this
-        /// gated on the now-unreachable <c>AuthOption.required</c>, so the endpoints were never gated in oauth
-        /// mode; fixed here.)
+        /// Authorization follows the same rules as the direct tool call endpoints: required in every
+        /// credential-bearing mode — <see cref="Consts.MCP.Server.AuthOption.oauth"/>, the offline
+        /// <see cref="Consts.MCP.Server.AuthOption.token"/> (mcp-authorize g6), and the deprecated
+        /// <see cref="Consts.MCP.Server.AuthOption.required"/> alias (fail closed) — open only in
+        /// <see cref="Consts.MCP.Server.AuthOption.none"/> mode. (Before mcp-authorize b7 this gated on the
+        /// then-unreachable <c>required</c> value, so it was never gated in oauth mode; g6 closes the token-mode gap.)
         /// </summary>
         public static WebApplication MapSystemToolApi(this WebApplication app, IDataArguments dataArguments)
         {
@@ -54,7 +55,7 @@ namespace com.IvanMurzak.McpPlugin.Server.Api
             if (dataArguments == null)
                 throw new ArgumentNullException(nameof(dataArguments));
 
-            var requireAuth = dataArguments.Authorization == Consts.MCP.Server.AuthOption.oauth;
+            var requireAuth = AuthGating.RequiresAuthorization(dataArguments.Authorization);
             var group = app.MapGroup(RoutePrefix);
 
             // GET /api/system-tools — list all registered system tools

--- a/McpPlugin.Server/src/Auth/TokenAuthenticationHandler.cs
+++ b/McpPlugin.Server/src/Auth/TokenAuthenticationHandler.cs
@@ -94,14 +94,50 @@ namespace com.IvanMurzak.McpPlugin.Server.Auth
 
         protected override Task<AuthenticateResult> HandleAuthenticateAsync()
         {
-            // OAuth mode (mcp-authorize b2): validate ES256 JWT / opaque-PAT introspection.
-            // Non-OAuth mode is `none` (offline / local dev / CI): anonymous — no token is
-            // required or accepted. The legacy shared-token (`--token` ServerToken) and DCR /
-            // client-credentials token-equality paths were removed in mcp-authorize b5, so there
-            // is no orphaned code path that still accepts a deleted credential (fail closed).
-            return Options.OAuthMode
-                ? HandleOAuthAuthenticateAsync()
-                : Task.FromResult(AuthenticateResult.NoResult());
+            // Three mutually-exclusive modes, chosen by the resolved connection strategy:
+            //   • OAuthMode (mcp-authorize b2) — validate ES256 JWT / opaque-PAT introspection.
+            //   • LocalTokenMode (mcp-authorize g6) — offline shared-secret: constant-time compare the
+            //     presented bearer against the configured --token secret.
+            //   • neither → `none` (offline / local dev / CI): anonymous, no token accepted.
+            // The legacy multi-tier shared-token / DCR token-equality paths were removed in b5; the g6
+            // local-token path is a single constant-time comparison, not their reintroduction.
+            if (Options.OAuthMode)
+                return HandleOAuthAuthenticateAsync();
+            if (Options.LocalTokenMode)
+                return Task.FromResult(HandleLocalTokenAuthenticate());
+            return Task.FromResult(AuthenticateResult.NoResult());
+        }
+
+        // ── Offline local-token path (mcp-authorize g6) ───────────────────────────────────────────
+        AuthenticateResult HandleLocalTokenAuthenticate()
+        {
+            if (!TryGetBearerToken(out var token))
+            {
+                // No/empty/non-Bearer credential. On the hub path stay silent (BaseHub does its own
+                // auth via the strategy). Elsewhere NoResult lets the RequireAuthorization pipeline
+                // issue the non-OAuth `Bearer realm="MCP Plugin Server"` 401 challenge.
+                return AuthenticateResult.NoResult();
+            }
+
+            // Constant-time compare over SHA-256 digests — no length/content timing side channel, and a
+            // deliberate upgrade over the deleted b5 `string.Equals(Ordinal)`.
+            if (!TokenComparison.FixedTimeEquals(token, Options.LocalToken))
+            {
+                if (!IsHubPath())
+                {
+                    Logger.LogWarning(
+                        "MCP local-token auth rejected: token mismatch. RemoteIp: {RemoteIpAddress}, UserAgent: {UserAgent}, RequestPath: {RequestPath}, TokenFingerprint: {TokenFingerprint}",
+                        GetClientIpAddress(), Request.Headers.UserAgent.ToString(), Request.Path.Value, FingerprintToken(token));
+                }
+                return IsHubPath()
+                    ? AuthenticateResult.NoResult()
+                    : AuthenticateResult.Fail("Invalid token.");
+            }
+
+            var claims = new List<Claim> { new Claim(TokenClaimType, token) };
+            var identity = new ClaimsIdentity(claims, SchemeName);
+            var principal = new ClaimsPrincipal(identity);
+            return AuthenticateResult.Success(new AuthenticationTicket(principal, SchemeName));
         }
 
         // ── OAuth resource-server path (mcp-authorize b2) ─────────────────────────────────────────
@@ -214,10 +250,23 @@ namespace com.IvanMurzak.McpPlugin.Server.Auth
     {
         /// <summary>
         /// When true, the handler runs the OAuth resource-server validation path (ES256/JWKS +
-        /// introspection). When false (the only other mode, <c>none</c>), the handler is anonymous:
-        /// no token is required or accepted. The legacy shared-token (<c>ServerToken</c>) and DCR
+        /// introspection). Mutually exclusive with <see cref="LocalTokenMode"/>; when both are false
+        /// the handler is anonymous (<c>none</c> mode). The legacy multi-tier shared-token / DCR
         /// token-equality options were removed in mcp-authorize b5.
         /// </summary>
         public bool OAuthMode { get; set; }
+
+        /// <summary>
+        /// When true, the handler runs the offline local-token path (mcp-authorize g6): the presented
+        /// bearer is compared against <see cref="LocalToken"/> in constant time. Mutually exclusive with
+        /// <see cref="OAuthMode"/>. Set by <c>LocalTokenMcpStrategy.ConfigureAuthentication</c>.
+        /// </summary>
+        public bool LocalTokenMode { get; set; }
+
+        /// <summary>
+        /// The static shared secret accepted in <see cref="LocalTokenMode"/> (from <c>--token</c> /
+        /// <c>MCP_PLUGIN_TOKEN</c>). Never logged; compared with a fixed-length constant-time digest.
+        /// </summary>
+        public string? LocalToken { get; set; }
     }
 }

--- a/McpPlugin.Server/src/Auth/TokenAuthenticationHandler.cs
+++ b/McpPlugin.Server/src/Auth/TokenAuthenticationHandler.cs
@@ -123,13 +123,14 @@ namespace com.IvanMurzak.McpPlugin.Server.Auth
             // deliberate upgrade over the deleted b5 `string.Equals(Ordinal)`.
             if (!TokenComparison.FixedTimeEquals(token, Options.LocalToken))
             {
-                if (!IsHubPath())
+                var isHubPath = IsHubPath();
+                if (!isHubPath)
                 {
                     Logger.LogWarning(
                         "MCP local-token auth rejected: token mismatch. RemoteIp: {RemoteIpAddress}, UserAgent: {UserAgent}, RequestPath: {RequestPath}, TokenFingerprint: {TokenFingerprint}",
                         GetClientIpAddress(), Request.Headers.UserAgent.ToString(), Request.Path.Value, FingerprintToken(token));
                 }
-                return IsHubPath()
+                return isHubPath
                     ? AuthenticateResult.NoResult()
                     : AuthenticateResult.Fail("Invalid token.");
             }

--- a/McpPlugin.Server/src/Auth/TokenComparison.cs
+++ b/McpPlugin.Server/src/Auth/TokenComparison.cs
@@ -1,0 +1,48 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace com.IvanMurzak.McpPlugin.Server.Auth
+{
+    /// <summary>
+    /// Constant-time secret comparison for the offline <c>token</c> auth mode (mcp-authorize g6).
+    /// <para>
+    /// Both the presented and expected secrets are reduced to a fixed 32-byte SHA-256 digest, then
+    /// compared with <see cref="CryptographicOperations.FixedTimeEquals(ReadOnlySpan{byte},ReadOnlySpan{byte})"/>.
+    /// Hashing to a fixed length is deliberate: it removes the length side channel a raw
+    /// <c>FixedTimeEquals</c> over the utf-8 bytes would still leak (the method short-circuits on a
+    /// length mismatch), and it upgrades the security posture over the deleted b5 code, which compared
+    /// with <c>string.Equals(StringComparison.Ordinal)</c> — an early-exit, timing-leaky comparison.
+    /// </para>
+    /// </summary>
+    public static class TokenComparison
+    {
+        /// <summary>
+        /// Returns <c>true</c> when <paramref name="presented"/> equals <paramref name="expected"/> in
+        /// constant time relative to the secret's content. A null/empty operand never matches (the
+        /// server never runs the token strategy without a configured secret).
+        /// </summary>
+        public static bool FixedTimeEquals(string? presented, string? expected)
+        {
+            if (string.IsNullOrEmpty(presented) || string.IsNullOrEmpty(expected))
+                return false;
+
+            Span<byte> presentedDigest = stackalloc byte[32];
+            Span<byte> expectedDigest = stackalloc byte[32];
+            SHA256.HashData(Encoding.UTF8.GetBytes(presented), presentedDigest);
+            SHA256.HashData(Encoding.UTF8.GetBytes(expected), expectedDigest);
+            return CryptographicOperations.FixedTimeEquals(presentedDigest, expectedDigest);
+        }
+    }
+}

--- a/McpPlugin.Server/src/Strategy/LocalTokenMcpStrategy.cs
+++ b/McpPlugin.Server/src/Strategy/LocalTokenMcpStrategy.cs
@@ -1,0 +1,160 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Linq;
+using System.Net;
+using com.IvanMurzak.McpPlugin.Common;
+using com.IvanMurzak.McpPlugin.Common.Model;
+using com.IvanMurzak.McpPlugin.Common.Utils;
+using com.IvanMurzak.McpPlugin.Server.Auth;
+using Microsoft.Extensions.Logging;
+
+namespace com.IvanMurzak.McpPlugin.Server.Strategy
+{
+    /// <summary>
+    /// The offline <c>token</c> auth plane (mcp-authorize g6) — the loopback single-project counterpart
+    /// of the account-scoped <see cref="AccountMcpStrategy"/>. Modeled on <see cref="NoAuthMcpStrategy"/>
+    /// (single plugin connection, broadcast routing) but gated on a single static shared secret:
+    /// <list type="bullet">
+    ///   <item><b>Auth config</b> — flags the local-token validation path on
+    ///   <see cref="TokenAuthenticationOptions"/> so the streamableHttp MCP endpoint is bearer-gated
+    ///   (constant-time compare), never anonymous.</item>
+    ///   <item><b>Hub gate</b> — <see cref="OnPluginConnected"/> rejects a tokenless or mismatched plugin
+    ///   connection (constant-time compare), then enforces the single-connection invariant.</item>
+    ///   <item><b>Routing / notifications / data</b> — single connection, so routing resolves the one
+    ///   registered plugin and notifications broadcast (exactly like <see cref="NoAuthMcpStrategy"/>).</item>
+    /// </list>
+    /// A loopback single-project server needs one plugin plus one secret; the multi-tenant token-equality
+    /// pairing of the deleted b5 <c>RequiredAuthMcpStrategy</c> is intentionally NOT reintroduced.
+    /// </summary>
+    public sealed class LocalTokenMcpStrategy : IMcpConnectionStrategy
+    {
+        // Set once at startup by Validate / ConfigureAuthentication (both run before any connection).
+        // volatile so the write is visible to the SignalR threads that read it in OnPluginConnected.
+        private volatile string? _serverToken;
+
+        public Consts.MCP.Server.AuthOption AuthOption
+            => Consts.MCP.Server.AuthOption.token;
+
+        // Single-project loopback server: exactly one plugin connection, like no-auth mode.
+        public bool AllowMultipleConnections => false;
+
+        public void Validate(DataArguments dataArguments)
+        {
+            if (string.IsNullOrWhiteSpace(dataArguments.Token))
+                throw new ArgumentException(
+                    "auth=token mode requires a non-empty --token (or MCP_PLUGIN_TOKEN) shared secret.");
+
+            _serverToken = dataArguments.Token;
+
+            // Owner ruling (design g5 §Security, sanity-checked): a token over cleartext local HTTP is
+            // LAN-sniffable, so binding non-loopback is WARNED but ALLOWED (enables LAN use) rather than
+            // rejected. Reuse the tested bind→address resolution so the warning matches the real listener.
+            if (IsNonLoopbackBind(dataArguments.Bind))
+            {
+                NLog.LogManager.GetCurrentClassLogger().Warn(
+                    "auth=token mode is bound to a non-loopback address (--bind '{0}'). The shared token travels over cleartext local HTTP and is sniffable on the LAN. Prefer loopback-only, or terminate TLS in front of the server.",
+                    dataArguments.Bind);
+            }
+        }
+
+        static bool IsNonLoopbackBind(string? bind)
+        {
+            try
+            {
+                return ExtensionsWebHost.ResolveBindAddresses(bind).Any(addr => !IPAddress.IsLoopback(addr));
+            }
+            catch (ArgumentException)
+            {
+                // An unparseable --bind is surfaced by the listener setup; do not warn from here.
+                return false;
+            }
+        }
+
+        public void ConfigureAuthentication(TokenAuthenticationOptions options, DataArguments dataArguments)
+        {
+            // Offline token mode: the handler validates the presented bearer against this static secret
+            // with a constant-time compare. Not the OAuth (JWKS/introspection) path.
+            options.OAuthMode = false;
+            options.LocalTokenMode = true;
+            options.LocalToken = dataArguments.Token;
+            _serverToken = dataArguments.Token;
+        }
+
+        public void OnPluginConnected(Type hubType, string connectionId, string? token,
+            ILogger logger, Action<string, string?> disconnectClient)
+        {
+            if (string.IsNullOrEmpty(token))
+            {
+                logger.LogWarning("auth=token mode: plugin connected without a token, disconnecting {ConnectionId}.", connectionId);
+                disconnectClient(connectionId, "Connection rejected: auth=token mode requires a token but none was provided.");
+                return;
+            }
+
+            if (!TokenComparison.FixedTimeEquals(token, _serverToken))
+            {
+                logger.LogWarning("auth=token mode: plugin token does not match the server token, disconnecting {ConnectionId}.", connectionId);
+                disconnectClient(connectionId, "Connection rejected: the provided token does not match the server token.");
+                return;
+            }
+
+            ClientUtils.AddClient(hubType, connectionId, logger, token);
+
+            // Single-connection invariant: disconnect any previously-registered plugin (like no-auth mode).
+            foreach (var otherId in ClientUtils.GetAllConnectionIds(hubType).Where(id => id != connectionId).ToList())
+            {
+                logger.LogInformation("auth=token mode: disconnecting other client '{0}' for {1}.", otherId, hubType.Name);
+                ClientUtils.RemoveClient(hubType, otherId, logger);
+                disconnectClient(otherId, "A newer plugin connection has replaced this one (auth=token mode allows only one connection).");
+            }
+        }
+
+        public void OnPluginDisconnected(Type hubType, string connectionId, ILogger logger)
+        {
+            ClientUtils.RemoveClient(hubType, connectionId, logger);
+        }
+
+        public string? ResolveConnectionId(string? token, int retryOffset)
+        {
+            return ClientUtils.GetConnectionIdByToken(token)
+                ?? ClientUtils.GetBestConnectionId(typeof(McpServerHub), retryOffset);
+        }
+
+        public bool ShouldNotifySession(string pluginConnectionId, string sessionId)
+        {
+            // Single-connection mode: broadcast all notifications to the one session.
+            return true;
+        }
+
+        public NotificationTarget ResolveNotificationTarget(string? routingToken)
+        {
+            // OnPluginConnected enforces a single plugin connection, so a broadcast targets at most one
+            // recipient. Routing token is ignored (there is no per-token multi-tenant mapping here).
+            return NotificationTarget.Broadcast();
+        }
+
+        public McpClientData GetClientData(string? connectionId, IMcpSessionTracker sessionTracker)
+        {
+            return sessionTracker.GetClientData();
+        }
+
+        public McpClientData[] GetAllClientData(string? connectionId, IMcpSessionTracker sessionTracker)
+        {
+            return sessionTracker.GetAllClientData().ToArray();
+        }
+
+        public McpServerData GetServerData(string? connectionId, IMcpSessionTracker sessionTracker)
+        {
+            return sessionTracker.GetServerData();
+        }
+    }
+}

--- a/McpPlugin.Server/src/Strategy/McpStrategyFactory.cs
+++ b/McpPlugin.Server/src/Strategy/McpStrategyFactory.cs
@@ -22,20 +22,37 @@ namespace com.IvanMurzak.McpPlugin.Server.Strategy
     {
         public IMcpConnectionStrategy Create(Consts.MCP.Server.AuthOption mode)
         {
-            return mode switch
+            switch (mode)
             {
-                Consts.MCP.Server.AuthOption.none => new NoAuthMcpStrategy(),
+                case Consts.MCP.Server.AuthOption.none:
+                    return new NoAuthMcpStrategy();
+
                 // mcp-authorize b3: oauth mode is the account+instance pairing plane.
-                Consts.MCP.Server.AuthOption.oauth => new AccountMcpStrategy(),
-                // mcp-authorize b5 (coordinated breaking removal): the legacy shared-token
-                // pairing mode (`required`) is deleted. The RS never mints or equality-pairs
-                // tokens; it only validates them (oauth) or runs anonymous (none). Any other
-                // value — including the retired `required` — fails closed with an explicit error;
-                // no silent downgrade to `none`.
-                _ => throw new ArgumentException(
-                    $"Unsupported auth option: {mode}. " +
-                    $"Supported auth options are: {Consts.MCP.Server.AuthOption.none}, {Consts.MCP.Server.AuthOption.oauth}")
-            };
+                case Consts.MCP.Server.AuthOption.oauth:
+                    return new AccountMcpStrategy();
+
+                // mcp-authorize g6: offline shared-secret mode — a loopback single-project server
+                // gated on a single static token, validated with a constant-time compare.
+                case Consts.MCP.Server.AuthOption.token:
+                    return new LocalTokenMcpStrategy();
+
+                // mcp-authorize g6 back-compat alias: an un-migrated binary still emitting
+                // `authorization=required` (+ token) runs token-gated instead of crashing. This is a
+                // strict superset that ALSO resolves the g5 boot crash for un-migrated configs — never
+                // a silent downgrade to anonymous (which dropping `required` would cause). Deprecated:
+                // migrate the config to `auth=token`.
+                case Consts.MCP.Server.AuthOption.required:
+                    NLog.LogManager.GetCurrentClassLogger().Warn(
+                        "auth=required is deprecated (mcp-authorize g6): aliasing it onto the offline 'token' strategy. Migrate the configuration to 'auth=token'.");
+                    return new LocalTokenMcpStrategy();
+
+                // Any other value — including the retired `unknown` — fails closed with an explicit
+                // error; no silent downgrade to `none`.
+                default:
+                    throw new ArgumentException(
+                        $"Unsupported auth option: {mode}. " +
+                        $"Supported auth options are: {Consts.MCP.Server.AuthOption.none}, {Consts.MCP.Server.AuthOption.oauth}, {Consts.MCP.Server.AuthOption.token} (and the deprecated {Consts.MCP.Server.AuthOption.required} alias).");
+            }
         }
     }
 }

--- a/McpPlugin.Server/src/Transport/StreamableHttpTransportLayer.cs
+++ b/McpPlugin.Server/src/Transport/StreamableHttpTransportLayer.cs
@@ -166,6 +166,19 @@ namespace com.IvanMurzak.McpPlugin.Server.Transport
                 app.MapMcp("/mcp").RequireAuthorization();
                 MapPinnedMcp(app, requireAuthorization: true);
             }
+            else if (mode == Consts.MCP.Server.AuthOption.token
+                || mode == Consts.MCP.Server.AuthOption.required)
+            {
+                // Offline token mode (mcp-authorize g6): gate the MCP endpoint with RequireAuthorization
+                // exactly like oauth, but WITHOUT the RFC 9728 Protected-Resource-Metadata routes — there
+                // is no authorization server to discover; the credential is the local static --token,
+                // validated by TokenAuthenticationHandler's constant-time compare. Without this gate the
+                // token would be validated but never ENFORCED (unauthenticated requests would still reach
+                // the endpoint). `required` is aliased onto the same token strategy (back-compat).
+                app.MapMcp("/").RequireAuthorization();
+                app.MapMcp("/mcp").RequireAuthorization();
+                MapPinnedMcp(app, requireAuthorization: true);
+            }
             else
             {
                 // none mode (offline / local dev / CI): anonymous MCP endpoint, no auth gate.

--- a/McpPlugin.Tests/AgentConfig/AgentConfiguratorSettingsAuthTests.cs
+++ b/McpPlugin.Tests/AgentConfig/AgentConfiguratorSettingsAuthTests.cs
@@ -1,0 +1,67 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System.IO;
+using com.IvanMurzak.McpPlugin.Common;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
+{
+    /// <summary>
+    /// The configurator's per-mode HTTP/STDIO auth flags (mcp-authorize g6). Token mode must inject the
+    /// HTTP <c>Authorization: Bearer &lt;secret&gt;</c> header (HTTP only — stdio stays credential-free per
+    /// b6); none and oauth stay URL-only (oauth authorizes natively, none is anonymous).
+    /// </summary>
+    public class AgentConfiguratorSettingsAuthTests
+    {
+        static AgentConfiguratorSettings Settings(
+            Consts.MCP.Server.AuthOption authOption,
+            ConnectionMode connectionMode = ConnectionMode.Local)
+            => new AgentConfiguratorSettings(
+                operatingSystem: OperatingSystemKind.Windows,
+                projectRootPath: Path.GetTempPath(),
+                executableFullPath: "C:/Tools/srv.exe",
+                port: 8080,
+                timeoutMs: 30000,
+                host: "http://localhost:8080/mcp",
+                token: "secret-token",
+                connectionMode: connectionMode,
+                authOption: authOption);
+
+        [Theory]
+        [InlineData(Consts.MCP.Server.AuthOption.token, true)]
+        [InlineData(Consts.MCP.Server.AuthOption.required, true)] // deprecated back-compat alias
+        [InlineData(Consts.MCP.Server.AuthOption.none, false)]
+        [InlineData(Consts.MCP.Server.AuthOption.oauth, false)]
+        public void IsHttpAuthRequired_PerMode(Consts.MCP.Server.AuthOption mode, bool expected)
+        {
+            Settings(mode).IsHttpAuthRequired.ShouldBe(expected);
+        }
+
+        [Fact]
+        public void IsHttpAuthRequired_Cloud_AlwaysTrue()
+        {
+            // Cloud enforces auth regardless of the local auth option (even none).
+            Settings(Consts.MCP.Server.AuthOption.none, ConnectionMode.Cloud).IsHttpAuthRequired.ShouldBeTrue();
+        }
+
+        [Theory]
+        [InlineData(Consts.MCP.Server.AuthOption.required, true)]
+        [InlineData(Consts.MCP.Server.AuthOption.token, false)] // token mode is HTTP-only; stdio credential-free
+        [InlineData(Consts.MCP.Server.AuthOption.none, false)]
+        [InlineData(Consts.MCP.Server.AuthOption.oauth, false)]
+        public void IsStdioAuthRequired_PerMode(Consts.MCP.Server.AuthOption mode, bool expected)
+        {
+            Settings(mode).IsStdioAuthRequired.ShouldBe(expected);
+        }
+    }
+}

--- a/McpPlugin.Tests/ServerLaunch/ServerLaunchArgumentsTests.cs
+++ b/McpPlugin.Tests/ServerLaunch/ServerLaunchArgumentsTests.cs
@@ -1,0 +1,128 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using com.IvanMurzak.McpPlugin.Common;
+using com.IvanMurzak.McpPlugin.ServerLaunch;
+using Shouldly;
+using Xunit;
+using static com.IvanMurzak.McpPlugin.Common.Consts.MCP.Server;
+
+namespace com.IvanMurzak.McpPlugin.ServerLaunch.Tests
+{
+    /// <summary>
+    /// The shared server launch-arg builder (mcp-authorize g6 consolidation): one canonical emitter of
+    /// the <c>auth=&lt;mode&gt;</c> / <c>token</c> / <c>auth-issuer</c> / <c>public-url</c> argument shape
+    /// so Unity, Godot, and Unreal's sidecar never re-derive it divergently.
+    /// </summary>
+    public class ServerLaunchArgumentsTests
+    {
+        [Fact]
+        public void Build_None_EmitsBaseArgs_NoCredentials()
+        {
+            var args = ServerLaunchArguments.Build(
+                port: 8080, pluginTimeoutMs: 30000,
+                clientTransport: Consts.MCP.Server.TransportMethod.streamableHttp,
+                authOption: Consts.MCP.Server.AuthOption.none);
+
+            args.ShouldBe(new[]
+            {
+                $"{Args.Port}=8080",
+                $"{Args.PluginTimeout}=30000",
+                $"{Args.ClientTransportMethod}={Consts.MCP.Server.TransportMethod.streamableHttp}",
+                $"{Args.Auth}={Consts.MCP.Server.AuthOption.none}"
+            });
+        }
+
+        [Fact]
+        public void Build_Token_EmitsTokenArg()
+        {
+            var args = ServerLaunchArguments.Build(
+                port: 9000, pluginTimeoutMs: 10000,
+                clientTransport: Consts.MCP.Server.TransportMethod.streamableHttp,
+                authOption: Consts.MCP.Server.AuthOption.token,
+                token: "the-secret");
+
+            args.ShouldContain($"{Args.Auth}={Consts.MCP.Server.AuthOption.token}");
+            args.ShouldContain($"{Args.Token}=the-secret");
+            // Token mode never emits the OAuth resource-server args.
+            args.ShouldNotContain($"{Args.AuthIssuer}=");
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void Build_Token_WithoutSecret_Throws(string? token)
+        {
+            Should.Throw<ArgumentException>(() => ServerLaunchArguments.Build(
+                port: 9000, pluginTimeoutMs: 10000,
+                clientTransport: Consts.MCP.Server.TransportMethod.streamableHttp,
+                authOption: Consts.MCP.Server.AuthOption.token,
+                token: token));
+        }
+
+        [Fact]
+        public void Build_OAuth_EmitsIssuerAndPublicUrl_NoToken()
+        {
+            var args = ServerLaunchArguments.Build(
+                port: 7000, pluginTimeoutMs: 20000,
+                clientTransport: Consts.MCP.Server.TransportMethod.streamableHttp,
+                authOption: Consts.MCP.Server.AuthOption.oauth,
+                authIssuer: "https://ai-game.dev",
+                publicUrl: "http://localhost:7000/mcp/p/abcd1234");
+
+            args.ShouldContain($"{Args.Auth}={Consts.MCP.Server.AuthOption.oauth}");
+            args.ShouldContain($"{Args.AuthIssuer}=https://ai-game.dev");
+            args.ShouldContain($"{Args.PublicUrl}=http://localhost:7000/mcp/p/abcd1234");
+            // OAuth mode carries no static token.
+            args.ShouldNotContain($"{Args.Token}=");
+        }
+
+        [Theory]
+        [InlineData(null, "http://localhost:7000")]
+        [InlineData("https://ai-game.dev", null)]
+        [InlineData("", "http://localhost:7000")]
+        [InlineData("https://ai-game.dev", "")]
+        public void Build_OAuth_MissingIssuerOrPublicUrl_Throws(string? issuer, string? publicUrl)
+        {
+            Should.Throw<ArgumentException>(() => ServerLaunchArguments.Build(
+                port: 7000, pluginTimeoutMs: 20000,
+                clientTransport: Consts.MCP.Server.TransportMethod.streamableHttp,
+                authOption: Consts.MCP.Server.AuthOption.oauth,
+                authIssuer: issuer,
+                publicUrl: publicUrl));
+        }
+
+        [Fact]
+        public void Build_Required_Throws_NewCallersUseToken()
+        {
+            // The NEW builder emits the target-state key only; the deprecated `required` alias is a
+            // server-side back-compat concern, not something a fresh launch should produce.
+            Should.Throw<ArgumentException>(() => ServerLaunchArguments.Build(
+                port: 9000, pluginTimeoutMs: 10000,
+                clientTransport: Consts.MCP.Server.TransportMethod.streamableHttp,
+                authOption: Consts.MCP.Server.AuthOption.required,
+                token: "x"));
+        }
+
+        [Fact]
+        public void BuildCommandLine_SpaceJoinsArgs()
+        {
+            var line = ServerLaunchArguments.BuildCommandLine(
+                port: 8080, pluginTimeoutMs: 30000,
+                clientTransport: Consts.MCP.Server.TransportMethod.stdio,
+                authOption: Consts.MCP.Server.AuthOption.none);
+
+            line.ShouldBe($"{Args.Port}=8080 {Args.PluginTimeout}=30000 {Args.ClientTransportMethod}={Consts.MCP.Server.TransportMethod.stdio} {Args.Auth}={Consts.MCP.Server.AuthOption.none}");
+        }
+    }
+}

--- a/McpPlugin/src/AgentConfig/AgentConfiguratorSettings.cs
+++ b/McpPlugin/src/AgentConfig/AgentConfiguratorSettings.cs
@@ -183,11 +183,23 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
                 dockerImage: dockerImage);
         }
 
-        /// <summary>True when HTTP authorization should be injected (cloud always requires it).</summary>
+        /// <summary>
+        /// True when HTTP authorization should be injected — i.e. the client config must carry an
+        /// <c>Authorization: Bearer &lt;secret&gt;</c> header. Cloud always requires it; the offline
+        /// <c>token</c> mode requires it (mcp-authorize g6, HTTP only); the deprecated <c>required</c>
+        /// alias keeps it for back-compat. <c>none</c> and <c>oauth</c> stay URL-only (oauth authorizes
+        /// natively against the server URL; none is anonymous).
+        /// </summary>
         public bool IsHttpAuthRequired =>
-            ConnectionMode == ConnectionMode.Cloud || AuthOption == Consts.MCP.Server.AuthOption.required;
+            ConnectionMode == ConnectionMode.Cloud
+            || AuthOption == Consts.MCP.Server.AuthOption.token
+            || AuthOption == Consts.MCP.Server.AuthOption.required;
 
-        /// <summary>True when STDIO authorization (token arg) should be injected.</summary>
+        /// <summary>
+        /// True when STDIO authorization (token arg) should be injected. Only the deprecated
+        /// <c>required</c> mode ever gated stdio; the offline <c>token</c> mode is HTTP-only —
+        /// stdio spawns stay credential-free (mcp-authorize b6 / g6).
+        /// </summary>
         public bool IsStdioAuthRequired =>
             AuthOption == Consts.MCP.Server.AuthOption.required;
 

--- a/McpPlugin/src/ServerLaunch/ServerLaunchArguments.cs
+++ b/McpPlugin/src/ServerLaunch/ServerLaunchArguments.cs
@@ -1,0 +1,115 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using com.IvanMurzak.McpPlugin.Common;
+using static com.IvanMurzak.McpPlugin.Common.Consts.MCP.Server;
+
+namespace com.IvanMurzak.McpPlugin.ServerLaunch
+{
+    /// <summary>
+    /// Builds the launch-argument list an engine plugin passes to the shared MCP server executable
+    /// (mcp-authorize g6 consolidation). One canonical builder replaces the per-engine
+    /// <c>BuildArguments</c> duplicates: Unity and Godot (C#) call it directly; Unreal's C++ editor
+    /// delegates to its .NET sidecar, which calls it too. Emitting the argument shape here — rather than
+    /// re-deriving it in three engines — guarantees every engine wires <c>auth</c>, <c>token</c>, and the
+    /// OAuth resource-server args identically.
+    /// <para>
+    /// The emitted shape (in order): <c>port</c>, <c>plugin-timeout</c>, <c>client-transport</c>,
+    /// <c>auth=&lt;mode&gt;</c> (the target-state key), then per mode:
+    /// </para>
+    /// <list type="bullet">
+    ///   <item><see cref="Consts.MCP.Server.AuthOption.none"/> — no credential args.</item>
+    ///   <item><see cref="Consts.MCP.Server.AuthOption.token"/> — <c>token=&lt;secret&gt;</c> (required).</item>
+    ///   <item><see cref="Consts.MCP.Server.AuthOption.oauth"/> — <c>auth-issuer</c> + <c>public-url</c> (both required).</item>
+    /// </list>
+    /// </summary>
+    public static class ServerLaunchArguments
+    {
+        /// <summary>
+        /// Builds the ordered launch arguments (each a <c>key=value</c> token) for the given server
+        /// configuration. Throws <see cref="ArgumentException"/> when a mode's required credential is
+        /// missing (token mode without a secret; oauth mode without both issuer and public URL) — the
+        /// same fail-closed contract the server's strategy <c>Validate</c> enforces at boot.
+        /// </summary>
+        /// <param name="port">The MCP server port.</param>
+        /// <param name="pluginTimeoutMs">Plugin connection timeout, milliseconds.</param>
+        /// <param name="clientTransport">stdio or streamableHttp.</param>
+        /// <param name="authOption">The auth mode (target state: none / token / oauth).</param>
+        /// <param name="token">The shared secret; required in <see cref="Consts.MCP.Server.AuthOption.token"/> mode, ignored otherwise.</param>
+        /// <param name="authIssuer">The authorization-server URL; required in <see cref="Consts.MCP.Server.AuthOption.oauth"/> mode.</param>
+        /// <param name="publicUrl">This server's canonical public URL; required in <see cref="Consts.MCP.Server.AuthOption.oauth"/> mode.</param>
+        public static IReadOnlyList<string> Build(
+            int port,
+            int pluginTimeoutMs,
+            Consts.MCP.Server.TransportMethod clientTransport,
+            Consts.MCP.Server.AuthOption authOption,
+            string? token = null,
+            string? authIssuer = null,
+            string? publicUrl = null)
+        {
+            var args = new List<string>
+            {
+                $"{Args.Port}={port}",
+                $"{Args.PluginTimeout}={pluginTimeoutMs}",
+                $"{Args.ClientTransportMethod}={clientTransport}",
+                $"{Args.Auth}={authOption}"
+            };
+
+            switch (authOption)
+            {
+                case Consts.MCP.Server.AuthOption.none:
+                    break;
+
+                case Consts.MCP.Server.AuthOption.token:
+                    if (string.IsNullOrWhiteSpace(token))
+                        throw new ArgumentException($"auth={Consts.MCP.Server.AuthOption.token} requires a non-empty token.", nameof(token));
+                    args.Add($"{Args.Token}={token}");
+                    break;
+
+                case Consts.MCP.Server.AuthOption.oauth:
+                    if (string.IsNullOrWhiteSpace(authIssuer))
+                        throw new ArgumentException($"auth={Consts.MCP.Server.AuthOption.oauth} requires a non-empty auth-issuer.", nameof(authIssuer));
+                    if (string.IsNullOrWhiteSpace(publicUrl))
+                        throw new ArgumentException($"auth={Consts.MCP.Server.AuthOption.oauth} requires a non-empty public-url.", nameof(publicUrl));
+                    args.Add($"{Args.AuthIssuer}={authIssuer}");
+                    args.Add($"{Args.PublicUrl}={publicUrl}");
+                    break;
+
+                default:
+                    // `required` is the deprecated alias resolved server-side; a NEW caller emits the
+                    // target-state `token` instead. `unknown` is never a launch target.
+                    throw new ArgumentException(
+                        $"Unsupported launch auth option: {authOption}. Use {Consts.MCP.Server.AuthOption.none}, {Consts.MCP.Server.AuthOption.token}, or {Consts.MCP.Server.AuthOption.oauth}.",
+                        nameof(authOption));
+            }
+
+            return args;
+        }
+
+        /// <summary>
+        /// Convenience wrapper over <see cref="Build"/> that space-joins the arguments into a single
+        /// command-line string (for engines that pass a raw string rather than an argv array). Values
+        /// are emitted verbatim; the server's <c>DataArguments</c> parser tokenizes on whitespace, so
+        /// callers whose values could contain spaces should prefer the argv-array <see cref="Build"/>.
+        /// </summary>
+        public static string BuildCommandLine(
+            int port,
+            int pluginTimeoutMs,
+            Consts.MCP.Server.TransportMethod clientTransport,
+            Consts.MCP.Server.AuthOption authOption,
+            string? token = null,
+            string? authIssuer = null,
+            string? publicUrl = null)
+            => string.Join(" ", Build(port, pluginTimeoutMs, clientTransport, authOption, token, authIssuer, publicUrl));
+    }
+}

--- a/docs/architecture-transport-auth.md
+++ b/docs/architecture-transport-auth.md
@@ -19,6 +19,16 @@
 > previously gated on the deleted `required` mode and were unintentionally never gated), and stay
 > open in `none` mode.
 
+> **Offline token mode (mcp-authorize g6).** A third auth mode, **`token`**, is the OFFLINE
+> counterpart of `oauth`: a loopback single-project server gates BOTH the SignalR plugin connection
+> and the streamableHttp MCP endpoint on a single static bearer secret (`--token` /
+> `MCP_PLUGIN_TOKEN`), validated with a **constant-time** compare (`LocalTokenMcpStrategy`). No
+> authorization server, JWT, or egress is required. This is NOT a revival of the b5 multi-tenant
+> token-equality pairing — it is one plugin + one secret. The legacy `authorization=required` value
+> is **retained as a deprecated alias** onto this strategy (so an un-migrated config runs token-gated
+> instead of crashing), never a silent downgrade to anonymous. Constant-time compare is a deliberate
+> security upgrade over the b5-era `string.Equals(Ordinal)`.
+
 ## Overview
 
 The MCP Plugin Server is configured through **two independent axes**: **Transport** and **Auth**.
@@ -27,6 +37,7 @@ Each axis has its own enum, CLI argument, and environment variable. They combine
 ```
 Transport  ×  Auth
    stdio          none    (offline / local dev / CI — anonymous, single plugin)
+   streamableHttp token   (offline shared-secret — loopback single-project, constant-time gate)
    streamableHttp oauth   (OAuth 2.1 resource server — account-scoped pairing)
 ```
 
@@ -47,23 +58,25 @@ All combinations are supported without conditional branching in the server code.
 
 ### Auth — how plugin connections are authenticated and isolated
 
-| Source           | Key                          | Values           |
-|------------------|------------------------------|------------------|
-| CLI argument     | `auth=<value>`               | `none`, `oauth`  |
-| Environment var  | `MCP_AUTH=<value>`           | `none`, `oauth`  |
+| Source           | Key                          | Values                    |
+|------------------|------------------------------|---------------------------|
+| CLI argument     | `auth=<value>`               | `none`, `token`, `oauth`  |
+| Environment var  | `MCP_AUTH=<value>`           | `none`, `token`, `oauth`  |
 
 **Default**: `none` (when not set). `auth=oauth` additionally requires `auth-issuer=<AS url>` and
-`public-url=<this RS's canonical resource id>`. (The legacy `authorization=` / `MCP_AUTHORIZATION=`
-argument names still parse for the `none` value; the retired `required` value now fails closed with
-an explicit startup error.)
+`public-url=<this RS's canonical resource id>`; `auth=token` additionally requires a non-empty
+`token=<secret>` / `MCP_PLUGIN_TOKEN`. (The legacy `authorization=` / `MCP_AUTHORIZATION=` argument
+names still parse; the deprecated `required` value is aliased onto `token` — see the g6 note above.)
 
 ### Credentials — validated, never minted
 
 In `oauth` mode the RS validates presented credentials against the external authorization server
 (ai-game.dev) — ES256 JWTs via cached JWKS, and opaque PATs via RFC 7662 introspection. It **never**
 mints, self-issues, or equality-pairs tokens; there is no server-side shared secret. See
-`03-auth-flows.md` (Flows A–C) for the full credential lifecycle. In `none` mode no credential is
-required or accepted (the endpoint is anonymous).
+`03-auth-flows.md` (Flows A–C) for the full credential lifecycle. In `token` mode the RS holds a
+single static shared secret (from `--token` / `MCP_PLUGIN_TOKEN`) and constant-time-compares the
+presented bearer against it — the offline, loopback-only counterpart of `oauth`; it still never mints
+tokens. In `none` mode no credential is required or accepted (the endpoint is anonymous).
 
 ### Idle Timeout — streamableHttp session eviction window
 
@@ -107,15 +120,21 @@ The `IMcpConnectionStrategy` interface is the central coordinator for all auth-d
 
 ```
 McpStrategyFactory
-  ├── AuthOption.none  → NoAuthMcpStrategy
-  └── AuthOption.oauth → AccountMcpStrategy
+  ├── AuthOption.none     → NoAuthMcpStrategy
+  ├── AuthOption.token    → LocalTokenMcpStrategy
+  ├── AuthOption.required → LocalTokenMcpStrategy   (deprecated alias, g6)
+  └── AuthOption.oauth    → AccountMcpStrategy
 ```
 
-Any other value (including the retired `required`) throws at startup — fail closed, never a silent downgrade to `none`.
+`unknown` (or any unrecognised value) throws at startup — fail closed, never a silent downgrade to `none`.
 
 ### NoAuthMcpStrategy (`auth=none`)
 
 Designed for a **single trusted plugin** connecting to a single MCP client (e.g. a developer's local machine running one Unity editor). The HTTP endpoint is never token-gated in this mode; the anonymous, single-connection behavior is unchanged. This is the offline / local-dev / CI default and the stdio default.
+
+### LocalTokenMcpStrategy (`auth=token`, mcp-authorize g6)
+
+The **offline shared-secret** plane — the loopback single-project counterpart of `AccountMcpStrategy`. Modeled on `NoAuthMcpStrategy` (single plugin connection, broadcast routing) but gated on one static secret: `Validate` requires a non-empty `--token`; `ConfigureAuthentication` flags the local-token validation path so the streamableHttp endpoint is `RequireAuthorization`-gated (constant-time compare, **no** RFC 9728 resource metadata — there is no AS to discover); `OnPluginConnected` rejects a tokenless or mismatched plugin (constant-time compare) then enforces the single-connection invariant. The secret is compared via `TokenComparison.FixedTimeEquals` (fixed-length SHA-256 digest, no length side channel). A non-loopback `--bind` is **warned but allowed** (LAN cleartext-token caveat, owner ruling). The deprecated `required` value resolves to this same strategy (back-compat).
 
 ### AccountMcpStrategy (`auth=oauth`)
 
@@ -125,15 +144,15 @@ The OAuth 2.1 resource-server **account + instance pairing plane**. A presented 
 
 ## Behavior Comparison
 
-| Property / method                 | `NoAuthMcpStrategy` (`none`)                                   | `AccountMcpStrategy` (`oauth`)                                                        |
-|-----------------------------------|----------------------------------------------------------------|--------------------------------------------------------------------------------------|
-| `AllowMultipleConnections`        | `false`                                                        | `true`                                                                               |
-| `Validate`                        | No-op.                                                          | Requires `auth-issuer` + `public-url`.                                                |
-| `ConfigureAuthentication`         | `OAuthMode = false` (anonymous endpoint).                      | `OAuthMode = true` (validate JWT/PAT against the AS; the RS never mints tokens).      |
-| `OnPluginConnected`               | Registers, then **disconnects all others** (single-connection).| Registration is driven by `McpServerHub` after it validates the plugin's token + reads its instance metadata (account-scoped registry). |
-| `ResolveConnectionId`             | Token lookup, then round-robin fallback.                       | Account-scoped instance resolution; no fallback across accounts (fail closed).       |
-| `ShouldNotifySession` / `ResolveNotificationTarget` | Broadcast (single-plugin invariant).        | Targets the session's account-resolved instance, else **drops** — never leaks across accounts. |
-| `GetClientData` / `GetServerData` | First available session (only one).                           | Scoped to the connection's account; empty when it resolves to no account.            |
+| Property / method                 | `NoAuthMcpStrategy` (`none`)                                   | `LocalTokenMcpStrategy` (`token`)                                                     | `AccountMcpStrategy` (`oauth`)                                                        |
+|-----------------------------------|----------------------------------------------------------------|--------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|
+| `AllowMultipleConnections`        | `false`                                                        | `false`                                                                              | `true`                                                                               |
+| `Validate`                        | No-op.                                                          | Requires a non-empty `--token`; warns (allows) on non-loopback `--bind`.             | Requires `auth-issuer` + `public-url`.                                                |
+| `ConfigureAuthentication`         | `OAuthMode = false` (anonymous endpoint).                      | `LocalTokenMode = true` (constant-time compare vs the static `--token`).             | `OAuthMode = true` (validate JWT/PAT against the AS; the RS never mints tokens).      |
+| `OnPluginConnected`               | Registers, then **disconnects all others** (single-connection).| **Rejects** tokenless/mismatched (constant-time); else registers + disconnects others (single-connection). | Registration is driven by `McpServerHub` after it validates the plugin's token + reads its instance metadata (account-scoped registry). |
+| `ResolveConnectionId`             | Token lookup, then round-robin fallback.                       | Token lookup, then round-robin fallback (single connection).                        | Account-scoped instance resolution; no fallback across accounts (fail closed).       |
+| `ShouldNotifySession` / `ResolveNotificationTarget` | Broadcast (single-plugin invariant).        | Broadcast (single-plugin invariant).                                                | Targets the session's account-resolved instance, else **drops** — never leaks across accounts. |
+| `GetClientData` / `GetServerData` | First available session (only one).                           | First available session (only one).                                                 | Scoped to the connection's account; empty when it resolves to no account.            |
 
 ---
 
@@ -143,6 +162,7 @@ The OAuth 2.1 resource-server **account + instance pairing plane**. A presented 
 |------------------|---------|----------------------------------------------------------------------------------------------------------|
 | `stdio`          | `none`  | **Local dev, single user, offline.** The MCP client spawns the server as a subprocess. No accounts, no network. First spawn owns the derived per-project port; a later same-project spawn detects the live server and exits with an actionable message (design 03 Flow D). |
 | `streamableHttp` | `none`  | **Local HTTP server, single plugin.** Anonymous HTTP transport for local testing.                        |
+| `streamableHttp` | `token` | **Offline shared-secret, single plugin.** Loopback-only local server gated on one static `--token`, constant-time compared — no authorization server / egress required. The offline counterpart of `oauth`. |
 | `streamableHttp` | `oauth` | **Signed-in localhost AND hosted.** Account-scoped pairing: many engine instances across accounts, each isolated to its own account's agent sessions; multiple agent sessions in one project fan in to one server. |
 
 `stdio` + `oauth` is valid but uncommon — a signed-in engine may connect with its JWT; in `none` mode the token is ignored for routing (identity is still logged for diagnostics).


### PR DESCRIPTION
## Summary
- Adds the offline **`token`** auth mode to the shared McpPlugin server — the loopback single-project counterpart of `oauth`. One static shared secret (`--token` / `MCP_PLUGIN_TOKEN`) gates BOTH the SignalR plugin connection and the streamableHttp MCP endpoint, validated with a **constant-time** compare.
- Keeps `required` as a deprecated alias onto the same strategy so un-migrated `authorization=required` configs run token-gated instead of crashing or downgrading to anonymous.
- Adds a shared launch-arg builder in `McpPlugin` (consolidation) and confirms `oauth-local` needs no server change.

## Changes
- `Consts.MCP.Server.AuthOption`: add `token` (keep `required`).
- New `LocalTokenMcpStrategy` (single-connection, broadcast; token-gated at the hub).
- `McpStrategyFactory`: `token` → LocalToken; `required` → LocalToken (deprecated alias, logged).
- `TokenAuthenticationHandler`: `LocalTokenMode`/`LocalToken` + local-token path; constant-time compare via `CryptographicOperations.FixedTimeEquals` over fixed-length SHA-256 digests — **a deliberate security upgrade over the deleted b5 `string.Equals(Ordinal)` timing leak** (shared `TokenComparison` helper).
- `StreamableHttpTransportLayer.ConfigureApp`: `RequireAuthorization()` gate in `token` mode (no PRM). Without it the token would be validated but never ENFORCED.
- 🔒 `Api/{DirectToolCall,SystemTool}Endpoints`: gate the REST tool surfaces (which can **execute** tools) in `token`/`required` mode too — closes an unauthenticated bypass of the token gate (shared `AuthGating` helper).
- `AgentConfiguratorSettings.IsHttpAuthRequired`: true for `token` (HTTP only; stdio stays credential-free per b6).
- New shared `ServerLaunchArguments` builder in `McpPlugin` (auth/token/issuer/public-url arg emitter for Unity/Godot/Unreal's sidecar).
- `docs/architecture-transport-auth.md` updated for the new mode.

## Test plan
- [x] Target-specific local tests passed (see profile `test.md`): full xUnit suite green across **net8.0 + net9.0**, `McpPlugin.Tests` + `McpPlugin.Server.Tests`.
- New coverage: `LocalTokenMcpStrategyTests`, `TokenComparisonTests`, `TokenAuthenticationHandlerLocalTokenTests`, `TokenModeTransportGatingTests` (real loopback host: no/wrong bearer → 401, correct bearer → session), `McpStrategyFactoryTests` (token + required-alias), `DirectToolEndpointsAuthGatingTests` (token/required now gated), `ServerLaunchArgumentsTests`, `AgentConfiguratorSettingsAuthTests`.

Scope: `shared/MCP-Plugin-dotnet` only (engine plugins + cloud AS unchanged). No `<Version>` bump (release pipeline owns that).

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)