### PR TITLE
fix: token-aware AI-agent config validator (fix permanent Reconfiguration Required in token mode)

### DIFF
--- a/McpPlugin.Tests/AgentConfig/AiAgentConfiguratorTests.cs
+++ b/McpPlugin.Tests/AgentConfig/AiAgentConfiguratorTests.cs
@@ -80,6 +80,79 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
             }
         }
 
+        // --- mcp-authorize i1 (BUG-A): the status validator must be token-aware. A LOCAL server in
+        // the offline `token` auth mode writes an Authorization: Bearer header (HttpCredentialMode
+        // .AccessToken); the "expected" config a status check builds must resolve the SAME credential
+        // mode from settings, else a correctly-written token config reads back as ReconfigureNeeded
+        // forever. These two tests pin the round-trip and the stale-token signal. ---
+
+        private static AgentConfiguratorSettings TokenSettings(string root, string token) => new(
+            operatingSystem: OperatingSystemKind.Windows,
+            projectRootPath: root,
+            executableFullPath: "C:/Tools/srv.exe",
+            port: 50000,
+            timeoutMs: 30000,
+            host: "http://localhost:50000/mcp",
+            token: token,
+            connectionMode: ConnectionMode.Local,
+            authOption: Consts.MCP.Server.AuthOption.token);
+
+        [Fact]
+        public void TokenMode_HttpConfig_RoundTrips_AsConfigured()
+        {
+            var root = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(root);
+            try
+            {
+                var c = new ClaudeCodeConfigurator();
+                var settings = TokenSettings(root, "local-secret");
+
+                // Local + token mode resolves to the Bearer-header (AccessToken) credential mode.
+                settings.ResolveHttpCredentialMode().ShouldBe(HttpCredentialMode.AccessToken);
+
+                // Write exactly what the engine Configure button writes for these settings.
+                c.GetHttpConfig(settings, credentialMode: settings.ResolveHttpCredentialMode())
+                    .Configure().ShouldBeTrue();
+
+                // Regression: the token-mode config must read back as Configured — no spurious banner.
+                c.IsConfigured(settings, TransportMethod.streamableHttp).ShouldBeTrue();
+                c.GetStatus(settings, TransportMethod.streamableHttp).ShouldBe(ConfiguratorStatus.Configured);
+                c.Describe(settings, TransportMethod.streamableHttp).Status.ShouldBe(ConfiguratorStatus.Configured);
+            }
+            finally
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+
+        [Fact]
+        public void TokenMode_StaleToken_ReadsAsReconfigureNeeded()
+        {
+            var root = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(root);
+            try
+            {
+                var c = new ClaudeCodeConfigurator();
+
+                // Configure was run earlier with the OLD local token.
+                var oldSettings = TokenSettings(root, "old-secret");
+                c.GetHttpConfig(oldSettings, credentialMode: oldSettings.ResolveHttpCredentialMode())
+                    .Configure().ShouldBeTrue();
+
+                // The current LocalToken has since rotated — same project, new token value.
+                var newSettings = TokenSettings(root, "new-secret");
+
+                // The on-disk Bearer <old> no longer matches the expected Bearer <new>: detected, stale.
+                c.IsConfigured(newSettings, TransportMethod.streamableHttp).ShouldBeFalse();
+                c.GetStatus(newSettings, TransportMethod.streamableHttp).ShouldBe(ConfiguratorStatus.ReconfigureNeeded);
+                c.Describe(newSettings, TransportMethod.streamableHttp).Status.ShouldBe(ConfiguratorStatus.ReconfigureNeeded);
+            }
+            finally
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+
         [Fact]
         public void Codex_IsTomlBased_AndAdvancedPatInjectsEnvVar_ButDefaultPathDoesNot()
         {

--- a/McpPlugin/src/AgentConfig/AgentConfiguratorSettings.cs
+++ b/McpPlugin/src/AgentConfig/AgentConfiguratorSettings.cs
@@ -203,6 +203,23 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
         public bool IsStdioAuthRequired =>
             AuthOption == Consts.MCP.Server.AuthOption.required;
 
+        /// <summary>
+        /// The <see cref="HttpCredentialMode"/> the HTTP config writer uses for these settings
+        /// (mcp-authorize g5/g6). A LOCAL server in the offline <c>token</c> mode is Bearer-gated, so
+        /// its client config MUST carry the <c>Authorization: Bearer &lt;local-secret&gt;</c> header
+        /// (<see cref="HttpCredentialMode.AccessToken"/>). Every other case — <c>none</c>, <c>oauth</c>,
+        /// and Cloud — keeps the default credential-free OAuth path (URL-only; the client authorizes
+        /// natively against the server URL). Single source of truth shared across engines so Unity /
+        /// Godot / Unreal resolve the credential mode identically — the "expected" config a status
+        /// check builds always matches what Configure writes. Pure; hoisted from Unity's former
+        /// <c>AiAgentConfiguratorView.ResolveHttpCredentialMode</c> (mcp-authorize i1).
+        /// </summary>
+        public HttpCredentialMode ResolveHttpCredentialMode() =>
+            ConnectionMode == ConnectionMode.Local
+            && AuthOption == Consts.MCP.Server.AuthOption.token
+                ? HttpCredentialMode.AccessToken
+                : HttpCredentialMode.Oauth;
+
         /// <summary>Convenience: <see cref="OperatingSystem"/> is <see cref="OperatingSystemKind.Windows"/>.</summary>
         public bool IsWindows => OperatingSystem == OperatingSystemKind.Windows;
 

--- a/McpPlugin/src/AgentConfig/AiAgentConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/AiAgentConfigurator.cs
@@ -208,7 +208,7 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
         public bool IsDetected(AgentConfiguratorSettings settings, ILogger? logger = null)
         {
             return GetStdioConfig(settings, logger).IsDetected()
-                || GetHttpConfig(settings, logger).IsDetected();
+                || GetHttpConfig(settings, logger, settings.ResolveHttpCredentialMode()).IsDetected();
         }
 
         /// <summary>
@@ -222,7 +222,7 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
         {
             var config = transport == Common.Consts.MCP.Server.TransportMethod.stdio
                 ? GetStdioConfig(settings, logger)
-                : GetHttpConfig(settings, logger);
+                : GetHttpConfig(settings, logger, settings.ResolveHttpCredentialMode());
             return config.IsConfigured();
         }
 
@@ -244,7 +244,7 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
 
             var config = transport == Common.Consts.MCP.Server.TransportMethod.stdio
                 ? GetStdioConfig(settings, logger)
-                : GetHttpConfig(settings, logger);
+                : GetHttpConfig(settings, logger, settings.ResolveHttpCredentialMode());
 
             return config.IsDetected()
                 ? ConfiguratorStatus.ReconfigureNeeded

--- a/McpPlugin/src/AgentConfig/AiAgentConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/AiAgentConfigurator.cs
@@ -119,6 +119,15 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
         /// <see cref="HttpCredentialMode.AccessToken"/> is the explicit advanced PAT path (Flow C):
         /// it writes the legacy bearer shape and, when that credential would land in a
         /// project-scoped file, emits a warning (prefer env-var / user-scope placement).
+        /// <para>
+        /// CONTRACT (mcp-authorize i1 / BUG-A): any caller that builds an EXPECTED config to compare
+        /// against what <c>Configure()</c> writes — i.e. a status / detect / match check — MUST pass
+        /// <c>settings.ResolveHttpCredentialMode()</c>, not rely on this credential-free
+        /// <see cref="HttpCredentialMode.Oauth"/> default. Omitting it makes a token-mode config read
+        /// as permanent <see cref="ConfiguratorStatus.ReconfigureNeeded"/> (the original BUG-A). The
+        /// default stays credential-free on purpose: it is fail-safe (never surfaces the Bearer
+        /// secret) and correct for display / write-suppressed paths.
+        /// </para>
         /// </summary>
         public AiAgentConfig GetHttpConfig(
             AgentConfiguratorSettings settings,
@@ -359,6 +368,12 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
             Common.Consts.MCP.Server.TransportMethod transport,
             ILogger? logger)
         {
+            // Display path: intentionally renders the credential-free OAuth shape (no resolved
+            // credential mode). Do NOT thread settings.ResolveHttpCredentialMode() here — this is a
+            // user-visible ReadOnlyField, and the AccessToken shape would surface the raw
+            // Authorization: Bearer <secret> in the UI. Only the status validators (IsDetected /
+            // IsConfigured / GetStatus) resolve the mode, because they must MATCH what Configure
+            // wrote; display must not EXPOSE the secret (mcp-authorize i1 / BUG-A scoping).
             var config = transport == Common.Consts.MCP.Server.TransportMethod.stdio
                 ? GetStdioConfig(settings, logger)
                 : GetHttpConfig(settings, logger);


### PR DESCRIPTION
## Summary

- `IsConfigured` / `GetStatus` / `Describe` / `IsDetected` built the EXPECTED HTTP config with the default OAuth credential mode (no `Authorization` header), so a token-mode Configure (which writes an `Authorization: Bearer` header) always read back as `ReconfigureNeeded` — a permanent "Reconfiguration Required" banner even when the written config was correct (mcp-authorize BUG-A).
- Added shared `AgentConfiguratorSettings.ResolveHttpCredentialMode()` (Local + `AuthOption==token` → `AccessToken`, else `Oauth`), hoisted from Unity's `AiAgentConfiguratorView` so Unity / Godot / Unreal consume ONE resolver. The four validator methods now build the expected config with the settings-derived mode → a correctly-written token-mode config reads back as `Configured`.
- A stale token (written value differs from the current `LocalToken`) now correctly reads as `ReconfigureNeeded` — the accurate re-Configure signal the Unity token-lifecycle fix (i2) needs.
- Client-side only: `McpPlugin.Server` and GameDev-MCP-Server are unaffected. No `<Version>` bump (7.1.1 + engine-plugin cascade is separate task i6).

## Test plan

- [x] Target-specific local tests passed (see profile test.md): full `dotnet test` Release across `McpPlugin.Tests` (520) + `McpPlugin.Server.Tests` (722), both `net8.0` and `net9.0`, 0 failures.
- [x] New regression tests: token-mode HTTP round-trip → `Configured`; stale token → `ReconfigureNeeded`.

Closes #161