### PR TITLE
feat: ProjectIdentity pin v2 (separator normalization) + dual-hash transition

### DIFF
--- a/McpPlugin.Common/src/Utils/Consts.MCP.cs
+++ b/McpPlugin.Common/src/Utils/Consts.MCP.cs
@@ -86,6 +86,12 @@ namespace com.IvanMurzak.McpPlugin.Common
                     public const string Engine = "engine";
                     public const string ProjectName = "project_name";
                     public const string ProjectPathHash = "project_path_hash";
+
+                    // Dual-hash transition (auth-fixes T3 / defect B5). The plugin sends BOTH the v2
+                    // hash (above, separator-normalized) AND this v1 legacy hash so a session pinned by
+                    // an OLD config (v1 pin) still matches a NEW plugin. The server pin-matches either.
+                    public const string ProjectPathHashLegacy = "project_path_hash_legacy";
+
                     public const string MachineName = "machine_name";
                 }
 

--- a/McpPlugin.Server.Tests/McpPlugin.Server.Tests.csproj
+++ b/McpPlugin.Server.Tests/McpPlugin.Server.Tests.csproj
@@ -20,6 +20,10 @@
 
   <ItemGroup>
     <ProjectReference Include="../McpPlugin.Server/McpPlugin.Server.csproj" />
+    <!-- Test-only: the routing tests derive REAL path hashes via ProjectIdentity (McpPlugin client
+         assembly). The server itself never derives hashes — it prefix-matches wire values — so this
+         reference is deliberately NOT on McpPlugin.Server. -->
+    <ProjectReference Include="../McpPlugin/McpPlugin.csproj" />
   </ItemGroup>
 
 </Project>

--- a/McpPlugin.Server.Tests/ProjectPinV2RoutingTests.cs
+++ b/McpPlugin.Server.Tests/ProjectPinV2RoutingTests.cs
@@ -1,0 +1,267 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak)                    │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+using com.IvanMurzak.McpPlugin.AgentConfig;
+using com.IvanMurzak.McpPlugin.Server.Strategy;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.Server.Tests
+{
+    /// <summary>
+    /// End-to-end routing coverage for the pin v2 / dual-hash transition (auth-fixes T3 / defect B5),
+    /// exercising <see cref="AccountInstances.Resolve"/> with REAL path-derived hashes rather than
+    /// synthetic strings. A "new plugin" registers with BOTH the v2 (separator-normalized) hash and the
+    /// v1 legacy hash of its reported project root (as <see cref="ConnectionInstanceMetadata.Create"/>
+    /// builds it); config pins are derived from the config's project root the same way Editor Configure
+    /// / cli-core setup-mcp (v2) and an OLD <c>.mcp.json</c> (v1) do. Covers:
+    /// <list type="bullet">
+    ///   <item>the B5 fix — a Windows backslash-root plugin and a forward-slash-root config now route
+    ///   together under v2 (they diverged under v1);</item>
+    ///   <item>the compat pairs — old-config(v1-pin)+new-plugin and new-config(v2-pin)+new-plugin;</item>
+    ///   <item>the precedence chain pin(strict) → sticky → single → MRU with path-derived pins;</item>
+    ///   <item>the cross-account isolation regression — a pin never crosses the <c>sub</c> bucket.</item>
+    /// </list>
+    /// </summary>
+    [Collection("McpPlugin.Server")]
+    public class ProjectPinV2RoutingTests
+    {
+        const string PosixA = "/home/dev/GameA";
+        const string PosixB = "/home/dev/GameB";
+        static string WinBackslash => "C:" + Bs + "Users" + Bs + "dev" + Bs + "MyGame";
+        const string WinForward = "C:/Users/dev/MyGame";
+
+        static string Bs => ((char)92).ToString();
+
+        sealed class Clock
+        {
+            public DateTimeOffset Now;
+            public Clock(DateTimeOffset start) => Now = start;
+            public void Advance(TimeSpan by) => Now += by;
+        }
+
+        static (AccountInstances reg, Clock clock) NewRegistry()
+        {
+            var clock = new Clock(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+            return (new AccountInstances(() => clock.Now), clock);
+        }
+
+        /// <summary>
+        /// A "new plugin" handshake: carries the v2 hash as the primary <c>ProjectPathHash</c> and the
+        /// v1 hash as <c>ProjectPathHashLegacy</c> — exactly what <see cref="ConnectionInstanceMetadata.Create"/>
+        /// sends for <paramref name="pluginReportedRoot"/>.
+        /// </summary>
+        static PluginInstanceMetadata NewPlugin(
+            string pluginReportedRoot,
+            string instanceId = "i1",
+            string engine = "unity",
+            string project = "MyGame",
+            string machine = "PC-1")
+            => new PluginInstanceMetadata(
+                instanceId,
+                engine,
+                project,
+                ProjectIdentity.DeriveProjectPathHashV2(pluginReportedRoot),
+                machine,
+                ProjectIdentity.DeriveProjectPathHash(pluginReportedRoot));
+
+        /// <summary>
+        /// An OLD (pre-dual-hash) plugin: it sent only the v1 hash of its reported root as
+        /// <c>ProjectPathHash</c>, with no legacy field. Models the world before this change.
+        /// </summary>
+        static PluginInstanceMetadata OldPlugin(
+            string pluginReportedRoot,
+            string instanceId = "i1",
+            string engine = "unity",
+            string project = "MyGame",
+            string machine = "PC-1")
+            => new PluginInstanceMetadata(
+                instanceId,
+                engine,
+                project,
+                ProjectIdentity.DeriveProjectPathHash(pluginReportedRoot),
+                machine);
+
+        // The pin a NEW config (Editor Configure / cli-core setup-mcp) writes for a project root.
+        static string V2Pin(string configRoot) => ProjectIdentity.DerivePinV2(configRoot);
+
+        // The pin an OLD (v1) config already on disk carries for a project root.
+        static string V1Pin(string configRoot) => ProjectIdentity.DerivePin(configRoot);
+
+        // ─────────────────────── Compat pair: new-config (v2 pin) + new-plugin ───────────────────────
+
+        [Theory]
+        [InlineData(PosixA)]
+        [InlineData(WinForward)]
+        public void NewConfig_V2Pin_NewPlugin_SamePath_Resolves(string path)
+        {
+            var (reg, _) = NewRegistry();
+            var instance = reg.Register("acc-1", NewPlugin(path), "conn-1");
+
+            var res = reg.Resolve("acc-1", V2Pin(path), selectedInstanceId: null);
+
+            res.Kind.ShouldBe(InstanceResolutionKind.Resolved);
+            res.Instance!.InstanceId.ShouldBe(instance.InstanceId);
+        }
+
+        // ─────────────────── Compat pair: old-config (v1 pin) + new-plugin (legacy) ───────────────────
+
+        [Theory]
+        [InlineData(PosixA)]
+        [InlineData(WinForward)]
+        public void OldConfig_V1Pin_NewPlugin_Resolves_ViaLegacyHash(string path)
+        {
+            // A user with an OLD .mcp.json still on disk (v1 pin) connecting a NEW plugin must keep
+            // routing — the plugin's v1 legacy hash is what the old pin prefix-matches.
+            var (reg, _) = NewRegistry();
+            var instance = reg.Register("acc-1", NewPlugin(path), "conn-1");
+
+            var res = reg.Resolve("acc-1", V1Pin(path), selectedInstanceId: null);
+
+            res.Kind.ShouldBe(InstanceResolutionKind.Resolved);
+            res.Instance!.InstanceId.ShouldBe(instance.InstanceId);
+        }
+
+        // ─────────────────────────── The B5 fix: separators no longer divide ──────────────────────────
+
+        [Fact]
+        public void B5Fix_WindowsBackslashPlugin_ForwardSlashConfig_Resolves_UnderV2()
+        {
+            // Plugin reports a Windows backslash root; the config was generated from the forward-slash
+            // form of the SAME project. Under v2 both normalize identically, so the v2 pin matches.
+            var (reg, _) = NewRegistry();
+            var instance = reg.Register("acc-1", NewPlugin(WinBackslash), "conn-1");
+
+            var res = reg.Resolve("acc-1", V2Pin(WinForward), selectedInstanceId: null);
+
+            res.Kind.ShouldBe(InstanceResolutionKind.Resolved);
+            res.Instance!.InstanceId.ShouldBe(instance.InstanceId);
+        }
+
+        [Fact]
+        public void B5_PreV2_ForwardSlashConfig_DidNotMatch_OldBackslashPlugin()
+        {
+            // Regression witness of the pre-fix world: an OLD plugin (single v1 hash of its backslash
+            // root) + a forward-slash config could NOT route on Windows — the forward-slash pin is not
+            // a prefix of the backslash v1 hash. That WAS B5; the v2 path above is what recovers it.
+            var (reg, _) = NewRegistry();
+            reg.Register("acc-1", OldPlugin(WinBackslash), "conn-1");
+
+            reg.Resolve("acc-1", V1Pin(WinForward), selectedInstanceId: null)
+                .Kind.ShouldBe(InstanceResolutionKind.NoMatchPinned);
+            reg.Resolve("acc-1", V2Pin(WinForward), selectedInstanceId: null)
+                .Kind.ShouldBe(InstanceResolutionKind.NoMatchPinned);
+        }
+
+        // ───────────────────────────────── Precedence: pin is strict ─────────────────────────────────
+
+        [Fact]
+        public void Pin_IsStrict_NeverFallsThroughToAnotherProject()
+        {
+            var (reg, _) = NewRegistry();
+            var a = reg.Register("acc-1", NewPlugin(PosixA, instanceId: "a", project: "GameA"), "conn-a");
+            reg.Register("acc-1", NewPlugin(PosixB, instanceId: "b", project: "GameB"), "conn-b");
+
+            // Pinned to A resolves ONLY to A even though B is live.
+            var res = reg.Resolve("acc-1", V2Pin(PosixA), selectedInstanceId: null);
+            res.Kind.ShouldBe(InstanceResolutionKind.Resolved);
+            res.Instance!.InstanceId.ShouldBe(a.InstanceId);
+        }
+
+        [Fact]
+        public void Pin_MatchingNoInstance_ButAccountNonEmpty_IsNoMatchPinned()
+        {
+            var (reg, _) = NewRegistry();
+            reg.Register("acc-1", NewPlugin(PosixA), "conn-a");
+
+            var res = reg.Resolve("acc-1", V2Pin(PosixB), selectedInstanceId: null); // B's editor is closed
+            res.Kind.ShouldBe(InstanceResolutionKind.NoMatchPinned);
+        }
+
+        // ─────────────────────────────── Precedence: sticky within pin ───────────────────────────────
+
+        [Fact]
+        public void Sticky_NarrowsWithinPinnedCandidateSet()
+        {
+            // Two live instances of the SAME project (different machines → distinct dedup keys), so a
+            // pin matches BOTH; the sticky selectedInstanceId picks one.
+            var (reg, _) = NewRegistry();
+            reg.Register("acc-1", NewPlugin(WinForward, instanceId: "m1", machine: "PC-1"), "conn-1");
+            var m2 = reg.Register("acc-1", NewPlugin(WinForward, instanceId: "m2", machine: "PC-2"), "conn-2");
+
+            var res = reg.Resolve("acc-1", V2Pin(WinForward), selectedInstanceId: "m2");
+
+            res.Kind.ShouldBe(InstanceResolutionKind.Resolved);
+            res.Instance!.InstanceId.ShouldBe(m2.InstanceId);
+        }
+
+        // ─────────────────────────────── Precedence: single auto-pair ────────────────────────────────
+
+        [Fact]
+        public void Single_PinnedCandidate_AutoPairs()
+        {
+            var (reg, _) = NewRegistry();
+            var only = reg.Register("acc-1", NewPlugin(PosixA), "conn-a");
+
+            var res = reg.Resolve("acc-1", V2Pin(PosixA), selectedInstanceId: null);
+            res.Kind.ShouldBe(InstanceResolutionKind.Resolved);
+            res.Instance!.InstanceId.ShouldBe(only.InstanceId);
+            res.AdvisoryNote.ShouldBeNull(); // single candidate → no MRU advisory
+        }
+
+        // ──────────────────────────────── Precedence: MRU when many ──────────────────────────────────
+
+        [Fact]
+        public void MultiplePinnedCandidates_Unresolved_PickMostRecentlyActive_WithAdvisory()
+        {
+            var (reg, clock) = NewRegistry();
+            var m1 = reg.Register("acc-1", NewPlugin(WinForward, instanceId: "m1", machine: "PC-1"), "conn-1");
+            reg.Register("acc-1", NewPlugin(WinForward, instanceId: "m2", machine: "PC-2"), "conn-2");
+
+            // Make m1 the most-recently-active.
+            clock.Advance(TimeSpan.FromMinutes(5));
+            reg.TouchByConnection("conn-1");
+
+            var res = reg.Resolve("acc-1", V2Pin(WinForward), selectedInstanceId: null);
+
+            res.Kind.ShouldBe(InstanceResolutionKind.Resolved);
+            res.Instance!.InstanceId.ShouldBe(m1.InstanceId);
+            res.AdvisoryNote.ShouldNotBeNull(); // one-time "routed to … switch with select_engine_instance" note
+        }
+
+        // ──────────────────── Cross-account isolation regression (bucket-by-sub) ──────────────────────
+
+        [Fact]
+        public void Pin_NeverCrossesAccounts_EmptyOtherAccount_IsAccountEmpty()
+        {
+            var (reg, _) = NewRegistry();
+            reg.Register("acc-1", NewPlugin(PosixA), "conn-a");
+
+            // Account 2 has no live instances; account-1's pin must not reach into account-1's bucket.
+            var res = reg.Resolve("acc-2", V2Pin(PosixA), selectedInstanceId: null);
+            res.Kind.ShouldBe(InstanceResolutionKind.AccountEmpty);
+        }
+
+        [Fact]
+        public void Pin_NeverCrossesAccounts_OtherAccountHasOwnInstance_IsNoMatchPinned()
+        {
+            var (reg, _) = NewRegistry();
+            reg.Register("acc-1", NewPlugin(PosixA, project: "GameA"), "conn-a"); // account 1 owns GameA
+
+            // Account 2 owns a DIFFERENT project and pins account-1's project — it must never resolve
+            // account-1's instance; it fails closed with NoMatchPinned (its own bucket has no match).
+            reg.Register("acc-2", NewPlugin(PosixB, project: "GameB"), "conn-b");
+            var res = reg.Resolve("acc-2", V2Pin(PosixA), selectedInstanceId: null);
+            res.Kind.ShouldBe(InstanceResolutionKind.NoMatchPinned);
+            res.Instance.ShouldBeNull();
+        }
+    }
+}

--- a/McpPlugin.Server/src/Hub/McpServerHub.cs
+++ b/McpPlugin.Server/src/Hub/McpServerHub.cs
@@ -132,7 +132,8 @@ namespace com.IvanMurzak.McpPlugin.Server
                 engine: QueryValue(query, Consts.MCP.Server.HubQuery.Engine),
                 projectName: QueryValue(query, Consts.MCP.Server.HubQuery.ProjectName),
                 projectPathHash: QueryValue(query, Consts.MCP.Server.HubQuery.ProjectPathHash),
-                machineName: QueryValue(query, Consts.MCP.Server.HubQuery.MachineName));
+                machineName: QueryValue(query, Consts.MCP.Server.HubQuery.MachineName),
+                projectPathHashLegacy: QueryValue(query, Consts.MCP.Server.HubQuery.ProjectPathHashLegacy));
 
             account.RegisterInstance(identity, metadata, Context.ConnectionId, _logger);
         }

--- a/McpPlugin.Server/src/Strategy/AccountMcpStrategy.cs
+++ b/McpPlugin.Server/src/Strategy/AccountMcpStrategy.cs
@@ -194,14 +194,16 @@ namespace com.IvanMurzak.McpPlugin.Server.Strategy
             string? engine,
             string? projectName,
             string? projectPathHash,
-            string? machineName)
+            string? machineName,
+            string? projectPathHashLegacy = null)
         {
             return new PluginInstanceMetadata(
                 InstanceId: string.IsNullOrEmpty(instanceId) ? connectionId : instanceId!,
                 Engine: engine ?? string.Empty,
                 ProjectName: projectName ?? string.Empty,
                 ProjectPathHash: projectPathHash ?? string.Empty,
-                MachineName: machineName ?? string.Empty);
+                MachineName: machineName ?? string.Empty,
+                ProjectPathHashLegacy: projectPathHashLegacy ?? string.Empty);
         }
     }
 }

--- a/McpPlugin.Server/src/Strategy/PluginInstance.cs
+++ b/McpPlugin.Server/src/Strategy/PluginInstance.cs
@@ -23,8 +23,12 @@ namespace com.IvanMurzak.McpPlugin.Server.Strategy
         string InstanceId,       // GUID minted per editor session (engine-side)
         string Engine,           // "unity" | "godot" | "unreal"
         string ProjectName,      // e.g. "MyGame"
-        string ProjectPathHash,  // stable id across editor restarts (sha256 hex of normalized path)
-        string MachineName);
+        string ProjectPathHash,  // v2 hash: stable id across editor restarts (sha256 hex of v2-normalized path)
+        string MachineName,
+        // Dual-hash transition (auth-fixes T3 / defect B5): the v1 (legacy) hash of the same path,
+        // sent alongside the v2 hash so a session pinned by an OLD (v1-pin) config still matches. May
+        // be empty for a pre-dual-hash plugin (then only the v2 hash is pin-matchable).
+        string ProjectPathHashLegacy = "");
 
     /// <summary>
     /// A single live engine-plugin connection within one account's bucket (mcp-authorize b3). Identity
@@ -46,8 +50,15 @@ namespace com.IvanMurzak.McpPlugin.Server.Strategy
         /// <summary>Human-facing project name, e.g. "MyGame".</summary>
         public string ProjectName { get; }
 
-        /// <summary>SHA-256 hex of the normalized project path — stable across editor restarts. Pin-matched by prefix.</summary>
+        /// <summary>SHA-256 hex of the v2-normalized project path — stable across editor restarts. Pin-matched by prefix.</summary>
         public string ProjectPathHash { get; }
+
+        /// <summary>
+        /// SHA-256 hex of the v1 (legacy)-normalized project path — sent alongside <see cref="ProjectPathHash"/>
+        /// so a session pinned by an OLD (v1-pin) config still matches (dual-hash transition, auth-fixes
+        /// T3 / defect B5). Empty for a pre-dual-hash plugin; never matches a pin when empty.
+        /// </summary>
+        public string ProjectPathHashLegacy { get; }
 
         /// <summary>The engine plugin's host machine name.</summary>
         public string MachineName { get; }
@@ -72,6 +83,7 @@ namespace com.IvanMurzak.McpPlugin.Server.Strategy
             Engine = metadata.Engine ?? string.Empty;
             ProjectName = metadata.ProjectName ?? string.Empty;
             ProjectPathHash = metadata.ProjectPathHash ?? string.Empty;
+            ProjectPathHashLegacy = metadata.ProjectPathHashLegacy ?? string.Empty;
             MachineName = metadata.MachineName ?? string.Empty;
             ConnectedAt = connectedAt;
             _connectionId = connectionId;
@@ -102,15 +114,22 @@ namespace com.IvanMurzak.McpPlugin.Server.Strategy
         /// <summary>
         /// True when a session pin routes to this instance: the pin is the first 8 hex chars of the
         /// project's SHA-256, so it matches when it is a case-insensitive prefix of the full
-        /// <see cref="ProjectPathHash"/>. A dedup key ties an instance to its (path,engine,machine).
+        /// project-path hash. Dual-hash transition (auth-fixes T3 / defect B5): the pin matches when it
+        /// is a prefix of EITHER the v2 <see cref="ProjectPathHash"/> (new configs) OR the v1
+        /// <see cref="ProjectPathHashLegacy"/> (old configs), so an old <c>.mcp.json</c> keeps routing
+        /// to a new plugin. A dedup key ties an instance to its (path,engine,machine).
         /// </summary>
         public bool MatchesPin(string? pin)
         {
             if (string.IsNullOrEmpty(pin))
                 return false;
-            if (string.IsNullOrEmpty(ProjectPathHash))
-                return false;
-            return ProjectPathHash.StartsWith(pin, StringComparison.OrdinalIgnoreCase);
+            if (!string.IsNullOrEmpty(ProjectPathHash) &&
+                ProjectPathHash.StartsWith(pin, StringComparison.OrdinalIgnoreCase))
+                return true;
+            if (!string.IsNullOrEmpty(ProjectPathHashLegacy) &&
+                ProjectPathHashLegacy.StartsWith(pin, StringComparison.OrdinalIgnoreCase))
+                return true;
+            return false;
         }
 
         /// <summary>The dedup key: same physical editor project re-launched (new InstanceId) collides on this.</summary>

--- a/McpPlugin.Server/src/Strategy/PluginInstance.cs
+++ b/McpPlugin.Server/src/Strategy/PluginInstance.cs
@@ -123,13 +123,12 @@ namespace com.IvanMurzak.McpPlugin.Server.Strategy
         {
             if (string.IsNullOrEmpty(pin))
                 return false;
-            if (!string.IsNullOrEmpty(ProjectPathHash) &&
-                ProjectPathHash.StartsWith(pin, StringComparison.OrdinalIgnoreCase))
-                return true;
-            if (!string.IsNullOrEmpty(ProjectPathHashLegacy) &&
-                ProjectPathHashLegacy.StartsWith(pin, StringComparison.OrdinalIgnoreCase))
-                return true;
-            return false;
+            string prefix = pin; // narrowed to non-null/non-empty by the guard above
+            // The pin matches when it prefixes EITHER hash (v2 for new configs, v1 legacy for old ones).
+            return IsPrefixedBy(ProjectPathHash) || IsPrefixedBy(ProjectPathHashLegacy);
+
+            bool IsPrefixedBy(string hash) =>
+                !string.IsNullOrEmpty(hash) && hash.StartsWith(prefix, StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>The dedup key: same physical editor project re-launched (new InstanceId) collides on this.</summary>

--- a/McpPlugin.Tests/AgentConfig/ConfigWritersB6Tests.cs
+++ b/McpPlugin.Tests/AgentConfig/ConfigWritersB6Tests.cs
@@ -187,6 +187,33 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
             finally { Directory.Delete(root, recursive: true); }
         }
 
+        // ---- auth-fixes T3 / defect B5: the emitted pin is the v2 (separator-normalized) pin. ----
+
+        [Fact]
+        public void ProjectPin_IsV2Pin_NotV1_ForBackslashRoot_AndCarriesIntoConfigs()
+        {
+            // The configurator MUST emit the v2 pin so a Windows backslash root and its forward-slash
+            // form route together (B5). A hardcoded backslash literal keeps this deterministic on Linux
+            // CI, where Path.GetTempPath() is forward-slash (there v1 == v2 and the divergence hides).
+            var backslashRoot = "C:" + ((char)92) + "Games" + ((char)92) + "MyProj";
+            var settings = new AgentConfiguratorSettings(
+                operatingSystem: OperatingSystemKind.Windows,
+                projectRootPath: backslashRoot,
+                executableFullPath: "C:/Tools/server.exe",
+                port: 50000,
+                timeoutMs: 30000,
+                host: "https://ai-game.dev/mcp",
+                connectionMode: ConnectionMode.Cloud);
+
+            var v2Pin = ProjectIdentity.DerivePinV2(backslashRoot);
+            settings.ProjectPin.ShouldBe(v2Pin);
+            settings.ProjectPin.ShouldNotBe(ProjectIdentity.DerivePin(backslashRoot)); // v2 ≠ v1 on Windows
+
+            var c = new ClaudeCodeConfigurator();
+            c.GetHttpConfig(settings).ExpectedFileContent.ShouldContain($"/p/{v2Pin}");
+            c.GetStdioConfig(settings).ExpectedFileContent.ShouldContain($"{Consts.MCP.Server.Args.Project}={v2Pin}");
+        }
+
         // ---- DoD 1: dedup / upsert regression on the new pinned shape. ----
 
         [Fact]

--- a/McpPlugin.Tests/AgentConfig/ProjectIdentityGoldenVectorV2Tests.cs
+++ b/McpPlugin.Tests/AgentConfig/ProjectIdentityGoldenVectorV2Tests.cs
@@ -1,0 +1,166 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using com.IvanMurzak.McpPlugin.AgentConfig;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
+{
+    /// <summary>
+    /// Verifies <see cref="ProjectIdentity"/> v2 (auth-fixes T3 / defect B5) against the committed
+    /// cross-language golden-vector file <c>ProjectIdentity.GoldenVectors.v2.json</c>. v2 differs from
+    /// v1 by converting <c>'\'</c> to <c>'/'</c> before hashing, so a Windows project root reported
+    /// with backslashes and the same root reported with forward slashes hash IDENTICALLY. The v1
+    /// vectors + <see cref="ProjectIdentityGoldenVectorTests"/> are kept untouched for the legacy hash.
+    /// Named with the <c>ProjectIdentityGoldenVector</c> prefix so the CI <c>golden-vector-parity</c>
+    /// job (filter <c>FullyQualifiedName~ProjectIdentityGoldenVector</c>) picks it up.
+    /// </summary>
+    public class ProjectIdentityGoldenVectorV2Tests
+    {
+        private const string GoldenFileName = "ProjectIdentity.GoldenVectors.v2.json";
+
+        private static string GoldenFilePath => Path.Combine(System.AppContext.BaseDirectory, GoldenFileName);
+
+        public static IEnumerable<object[]> GoldenVectors()
+        {
+            using var doc = JsonDocument.Parse(File.ReadAllText(GoldenFilePath));
+            foreach (var v in doc.RootElement.GetProperty("vectors").EnumerateArray())
+            {
+                yield return new object[]
+                {
+                    v.GetProperty("path").GetString()!,
+                    v.GetProperty("pin").GetString()!,
+                    v.GetProperty("port").GetInt32(),
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GoldenVectors))]
+        public void ProjectIdentityV2_ReproducesEveryGoldenVector(string path, string expectedPin, int expectedPort)
+        {
+            ProjectIdentity.DerivePinV2(path).ShouldBe(expectedPin);
+            ProjectIdentity.DerivePortV2(path).ShouldBe(expectedPort);
+        }
+
+        [Theory]
+        [MemberData(nameof(GoldenVectors))]
+        public void EveryV2GoldenVector_HasValidPinAndPortShape(string path, string expectedPin, int expectedPort)
+        {
+            _ = path;
+            expectedPin.Length.ShouldBe(ProjectIdentity.PinLength);
+            foreach (var c in expectedPin)
+                ((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')).ShouldBeTrue($"pin '{expectedPin}' must be lowercase hex");
+
+            expectedPort.ShouldBeInRange(ProjectIdentity.MinPort, ProjectIdentity.MaxPort);
+        }
+
+        [Theory]
+        [MemberData(nameof(GoldenVectors))]
+        public void V2Pin_IsPrefixOfV2ProjectPathHash(string path, string expectedPin, int expectedPort)
+        {
+            _ = expectedPort;
+            var hash = ProjectIdentity.DeriveProjectPathHashV2(path);
+            hash.Length.ShouldBe(64);
+            hash.ShouldStartWith(expectedPin);
+        }
+
+        /// <summary>
+        /// The defining property of v2 (the B5 fix): a backslash project root and its forward-slash
+        /// equivalent hash IDENTICALLY. Read straight from the committed <c>separatorEquivalence</c>
+        /// block so the shared artifact and the C# reference can never silently drift.
+        /// </summary>
+        [Fact]
+        public void Backslash_And_ForwardSlash_HashIdentically_UnderV2()
+        {
+            using var doc = JsonDocument.Parse(File.ReadAllText(GoldenFilePath));
+            foreach (var p in doc.RootElement.GetProperty("separatorEquivalence").GetProperty("pairs").EnumerateArray())
+            {
+                var backslash = p.GetProperty("backslash").GetString()!;
+                var forward = p.GetProperty("forwardSlash").GetString()!;
+                var pin = p.GetProperty("pin").GetString()!;
+                var port = p.GetProperty("port").GetInt32();
+
+                ProjectIdentity.DerivePinV2(backslash).ShouldBe(pin);
+                ProjectIdentity.DerivePinV2(forward).ShouldBe(pin);
+                ProjectIdentity.DerivePinV2(backslash).ShouldBe(ProjectIdentity.DerivePinV2(forward));
+
+                ProjectIdentity.DerivePortV2(backslash).ShouldBe(port);
+                ProjectIdentity.DerivePortV2(forward).ShouldBe(port);
+
+                ProjectIdentity.DeriveProjectPathHashV2(backslash).ShouldBe(ProjectIdentity.DeriveProjectPathHashV2(forward));
+            }
+        }
+
+        /// <summary>
+        /// v1 and v2 MUST AGREE for a forward-slash-only path (no backslash to convert) — the seamless
+        /// transition depends on POSIX/forward-slash configs being unchanged by v2.
+        /// </summary>
+        [Fact]
+        public void V1_And_V2_Agree_ForForwardSlashOnlyPaths()
+        {
+            const string path = "/home/user/my-game";
+            ProjectIdentity.DerivePinV2(path).ShouldBe(ProjectIdentity.DerivePin(path));
+            ProjectIdentity.DerivePortV2(path).ShouldBe(ProjectIdentity.DerivePort(path));
+            ProjectIdentity.DeriveProjectPathHashV2(path).ShouldBe(ProjectIdentity.DeriveProjectPathHash(path));
+        }
+
+        /// <summary>
+        /// v1 and v2 MUST DIFFER for a backslash path — proving v2 actually changed the normalization
+        /// (the whole point of B5). This is the legacy-vs-new hash the dual-hash transition relies on.
+        /// </summary>
+        [Fact]
+        public void V1_And_V2_Differ_ForBackslashPaths()
+        {
+            var backslash = "C:" + Bs + "Users" + Bs + "user" + Bs + "my-game";
+            ProjectIdentity.DerivePinV2(backslash).ShouldNotBe(ProjectIdentity.DerivePin(backslash));
+            ProjectIdentity.DeriveProjectPathHashV2(backslash).ShouldNotBe(ProjectIdentity.DeriveProjectPathHash(backslash));
+        }
+
+        [Fact]
+        public void NormalizeV2_TrimsTrailingSeparators_ConvertsBackslash_AndLowercases()
+        {
+            ProjectIdentity.NormalizeV2("C:" + Bs + "Users" + Bs + "User" + Bs).ShouldBe("c:/users/user");
+            ProjectIdentity.NormalizeV2("/Home/User/My-Game/").ShouldBe("/home/user/my-game");
+        }
+
+        [Fact]
+        public void UnicodeDivergenceV2_CanonicalIsCSharp_AndDiffersFromNaiveJs()
+        {
+            using var doc = JsonDocument.Parse(File.ReadAllText(GoldenFilePath));
+            foreach (var c in doc.RootElement.GetProperty("unicodeDivergence").GetProperty("cases").EnumerateArray())
+            {
+                var path = c.GetProperty("path").GetString()!;
+                var canonical = c.GetProperty("canonical");
+                var jsNaive = c.GetProperty("jsNaiveToLowerCase");
+
+                ProjectIdentity.DerivePinV2(path).ShouldBe(canonical.GetProperty("pin").GetString());
+                ProjectIdentity.DerivePortV2(path).ShouldBe(canonical.GetProperty("port").GetInt32());
+
+                ProjectIdentity.DerivePortV2(path).ShouldNotBe(jsNaive.GetProperty("port").GetInt32());
+                ProjectIdentity.DerivePinV2(path).ShouldNotBe(jsNaive.GetProperty("pin").GetString());
+            }
+        }
+
+        [Fact]
+        public void DeriveV2_NullPath_Throws()
+        {
+            Should.Throw<System.ArgumentNullException>(() => ProjectIdentity.DerivePinV2(null!));
+            Should.Throw<System.ArgumentNullException>(() => ProjectIdentity.DerivePortV2(null!));
+            Should.Throw<System.ArgumentNullException>(() => ProjectIdentity.DeriveProjectPathHashV2(null!));
+            Should.Throw<System.ArgumentNullException>(() => ProjectIdentity.NormalizeV2(null!));
+        }
+
+        private static string Bs => ((char)92).ToString();
+    }
+}

--- a/McpPlugin.Tests/McpPlugin.Tests.csproj
+++ b/McpPlugin.Tests/McpPlugin.Tests.csproj
@@ -26,6 +26,7 @@
     <!-- Committed cross-language golden vectors for ProjectIdentity; copied next to the test
          assembly so ProjectIdentityGoldenVectorTests can load them at runtime. -->
     <None Include="../McpPlugin/src/AgentConfig/ProjectIdentity.GoldenVectors.json" Link="ProjectIdentity.GoldenVectors.json" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="../McpPlugin/src/AgentConfig/ProjectIdentity.GoldenVectors.v2.json" Link="ProjectIdentity.GoldenVectors.v2.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>

--- a/McpPlugin.Tests/Network/Connection/ConnectionInstanceMetadataTests.cs
+++ b/McpPlugin.Tests/Network/Connection/ConnectionInstanceMetadataTests.cs
@@ -24,17 +24,47 @@ namespace com.IvanMurzak.McpPlugin.Tests.Network.Connection
         const string ProjectRoot = "/home/dev/MyGame";
 
         [Fact]
-        public void Create_DerivesProjectPathHash_WithPinAsPrefix()
+        public void Create_DerivesDualHash_V2Primary_V1Legacy_WithPinsAsPrefix()
         {
             var metadata = ConnectionInstanceMetadata.Create("unity", "MyGame", ProjectRoot);
 
-            metadata.ProjectPathHash.ShouldBe(ProjectIdentity.DeriveProjectPathHash(ProjectRoot));
+            // Primary hash is the v2 (separator-normalized) hash; the v2 pin is its prefix.
+            metadata.ProjectPathHash.ShouldBe(ProjectIdentity.DeriveProjectPathHashV2(ProjectRoot));
             metadata.ProjectPathHash.Length.ShouldBe(64);
-            // The routing pin is the first 8 hex chars of the same hash — so the server pin-matches by prefix.
-            metadata.ProjectPathHash.ShouldStartWith(ProjectIdentity.DerivePin(ProjectRoot));
+            metadata.ProjectPathHash.ShouldStartWith(ProjectIdentity.DerivePinV2(ProjectRoot));
+
+            // Legacy hash is the v1 hash of the same path; the v1 pin is its prefix.
+            metadata.ProjectPathHashLegacy.ShouldBe(ProjectIdentity.DeriveProjectPathHash(ProjectRoot));
+            metadata.ProjectPathHashLegacy.Length.ShouldBe(64);
+            metadata.ProjectPathHashLegacy.ShouldStartWith(ProjectIdentity.DerivePin(ProjectRoot));
+
             metadata.InstanceId.ShouldNotBeNullOrEmpty();
             metadata.Engine.ShouldBe("unity");
             metadata.ProjectName.ShouldBe("MyGame");
+        }
+
+        [Fact]
+        public void Create_OnWindowsBackslashRoot_V2AndLegacyHashesDiffer()
+        {
+            var backslashRoot = "C:" + ((char)92) + "Games" + ((char)92) + "MyGame";
+            var metadata = ConnectionInstanceMetadata.Create("unity", "MyGame", backslashRoot);
+
+            // v2 normalizes '\' -> '/', so the primary hash differs from the v1 legacy hash on Windows —
+            // this is exactly the divergence (B5) the dual-hash transition carries both sides of.
+            metadata.ProjectPathHash.ShouldBe(ProjectIdentity.DeriveProjectPathHashV2(backslashRoot));
+            metadata.ProjectPathHashLegacy.ShouldBe(ProjectIdentity.DeriveProjectPathHash(backslashRoot));
+            metadata.ProjectPathHash.ShouldNotBe(metadata.ProjectPathHashLegacy);
+        }
+
+        [Fact]
+        public void ToQuery_CarriesBothV2AndLegacyHashes()
+        {
+            var metadata = ConnectionInstanceMetadata.Create("unity", "MyGame", ProjectRoot);
+
+            var query = metadata.ToQuery();
+
+            query[Consts.MCP.Server.HubQuery.ProjectPathHash].ShouldBe(metadata.ProjectPathHash);
+            query[Consts.MCP.Server.HubQuery.ProjectPathHashLegacy].ShouldBe(metadata.ProjectPathHashLegacy);
         }
 
         [Fact]

--- a/McpPlugin/src/AgentConfig/AgentConfiguratorSettings.cs
+++ b/McpPlugin/src/AgentConfig/AgentConfiguratorSettings.cs
@@ -229,6 +229,7 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
         // terminal-written config. Resolved lazily and cached (a marker read is file I/O, and the
         // identity is stable for the settings' <see cref="ProjectRootPath"/>).
         private ProjectIdentity? _identity;
+        private string? _projectPin;
 
         /// <summary>
         /// The project's <see cref="ProjectIdentity"/> — routing pin plus the resolved local port
@@ -244,9 +245,10 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
         /// generated from a Windows backslash root matches a plugin whose forward-slash hash it now
         /// equals (auth-fixes T3 / defect B5). Old (v1-pin) configs still route via the plugin's legacy
         /// hash. Non-secret, safe to commit. The port stays on the v1 derivation (<see cref="ResolvedPort"/>)
-        /// until the engine runtimes adopt the v2 port primitive.
+        /// until the engine runtimes adopt the v2 port primitive. Derived once and cached (the pin is
+        /// stable for the settings' <see cref="ProjectRootPath"/>), matching <see cref="Identity"/>.
         /// </summary>
-        public string ProjectPin => ProjectIdentity.DerivePinV2(ProjectRootPath);
+        public string ProjectPin => _projectPin ??= ProjectIdentity.DerivePinV2(ProjectRootPath);
 
         /// <summary>
         /// The resolved per-project local port: the project marker's <c>portOverride</c> when set,

--- a/McpPlugin/src/AgentConfig/AgentConfiguratorSettings.cs
+++ b/McpPlugin/src/AgentConfig/AgentConfiguratorSettings.cs
@@ -237,8 +237,16 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
         /// </summary>
         public ProjectIdentity Identity => _identity ??= ProjectIdentity.Derive(ProjectRootPath, ProjectMarker.Read(ProjectRootPath));
 
-        /// <summary>The routing pin (first 8 hex chars of the ProjectIdentity SHA-256). Non-secret, safe to commit.</summary>
-        public string ProjectPin => Identity.Pin;
+        /// <summary>
+        /// The routing pin written into every config (HTTP <c>/p/&lt;pin&gt;</c> segment and stdio
+        /// <c>project=&lt;pin&gt;</c> arg). This is the <b>v2</b> pin (first 8 hex chars of the
+        /// separator-normalized SHA-256, see <see cref="ProjectIdentity.DerivePinV2"/>) so a config
+        /// generated from a Windows backslash root matches a plugin whose forward-slash hash it now
+        /// equals (auth-fixes T3 / defect B5). Old (v1-pin) configs still route via the plugin's legacy
+        /// hash. Non-secret, safe to commit. The port stays on the v1 derivation (<see cref="ResolvedPort"/>)
+        /// until the engine runtimes adopt the v2 port primitive.
+        /// </summary>
+        public string ProjectPin => ProjectIdentity.DerivePinV2(ProjectRootPath);
 
         /// <summary>
         /// The resolved per-project local port: the project marker's <c>portOverride</c> when set,

--- a/McpPlugin/src/AgentConfig/ProjectIdentity.GoldenVectors.v2.json
+++ b/McpPlugin/src/AgentConfig/ProjectIdentity.GoldenVectors.v2.json
@@ -1,0 +1,100 @@
+{
+  "version": 2,
+  "description": "Cross-language golden vectors for ProjectIdentity v2 (auth-fixes T3 / defect B5). v2 differs from v1 (ProjectIdentity.GoldenVectors.json) by ONE normalization step: backslashes are converted to forward slashes BEFORE hashing, so a Windows project root reported with '\\' and the same root reported with '/' hash IDENTICALLY. This is the shared cross-language artifact the cli-core TS port MUST reproduce (routing pin + deterministic local port). The C# reference implementation (McpPlugin/src/AgentConfig/ProjectIdentity.cs — DerivePinV2 / DerivePortV2 / DeriveProjectPathHashV2 / NormalizeV2) is the canonical origin. The v1 file is kept untouched for the legacy dual-hash transition. Regenerate/verify via McpPlugin.Tests ProjectIdentityGoldenVectorV2Tests.",
+  "algorithm": {
+    "steps": [
+      "1. Trim trailing directory separators ('/' and '\\') from the project root (so '/a/b' and '/a/b/' are the same project).",
+      "2. Convert every backslash '\\' to a forward slash '/'  (THIS is the only difference from v1 — it makes 'C:\\a' and 'C:/a' identical).",
+      "3. Lowercase the result. C#: string.ToLowerInvariant(). NOTE: this diverges from JS String.prototype.toLowerCase() for some Unicode chars — see `unicodeDivergence`.",
+      "4. UTF-8 encode, then SHA-256 hash.",
+      "5. pin  = the first 4 bytes of the hash as 8 lowercase hex characters.",
+      "6. port = 20000 + (littleEndianUInt32(first 4 bytes of the hash) % 10000).  Range: 20000-29999."
+    ],
+    "minPort": 20000,
+    "maxPort": 29999,
+    "pinLength": 8,
+    "separatorNormalization": "v2: backslashes ARE converted to forward slashes before hashing ('C:\\a' and 'C:/a' hash IDENTICALLY). Trim trailing separators first, then replace '\\' -> '/', then lowercase. Do NOT path.normalize()/path.resolve() before deriving — only the '\\' -> '/' substitution.",
+    "whichStringIsHashed": "the normalized project root supplied by the caller, NOT Environment.CurrentDirectory / process.cwd()."
+  },
+  "vectors": [
+    {
+      "path": "/home/user/my-game",
+      "pin": "34ea75f2",
+      "port": 23940,
+      "note": "POSIX typical project path — no backslashes, so v2 == v1."
+    },
+    {
+      "path": "/home/user/my-game/",
+      "pin": "34ea75f2",
+      "port": 23940,
+      "note": "Trailing slash is trimmed -> identical to '/home/user/my-game'."
+    },
+    {
+      "path": "/home/USER/My-Game",
+      "pin": "34ea75f2",
+      "port": 23940,
+      "note": "Case-folded -> identical to '/home/user/my-game'."
+    },
+    {
+      "path": "C:\\Users\\user\\my-game",
+      "pin": "5a87324e",
+      "port": 24298,
+      "note": "Windows backslash form. v2 converts '\\' -> '/' so this now hashes IDENTICALLY to the forward-slash form below (v1 gave a DIFFERENT pin 8ef72cf7 here — that divergence was B5)."
+    },
+    {
+      "path": "C:\\Users\\user\\my-game\\",
+      "pin": "5a87324e",
+      "port": 24298,
+      "note": "Trailing backslash trimmed, then '\\' -> '/' -> identical to the two forms."
+    },
+    {
+      "path": "C:/Users/user/my-game",
+      "pin": "5a87324e",
+      "port": 24298,
+      "note": "Forward-slash form. Under v2 it MATCHES the backslash form (the B5 fix); under v1 the two differed."
+    },
+    {
+      "path": "/home/İstanbul/game",
+      "pin": "672d80a7",
+      "port": 25303,
+      "note": "Contains U+0130 (LATIN CAPITAL LETTER I WITH DOT ABOVE). No backslash -> v2 == v1. Canonical C# value; see `unicodeDivergence`."
+    },
+    {
+      "path": "/srv/games/space sim",
+      "pin": "08c6cbb6",
+      "port": 27816,
+      "note": "Path containing a space; no backslash -> v2 == v1."
+    }
+  ],
+  "separatorEquivalence": {
+    "note": "The defining property of v2: a backslash project root and its forward-slash equivalent produce the SAME pin/port. This is what fixes B5 (Windows CLI enroll-pin vs plugin forward-slash hash divergence).",
+    "pairs": [
+      {
+        "backslash": "C:\\Users\\user\\my-game",
+        "forwardSlash": "C:/Users/user/my-game",
+        "pin": "5a87324e",
+        "port": 24298
+      }
+    ]
+  },
+  "unicodeDivergence": {
+    "note": "C# string.ToLowerInvariant() and JS String.prototype.toLowerCase() do NOT agree on every character. The value in `vectors` (produced by the C# origin) is canonical; a JS/TS port MUST reproduce it. This section records what a NAIVE toLowerCase() port produces so the divergence is explicit and testable in the consuming CLIs.",
+    "cases": [
+      {
+        "path": "/home/İstanbul/game",
+        "char": "U+0130 LATIN CAPITAL LETTER I WITH DOT ABOVE",
+        "canonical": {
+          "pin": "672d80a7",
+          "port": 25303,
+          "producedBy": "C# ToLowerInvariant leaves U+0130 unchanged (no case fold)."
+        },
+        "jsNaiveToLowerCase": {
+          "pin": "77300275",
+          "port": 27751,
+          "loweredCodepoints": "U+0069 U+0307 (i + COMBINING DOT ABOVE)",
+          "warning": "A naive JS/TS port would produce THIS incorrect value. It must special-case U+0130 (and any char where toLowerCase() disagrees with ToLowerInvariant) to match `canonical`."
+        }
+      }
+    ]
+  }
+}

--- a/McpPlugin/src/AgentConfig/ProjectIdentity.cs
+++ b/McpPlugin/src/AgentConfig/ProjectIdentity.cs
@@ -159,9 +159,85 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
             return TrimTrailingSeparators(projectRoot).ToLowerInvariant();
         }
 
+        // ─────────────────────────────────────────────────────────────────────────────────────────
+        // v2 identity (auth-fixes T3 / defect B5). The v1 methods above are kept verbatim for the
+        // legacy hash so old configs keep matching (dual-hash transition, decision M1). v2 adds ONE
+        // step to the normalization — converting '\' to '/' — so a Windows project root reported with
+        // backslashes (<c>C:\a\b</c>) and the same root reported with forward slashes (<c>C:/a/b</c>)
+        // hash IDENTICALLY. That kills B5: the CLI enroll-pin (derived from a backslash path) and the
+        // plugin's forward-slash hash no longer diverge on Windows. Cross-language parity is gated by
+        // the committed <c>ProjectIdentity.GoldenVectors.v2.json</c> (alongside the untouched v1 file).
+        // ─────────────────────────────────────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// The v2 pre-hash string: the project root with trailing directory separators trimmed, every
+        /// backslash converted to a forward slash, then lowercased with <see cref="string.ToLowerInvariant"/>.
+        /// This is the single normalization primitive the pin (v2), the full project-path hash (v2), and
+        /// the deterministic port (<see cref="DerivePortV2"/>) all share. Exposed so the golden-vector
+        /// tooling, the cross-language cli-core port, AND the engine runtimes can reproduce the exact
+        /// pre-hash string — the latter is the <b>B10</b> primitive: an engine deriving its local port
+        /// from an ad-hoc (untrimmed, un-separator-normalized) path can switch to this and stay in
+        /// lock-step with the routing pin.
+        /// </summary>
+        public static string NormalizeV2(string projectRoot)
+        {
+            if (projectRoot == null)
+                throw new ArgumentNullException(nameof(projectRoot));
+            return TrimTrailingSeparators(projectRoot).Replace('\\', '/').ToLowerInvariant();
+        }
+
+        /// <summary>
+        /// The v2 routing pin (first 8 lowercase hex chars of the SHA-256 of <see cref="NormalizeV2"/>).
+        /// This is the pin the configurators (Editor Configure / cli-core setup-mcp / enroll) now emit;
+        /// it prefix-matches an engine plugin's v2 <c>projectPathHash</c> in the hub handshake.
+        /// </summary>
+        public static string DerivePinV2(string projectRoot)
+        {
+            if (projectRoot == null)
+                throw new ArgumentNullException(nameof(projectRoot));
+            return ToHex(HashOfV2(projectRoot), PinLength / 2);
+        }
+
+        /// <summary>
+        /// The FULL v2 project-path hash (64-char lowercase hex of the SHA-256 of <see cref="NormalizeV2"/>).
+        /// This is the <c>projectPathHash</c> (v2) an engine plugin sends in its hub instance-metadata
+        /// handshake; the server pin-matches by checking the routing pin is a case-insensitive prefix of
+        /// it (<c>PluginInstance.MatchesPin</c>, which now also checks the v1 legacy hash for old configs).
+        /// </summary>
+        public static string DeriveProjectPathHashV2(string projectRoot)
+        {
+            if (projectRoot == null)
+                throw new ArgumentNullException(nameof(projectRoot));
+            return ToHex(HashOfV2(projectRoot), 32);
+        }
+
+        /// <summary>
+        /// The v2 hash-derived port (ignores any override) — the deterministic local port computed from
+        /// the <see cref="NormalizeV2"/> string. Same byte math as <see cref="DerivePort"/>, only the
+        /// pre-hash normalization differs (separators converted). This is the <b>B10</b> port-derivation
+        /// primitive engines consume so the local port and the routing pin derive from one normalized
+        /// string (Unity-side consumption is a follow-up task).
+        /// </summary>
+        public static int DerivePortV2(string projectRoot)
+        {
+            if (projectRoot == null)
+                throw new ArgumentNullException(nameof(projectRoot));
+            return PortFromHash(HashOfV2(projectRoot));
+        }
+
         internal static byte[] HashOf(string projectRoot)
         {
             var normalized = Normalize(projectRoot);
+            var bytes = Encoding.UTF8.GetBytes(normalized);
+            using (var sha256 = SHA256.Create())
+            {
+                return sha256.ComputeHash(bytes);
+            }
+        }
+
+        internal static byte[] HashOfV2(string projectRoot)
+        {
+            var normalized = NormalizeV2(projectRoot);
             var bytes = Encoding.UTF8.GetBytes(normalized);
             using (var sha256 = SHA256.Create())
             {

--- a/McpPlugin/src/McpPlugin/Network/Connection/ConnectionInstanceMetadata.cs
+++ b/McpPlugin/src/McpPlugin/Network/Connection/ConnectionInstanceMetadata.cs
@@ -37,8 +37,16 @@ namespace com.IvanMurzak.McpPlugin
         /// <summary>Human-facing project name, e.g. <c>"MyGame"</c>.</summary>
         public string ProjectName { get; }
 
-        /// <summary>Full SHA-256 hex of the normalized project path (see <see cref="ProjectIdentity.DeriveProjectPathHash"/>). Stable across editor restarts; pin-matched by prefix.</summary>
+        /// <summary>Full SHA-256 hex of the <b>v2</b>-normalized project path (see <see cref="ProjectIdentity.DeriveProjectPathHashV2"/>). Stable across editor restarts; pin-matched by prefix.</summary>
         public string ProjectPathHash { get; }
+
+        /// <summary>
+        /// Full SHA-256 hex of the <b>v1 (legacy)</b>-normalized project path (see
+        /// <see cref="ProjectIdentity.DeriveProjectPathHash"/>). Sent alongside the v2 hash so a
+        /// session pinned by an OLD config (v1 pin) still matches this NEW plugin (dual-hash
+        /// transition, auth-fixes T3 / defect B5). Empty when unknown; never matches a pin when empty.
+        /// </summary>
+        public string ProjectPathHashLegacy { get; }
 
         /// <summary>The host machine name.</summary>
         public string MachineName { get; }
@@ -48,7 +56,8 @@ namespace com.IvanMurzak.McpPlugin
             string engine,
             string projectName,
             string projectPathHash,
-            string machineName)
+            string machineName,
+            string? projectPathHashLegacy = null)
         {
             if (string.IsNullOrEmpty(instanceId))
                 throw new ArgumentException("InstanceId must be non-empty.", nameof(instanceId));
@@ -57,14 +66,18 @@ namespace com.IvanMurzak.McpPlugin
             Engine = engine ?? string.Empty;
             ProjectName = projectName ?? string.Empty;
             ProjectPathHash = projectPathHash ?? string.Empty;
+            ProjectPathHashLegacy = projectPathHashLegacy ?? string.Empty;
             MachineName = machineName ?? string.Empty;
         }
 
         /// <summary>
         /// Builds metadata for a project. The <see cref="ProjectPathHash"/> is derived deterministically
-        /// from <paramref name="projectRootPath"/> (same hash whose first 8 hex chars are the routing pin);
-        /// <paramref name="instanceId"/> defaults to a fresh GUID (mint one per editor session and reuse it
-        /// across reconnects); <paramref name="machineName"/> defaults to <see cref="Environment.MachineName"/>.
+        /// from <paramref name="projectRootPath"/> using the <b>v2</b> normalization (same hash whose
+        /// first 8 hex chars are the v2 routing pin); <see cref="ProjectPathHashLegacy"/> carries the
+        /// <b>v1</b> hash of the same path so old (v1-pin) configs still match (dual-hash transition,
+        /// auth-fixes T3 / defect B5). <paramref name="instanceId"/> defaults to a fresh GUID (mint one
+        /// per editor session and reuse it across reconnects); <paramref name="machineName"/> defaults
+        /// to <see cref="Environment.MachineName"/>.
         /// </summary>
         public static ConnectionInstanceMetadata Create(
             string engine,
@@ -80,8 +93,9 @@ namespace com.IvanMurzak.McpPlugin
                 instanceId: string.IsNullOrEmpty(instanceId) ? Guid.NewGuid().ToString() : instanceId!,
                 engine: engine ?? string.Empty,
                 projectName: projectName ?? string.Empty,
-                projectPathHash: ProjectIdentity.DeriveProjectPathHash(projectRootPath),
-                machineName: string.IsNullOrEmpty(machineName) ? SafeMachineName() : machineName!);
+                projectPathHash: ProjectIdentity.DeriveProjectPathHashV2(projectRootPath),
+                machineName: string.IsNullOrEmpty(machineName) ? SafeMachineName() : machineName!,
+                projectPathHashLegacy: ProjectIdentity.DeriveProjectPathHash(projectRootPath));
         }
 
         /// <summary>
@@ -98,6 +112,7 @@ namespace com.IvanMurzak.McpPlugin
             AddIfPresent(query, Consts.MCP.Server.HubQuery.Engine, Engine);
             AddIfPresent(query, Consts.MCP.Server.HubQuery.ProjectName, ProjectName);
             AddIfPresent(query, Consts.MCP.Server.HubQuery.ProjectPathHash, ProjectPathHash);
+            AddIfPresent(query, Consts.MCP.Server.HubQuery.ProjectPathHashLegacy, ProjectPathHashLegacy);
             AddIfPresent(query, Consts.MCP.Server.HubQuery.MachineName, MachineName);
             return query;
         }

--- a/docs/architecture-transport-auth.md
+++ b/docs/architecture-transport-auth.md
@@ -13,7 +13,7 @@
 > shared token. `ConnectionConfig.Token` is replaced by a **credential-provider callback** that
 > presents an auto-refreshed account JWT (machine-store auto-adopt — the zero-button rule) in the
 > `Authorization` header, and the instance-metadata handshake
-> `{instanceId, engine, projectName, projectPathHash, machineName}` rides as non-secret hub query
+> `{instanceId, engine, projectName, projectPathHash, projectPathHashLegacy, machineName}` rides as non-secret hub query
 > parameters (the token never appears in the query). It also fixes the direct-tool REST endpoints
 > (`/api/tools`, `/api/system-tools`): they now **require authorization in `oauth` mode** (they
 > previously gated on the deleted `required` mode and were unintentionally never gated), and stay
@@ -28,6 +28,18 @@
 > is **retained as a deprecated alias** onto this strategy (so an un-migrated config runs token-gated
 > instead of crashing), never a silent downgrade to anonymous. Constant-time compare is a deliberate
 > security upgrade over the b5-era `string.Equals(Ordinal)`.
+
+> **Pin v2 + dual-hash (auth-fixes T3, defect B5).** The routing pin/hash derivation
+> (`ProjectIdentity`) gained a **v2** normalization that converts `\` to `/` before hashing, so a
+> Windows project root reported with backslashes and the same root reported with forward slashes hash
+> IDENTICALLY (previously they diverged — B5, a Windows-only routing failure). The transition is
+> **seamless** and requires no server protocol change: the plugin sends BOTH the v2 hash
+> (`project_path_hash`) AND the v1 hash (`project_path_hash_legacy`) in the handshake, and
+> `PluginInstance.MatchesPin` matches a session pin as a prefix of **either** hash — so an OLD
+> `.mcp.json` (v1 pin) keeps routing to a NEW plugin, and a NEW config (v2 pin) routes too. The v1
+> methods and their golden vectors (`ProjectIdentity.GoldenVectors.json`) are kept untouched for the
+> legacy hash; the v2 vectors live alongside in `ProjectIdentity.GoldenVectors.v2.json` (the shared
+> cross-language artifact the engine-CLI ports reproduce). Configurators now emit the v2 pin.
 
 ## Overview
 


### PR DESCRIPTION
## Summary
- Adds a **v2** `ProjectIdentity` derivation that converts `\` → `/` before hashing, so a Windows backslash project root and its forward-slash form hash **identically** (fixes **B5**, the Windows-only routing failure). v1 methods + golden vectors untouched for the legacy hash.
- **Dual-hash transition** (no server protocol change, additive only): the plugin handshake carries `projectPathHash` (v2) **and** `projectPathHashLegacy` (v1); `PluginInstance.MatchesPin` prefix-matches **either**, so an OLD (v1-pin) config keeps routing to a NEW plugin and a NEW config (v2-pin) routes too.
- Configurators emit the **v2** pin (`/p/<pin>` HTTP + `project=<pin>` stdio). Exposes the **B10** port-derivation primitive (`DerivePortV2`/`NormalizeV2`) for later engine adoption (port stays on v1 here).
- New `ProjectIdentity.GoldenVectors.v2.json` alongside the untouched v1 file — the shared cross-language artifact the engine-CLI ports reproduce.

## Test plan
- [x] Target-specific local tests passed (see profile test.md): `dotnet test` Release, **net8.0 + net9.0**, both `McpPlugin.Tests` (755) and `McpPlugin.Server.Tests` (533) — 0 failures.
- [x] New routing matrix over `AccountInstances.Resolve` (separators × platforms × config generations), compat pairs (old-config v1-pin + new-plugin; new-config + new-plugin), and cross-account isolation regression.
- [x] Golden-vector-parity filter (`FullyQualifiedName~ProjectIdentityGoldenVector`) picks up the v2 class and is green.

Closes #164