### PR TITLE
fix(auth): B11 plugin-plane hub registration + T6 routing diagnostics (B6/B7/B8)

### DIFF
--- a/McpPlugin.Server.Tests/B11PluginPlaneRegistrationTests.cs
+++ b/McpPlugin.Server.Tests/B11PluginPlaneRegistrationTests.cs
@@ -1,0 +1,130 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.Server.Auth;
+using com.IvanMurzak.McpPlugin.Server.Auth.OAuth;
+using com.IvanMurzak.McpPlugin.Server.Strategy;
+using com.IvanMurzak.McpPlugin.Server.Tests.OAuth;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.Server.Tests
+{
+    /// <summary>
+    /// End-to-end regression for the B11 root cause (auth-fixes, k1 code-trace 2026-07-18): a plugin
+    /// hub-token (<c>aud=urn:agd:hub</c>) is validated by the REAL <see cref="AccessTokenValidator"/> on
+    /// the plugin plane and drives an instance registration into <see cref="AccountMcpStrategy"/> exactly
+    /// as <c>McpServerHub.TryRegisterOAuthInstanceAsync</c> does — closing the test blind spot noted in
+    /// 01 §7 (the prior handshake tests build <see cref="ConnectionIdentity"/> directly and never drove
+    /// the aud validator with a real <c>urn:agd:hub</c> token). Before the fix the strict agent-plane
+    /// aud check rejected the token → the bucket stayed empty → the agent's <c>tools/list</c> silently
+    /// degraded to the 3 native tools (B6). Also covers plane separation (an agent token cannot register)
+    /// and the late-connect <c>list_changed</c> delivery (B6) that registration restores.
+    /// </summary>
+    public sealed class B11PluginPlaneRegistrationTests
+    {
+        const string Issuer = "https://as.example";
+        const string Resource = "http://localhost:23471";
+        const string Kid = "key-1";
+        const string Account = "user-abc"; // the plugin token's `sub` == the agent's account
+        const string PluginConnectionId = "plugin-conn-1";
+        const string ProjectPathHash = "abcd1234ef567890abcd1234ef567890abcd1234ef567890abcd1234ef567890";
+        const string Pin = "abcd1234";
+        static readonly DateTimeOffset Now = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+
+        static AccessTokenValidator Validator(ECDsa key)
+        {
+            var jwks = new FakeJwksKeyProvider().Add(Kid, key);
+            return new AccessTokenValidator(new OAuthResourceServerConfig(Issuer, Resource), jwks, FakeIntrospectionClient.AlwaysInactive, () => Now);
+        }
+
+        static string PluginHubToken(ECDsa key)
+            => TestJwt.SignEs256(key, Kid, TestJwt.Claims(Issuer, AccessTokenValidator.PluginAudience, Now.AddHours(1), sub: Account, scope: ConnectionIdentity.ScopePlugin));
+
+        static string AgentToken(ECDsa key)
+            => TestJwt.SignEs256(key, Kid, TestJwt.Claims(Issuer, Resource, Now.AddHours(1), sub: Account, scope: ConnectionIdentity.ScopeAgent));
+
+        static PluginInstanceMetadata Metadata()
+            => AccountMcpStrategy.BuildInstanceMetadata(
+                connectionId: PluginConnectionId,
+                instanceId: "sess-42",
+                engine: "unity",
+                projectName: "MyGame",
+                projectPathHash: ProjectPathHash,
+                machineName: "DESKTOP-9");
+
+        [Fact]
+        public async Task ValidatedPluginHubToken_RegistersInstance_AndAgentSeesIt()
+        {
+            using var key = TestJwt.CreateKey();
+            var strategy = new AccountMcpStrategy();
+
+            // Before: the agent's account bucket is empty → tools/list = AccountEmpty (the B11 symptom).
+            strategy.Instances.Resolve(Account, Pin, selectedInstanceId: null)
+                .Kind.ShouldBe(InstanceResolutionKind.AccountEmpty);
+
+            // Drive the REAL validator on the plugin plane exactly as McpServerHub does.
+            var validation = await Validator(key).ValidateAsync(PluginHubToken(key), TokenValidationPlane.Plugin, CancellationToken.None);
+            validation.Succeeded.ShouldBeTrue(validation.FailureReason);
+
+            var identity = ConnectionIdentity.Create(validation.Subject, validation.Scope, validation.ClientId);
+            identity.ShouldNotBeNull();
+            identity!.AccountId.ShouldBe(Account);
+            identity.IsPlugin.ShouldBeTrue();
+
+            strategy.RegisterInstance(identity, Metadata(), PluginConnectionId, NullLogger.Instance);
+
+            // After: the agent (same sub) now resolves the live instance by its project pin — full toolset.
+            var resolution = strategy.Instances.Resolve(Account, Pin, selectedInstanceId: null);
+            resolution.Kind.ShouldBe(InstanceResolutionKind.Resolved);
+            resolution.Instance!.InstanceId.ShouldBe("sess-42");
+        }
+
+        [Fact]
+        public async Task AgentToken_OnPluginPlane_IsRejected_SoItNeverRegisters()
+        {
+            // Plane separation: an agent token validated on the plugin plane fails, so
+            // McpServerHub gets identity==null and never registers a plugin instance for it.
+            using var key = TestJwt.CreateKey();
+
+            var validation = await Validator(key).ValidateAsync(AgentToken(key), TokenValidationPlane.Plugin, CancellationToken.None);
+
+            validation.Succeeded.ShouldBeFalse();
+            ConnectionIdentity.Create(validation.Subject, validation.Scope, validation.ClientId).ShouldBeNull();
+        }
+
+        [Fact]
+        public async Task LateConnect_AfterRegistration_NotifiesTheLiveAgentSession()
+        {
+            // B6 late-connect: an editor connecting AFTER the agent's first tools/list must deliver
+            // notifications/tools/list_changed to the live session. That delivery is gated by
+            // ShouldNotifySession → GetAccountByConnection(pluginConnectionId), which is null for an
+            // unregistered plugin. Fixing registration (B11) restores it.
+            using var key = TestJwt.CreateKey();
+            var strategy = new AccountMcpStrategy();
+
+            // Agent session (sessionId == account in oauth) is already live; the plugin has NOT registered.
+            strategy.ShouldNotifySession(PluginConnectionId, sessionId: Account).ShouldBeFalse();
+
+            var validation = await Validator(key).ValidateAsync(PluginHubToken(key), TokenValidationPlane.Plugin, CancellationToken.None);
+            var identity = ConnectionIdentity.Create(validation.Subject, validation.Scope, validation.ClientId)!;
+            strategy.RegisterInstance(identity, Metadata(), PluginConnectionId, NullLogger.Instance);
+
+            // Now the late-connect list_changed reaches the live agent session — and no other account's.
+            strategy.ShouldNotifySession(PluginConnectionId, sessionId: Account).ShouldBeTrue();
+            strategy.ShouldNotifySession(PluginConnectionId, sessionId: "someone-else").ShouldBeFalse();
+        }
+    }
+}

--- a/McpPlugin.Server.Tests/OAuth/AccessTokenValidatorTests.cs
+++ b/McpPlugin.Server.Tests/OAuth/AccessTokenValidatorTests.cs
@@ -44,6 +44,9 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests.OAuth
         static Task<OAuthValidationResult> Validate(AccessTokenValidator v, string token)
             => v.ValidateAsync(token, CancellationToken.None);
 
+        static Task<OAuthValidationResult> Validate(AccessTokenValidator v, string token, TokenValidationPlane plane)
+            => v.ValidateAsync(token, plane, CancellationToken.None);
+
         [Fact]
         public async Task ValidEs256Token_Succeeds()
         {
@@ -238,6 +241,131 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests.OAuth
 
             result.Succeeded.ShouldBeFalse();
             result.FailureReason!.ShouldContain("exp");
+        }
+
+        // ── Plane separation (auth-fixes B11) ───────────────────────────────────────────────────────
+        // The plugin hub-token carries aud=urn:agd:hub. The agent plane (strict, canonical resource)
+        // rejects it, so before this fix McpServerHub never registered the instance → agent tools/list
+        // silently degraded to the 3 native tools. The plugin plane allow-lists urn:agd:hub while
+        // keeping the agent plane strict — plane separation must hold in BOTH directions.
+
+        const string PluginAud = AccessTokenValidator.PluginAudience; // "urn:agd:hub"
+
+        static string PluginToken(ECDsa key, string? aud = PluginAud, string scope = "mcp:plugin", string sub = "user-123")
+            => TestJwt.SignEs256(key, Kid, TestJwt.Claims(Issuer, aud ?? PluginAud, Now.AddHours(1), sub: sub, scope: scope));
+
+        [Fact]
+        public async Task PluginHubToken_OnPluginPlane_Registers()
+        {
+            // (a) k1 repro control: a real plugin hub-token (aud=urn:agd:hub, scope=mcp:plugin) is now
+            // ACCEPTED on the plugin plane, so McpServerHub can register the instance.
+            using var key = TestJwt.CreateKey();
+            var token = PluginToken(key);
+
+            var result = await Validate(Validator(key), token, TokenValidationPlane.Plugin);
+
+            result.Succeeded.ShouldBeTrue(result.FailureReason);
+            result.Subject.ShouldBe("user-123");
+            result.Scope.ShouldBe("mcp:plugin");
+        }
+
+        [Fact]
+        public async Task PluginHubToken_OnAgentPlane_Rejected()
+        {
+            // (b) A plugin hub-token (aud=urn:agd:hub) is STILL rejected for agent-plane operations:
+            // the agent plane only accepts the canonical resource id.
+            using var key = TestJwt.CreateKey();
+            var token = PluginToken(key);
+
+            var result = await Validate(Validator(key), token, TokenValidationPlane.Agent);
+
+            result.Succeeded.ShouldBeFalse();
+            result.FailureReason!.ShouldContain("audience");
+        }
+
+        [Fact]
+        public async Task PluginHubToken_OnDefaultOverload_IsAgentPlane_Rejected()
+        {
+            // The parameterless overload is the agent plane — a plugin audience is rejected, proving the
+            // default path never silently accepts urn:agd:hub.
+            using var key = TestJwt.CreateKey();
+            var token = PluginToken(key);
+
+            var result = await Validate(Validator(key), token); // agent plane (default)
+
+            result.Succeeded.ShouldBeFalse();
+            result.FailureReason!.ShouldContain("audience");
+        }
+
+        [Fact]
+        public async Task AgentToken_OnPluginPlane_CannotRegister()
+        {
+            // Plane separation, the vice-versa direction (k1 §7): an agent token (aud=canonical resource,
+            // scope=mcp:agent) must NEVER register as a plugin instance. The canonical resource is in the
+            // plugin allow-list, so ONLY the mcp:plugin scope guard keeps this out.
+            using var key = TestJwt.CreateKey();
+            var token = TestJwt.SignEs256(key, Kid, TestJwt.Claims(Issuer, Resource, Now.AddHours(1), scope: "mcp:agent"));
+
+            var result = await Validate(Validator(key), token, TokenValidationPlane.Plugin);
+
+            result.Succeeded.ShouldBeFalse();
+            result.FailureReason!.ShouldContain("audience");
+        }
+
+        [Fact]
+        public async Task PluginToken_AudiencedToCanonicalResource_OnPluginPlane_Registers()
+        {
+            // A plugin-scoped token audienced to the canonical resource (the other allow-list member) is
+            // accepted on the plugin plane — the mcp:plugin scope distinguishes it from an agent token.
+            using var key = TestJwt.CreateKey();
+            var token = TestJwt.SignEs256(key, Kid, TestJwt.Claims(Issuer, Resource, Now.AddHours(1), scope: "mcp:plugin"));
+
+            var result = await Validate(Validator(key), token, TokenValidationPlane.Plugin);
+
+            result.Succeeded.ShouldBeTrue(result.FailureReason);
+        }
+
+        [Fact]
+        public async Task AgentToken_OnAgentPlane_StillSucceeds()
+        {
+            // Regression guard: the agent plane's behavior is entirely unchanged by the fix.
+            using var key = TestJwt.CreateKey();
+            var token = TestJwt.SignEs256(key, Kid, TestJwt.Claims(Issuer, Resource, Now.AddHours(1), scope: "mcp:agent"));
+
+            var result = await Validate(Validator(key), token, TokenValidationPlane.Agent);
+
+            result.Succeeded.ShouldBeTrue(result.FailureReason);
+            result.Scope.ShouldBe("mcp:agent");
+        }
+
+        [Theory]
+        [InlineData(TokenValidationPlane.Agent)]
+        [InlineData(TokenValidationPlane.Plugin)]
+        public async Task SpoofedAudience_RejectedOnEveryPlane(TokenValidationPlane plane)
+        {
+            // (c) A spoofed/unknown audience is rejected on BOTH planes — the plugin allow-list is a
+            // strict set, never a lenient bypass. The scope is plugin so only the aud can cause the fail.
+            using var key = TestJwt.CreateKey();
+            var token = TestJwt.SignEs256(key, Kid, TestJwt.Claims(Issuer, "https://evil.example/mcp", Now.AddHours(1), scope: "mcp:plugin"));
+
+            var result = await Validate(Validator(key), token, plane);
+
+            result.Succeeded.ShouldBeFalse();
+            result.FailureReason!.ShouldContain("audience");
+        }
+
+        [Fact]
+        public async Task PluginAudienceInArray_OnPluginPlane_Registers()
+        {
+            // Array-aud plugin token: the plugin audience anywhere in the aud array is honored.
+            using var key = TestJwt.CreateKey();
+            var claims = TestJwt.Claims(Issuer, PluginAud, Now.AddHours(1), scope: "mcp:plugin");
+            claims["aud"] = new[] { "https://other.example", PluginAud };
+            var token = TestJwt.SignEs256(key, Kid, claims);
+
+            var result = await Validate(Validator(key), token, TokenValidationPlane.Plugin);
+
+            result.Succeeded.ShouldBeTrue(result.FailureReason);
         }
 
         // ── Opaque token path (introspection) ─────────────────────────────────────────────────────

--- a/McpPlugin.Server.Tests/ServerNativeToolsTests.cs
+++ b/McpPlugin.Server.Tests/ServerNativeToolsTests.cs
@@ -166,6 +166,85 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
             Text(response).ShouldNotContain("inst-X");
         }
 
+        // ─────────────────────────── Routing diagnostics (auth-fixes T6 / B6 / B7) ───────────────────────────
+
+        [Fact]
+        public async Task List_ShowsPerInstancePin_AndProjectBasename()
+        {
+            var (tools, registry, _, _, _) = NewTools();
+            registry.Register(Account, Meta("inst-A", project: "GameA"), "conn-A");
+
+            var text = Text(await tools.HandleAsync(ServerNativeTools.ListInstances, NoArgs, Ctx()));
+
+            // The instance line now carries the 8-hex routing pin and the project basename (B7).
+            text.ShouldContain($"pin {PinA}");
+            text.ShouldContain("unity:GameA");
+        }
+
+        [Fact]
+        public async Task List_PinnedSession_WithMatch_ShowsMatchedInstance()
+        {
+            var (tools, registry, _, _, _) = NewTools();
+            registry.Register(Account, Meta("inst-A", pathHash: HashA), "conn-A");
+
+            var text = Text(await tools.HandleAsync(ServerNativeTools.ListInstances, NoArgs, Ctx(pin: PinA)));
+
+            text.ShouldContain($"session pin: {PinA}");
+            text.ShouldContain("matched: inst-A");
+        }
+
+        [Fact]
+        public async Task List_PinnedSession_NoMatch_ShowsNoneWithActionableHint()
+        {
+            var (tools, registry, _, _, _) = NewTools();
+            // A live instance exists, but not for the pinned project (B6 NoMatchPinned diagnosis).
+            registry.Register(Account, Meta("inst-B", project: "Beta", pathHash: HashB, machine: "PC-2"), "conn-B");
+
+            var text = Text(await tools.HandleAsync(ServerNativeTools.ListInstances, NoArgs, Ctx(pin: PinA)));
+
+            text.ShouldContain($"session pin: {PinA}");
+            text.ShouldContain("matched: none");
+            text.ShouldContain("select_engine_instance");
+        }
+
+        [Fact]
+        public async Task List_UnpinnedSession_ReportsNoPin()
+        {
+            var (tools, registry, _, _, _) = NewTools();
+            registry.Register(Account, Meta("inst-A"), "conn-A");
+
+            var text = Text(await tools.HandleAsync(ServerNativeTools.ListInstances, NoArgs, Ctx(pin: null)));
+
+            text.ShouldContain("session pin: none");
+        }
+
+        [Fact]
+        public async Task List_EmptyAccount_PinnedSession_ShowsNoneWithEnrollHint()
+        {
+            var (tools, _, _, _, _) = NewTools();
+
+            var text = Text(await tools.HandleAsync(ServerNativeTools.ListInstances, NoArgs, Ctx(pin: PinA)));
+
+            text.ShouldContain($"session pin: {PinA}");
+            text.ShouldContain("matched: none");
+            text.ShouldContain("enroll_engine_plugin");
+        }
+
+        [Fact]
+        public async Task List_ProjectDiagnostic_ShowsBasenameOnly_NeverFullPath()
+        {
+            var (tools, registry, _, _, _) = NewTools();
+            // A plugin self-reports a path-like project name; diagnostics must leak only the basename
+            // (06 threat table — never a full filesystem path).
+            registry.Register(Account, Meta("inst-A", project: @"C:\Users\secret\Projects\MyGame"), "conn-A");
+
+            var text = Text(await tools.HandleAsync(ServerNativeTools.ListInstances, NoArgs, Ctx()));
+
+            text.ShouldContain("unity:MyGame");
+            text.ShouldNotContain("secret");
+            text.ShouldNotContain(@"C:\Users");
+        }
+
         // ─────────────────────────────── select_engine_instance ───────────────────────────────
 
         [Fact]

--- a/McpPlugin.Server.Tests/TokenAuthenticationHandlerOAuthTests.cs
+++ b/McpPlugin.Server.Tests/TokenAuthenticationHandlerOAuthTests.cs
@@ -35,6 +35,8 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
             public FakeValidator(OAuthValidationResult result) => _result = result;
             public Task<OAuthValidationResult> ValidateAsync(string token, CancellationToken cancellationToken)
                 => Task.FromResult(_result);
+            public Task<OAuthValidationResult> ValidateAsync(string token, TokenValidationPlane plane, CancellationToken cancellationToken)
+                => Task.FromResult(_result);
         }
 
         static readonly OAuthResourceServerConfig Config = new OAuthResourceServerConfig("https://as.example", "http://localhost:23471");

--- a/McpPlugin.Server/src/Auth/OAuth/AccessTokenValidator.cs
+++ b/McpPlugin.Server/src/Auth/OAuth/AccessTokenValidator.cs
@@ -46,9 +46,6 @@ namespace com.IvanMurzak.McpPlugin.Server.Auth.OAuth
         /// </summary>
         public const string PluginAudience = "urn:agd:hub";
 
-        /// <summary>The OAuth scope that marks a plugin-plane token (kept in lockstep with <c>ConnectionIdentity.ScopePlugin</c>).</summary>
-        private const string PluginScope = "mcp:plugin";
-
         private readonly OAuthResourceServerConfig _config;
         private readonly IJwksKeyProvider _jwks;
         private readonly IIntrospectionClient _introspection;
@@ -225,7 +222,7 @@ namespace com.IvanMurzak.McpPlugin.Server.Auth.OAuth
             if (!claims.TryGetProperty("aud", out var aud))
                 return false;
 
-            var hasPluginScope = plane == TokenValidationPlane.Plugin && ScopeContains(claims, PluginScope);
+            var hasPluginScope = plane == TokenValidationPlane.Plugin && ScopeContains(claims, ConnectionIdentity.ScopePlugin);
 
             if (aud.ValueKind == JsonValueKind.String)
                 return AudienceEntryAccepted(aud.GetString(), plane, hasPluginScope);

--- a/McpPlugin.Server/src/Auth/OAuth/AccessTokenValidator.cs
+++ b/McpPlugin.Server/src/Auth/OAuth/AccessTokenValidator.cs
@@ -26,8 +26,9 @@ namespace com.IvanMurzak.McpPlugin.Server.Auth.OAuth
     ///         defeats the <c>alg:none</c> and HS256-with-the-public-key key-confusion attacks:
     ///         no symmetric or "none" path is ever taken and no key material is loaded before the
     ///         algorithm is confirmed); signature verified with the JWKS P-256 key resolved by
-    ///         <c>kid</c>; strict <c>iss</c>, strict per-resource <c>aud</c> (loopback-aliased),
-    ///         and <c>exp</c>/<c>nbf</c> with ±5 min skew.</item>
+    ///         <c>kid</c>; strict <c>iss</c>, plane-aware <c>aud</c> (loopback-aliased) — the agent plane
+    ///         requires the canonical resource id, the plugin plane additionally allow-lists the plugin
+    ///         audience <c>urn:agd:hub</c> (auth-fixes B11) — and <c>exp</c>/<c>nbf</c> with ±5 min skew.</item>
     ///   <item><b>Opaque tokens</b> — routed to introspection (fail-closed).</item>
     /// </list>
     /// Every failure path returns <see cref="OAuthValidationResult.Fail"/>; nothing throws.
@@ -36,6 +37,17 @@ namespace com.IvanMurzak.McpPlugin.Server.Auth.OAuth
     {
         private const string RequiredAlgorithm = "ES256";
         private const int P256SignatureLength = 64; // r(32) || s(32), IEEE P1363
+
+        /// <summary>
+        /// The plugin-plane audience (auth-fixes B11). Plugin hub-tokens are minted with
+        /// <c>aud=urn:agd:hub</c> (a plane marker, distinct from the RS resource id). Accepted ONLY on
+        /// the <see cref="TokenValidationPlane.Plugin"/> plane, never on the agent plane. Compared by
+        /// exact ordinal value — it is a URN, not a URL, so it is NOT run through URL normalization.
+        /// </summary>
+        public const string PluginAudience = "urn:agd:hub";
+
+        /// <summary>The OAuth scope that marks a plugin-plane token (kept in lockstep with <c>ConnectionIdentity.ScopePlugin</c>).</summary>
+        private const string PluginScope = "mcp:plugin";
 
         private readonly OAuthResourceServerConfig _config;
         private readonly IJwksKeyProvider _jwks;
@@ -58,12 +70,15 @@ namespace com.IvanMurzak.McpPlugin.Server.Auth.OAuth
         }
 
         public Task<OAuthValidationResult> ValidateAsync(string token, CancellationToken cancellationToken)
+            => ValidateAsync(token, TokenValidationPlane.Agent, cancellationToken);
+
+        public Task<OAuthValidationResult> ValidateAsync(string token, TokenValidationPlane plane, CancellationToken cancellationToken)
         {
             if (string.IsNullOrWhiteSpace(token))
                 return Task.FromResult(OAuthValidationResult.Fail("unknown", "empty token"));
 
             return LooksLikeJwt(token, out var header, out var payload, out var signature)
-                ? ValidateJwtAsync(header, payload, signature, cancellationToken)
+                ? ValidateJwtAsync(header, payload, signature, plane, cancellationToken)
                 : ValidateOpaqueAsync(token, cancellationToken);
         }
 
@@ -95,7 +110,7 @@ namespace com.IvanMurzak.McpPlugin.Server.Auth.OAuth
             return true;
         }
 
-        private async Task<OAuthValidationResult> ValidateJwtAsync(string headerSeg, string payloadSeg, string signatureSeg, CancellationToken cancellationToken)
+        private async Task<OAuthValidationResult> ValidateJwtAsync(string headerSeg, string payloadSeg, string signatureSeg, TokenValidationPlane plane, CancellationToken cancellationToken)
         {
             // ---- Header: enforce ES256 BEFORE touching any key material (alg-confusion defense) --
             if (!Base64Url.TryDecode(headerSeg, out var headerBytes))
@@ -157,7 +172,7 @@ namespace com.IvanMurzak.McpPlugin.Server.Auth.OAuth
                 if (!string.Equals(iss, _config.Issuer, StringComparison.Ordinal))
                     return OAuthValidationResult.Fail("jwt", "issuer mismatch");
 
-                if (!AudienceContainsResource(claims))
+                if (!AudienceAcceptedForPlane(claims, plane))
                     return OAuthValidationResult.Fail("jwt", "audience mismatch");
 
                 var now = _now();
@@ -193,24 +208,72 @@ namespace com.IvanMurzak.McpPlugin.Server.Auth.OAuth
             return OAuthValidationResult.Success("opaque", result.Subject, result.Scope);
         }
 
-        private bool AudienceContainsResource(JsonElement claims)
+        /// <summary>
+        /// Plane-aware audience acceptance (auth-fixes B11). Both planes fail-closed when <c>aud</c> is
+        /// absent or matches nothing.
+        /// <list type="bullet">
+        ///   <item><b>Agent plane:</b> <c>aud</c> must be the canonical RS <see cref="OAuthResourceServerConfig.ResourceUrl"/>
+        ///         (loopback-normalized). The plugin audience <c>urn:agd:hub</c> is NOT accepted.</item>
+        ///   <item><b>Plugin plane:</b> a strict allow-list — <c>aud</c> is accepted when it is the plugin
+        ///         audience <c>urn:agd:hub</c> (exact), OR the canonical RS resource AND the token also
+        ///         carries the <c>mcp:plugin</c> scope. The scope guard keeps an agent token
+        ///         (<c>aud=</c>canonical, <c>scope=mcp:agent</c>) from ever registering as a plugin.</item>
+        /// </list>
+        /// </summary>
+        private bool AudienceAcceptedForPlane(JsonElement claims, TokenValidationPlane plane)
         {
             if (!claims.TryGetProperty("aud", out var aud))
                 return false;
 
+            var hasPluginScope = plane == TokenValidationPlane.Plugin && ScopeContains(claims, PluginScope);
+
             if (aud.ValueKind == JsonValueKind.String)
-                return UrlNormalization.ResourcesMatch(aud.GetString(), _config.ResourceUrl);
+                return AudienceEntryAccepted(aud.GetString(), plane, hasPluginScope);
 
             if (aud.ValueKind == JsonValueKind.Array)
             {
                 foreach (var entry in aud.EnumerateArray())
                 {
                     if (entry.ValueKind == JsonValueKind.String
-                        && UrlNormalization.ResourcesMatch(entry.GetString(), _config.ResourceUrl))
+                        && AudienceEntryAccepted(entry.GetString(), plane, hasPluginScope))
                         return true;
                 }
             }
 
+            return false;
+        }
+
+        private bool AudienceEntryAccepted(string? audEntry, TokenValidationPlane plane, bool hasPluginScope)
+        {
+            if (string.IsNullOrEmpty(audEntry))
+                return false;
+
+            // The plugin-plane audience (urn:agd:hub) is ONLY ever accepted on the plugin plane — this is
+            // the whole plane separation. It is a URN (no authority), so it is compared by exact ordinal
+            // value, never routed through URL normalization.
+            if (string.Equals(audEntry, PluginAudience, StringComparison.Ordinal))
+                return plane == TokenValidationPlane.Plugin;
+
+            // The canonical RS resource id (loopback-normalized). Accepted on the agent plane always; on
+            // the plugin plane only when the token is genuinely plugin-scoped (mcp:plugin), so an
+            // agent-scoped token audienced to the canonical resource can never register as a plugin.
+            if (UrlNormalization.ResourcesMatch(audEntry, _config.ResourceUrl))
+                return plane == TokenValidationPlane.Agent || hasPluginScope;
+
+            return false;
+        }
+
+        /// <summary>True when the space-delimited <c>scope</c> claim contains <paramref name="scope"/> as a whole token.</summary>
+        private static bool ScopeContains(JsonElement claims, string scope)
+        {
+            var raw = GetString(claims, "scope");
+            if (string.IsNullOrEmpty(raw))
+                return false;
+            foreach (var s in raw!.Split(' '))
+            {
+                if (string.Equals(s, scope, StringComparison.Ordinal))
+                    return true;
+            }
             return false;
         }
 

--- a/McpPlugin.Server/src/Auth/OAuth/IOAuthTokenValidator.cs
+++ b/McpPlugin.Server/src/Auth/OAuth/IOAuthTokenValidator.cs
@@ -15,13 +15,44 @@ using System.Threading.Tasks;
 namespace com.IvanMurzak.McpPlugin.Server.Auth.OAuth
 {
     /// <summary>
+    /// Which authorization plane a token is being validated for (auth-fixes B11). The two planes accept
+    /// DIFFERENT audiences, which is the whole point of the separation:
+    /// <list type="bullet">
+    ///   <item><see cref="Agent"/> — an AI-agent MCP request. Strict: the token <c>aud</c> MUST be the
+    ///         canonical resource-server id (<c>--public-url</c>, e.g. <c>https://ai-game.dev/mcp</c>).
+    ///         A plugin hub-token (<c>aud=urn:agd:hub</c>) is REJECTED here.</item>
+    ///   <item><see cref="Plugin"/> — an engine-plugin hub registration. The token <c>aud</c> must be in
+    ///         the plugin-plane allow-list (the plugin audience <c>urn:agd:hub</c>, OR the canonical
+    ///         resource id when the token also carries the <c>mcp:plugin</c> scope). An agent token
+    ///         (<c>aud=</c>canonical + <c>scope=mcp:agent</c>) can NEVER register as a plugin instance.</item>
+    /// </list>
+    /// </summary>
+    public enum TokenValidationPlane
+    {
+        /// <summary>AI-agent MCP request plane — strict canonical-resource <c>aud</c> (the default/legacy behavior).</summary>
+        Agent = 0,
+
+        /// <summary>Engine-plugin hub-registration plane — accepts the plugin audience <c>urn:agd:hub</c> via a strict allow-list.</summary>
+        Plugin = 1,
+    }
+
+    /// <summary>
     /// Validates a presented bearer token in OAuth resource-server mode (mcp-authorize b2): ES256
     /// JWTs against the AS JWKS with strict <c>iss</c>/<c>aud</c>/<c>exp</c>, opaque tokens via
     /// introspection. Always fails closed.
     /// </summary>
     public interface IOAuthTokenValidator
     {
+        /// <summary>Validate a token for the <see cref="TokenValidationPlane.Agent"/> plane (strict canonical <c>aud</c>).</summary>
         Task<OAuthValidationResult> ValidateAsync(string token, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Validate a token for a specific authorization <paramref name="plane"/> (auth-fixes B11). The
+        /// plane selects which <c>aud</c> values are accepted; every other check (ES256/JWKS, iss,
+        /// exp/nbf, opaque introspection) is identical across planes. Plane separation is enforced
+        /// here: an agent token never validates on the plugin plane and vice-versa.
+        /// </summary>
+        Task<OAuthValidationResult> ValidateAsync(string token, TokenValidationPlane plane, CancellationToken cancellationToken);
     }
 
     /// <summary>Outcome of resource-server token validation.</summary>

--- a/McpPlugin.Server/src/Hub/McpServerHub.cs
+++ b/McpPlugin.Server/src/Hub/McpServerHub.cs
@@ -109,7 +109,12 @@ namespace com.IvanMurzak.McpPlugin.Server
             OAuthValidationResult validation;
             try
             {
-                validation = await _oauthValidator.ValidateAsync(token!, Context.ConnectionAborted);
+                // Plugin-plane validation (auth-fixes B11): the plugin hub-token carries
+                // aud=urn:agd:hub, which the strict agent-plane aud check rejects. The plugin plane
+                // allow-lists that audience while keeping the agent plane strict on the RS resource, so
+                // an unregistered-bucket → silent "3 tools" degrade no longer happens. Plane separation
+                // is enforced in the validator: an agent token can never register as a plugin instance.
+                validation = await _oauthValidator.ValidateAsync(token!, TokenValidationPlane.Plugin, Context.ConnectionAborted);
             }
             catch (Exception ex)
             {

--- a/McpPlugin.Server/src/Tools/ServerNativeTools.cs
+++ b/McpPlugin.Server/src/Tools/ServerNativeTools.cs
@@ -76,11 +76,19 @@ namespace com.IvanMurzak.McpPlugin.Server.Tools
         }
 
         // ─────────────────────────────── list_engine_instances ───────────────────────────────
+        // Routing observability (auth-fixes T6, closes B6/B7): each instance line carries its routing
+        // pin (8-hex) and project basename, and the response ends with a "session pin → matched" line
+        // plus an actionable hint when the session's pin resolves to nothing. All reads are account-
+        // scoped (never cross-sub); only the project BASENAME is ever emitted, never a full path.
         ResponseCallTool HandleList(SelectionToolContext context)
         {
             var instances = _instances.GetInstances(context.AccountId);
             if (instances.Count == 0)
-                return ResponseCallTool.Success("No engine instances are connected for your account. Use enroll_engine_plugin to set one up.");
+            {
+                return ResponseCallTool.Success(
+                    "No engine instances are connected for your account. Use enroll_engine_plugin to set one up.\n" +
+                    SessionPinDiagnostic(context.ProjectPin, matched: null, accountEmpty: true));
+            }
 
             var selected = _selections.Get(context.SessionId);
             var lines = instances
@@ -88,11 +96,63 @@ namespace com.IvanMurzak.McpPlugin.Server.Tools
                 .Select(i =>
                 {
                     var mark = string.Equals(i.InstanceId, selected, StringComparison.Ordinal) ? " (selected)" : string.Empty;
-                    return $"- {i.InstanceId}: {i.Engine}:{i.ProjectName} on {i.MachineName}; " +
+                    // Only the project BASENAME is ever emitted (06 threat table — never a full path),
+                    // plus the 8-hex routing pin so «why do I see these tools» is diagnosable (B7).
+                    return $"- {i.InstanceId}: {i.Engine}:{Basename(i.ProjectName)} on {i.MachineName}; " +
+                           $"pin {PinOf(i)}; " +
                            $"connected {i.ConnectedAt:u}, last active {i.LastActiveAt:u}{mark}";
                 });
 
-            return ResponseCallTool.Success("Connected engine instances for your account:\n" + string.Join("\n", lines));
+            var matched = string.IsNullOrEmpty(context.ProjectPin)
+                ? null
+                : instances.Where(i => i.MatchesPin(context.ProjectPin)).ToList();
+
+            return ResponseCallTool.Success(
+                "Connected engine instances for your account:\n" + string.Join("\n", lines) + "\n" +
+                SessionPinDiagnostic(context.ProjectPin, matched, accountEmpty: false));
+        }
+
+        /// <summary>
+        /// The T6 "session pin → matched" diagnostic line (+ an actionable hint on no-match). Explains,
+        /// in one tool call, WHY a session sees the engine tools it does — the core of B6/B7.
+        /// </summary>
+        static string SessionPinDiagnostic(string? sessionPin, IReadOnlyList<PluginInstance>? matched, bool accountEmpty)
+        {
+            if (string.IsNullOrEmpty(sessionPin))
+                return "session pin: none (this session is not pinned to a project; routing uses the single/most-recently-active instance).";
+
+            if (accountEmpty)
+                return $"session pin: {sessionPin} → matched: none. Your account has no connected engine instances — open your project's editor (it connects automatically) or use enroll_engine_plugin.";
+
+            if (matched == null || matched.Count == 0)
+                return $"session pin: {sessionPin} → matched: none. No connected editor matches this session's project pin — open that project's editor, or use select_engine_instance to route to a connected instance instead.";
+
+            var ids = string.Join(", ", matched.Select(i => i.InstanceId));
+            return $"session pin: {sessionPin} → matched: {ids}";
+        }
+
+        /// <summary>The instance's 8-hex routing pin (the leading chars of its v2 project-path hash), or a marker when absent.</summary>
+        static string PinOf(PluginInstance instance)
+        {
+            var hash = instance.ProjectPathHash;
+            if (string.IsNullOrEmpty(hash))
+                return "(none)";
+            return (hash.Length >= 8 ? hash.Substring(0, 8) : hash).ToLowerInvariant();
+        }
+
+        /// <summary>
+        /// The basename of a project identifier — never a full path (06 threat table). ProjectName is
+        /// normally already a bare name, but a plugin could self-report a path; this strips any
+        /// directory prefix defensively so diagnostics never leak a filesystem layout.
+        /// </summary>
+        static string Basename(string? projectName)
+        {
+            if (string.IsNullOrEmpty(projectName))
+                return "(unknown)";
+            var trimmed = projectName!.TrimEnd('/', '\\');
+            var cut = trimmed.LastIndexOfAny(new[] { '/', '\\' });
+            var name = cut >= 0 ? trimmed.Substring(cut + 1) : trimmed;
+            return string.IsNullOrEmpty(name) ? "(unknown)" : name;
         }
 
         // ─────────────────────────────── select_engine_instance ──────────────────────────────

--- a/McpPlugin.Tests/AgentConfig/ConfigWritersB6Tests.cs
+++ b/McpPlugin.Tests/AgentConfig/ConfigWritersB6Tests.cs
@@ -169,6 +169,37 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
         }
 
         [Fact]
+        public void ClaudeCode_ManualHttpCommand_UsesTheSamePinnedUrl_AsConfigure()
+        {
+            // B8 (auth-fixes): the displayed "manual" `claude mcp add` command must use the SAME pinned
+            // URL that Configure writes into .mcp.json (settings.PinnedHttpUrl, i.e. .../mcp/p/<pin>),
+            // not the bare unpinned host — an unpinned URL only routes when the account has one instance.
+            var root = NewTempDir();
+            try
+            {
+                var c = new ClaudeCodeConfigurator();
+                var settings = Settings(root);
+                var pinnedUrl = settings.PinnedHttpUrl;
+
+                // What Configure writes.
+                c.GetHttpConfig(settings).ExpectedFileContent.ShouldContain($"\"url\": \"{pinnedUrl}\"");
+
+                // The manual command shown in the UI.
+                var manualCommand = c.Describe(settings, TransportMethod.streamableHttp).Sections
+                    .SelectMany(s => s.Items)
+                    .Select(i => i.Text ?? string.Empty)
+                    .First(t => t.Contains("claude mcp add"));
+
+                manualCommand.ShouldContain(pinnedUrl);
+                manualCommand.ShouldContain("/p/" + settings.ProjectPin);
+                // Never the bare unpinned host (which lacks the /p/<pin> routing segment).
+                manualCommand.ShouldNotContain($"http {AiAgentConfig.DefaultMcpServerName} {settings.Host} ");
+                manualCommand.Trim().ShouldNotEndWith(settings.Host);
+            }
+            finally { Directory.Delete(root, recursive: true); }
+        }
+
+        [Fact]
         public void GlobalConfigurators_AreExplicitlyProjectPinned()
         {
             // Design 06 D14: the three inherently-global configurators still carry the project pin,

--- a/McpPlugin/src/AgentConfig/Impl/ClaudeCodeConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/Impl/ClaudeCodeConfigurator.cs
@@ -71,7 +71,10 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Impl
             }
 
             var authHeader = isAuthRequired ? $" --header \"Authorization: Bearer {token}\"" : string.Empty;
-            var addCommandHttp = $"claude mcp add --transport http {AiAgentConfig.DefaultMcpServerName} {settings.Host}{authHeader}";
+            // B8: the displayed "manual" command must use the SAME pinned URL that Configure writes into
+            // .mcp.json (settings.PinnedHttpUrl, i.e. .../mcp/p/<pin>), not the bare unpinned host — an
+            // unpinned URL only routes when the account has a single instance.
+            var addCommandHttp = $"claude mcp add --transport http {AiAgentConfig.DefaultMcpServerName} {settings.PinnedHttpUrl}{authHeader}";
             return new[]
             {
                 new ConfigurationSection("Start", true, new[]

--- a/docs/architecture-transport-auth.md
+++ b/docs/architecture-transport-auth.md
@@ -152,6 +152,11 @@ The **offline shared-secret** plane — the loopback single-project counterpart 
 
 The OAuth 2.1 resource-server **account + instance pairing plane**. A presented credential is validated against the authorization server (ES256 JWT via JWKS, or opaque PAT via introspection) and resolves to an ai-game.dev account (`sub`). Routing is strictly **account-scoped**: an agent session resolves to a live plugin instance by `pin(strict) → sticky → single → most-recently-active`, and a session for one account can never route to, be notified about, or observe another account's instances (fail closed). Full spec: the mcp-authorize design (`04-pairing-and-routing.md`).
 
+**Plane-aware audience validation (auth-fixes B11).** `AccessTokenValidator` accepts a `TokenValidationPlane` so the same validator enforces *different* audiences on the two planes, and the two must stay separated:
+
+- **Agent plane** (an AI-agent MCP request, via `TokenAuthenticationHandler`): the token `aud` must be the RS's canonical resource id (`--public-url`, e.g. `https://ai-game.dev/mcp`). A plugin hub-token is rejected here.
+- **Plugin plane** (an engine-plugin hub registration, via `McpServerHub.TryRegisterOAuthInstanceAsync`): a strict allow-list — the plugin audience `urn:agd:hub` (exact), **or** the canonical resource id when the token also carries the `mcp:plugin` scope. This is required because plugin hub-tokens are minted with `aud=urn:agd:hub` (a plane marker, not the RS resource id); without the plugin-plane allow-list the connection is accepted but the instance is never registered → the account bucket stays empty → the agent's `tools/list` silently degrades to the 3 native tools. The `mcp:plugin` scope guard keeps an agent token (`aud=`canonical, `scope=mcp:agent`) from ever registering as a plugin instance.
+
 ---
 
 ## Behavior Comparison


### PR DESCRIPTION
## Summary
- **B11 (security-critical):** fix the «3 tools» window-flow defect. Plugin hub-tokens carry `aud=urn:agd:hub`; the strict agent-plane audience check rejected them, so `McpServerHub` never registered the instance → the account bucket stayed empty → the agent's `tools/list` silently degraded to the 3 native tools (B6). `AccessTokenValidator` now takes a `TokenValidationPlane`: the **agent plane** stays strict on the canonical RS resource (rejects `urn:agd:hub`); the **plugin plane** accepts a strict allow-list (`urn:agd:hub` exact, or the canonical resource when the token is `mcp:plugin`-scoped). Plane separation holds both ways — an agent token can never register as a plugin instance.
- **T6 (B6/B7):** `list_engine_instances` shows each instance's 8-hex routing pin + project basename and a `session pin → matched: <instance|none>` line with an actionable hint on no-match / account-empty. Account-scoped; basename only, never a full path (06 threat table).
- **B6 late-connect:** a registered plugin now delivers `notifications/tools/list_changed` to live agent sessions (restored by the registration fix; covered by an integration test).
- **B8:** the manual `claude mcp add` HTTP command uses the same pinned URL Configure writes (`settings.PinnedHttpUrl`), not the bare unpinned host.

Builds on c1 (#164 / PR #165, dual-hash / pin v2).

## Test plan
- [x] Target-specific local tests passed (see profile test.md): `dotnet test` Release, **net8.0 + net9.0**, both `McpPlugin.Tests` and `McpPlugin.Server.Tests` — **756 passed, 0 failures** per TFM.
- [x] Plane-separation regression tests tied to k1's repro: plugin hub-token (`aud=urn:agd:hub`) registers; agent-plane token with `aud=urn:agd:hub` still rejected; agent token cannot register on the plugin plane; spoofed/unknown aud rejected on every plane.
- [x] End-to-end registration test drives the REAL `AccessTokenValidator` with a `urn:agd:hub` token through to registration (closes the prior test blind spot) + late-connect `ShouldNotifySession` regression.
- [x] T6 diagnostics tests (pin/basename/matched/hint) + isolation regression (basename only, account-scoped) + B8 manual-command == Configure URL.

Closes #166