### PR TITLE
feat(auth): optional server-side metadata/fetch-base override

### DIFF
--- a/McpPlugin.Common/src/Utils/Consts.MCP.cs
+++ b/McpPlugin.Common/src/Utils/Consts.MCP.cs
@@ -66,6 +66,13 @@ namespace com.IvanMurzak.McpPlugin.Common
                     public const string Auth = "auth";
                     public const string AuthIssuer = "auth-issuer";
                     public const string PublicUrl = "public-url";
+
+                    // Optional server-side metadata / fetch-base override (auth-fixes L2a / Gap B).
+                    // When set, the resource server fetches JWKS / OAuth discovery / introspection /
+                    // enrollment from this base instead of <c>auth-issuer</c>; the token <c>iss</c>
+                    // check and the RFC 9728 PRM <c>authorization_servers</c> stay on <c>auth-issuer</c>.
+                    // Unset (default, incl. all of prod) → byte-identical to deriving from the issuer.
+                    public const string AuthMetadataUrl = "auth-metadata-url";
                     public const string Bind = "bind";
 
                     // Project pin (mcp-authorize b3, design 04 D14). The stdio spawn arg carrying the
@@ -109,6 +116,10 @@ namespace com.IvanMurzak.McpPlugin.Common
                     public const string Auth = "MCP_AUTH";
                     public const string AuthIssuer = "MCP_AUTH_ISSUER";
                     public const string PublicUrl = "MCP_PUBLIC_URL";
+
+                    // Optional server-side metadata / fetch-base override (auth-fixes L2a / Gap B).
+                    // See <see cref="Args.AuthMetadataUrl"/> for semantics.
+                    public const string AuthMetadataUrl = "MCP_AUTH_METADATA_URL";
                     public const string Bind = "MCP_BIND";
                 }
 

--- a/McpPlugin.Common/src/Utils/Consts.MCP.cs
+++ b/McpPlugin.Common/src/Utils/Consts.MCP.cs
@@ -68,7 +68,7 @@ namespace com.IvanMurzak.McpPlugin.Common
                     public const string PublicUrl = "public-url";
 
                     // Optional server-side metadata / fetch-base override (auth-fixes L2a / Gap B).
-                    // When set, the resource server fetches JWKS / OAuth discovery / introspection /
+                    // When set, the resource server fetches JWKS / introspection /
                     // enrollment from this base instead of <c>auth-issuer</c>; the token <c>iss</c>
                     // check and the RFC 9728 PRM <c>authorization_servers</c> stay on <c>auth-issuer</c>.
                     // Unset (default, incl. all of prod) → byte-identical to deriving from the issuer.

--- a/McpPlugin.Common/src/Utils/DataArguments.cs
+++ b/McpPlugin.Common/src/Utils/DataArguments.cs
@@ -26,6 +26,9 @@ namespace com.IvanMurzak.McpPlugin.Common.Utils
         // OAuth resource-server configuration (mcp-authorize b2)
         string? AuthIssuer { get; }
         string? PublicUrl { get; }
+
+        // Optional server-side metadata / fetch-base override (auth-fixes L2a / Gap B). Null unless set.
+        string? AuthMetadataUrl { get; }
         string? Bind { get; }
 
         // Session project pin for stdio account routing (mcp-authorize b3, design 04 D14)
@@ -57,6 +60,17 @@ namespace com.IvanMurzak.McpPlugin.Common.Utils
         // OAuth resource-server configuration (mcp-authorize b2)
         public string? AuthIssuer { get; private set; }
         public string? PublicUrl { get; private set; }
+
+        /// <summary>
+        /// Optional server-side metadata / fetch-base override (auth-fixes L2a / Gap B). When set, the
+        /// OAuth resource server fetches JWKS / OAuth discovery / introspection / enrollment from this
+        /// base instead of <see cref="AuthIssuer"/>; the token <c>iss</c> claim check and the RFC 9728
+        /// PRM <c>authorization_servers</c> stay on <see cref="AuthIssuer"/> (client-facing). Null
+        /// (default, incl. all of prod) → behavior is byte-identical to deriving from the issuer. Set
+        /// via <c>--auth-metadata-url</c> / <c>MCP_AUTH_METADATA_URL</c> for a fully-local OAuth
+        /// deployment where the client-facing issuer host is unreachable from inside the RS container.
+        /// </summary>
+        public string? AuthMetadataUrl { get; private set; }
 
         /// <summary>
         /// Bind address for the streamableHttp Kestrel listener. <c>null</c>/empty defaults to
@@ -155,6 +169,10 @@ namespace com.IvanMurzak.McpPlugin.Common.Utils
             var envPublicUrl = Environment.GetEnvironmentVariable(Consts.MCP.Server.Env.PublicUrl);
             if (envPublicUrl != null)
                 PublicUrl = envPublicUrl;
+
+            var envAuthMetadataUrl = Environment.GetEnvironmentVariable(Consts.MCP.Server.Env.AuthMetadataUrl);
+            if (envAuthMetadataUrl != null)
+                AuthMetadataUrl = envAuthMetadataUrl;
 
             var envBind = Environment.GetEnvironmentVariable(Consts.MCP.Server.Env.Bind);
             if (envBind != null)
@@ -256,6 +274,10 @@ namespace com.IvanMurzak.McpPlugin.Common.Utils
             var argPublicUrl = commandLineArgs.GetValueOrDefault(Consts.MCP.Server.Args.PublicUrl.TrimStart('-'));
             if (argPublicUrl != null)
                 PublicUrl = argPublicUrl;
+
+            var argAuthMetadataUrl = commandLineArgs.GetValueOrDefault(Consts.MCP.Server.Args.AuthMetadataUrl.TrimStart('-'));
+            if (argAuthMetadataUrl != null)
+                AuthMetadataUrl = argAuthMetadataUrl;
 
             var argBind = commandLineArgs.GetValueOrDefault(Consts.MCP.Server.Args.Bind.TrimStart('-'));
             if (argBind != null)

--- a/McpPlugin.Common/src/Utils/DataArguments.cs
+++ b/McpPlugin.Common/src/Utils/DataArguments.cs
@@ -63,7 +63,7 @@ namespace com.IvanMurzak.McpPlugin.Common.Utils
 
         /// <summary>
         /// Optional server-side metadata / fetch-base override (auth-fixes L2a / Gap B). When set, the
-        /// OAuth resource server fetches JWKS / OAuth discovery / introspection / enrollment from this
+        /// OAuth resource server fetches JWKS / introspection / enrollment from this
         /// base instead of <see cref="AuthIssuer"/>; the token <c>iss</c> claim check and the RFC 9728
         /// PRM <c>authorization_servers</c> stay on <see cref="AuthIssuer"/> (client-facing). Null
         /// (default, incl. all of prod) → behavior is byte-identical to deriving from the issuer. Set

--- a/McpPlugin.Server.Tests/OAuth/OAuthResourceServerTests.cs
+++ b/McpPlugin.Server.Tests/OAuth/OAuthResourceServerTests.cs
@@ -34,6 +34,51 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests.OAuth
         }
 
         [Fact]
+        public void Config_MetadataUrlUnset_FetchEndpointsDeriveFromIssuer()
+        {
+            // auth-fixes L2a / Gap B regression guard: with NO --auth-metadata-url override (the
+            // default, incl. all of prod), the server-side fetch base and every fetch URL derived
+            // from it must stay byte-identical to deriving straight from the issuer.
+            var config = new OAuthResourceServerConfig("https://ai-game.dev/", "http://localhost:23471");
+
+            config.MetadataUrl.ShouldBe("https://ai-game.dev");
+            config.MetadataUrl.ShouldBe(config.Issuer);
+            config.JwksUri.ShouldBe("https://ai-game.dev/.well-known/jwks.json");
+            config.IntrospectionEndpoint.ShouldBe("https://ai-game.dev/oauth/introspect");
+            config.EnrollmentEndpoint.ShouldBe("https://ai-game.dev/api/auth/enroll/create");
+
+            // A whitespace-only override is treated as unset (falls back to the issuer).
+            var blankOverride = new OAuthResourceServerConfig("https://ai-game.dev", "http://localhost:23471", metadataUrl: "   ");
+            blankOverride.MetadataUrl.ShouldBe("https://ai-game.dev");
+            blankOverride.JwksUri.ShouldBe("https://ai-game.dev/.well-known/jwks.json");
+        }
+
+        [Fact]
+        public void Config_MetadataUrlSet_SplitsFetchBaseFromClientFacingIssuer()
+        {
+            // auth-fixes L2a / Gap B: when --auth-metadata-url is set, ONLY the server-side fetch
+            // URLs (JWKS / introspection / enrollment) move to the override base. The client-facing
+            // iss claim source (Issuer) and the RFC 9728 PRM authorization_servers must NOT move —
+            // that split is the whole point of the override (client resolves the AS on the host,
+            // the RS container fetches from an in-container/base address).
+            var config = new OAuthResourceServerConfig(
+                issuer: "https://ai-game.dev",
+                resourceUrl: "http://localhost:23471",
+                metadataUrl: "http://mcp-server:8080/");
+
+            // Server-side fetches move to the override base (trailing slash normalized away).
+            config.MetadataUrl.ShouldBe("http://mcp-server:8080");
+            config.JwksUri.ShouldBe("http://mcp-server:8080/.well-known/jwks.json");
+            config.IntrospectionEndpoint.ShouldBe("http://mcp-server:8080/oauth/introspect");
+            config.EnrollmentEndpoint.ShouldBe("http://mcp-server:8080/api/auth/enroll/create");
+
+            // Client-facing surface stays on the issuer.
+            config.Issuer.ShouldBe("https://ai-game.dev");
+            var prm = OAuthProtectedResourceMetadata.Build(config);
+            ((string[])prm["authorization_servers"]).ShouldBe(new[] { "https://ai-game.dev" });
+        }
+
+        [Fact]
         public void Config_RejectsMissingIssuerOrResource()
         {
             Should.Throw<ArgumentException>(() => new OAuthResourceServerConfig("", "http://localhost:1"));

--- a/McpPlugin.Server/src/Auth/OAuth/OAuthResourceServerConfig.cs
+++ b/McpPlugin.Server/src/Auth/OAuth/OAuthResourceServerConfig.cs
@@ -16,8 +16,12 @@ namespace com.IvanMurzak.McpPlugin.Server.Auth.OAuth
     /// <summary>
     /// Resolved OAuth resource-server configuration (mcp-authorize b2), built from
     /// <c>--auth-issuer</c> (the AS) and <c>--public-url</c> (this RS's canonical resource id / the
-    /// value a token's <c>aud</c> must contain). Endpoints are derived from the issuer per the
-    /// well-known conventions (RFC 8414 JWKS, RFC 7662 introspection).
+    /// value a token's <c>aud</c> must contain). Server-side fetch endpoints are derived from the
+    /// well-known conventions (RFC 8414 JWKS, RFC 7662 introspection) over a fetch base that defaults
+    /// to the issuer but can be repointed via an optional <c>--auth-metadata-url</c> override
+    /// (auth-fixes L2a / Gap B) — see <see cref="MetadataUrl"/>. The client-facing surface (the token
+    /// <c>iss</c> check and the RFC 9728 PRM <c>authorization_servers</c>) always stays on
+    /// <see cref="Issuer"/>.
     /// </summary>
     public sealed class OAuthResourceServerConfig
     {
@@ -35,13 +39,27 @@ namespace com.IvanMurzak.McpPlugin.Server.Auth.OAuth
 
         public TimeSpan ClockSkew { get; }
 
-        /// <summary>The AS JWKS document URL (<c>{issuer}/.well-known/jwks.json</c>).</summary>
+        /// <summary>
+        /// The server-side metadata / fetch base URL — the base from which JWKS, introspection, and
+        /// enrollment endpoints are derived. Defaults to <see cref="Issuer"/>; an explicit
+        /// <c>--auth-metadata-url</c> / <c>MCP_AUTH_METADATA_URL</c> override (auth-fixes L2a / Gap B)
+        /// repoints ONLY these server-side fetches, leaving the client-facing <c>iss</c> claim and PRM
+        /// <c>authorization_servers</c> on <see cref="Issuer"/>. Used by a fully-local OAuth deployment
+        /// where the client resolves the AS at a host address (e.g. <c>http://localhost</c>) that, from
+        /// inside the RS container, would point back at the container itself.
+        /// </summary>
+        public string MetadataUrl { get; }
+
+        /// <summary>The AS JWKS document URL (<c>{metadata-base}/.well-known/jwks.json</c>).</summary>
         public string JwksUri { get; }
 
-        /// <summary>The AS token-introspection endpoint (<c>{issuer}/oauth/introspect</c>).</summary>
+        /// <summary>The AS token-introspection endpoint (<c>{metadata-base}/oauth/introspect</c>).</summary>
         public string IntrospectionEndpoint { get; }
 
-        public OAuthResourceServerConfig(string issuer, string resourceUrl, TimeSpan? clockSkew = null)
+        /// <summary>The AS account-enrollment endpoint (<c>{metadata-base}/api/auth/enroll/create</c>).</summary>
+        public string EnrollmentEndpoint { get; }
+
+        public OAuthResourceServerConfig(string issuer, string resourceUrl, TimeSpan? clockSkew = null, string? metadataUrl = null)
         {
             if (string.IsNullOrWhiteSpace(issuer))
                 throw new ArgumentException("OAuth mode requires --auth-issuer (the authorization server URL).", nameof(issuer));
@@ -51,8 +69,17 @@ namespace com.IvanMurzak.McpPlugin.Server.Auth.OAuth
             Issuer = issuer.Trim().TrimEnd('/');
             ResourceUrl = resourceUrl.Trim();
             ClockSkew = clockSkew ?? DefaultClockSkew;
-            JwksUri = $"{Issuer}/.well-known/jwks.json";
-            IntrospectionEndpoint = $"{Issuer}/oauth/introspect";
+
+            // Server-side fetch base (auth-fixes L2a / Gap B). An empty/whitespace override falls back
+            // to Issuer, so all of prod (which never sets it) is byte-identical to the pre-override
+            // behavior. When set, ONLY the server-side fetch URLs below move to the override base —
+            // Issuer and ProtectedResourceMetadataUrl()/PRM stay on the issuer (client-facing).
+            MetadataUrl = string.IsNullOrWhiteSpace(metadataUrl)
+                ? Issuer
+                : metadataUrl!.Trim().TrimEnd('/');
+            JwksUri = $"{MetadataUrl}/.well-known/jwks.json";
+            IntrospectionEndpoint = $"{MetadataUrl}/oauth/introspect";
+            EnrollmentEndpoint = $"{MetadataUrl}/api/auth/enroll/create";
         }
 
         /// <summary>

--- a/McpPlugin.Server/src/Extension/ExtensionsMcpServerBuilder.cs
+++ b/McpPlugin.Server/src/Extension/ExtensionsMcpServerBuilder.cs
@@ -109,7 +109,7 @@ namespace com.IvanMurzak.McpPlugin.Server
             {
                 mcpServerBuilder.Services.AddHttpClient();
 
-                var oauthConfig = new OAuthResourceServerConfig(dataArguments.AuthIssuer!, dataArguments.PublicUrl!);
+                var oauthConfig = new OAuthResourceServerConfig(dataArguments.AuthIssuer!, dataArguments.PublicUrl!, metadataUrl: dataArguments.AuthMetadataUrl);
                 mcpServerBuilder.Services.AddSingleton(oauthConfig);
                 mcpServerBuilder.Services.AddSingleton<IJwksDiskCache>(_ => new FileJwksDiskCache());
 
@@ -162,7 +162,9 @@ namespace com.IvanMurzak.McpPlugin.Server
                 {
                     var httpFactory = sp.GetRequiredService<IHttpClientFactory>();
                     var config = sp.GetRequiredService<OAuthResourceServerConfig>();
-                    var enrollEndpoint = $"{config.Issuer.TrimEnd('/')}/api/auth/enroll/create";
+                    // Enroll (like JWKS + introspection) uses the server-side fetch base, which honors
+                    // the optional --auth-metadata-url override; unset → derived from Issuer (auth-fixes L2a).
+                    var enrollEndpoint = config.EnrollmentEndpoint;
                     EnrollCreatePost post = async (bearer, engine, publicUrl, ct) =>
                     {
                         var client = httpFactory.CreateClient();

--- a/docs/architecture-transport-auth.md
+++ b/docs/architecture-transport-auth.md
@@ -80,6 +80,15 @@ All combinations are supported without conditional branching in the server code.
 `token=<secret>` / `MCP_PLUGIN_TOKEN`. (The legacy `authorization=` / `MCP_AUTHORIZATION=` argument
 names still parse; the deprecated `required` value is aliased onto `token` — see the g6 note above.)
 
+**Optional server-side metadata / fetch-base override** (`auth-metadata-url=<url>` /
+`MCP_AUTH_METADATA_URL`): in `oauth` mode the RS normally fetches JWKS, OAuth introspection, and
+account enrollment from `auth-issuer`. When this override is set, those **server-side fetches** use
+`<url>` as their base instead; the token `iss` claim check and the RFC 9728 PRM
+`authorization_servers` (both client-facing) stay on `auth-issuer`. Unset (the default, incl. all of
+prod) → behavior is byte-identical to deriving every fetch URL from the issuer. Use it for a
+fully-local OAuth deployment where the client resolves the AS at a host address (e.g.
+`http://localhost`) that, inside the RS container, would point back at the container itself.
+
 ### Credentials — validated, never minted
 
 In `oauth` mode the RS validates presented credentials against the external authorization server


### PR DESCRIPTION
## Summary

- Add an optional server-side metadata/fetch-base override (`--auth-metadata-url` / `MCP_AUTH_METADATA_URL`). When set, the OAuth resource server fetches JWKS / introspection / enrollment from the override base; when unset (default, incl. all of prod) behavior is byte-identical to deriving from `--auth-issuer`.
- The client-facing surface — the token `iss` claim check and the RFC 9728 PRM `authorization_servers` — always stays on `--auth-issuer`. This split unblocks a fully-local OAuth E2E (auth-fixes k2 / Gap B), where the client resolves the AS on the host but the RS container cannot reach that host address.
- Wired end-to-end: `Consts.MCP` arg/env constants → `DataArguments.AuthMetadataUrl` → `OAuthResourceServerConfig.MetadataUrl` (with `JwksUri`/`IntrospectionEndpoint`/`EnrollmentEndpoint` derived from it) → `ExtensionsMcpServerBuilder`.

## Test plan
- [x] Target-specific local tests passed (see profile test.md): `dotnet test` 0-fail across `McpPlugin.Tests` + `McpPlugin.Server.Tests`, net8.0 + net9.0 (553×2 + 756×2).
- [x] New regression test: unset override → JwksUri/introspection/enroll derive from Issuer (whitespace override treated as unset).
- [x] New split test: set override → fetch endpoints move to the override base while `iss` source (Issuer) and PRM `authorization_servers` stay on the issuer.

Closes #170