### PR TITLE
chore: release MCP-Plugin-dotnet 7.2.0

### DIFF
--- a/McpPlugin.Common/McpPlugin.Common.csproj
+++ b/McpPlugin.Common/McpPlugin.Common.csproj
@@ -11,7 +11,7 @@
     <!-- NuGet Package Information -->
     <IsPackable>true</IsPackable>
     <PackageId>com.IvanMurzak.McpPlugin.Common</PackageId>
-    <Version>7.1.1</Version>
+    <Version>7.2.0</Version>
     <Authors>Ivan Murzak</Authors>
     <Company>Ivan Murzak</Company>
     <Copyright>Copyright © Ivan Murzak 2025</Copyright>

--- a/McpPlugin.Common/src/Utils/Consts.cs
+++ b/McpPlugin.Common/src/Utils/Consts.cs
@@ -12,7 +12,7 @@ namespace com.IvanMurzak.McpPlugin.Common
     public static partial class Consts
     {
         public const string ApiVersion = "2.0.0";
-        public const string PluginVersion = "7.1.1";
+        public const string PluginVersion = "7.2.0";
 
         public static class Guid
         {

--- a/McpPlugin.Server/McpPlugin.Server.csproj
+++ b/McpPlugin.Server/McpPlugin.Server.csproj
@@ -11,7 +11,7 @@
     <!-- NuGet Package Information -->
     <IsPackable>true</IsPackable>
     <PackageId>com.IvanMurzak.McpPlugin.Server</PackageId>
-    <Version>7.1.1</Version>
+    <Version>7.2.0</Version>
     <Authors>Ivan Murzak</Authors>
     <Company>Ivan Murzak</Company>
     <Copyright>Copyright © Ivan Murzak 2025</Copyright>

--- a/McpPlugin.Server/server.json
+++ b/McpPlugin.Server/server.json
@@ -8,13 +8,13 @@
     "source": "github",
     "subfolder": "McpPlugin.Server"
   },
-  "version": "7.1.1",
+  "version": "7.2.0",
   "packages": [
     {
       "registry_type": "oci",
       "registry_base_url": "https://docker.io",
       "identifier": "ivanmurzakdev/mcp-plugin-server",
-      "version": "7.1.1",
+      "version": "7.2.0",
       "transport": {
         "type": "stdio"
       },

--- a/McpPlugin/McpPlugin.csproj
+++ b/McpPlugin/McpPlugin.csproj
@@ -15,7 +15,7 @@
     <!-- NuGet Package Information -->
     <IsPackable>true</IsPackable>
     <PackageId>com.IvanMurzak.McpPlugin</PackageId>
-    <Version>7.1.1</Version>
+    <Version>7.2.0</Version>
     <Authors>Ivan Murzak</Authors>
     <Company>Ivan Murzak</Company>
     <Copyright>Copyright © Ivan Murzak 2025</Copyright>


### PR DESCRIPTION
Automated release bump `7.1.1` -> `7.2.0` (explicit). Squash-merging to the default branch fires `release.yml`.