### PR TITLE
fix(client): derive the config port and pin from one v2 normalization, and honour a user-typed loopback port

### DIFF
--- a/McpPlugin.Tests/AgentConfig/ConfigWritersB6Tests.cs
+++ b/McpPlugin.Tests/AgentConfig/ConfigWritersB6Tests.cs
@@ -265,7 +265,7 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
         ///
         /// <para>A hardcoded backslash literal keeps this deterministic on Linux CI, where
         /// <c>Path.GetTempPath()</c> is forward-slash and v1 == v2 — the exact blind spot that let the
-        /// bug ship.</para>
+        /// bug ship. The root is a HASH INPUT only; it is never created on disk.</para>
         /// </summary>
         [Fact]
         public void PinAndPort_ComeFromTheSameNormalization_ForBackslashRoot()
@@ -273,6 +273,11 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
             var backslashRoot = "C:" + Bs + "tmp" + Bs + "mcpauth-test" + Bs + "test-project";
             var forwardSlashRoot = backslashRoot.Replace(Bs, "/");
             var settings = Settings(backslashRoot);
+
+            // Identity resolution reads <root>/.ai-game-dev/project.json, so pin this test to the
+            // hash-derived branch explicitly: if that path ever gains a real marker with a
+            // portOverride, this fails HERE rather than as a baffling port mismatch below.
+            settings.Identity.PortIsOverridden.ShouldBeFalse();
 
             // Both halves of the identity agree with the v2 primitives...
             settings.ProjectPin.ShouldBe(ProjectIdentity.DerivePinV2(backslashRoot));
@@ -306,6 +311,9 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
             var v2Pin = ProjectIdentity.DerivePinV2(backslashRoot);
             var v2Port = ProjectIdentity.DerivePortV2(backslashRoot);
             var settings = Settings(backslashRoot, host: "http://localhost/mcp");
+
+            // Same ambient-state pin as the test above: the derived-port branch, not a marker override.
+            settings.Identity.PortIsOverridden.ShouldBeFalse();
 
             var c = new ClaudeCodeConfigurator();
 
@@ -409,65 +417,43 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
         // config point at a port nothing was listening on — the same class of failure as defect B, from
         // the opposite direction.
 
-        [Fact]
-        public void ExplicitHostPort_IsHonoured_NotOverwrittenByDerivedPort()
+        /// <summary>
+        /// Precedence levels 2 and 3, end-to-end. A <paramref name="typedPort"/> of <c>null</c> means the
+        /// host carries no explicit port, so the derived v2 port is expected instead.
+        ///
+        /// <para>The <c>:80</c> row is the case <c>Uri.Port</c> cannot express: it synthesises 80 for a
+        /// PORTLESS host too, so only the raw host string distinguishes "the user typed 80" (honour it)
+        /// from "no port at all" (derive one). Level 1 lives in
+        /// <c>MarkerPortOverride_PropagatesToWrittenPort_StdioAndHttp</c>, where it beats a typed port.</para>
+        /// </summary>
+        [Theory]
+        [InlineData("http://localhost:50000/mcp", 50000)] // a typed port is honoured, not overwritten
+        [InlineData("http://localhost:80/mcp", 80)]       // an explicit scheme-DEFAULT port is still explicit
+        [InlineData("http://localhost/mcp", null)]        // no port at all -> derived v2 port
+        public void LoopbackHttpUrl_HonoursTypedPort_ElseDerivedV2Port(string host, int? typedPort)
         {
             var root = NewTempDir();
             try
             {
-                var settings = Settings(root, host: "http://localhost:50000/mcp");
+                var settings = Settings(root, host: host);
+                var expectedPort = typedPort ?? settings.ResolvedPort;
 
-                settings.Identity.PortIsOverridden.ShouldBeFalse();
-                settings.ExplicitHostPort.ShouldBe(50000);
-                settings.PinnedHttpPort.ShouldBe(50000);
+                settings.Identity.PortIsOverridden.ShouldBeFalse(); // no marker => levels 2/3 only
+                settings.ExplicitHostPort.ShouldBe(typedPort);
+                settings.PinnedHttpPort.ShouldBe(expectedPort);
 
-                // The derived port is a DIFFERENT value, so this genuinely distinguishes the two paths.
-                settings.ResolvedPort.ShouldNotBe(50000);
+                if (typedPort.HasValue)
+                    // The derived port is a DIFFERENT value, so the row genuinely distinguishes the paths
+                    // (the derived range is 20000-29999, which neither 50000 nor 80 can collide with).
+                    settings.ResolvedPort.ShouldNotBe(typedPort.Value);
+                else
+                    settings.PinnedHttpPort.ShouldBe(ProjectIdentity.DerivePortV2(root));
 
-                settings.PinnedHttpUrl.ShouldBe($"http://localhost:50000/mcp/p/{settings.ProjectPin}");
-                settings.PinnedHttpUrl.ShouldNotContain($"localhost:{settings.ResolvedPort}");
+                settings.PinnedHttpUrl.ShouldBe($"http://localhost:{expectedPort}/mcp/p/{settings.ProjectPin}");
 
                 // ...and it reaches the file the user actually gets.
                 new ClaudeCodeConfigurator().GetHttpConfig(settings).ExpectedFileContent
-                    .ShouldContain($"\"url\": \"http://localhost:50000/mcp/p/{settings.ProjectPin}\"");
-            }
-            finally { Directory.Delete(root, recursive: true); }
-        }
-
-        [Fact]
-        public void PortlessHost_FallsBackToDerivedV2Port()
-        {
-            var root = NewTempDir();
-            try
-            {
-                var settings = Settings(root, host: "http://localhost/mcp");
-
-                settings.ExplicitHostPort.ShouldBeNull();
-                settings.PinnedHttpPort.ShouldBe(settings.ResolvedPort);
-                settings.PinnedHttpPort.ShouldBe(ProjectIdentity.DerivePortV2(root));
-
-                settings.PinnedHttpUrl.ShouldBe($"http://localhost:{settings.ResolvedPort}/mcp/p/{settings.ProjectPin}");
-            }
-            finally { Directory.Delete(root, recursive: true); }
-        }
-
-        [Fact]
-        public void ExplicitDefaultPort_IsStillAnExplicitPort_AndIsHonoured()
-        {
-            // The distinction Uri.Port cannot express: "http://localhost/mcp" (no port — fall back to
-            // the derived port) vs "http://localhost:80/mcp" (the user typed 80 — honour it). Uri
-            // synthesises 80 for both, which is why the explicit port is read off the raw host string.
-            var root = NewTempDir();
-            try
-            {
-                var typed = Settings(root, host: "http://localhost:80/mcp");
-                typed.ExplicitHostPort.ShouldBe(80);
-                typed.PinnedHttpPort.ShouldBe(80);
-                typed.PinnedHttpUrl.ShouldBe($"http://localhost:80/mcp/p/{typed.ProjectPin}");
-
-                var portless = Settings(root, host: "http://localhost/mcp");
-                portless.ExplicitHostPort.ShouldBeNull();
-                portless.PinnedHttpPort.ShouldBe(portless.ResolvedPort);
+                    .ShouldContain($"\"url\": \"http://localhost:{expectedPort}/mcp/p/{settings.ProjectPin}\"");
             }
             finally { Directory.Delete(root, recursive: true); }
         }
@@ -506,14 +492,25 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
         [InlineData("http://localhost:0/mcp", null)]
         [InlineData("http://localhost:65536/mcp", null)]
         [InlineData("http://localhost:99999999999999999999/mcp", null)]
+        // The authority ends at the first '/', '?' or '#' — a query/fragment with no path still terminates it.
+        [InlineData("http://localhost:8080?x=1", 8080)]
+        [InlineData("http://localhost:8080#frag", 8080)]
+        // Scheme-relative: no "://", so there is no authority to read and the answer is null. That
+        // AGREES with the writer and the binder, which both reject it at Uri.TryCreate(Absolute) and
+        // fall back to the derived port.
+        [InlineData("//localhost:8080/mcp", null)]
         // Colons that are NOT port separators.
         [InlineData("http://user:pass@localhost/mcp", null)]
         [InlineData("http://user:pass@localhost:8080/mcp", 8080)]
         [InlineData("http://[::1]/mcp", null)]
         [InlineData("http://[::1]:8080/mcp", 8080)]
-        // Malformed / empty.
+        // Malformed / empty. The non-ASCII-digit row (Arabic-Indic "34") pins that NumberStyles.None is
+        // the only validator needed — it is what lets the parser drop a hand-rolled digit scan.
         [InlineData("http://localhost:/mcp", null)]
         [InlineData("http://localhost:abc/mcp", null)]
+        [InlineData("http://localhost:٣٤/mcp", null)]
+        [InlineData("http://localhost:8 0/mcp", null)]
+        [InlineData("http://localhost:+80/mcp", null)]
         [InlineData("", null)]
         [InlineData(null, null)]
         public void TryGetExplicitPort_ReadsTheTypedPort_FromTheRawHost(string? host, int? expected)

--- a/McpPlugin.Tests/AgentConfig/ConfigWritersB6Tests.cs
+++ b/McpPlugin.Tests/AgentConfig/ConfigWritersB6Tests.cs
@@ -151,20 +151,24 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
             try
             {
                 var c = new ClaudeCodeConfigurator();
-                var settings = Settings(root);
+                var settings = Settings(root); // host "http://localhost:50000/mcp" — an EXPLICIT typed port
                 var pin = settings.ProjectPin;
-                var port = settings.ResolvedPort;
 
+                // stdio still carries the ProjectIdentity port (marker override, else derived v2).
                 var stdio = c.GetStdioConfig(settings).ExpectedFileContent;
-                stdio.ShouldContain($"\"{Consts.MCP.Server.Args.Port}={port}\"");
+                stdio.ShouldContain($"\"{Consts.MCP.Server.Args.Port}={settings.ResolvedPort}\"");
                 stdio.ShouldContain($"\"{Consts.MCP.Server.Args.PluginTimeout}=30000\"");
                 stdio.ShouldContain($"\"{Consts.MCP.Server.Args.ClientTransportMethod}=stdio\"");
                 stdio.ShouldContain($"\"{Consts.MCP.Server.Args.Project}={pin}\"");
                 stdio.ShouldNotContain("\"type\"");
                 stdio.ShouldNotContain("\"url\"");
 
+                // auth-fixes T1 / defect A (owner ruling 2026-07-19): the HTTP url keeps the port the
+                // user typed into Host (50000) instead of overwriting it with the derived port. The
+                // engine binds that same typed port (UnityMcpPluginEditor.Port -> uri.Port), so writer
+                // and binder now agree. This assertion previously named settings.ResolvedPort.
                 var http = c.GetHttpConfig(settings).ExpectedFileContent;
-                http.ShouldContain($"\"url\": \"http://localhost:{port}/mcp/p/{pin}\"");
+                http.ShouldContain($"\"url\": \"http://localhost:50000/mcp/p/{pin}\"");
                 http.ShouldContain("\"type\": \"http\"");
                 http.ShouldNotContain("\"headers\"");
             }
@@ -289,6 +293,11 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
         /// The same invariant observed end-to-end, through what Configure actually writes: the port in
         /// the URL authority and the pin in the <c>/p/&lt;pin&gt;</c> segment of one written config must
         /// both come from the v2 normalization. This is the user-visible shape from the bug report.
+        ///
+        /// <para>The host is deliberately PORTLESS so the URL exercises precedence level 3 (the derived
+        /// v2 port). With an explicit port in the host the URL would — correctly, per defect A's owner
+        /// ruling — carry that typed port instead, and this test would no longer be observing defect B.
+        /// The stdio half is unaffected by the host either way.</para>
         /// </summary>
         [Fact]
         public void WrittenConfig_UrlPortAndPin_AreBothV2_ForBackslashRoot()
@@ -296,7 +305,7 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
             var backslashRoot = "C:" + Bs + "tmp" + Bs + "mcpauth-test" + Bs + "test-project";
             var v2Pin = ProjectIdentity.DerivePinV2(backslashRoot);
             var v2Port = ProjectIdentity.DerivePortV2(backslashRoot);
-            var settings = Settings(backslashRoot);
+            var settings = Settings(backslashRoot, host: "http://localhost/mcp");
 
             var c = new ClaudeCodeConfigurator();
 
@@ -357,6 +366,12 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
 
         // ---- DoD 2: marker portOverride propagates into the written config port. ----
 
+        /// <summary>
+        /// DoD 2, and — since defect A's owner ruling — the ESSENTIAL precedence-level-1-beats-level-2
+        /// case: the marker's <c>portOverride</c> (27777) and an explicit port in the host
+        /// (<c>http://localhost:50000/mcp</c>) are BOTH present, and the override must win. A marker is
+        /// a deliberate per-project pin; a port in the host string is incidental by comparison.
+        /// </summary>
         [Fact]
         public void MarkerPortOverride_PropagatesToWrittenPort_StdioAndHttp()
         {
@@ -366,16 +381,143 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
                 const int overridePort = 27777;
                 new ProjectMarker { PortOverride = overridePort }.Write(root);
 
-                var settings = Settings(root);
+                var settings = Settings(root); // host carries an explicit :50000 the override must beat
+                settings.ExplicitHostPort.ShouldBe(50000);
                 settings.ResolvedPort.ShouldBe(overridePort);
                 settings.Identity.PortIsOverridden.ShouldBeTrue();
+                settings.PinnedHttpPort.ShouldBe(overridePort);
 
                 var c = new ClaudeCodeConfigurator();
                 c.GetStdioConfig(settings).ExpectedFileContent.ShouldContain($"{Consts.MCP.Server.Args.Port}={overridePort}");
-                c.GetHttpConfig(settings).ExpectedFileContent.ShouldContain($"localhost:{overridePort}/");
+
+                var http = c.GetHttpConfig(settings).ExpectedFileContent;
+                http.ShouldContain($"localhost:{overridePort}/");
+                http.ShouldNotContain("localhost:50000"); // the typed host port must NOT win over the marker
             }
             finally { Directory.Delete(root, recursive: true); }
         }
+
+        // ---- auth-fixes T1 / defect A (owner ruling 2026-07-19): the user's typed port is honoured. ----
+        //
+        // Precedence written into the config's loopback HTTP url:
+        //   1. project marker portOverride   (highest — MarkerPortOverride_PropagatesToWrittenPort_* above)
+        //   2. explicit port in the Host URL (the port the user typed)
+        //   3. deterministic derived v2 port (fallback when Host carries no explicit port)
+        //
+        // Level 2 is the fix: the engine ALREADY binds the typed port (UnityMcpPluginEditor.Port returns
+        // uri.Port when Host parses with an in-range port), so overwriting it in the writer made the
+        // config point at a port nothing was listening on — the same class of failure as defect B, from
+        // the opposite direction.
+
+        [Fact]
+        public void ExplicitHostPort_IsHonoured_NotOverwrittenByDerivedPort()
+        {
+            var root = NewTempDir();
+            try
+            {
+                var settings = Settings(root, host: "http://localhost:50000/mcp");
+
+                settings.Identity.PortIsOverridden.ShouldBeFalse();
+                settings.ExplicitHostPort.ShouldBe(50000);
+                settings.PinnedHttpPort.ShouldBe(50000);
+
+                // The derived port is a DIFFERENT value, so this genuinely distinguishes the two paths.
+                settings.ResolvedPort.ShouldNotBe(50000);
+
+                settings.PinnedHttpUrl.ShouldBe($"http://localhost:50000/mcp/p/{settings.ProjectPin}");
+                settings.PinnedHttpUrl.ShouldNotContain($"localhost:{settings.ResolvedPort}");
+
+                // ...and it reaches the file the user actually gets.
+                new ClaudeCodeConfigurator().GetHttpConfig(settings).ExpectedFileContent
+                    .ShouldContain($"\"url\": \"http://localhost:50000/mcp/p/{settings.ProjectPin}\"");
+            }
+            finally { Directory.Delete(root, recursive: true); }
+        }
+
+        [Fact]
+        public void PortlessHost_FallsBackToDerivedV2Port()
+        {
+            var root = NewTempDir();
+            try
+            {
+                var settings = Settings(root, host: "http://localhost/mcp");
+
+                settings.ExplicitHostPort.ShouldBeNull();
+                settings.PinnedHttpPort.ShouldBe(settings.ResolvedPort);
+                settings.PinnedHttpPort.ShouldBe(ProjectIdentity.DerivePortV2(root));
+
+                settings.PinnedHttpUrl.ShouldBe($"http://localhost:{settings.ResolvedPort}/mcp/p/{settings.ProjectPin}");
+            }
+            finally { Directory.Delete(root, recursive: true); }
+        }
+
+        [Fact]
+        public void ExplicitDefaultPort_IsStillAnExplicitPort_AndIsHonoured()
+        {
+            // The distinction Uri.Port cannot express: "http://localhost/mcp" (no port — fall back to
+            // the derived port) vs "http://localhost:80/mcp" (the user typed 80 — honour it). Uri
+            // synthesises 80 for both, which is why the explicit port is read off the raw host string.
+            var root = NewTempDir();
+            try
+            {
+                var typed = Settings(root, host: "http://localhost:80/mcp");
+                typed.ExplicitHostPort.ShouldBe(80);
+                typed.PinnedHttpPort.ShouldBe(80);
+                typed.PinnedHttpUrl.ShouldBe($"http://localhost:80/mcp/p/{typed.ProjectPin}");
+
+                var portless = Settings(root, host: "http://localhost/mcp");
+                portless.ExplicitHostPort.ShouldBeNull();
+                portless.PinnedHttpPort.ShouldBe(portless.ResolvedPort);
+            }
+            finally { Directory.Delete(root, recursive: true); }
+        }
+
+        [Fact]
+        public void ExplicitHostPort_IsIgnored_ForNonLoopbackAndCloud()
+        {
+            // The port rewrite only ever applied to a LOCAL loopback authority; a hosted target keeps
+            // its authority verbatim, which already preserved any typed port. Pinned so the defect-A
+            // change cannot leak into the cloud path.
+            var root = NewTempDir();
+            try
+            {
+                var cloud = Settings(root, connectionMode: ConnectionMode.Cloud, host: "https://ai-game.dev/mcp");
+                cloud.PinnedHttpUrl.ShouldBe($"https://ai-game.dev/mcp/p/{cloud.ProjectPin}");
+                cloud.PinnedHttpUrl.ShouldNotContain($":{cloud.ResolvedPort}");
+
+                var lan = Settings(root, host: "http://192.168.1.5:9000/mcp");
+                lan.PinnedHttpUrl.ShouldBe($"http://192.168.1.5:9000/mcp/p/{lan.ProjectPin}");
+            }
+            finally { Directory.Delete(root, recursive: true); }
+        }
+
+        [Theory]
+        // No port at all.
+        [InlineData("http://localhost/mcp", null)]
+        [InlineData("http://localhost", null)]
+        // Ordinary explicit ports, including a scheme-default one and the range bounds.
+        [InlineData("http://localhost:50000/mcp", 50000)]
+        [InlineData("http://localhost:80/mcp", 80)]
+        [InlineData("https://example.com:443", 443)]
+        [InlineData("http://localhost:1", 1)]
+        [InlineData("http://localhost:65535", 65535)]
+        // Out of range / unusable => null, mirroring the engine binder's guard, so BOTH sides fall back
+        // to the derived port rather than diverging.
+        [InlineData("http://localhost:0/mcp", null)]
+        [InlineData("http://localhost:65536/mcp", null)]
+        [InlineData("http://localhost:99999999999999999999/mcp", null)]
+        // Colons that are NOT port separators.
+        [InlineData("http://user:pass@localhost/mcp", null)]
+        [InlineData("http://user:pass@localhost:8080/mcp", 8080)]
+        [InlineData("http://[::1]/mcp", null)]
+        [InlineData("http://[::1]:8080/mcp", 8080)]
+        // Malformed / empty.
+        [InlineData("http://localhost:/mcp", null)]
+        [InlineData("http://localhost:abc/mcp", null)]
+        [InlineData("", null)]
+        [InlineData(null, null)]
+        public void TryGetExplicitPort_ReadsTheTypedPort_FromTheRawHost(string? host, int? expected)
+            => AgentConfiguratorSettings.TryGetExplicitPort(host).ShouldBe(expected);
 
         [Fact]
         public void NoMarker_UsesDeterministicDerivedPort()

--- a/McpPlugin.Tests/AgentConfig/ConfigWritersB6Tests.cs
+++ b/McpPlugin.Tests/AgentConfig/ConfigWritersB6Tests.cs
@@ -35,6 +35,9 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
         // A token value distinctive enough that a substring assertion cannot false-match.
         private const string PatValue = "S3CR3T-PAT-VALUE";
 
+        // A literal backslash, built from its char code so no escaping subtlety can alter it.
+        private static string Bs => ((char)92).ToString();
+
         private static AgentConfiguratorSettings Settings(
             string root,
             string? token = null,
@@ -245,6 +248,67 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
             c.GetStdioConfig(settings).ExpectedFileContent.ShouldContain($"{Consts.MCP.Server.Args.Project}={v2Pin}");
         }
 
+        // ---- auth-fixes T1 / defect B: the pin and the port come from ONE normalization. ----
+
+        /// <summary>
+        /// THE regression test for defect B. Before the fix, one settings object derived its pin from
+        /// <c>DerivePinV2</c> (separator-normalized) but its port from the v1 <c>ProjectIdentity.Derive</c>
+        /// (NOT normalized), so on a Windows backslash root the written config mixed a v1 port with a v2
+        /// pin — e.g. <c>http://localhost:29540/p/a8087ea6</c>, where 29540 is the v1 port of
+        /// <c>c:\tmp\mcpauth-test\test-project</c> and a8087ea6 is the v2 pin of
+        /// <c>c:/tmp/mcpauth-test/test-project</c>. The engine runtimes bind the v2 port (defect B10), so
+        /// the agent dialled a port nothing was listening on.
+        ///
+        /// <para>A hardcoded backslash literal keeps this deterministic on Linux CI, where
+        /// <c>Path.GetTempPath()</c> is forward-slash and v1 == v2 — the exact blind spot that let the
+        /// bug ship.</para>
+        /// </summary>
+        [Fact]
+        public void PinAndPort_ComeFromTheSameNormalization_ForBackslashRoot()
+        {
+            var backslashRoot = "C:" + Bs + "tmp" + Bs + "mcpauth-test" + Bs + "test-project";
+            var forwardSlashRoot = backslashRoot.Replace(Bs, "/");
+            var settings = Settings(backslashRoot);
+
+            // Both halves of the identity agree with the v2 primitives...
+            settings.ProjectPin.ShouldBe(ProjectIdentity.DerivePinV2(backslashRoot));
+            settings.ResolvedPort.ShouldBe(ProjectIdentity.DerivePortV2(backslashRoot));
+
+            // ...and, the defining property, with the SAME (forward-slash) pre-hash string, so the
+            // separator form the engine happens to report can never split pin from port.
+            settings.ProjectPin.ShouldBe(ProjectIdentity.DerivePinV2(forwardSlashRoot));
+            settings.ResolvedPort.ShouldBe(ProjectIdentity.DerivePortV2(forwardSlashRoot));
+
+            // The bug itself: the port must NOT be the v1 (un-normalized) derivation, which on a
+            // backslash root is a different hash of a different string.
+            ProjectIdentity.DerivePortV2(backslashRoot).ShouldNotBe(ProjectIdentity.DerivePort(backslashRoot));
+            settings.ResolvedPort.ShouldNotBe(ProjectIdentity.DerivePort(backslashRoot));
+        }
+
+        /// <summary>
+        /// The same invariant observed end-to-end, through what Configure actually writes: the port in
+        /// the URL authority and the pin in the <c>/p/&lt;pin&gt;</c> segment of one written config must
+        /// both come from the v2 normalization. This is the user-visible shape from the bug report.
+        /// </summary>
+        [Fact]
+        public void WrittenConfig_UrlPortAndPin_AreBothV2_ForBackslashRoot()
+        {
+            var backslashRoot = "C:" + Bs + "tmp" + Bs + "mcpauth-test" + Bs + "test-project";
+            var v2Pin = ProjectIdentity.DerivePinV2(backslashRoot);
+            var v2Port = ProjectIdentity.DerivePortV2(backslashRoot);
+            var settings = Settings(backslashRoot);
+
+            var c = new ClaudeCodeConfigurator();
+
+            var http = c.GetHttpConfig(settings).ExpectedFileContent;
+            http.ShouldContain($"\"url\": \"http://localhost:{v2Port}/mcp/p/{v2Pin}\"");
+            http.ShouldNotContain($"localhost:{ProjectIdentity.DerivePort(backslashRoot)}");
+
+            var stdio = c.GetStdioConfig(settings).ExpectedFileContent;
+            stdio.ShouldContain($"\"{Consts.MCP.Server.Args.Port}={v2Port}\"");
+            stdio.ShouldContain($"\"{Consts.MCP.Server.Args.Project}={v2Pin}\"");
+        }
+
         // ---- DoD 1: dedup / upsert regression on the new pinned shape. ----
 
         [Fact]
@@ -321,7 +385,11 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
             {
                 var settings = Settings(root);
                 settings.Identity.PortIsOverridden.ShouldBeFalse();
-                settings.ResolvedPort.ShouldBe(ProjectIdentity.DerivePort(root));
+                // auth-fixes T1 / defect B: the derived port is the v2 (separator-normalized) port —
+                // the SAME normalization ProjectPin uses. This assertion previously named DerivePort
+                // (v1); on a forward-slash root the two agree, which is precisely why the suite could
+                // not see the Windows divergence. See PinAndPort_ComeFromTheSameNormalization_* below.
+                settings.ResolvedPort.ShouldBe(ProjectIdentity.DerivePortV2(root));
                 settings.ResolvedPort.ShouldBeInRange(ProjectIdentity.MinPort, ProjectIdentity.MaxPort);
             }
             finally { Directory.Delete(root, recursive: true); }

--- a/McpPlugin.Tests/AgentConfig/ProjectIdentityGoldenVectorV2Tests.cs
+++ b/McpPlugin.Tests/AgentConfig/ProjectIdentityGoldenVectorV2Tests.cs
@@ -159,6 +159,69 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
             Should.Throw<System.ArgumentNullException>(() => ProjectIdentity.DerivePortV2(null!));
             Should.Throw<System.ArgumentNullException>(() => ProjectIdentity.DeriveProjectPathHashV2(null!));
             Should.Throw<System.ArgumentNullException>(() => ProjectIdentity.NormalizeV2(null!));
+            Should.Throw<System.ArgumentNullException>(() => ProjectIdentity.DeriveV2(null!));
+        }
+
+        // ---- auth-fixes T1 / defect B: the whole-identity v2 factory. ----
+
+        /// <summary>
+        /// Every golden vector, resolved through the whole-identity <see cref="ProjectIdentity.DeriveV2"/>
+        /// factory: pin AND port must match the standalone v2 primitives, so an identity object can
+        /// never carry a pin and a port derived from different normalizations.
+        /// </summary>
+        [Theory]
+        [MemberData(nameof(GoldenVectors))]
+        public void DeriveV2_ProducesV2PinAndV2Port_ForEveryGoldenVector(string path, string expectedPin, int expectedPort)
+        {
+            var identity = ProjectIdentity.DeriveV2(path);
+
+            identity.Pin.ShouldBe(expectedPin);
+            identity.Port.ShouldBe(expectedPort);
+            identity.PortIsOverridden.ShouldBeFalse();
+        }
+
+        /// <summary>
+        /// The defect-B invariant at the identity level: a backslash root and its forward-slash form
+        /// yield the same pin AND the same port, and that port is NOT the v1 derivation.
+        /// </summary>
+        [Fact]
+        public void DeriveV2_BackslashAndForwardSlash_AgreeOnBothPinAndPort()
+        {
+            var backslash = "C:" + Bs + "tmp" + Bs + "mcpauth-test" + Bs + "test-project";
+            var forward = backslash.Replace(Bs, "/");
+
+            var fromBackslash = ProjectIdentity.DeriveV2(backslash);
+            var fromForward = ProjectIdentity.DeriveV2(forward);
+
+            fromBackslash.Pin.ShouldBe(fromForward.Pin);
+            fromBackslash.Port.ShouldBe(fromForward.Port);
+
+            // v1 would have split them: same object, two different pre-hash strings.
+            fromBackslash.Port.ShouldNotBe(ProjectIdentity.Derive(backslash).Port);
+            fromBackslash.Pin.ShouldNotBe(ProjectIdentity.Derive(backslash).Pin);
+        }
+
+        /// <summary>
+        /// The marker's <c>portOverride</c> keeps precedence under v2 (unchanged behaviour); the pin
+        /// stays hash-derived from the v2 normalization.
+        /// </summary>
+        [Fact]
+        public void DeriveV2_PortOverride_Wins_AndPinStaysHashDerived()
+        {
+            var backslash = "C:" + Bs + "tmp" + Bs + "mcpauth-test" + Bs + "test-project";
+
+            var overridden = ProjectIdentity.DeriveV2(backslash, portOverride: 27618);
+            overridden.Port.ShouldBe(27618);
+            overridden.PortIsOverridden.ShouldBeTrue();
+            overridden.Pin.ShouldBe(ProjectIdentity.DerivePinV2(backslash));
+
+            var viaMarker = ProjectIdentity.DeriveV2(backslash, new ProjectMarker { PortOverride = 27618 });
+            viaMarker.Port.ShouldBe(27618);
+            viaMarker.PortIsOverridden.ShouldBeTrue();
+
+            var noOverride = ProjectIdentity.DeriveV2(backslash, (ProjectMarker?)null);
+            noOverride.Port.ShouldBe(ProjectIdentity.DerivePortV2(backslash));
+            noOverride.PortIsOverridden.ShouldBeFalse();
         }
 
         private static string Bs => ((char)92).ToString();

--- a/McpPlugin/src/AgentConfig/AgentConfiguratorSettings.cs
+++ b/McpPlugin/src/AgentConfig/AgentConfiguratorSettings.cs
@@ -83,7 +83,12 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
         /// <summary>Absolute path to the MCP server executable (stdio transport <c>command</c>).</summary>
         public string ExecutableFullPath { get; }
 
-        /// <summary>The MCP server port (stdio transport arg).</summary>
+        /// <summary>
+        /// The raw engine-supplied port (the port the engine's own binder resolved). NOT what the
+        /// config writers emit: the stdio <c>port=</c> arg uses <see cref="ResolvedPort"/> and the
+        /// loopback HTTP url uses <see cref="PinnedHttpPort"/>. This value backs the Docker container
+        /// name / port mapping and the displayed copy-paste <c>mcp add</c> one-liners.
+        /// </summary>
         public int Port { get; }
 
         /// <summary>Plugin timeout in milliseconds (stdio transport arg).</summary>
@@ -249,10 +254,8 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
         /// separator-normalized SHA-256, see <see cref="ProjectIdentity.DerivePinV2"/>) so a config
         /// generated from a Windows backslash root matches a plugin whose forward-slash hash it now
         /// equals (auth-fixes T3 / defect B5). Old (v1-pin) configs still route via the plugin's legacy
-        /// hash. Non-secret, safe to commit. Read straight off <see cref="Identity"/>, whose
-        /// <see cref="ResolvedPort"/> shares the same v2 normalization — the engine runtimes already
-        /// adopted the v2 port primitive (<c>UnityMcpPlugin.GeneratePortFromDirectory</c> →
-        /// <see cref="ProjectIdentity.DerivePortV2"/>, defect B10), and this writer now matches them.
+        /// hash. Non-secret, safe to commit. Read straight off <see cref="Identity"/> — see
+        /// <see cref="ProjectIdentity.DeriveV2"/> for why the pin and the port must share one derivation.
         /// </summary>
         public string ProjectPin => Identity.Pin;
 
@@ -262,13 +265,11 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
         /// <c>port=</c> arg, NOT the raw engine-supplied <see cref="Port"/> — b6 single-sources the
         /// local port from <see cref="ProjectIdentity"/>. The loopback HTTP URL uses
         /// <see cref="PinnedHttpPort"/>, which additionally honours a port the user typed into
-        /// <see cref="Host"/> (defect A) — a port that only exists on the HTTP path.
+        /// <see cref="Host"/> (defect A) — a level that only exists on the HTTP path.
         ///
-        /// <para>Shares <see cref="Identity"/> — and therefore the exact
-        /// <see cref="ProjectIdentity.NormalizeV2"/> pre-hash string — with <see cref="ProjectPin"/>.
-        /// Before auth-fixes T1 this read a v1 (non-separator-normalized) port while the pin was
-        /// already v2, so on Windows (where <c>ProjectRootPath</c> carries backslashes) the written
-        /// config mixed a v1 port with a v2 pin and pointed at a port the plugin never bound.</para>
+        /// <para>Shares the single cached <see cref="Identity"/> — and therefore the exact
+        /// <see cref="ProjectIdentity.NormalizeV2"/> pre-hash string — with <see cref="ProjectPin"/>
+        /// (auth-fixes T1 / defect B; see <see cref="ProjectIdentity.DeriveV2"/>).</para>
         /// </summary>
         public int ResolvedPort => Identity.Port;
 
@@ -298,11 +299,24 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
         ///
         /// <para>Level 1 still outranks level 2: <c>portOverride</c> is a deliberate per-project marker
         /// written to pin a project's port, so it beats an incidental port in the host string.</para>
+        ///
+        /// <para><b>Residual divergence from the binder</b> (both engine-side, both outside this writer's
+        /// reach — recorded so the agreement above is not read as absolute):
+        /// <list type="bullet">
+        ///   <item>A <see cref="Host"/> with NO port (or an empty <c>host:</c>) — the binder's
+        ///   <c>uri.Port</c> synthesises the scheme default (80/443), which passes its
+        ///   <c>&gt; 0 &amp;&amp; &lt;= MaxPort</c> guard, so it binds 80 while this writer falls back to the
+        ///   derived port. Unreachable on the shipped default, whose <c>Host</c> is
+        ///   <c>http://localhost:{derived}</c> — an explicit port that both sides agree on.</item>
+        ///   <item>Level 1 vs level 2 — the binder never reads the project marker, so a
+        ///   <c>portOverride</c> combined with an explicit port in <see cref="Host"/> resolves to the
+        ///   override here and to the typed port there. Latent: nothing writes <c>portOverride</c> in
+        ///   production today.</item>
+        /// </list></para>
         /// </summary>
         public int PinnedHttpPort =>
-            Identity.PortIsOverridden
-                ? ResolvedPort                      // 1. marker portOverride wins outright
-                : ExplicitHostPort ?? ResolvedPort; // 2. user-typed port, else 3. derived v2 port
+            // marker override (1) else typed host port (2) else derived v2 port (3) — see the list above.
+            Identity.PortIsOverridden ? ResolvedPort : ExplicitHostPort ?? ResolvedPort;
 
         /// <summary>
         /// The HTTP <c>url</c> written into configs on the default (credential-free) path: the base
@@ -352,7 +366,7 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
             // Isolate the authority: after "scheme://" (if present), up to the first '/', '?' or '#'.
             var schemeEnd = host!.IndexOf("://", StringComparison.Ordinal);
             var start = schemeEnd >= 0 ? schemeEnd + 3 : 0;
-            var end = host.IndexOfAny(new[] { '/', '?', '#' }, start);
+            var end = host.IndexOfAny(AuthorityTerminators, start);
             var authority = end >= 0 ? host.Substring(start, end - start) : host.Substring(start);
 
             // Drop any userinfo ("user:pass@host:port") — its colon is not a port separator.
@@ -367,17 +381,16 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
             if (colon < 0 || colon == authority.Length - 1)
                 return null;
 
-            var portText = authority.Substring(colon + 1);
-            foreach (var ch in portText)
-            {
-                if (ch < '0' || ch > '9')
-                    return null;
-            }
-
-            if (!int.TryParse(portText, NumberStyles.None, CultureInfo.InvariantCulture, out var port))
-                return null; // overflows int — far beyond MaxPort anyway
+            // NumberStyles.None is the whole validator: it rejects sign, whitespace, separators and any
+            // non-ASCII-digit character, so a hand-rolled digit scan on top would be redundant. The
+            // theory in ConfigWritersB6Tests locks that (non-numeric, non-ASCII-digit and overflow rows).
+            if (!int.TryParse(authority.Substring(colon + 1), NumberStyles.None, CultureInfo.InvariantCulture, out var port))
+                return null;
 
             return port > 0 && port <= Consts.Hub.MaxPort ? port : (int?)null;
         }
+
+        /// <summary>Characters that terminate a URL authority. Static so the parse allocates nothing.</summary>
+        private static readonly char[] AuthorityTerminators = { '/', '?', '#' };
     }
 }

--- a/McpPlugin/src/AgentConfig/AgentConfiguratorSettings.cs
+++ b/McpPlugin/src/AgentConfig/AgentConfiguratorSettings.cs
@@ -10,6 +10,7 @@
 
 #nullable enable
 using System;
+using System.Globalization;
 using System.Runtime.InteropServices;
 using com.IvanMurzak.McpPlugin.Common;
 
@@ -257,9 +258,11 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
 
         /// <summary>
         /// The resolved per-project local port: the project marker's <c>portOverride</c> when set,
-        /// otherwise the deterministic hash-derived port. This is the port written into configs
-        /// (stdio <c>port=</c> arg and the loopback HTTP URL), NOT the raw engine-supplied
-        /// <see cref="Port"/> — b6 single-sources the local port from <see cref="ProjectIdentity"/>.
+        /// otherwise the deterministic hash-derived port. This is the port written into the stdio
+        /// <c>port=</c> arg, NOT the raw engine-supplied <see cref="Port"/> — b6 single-sources the
+        /// local port from <see cref="ProjectIdentity"/>. The loopback HTTP URL uses
+        /// <see cref="PinnedHttpPort"/>, which additionally honours a port the user typed into
+        /// <see cref="Host"/> (defect A) — a port that only exists on the HTTP path.
         ///
         /// <para>Shares <see cref="Identity"/> — and therefore the exact
         /// <see cref="ProjectIdentity.NormalizeV2"/> pre-hash string — with <see cref="ProjectPin"/>.
@@ -270,10 +273,42 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
         public int ResolvedPort => Identity.Port;
 
         /// <summary>
+        /// The port the user explicitly typed into <see cref="Host"/>, or <c>null</c> when
+        /// <see cref="Host"/> carries no explicit port. See <see cref="TryGetExplicitPort"/> for why
+        /// this is read off the RAW host string rather than <c>Uri.Port</c>.
+        /// </summary>
+        public int? ExplicitHostPort => TryGetExplicitPort(Host);
+
+        /// <summary>
+        /// The port written into the loopback HTTP <c>url</c> (<see cref="PinnedHttpUrl"/>), resolved by
+        /// a three-level precedence (auth-fixes T1 / defect A, owner ruling 2026-07-19):
+        /// <list type="number">
+        ///   <item>the project marker's <c>portOverride</c> — an explicit per-project pin, wins outright;</item>
+        ///   <item>an explicit port in the <see cref="Host"/> URL — the port the USER typed;</item>
+        ///   <item>the deterministic v2 hash-derived port (<see cref="ResolvedPort"/>) — the fallback
+        ///         when <see cref="Host"/> carries no explicit port.</item>
+        /// </list>
+        ///
+        /// <para>Level 2 exists because the engine runtime ALREADY binds the typed port: Unity's
+        /// <c>UnityMcpPluginEditor.Port</c> returns <c>uri.Port</c> whenever <c>Host</c> parses as an
+        /// absolute URI with an in-range port, and only falls back to the derived port otherwise. Before
+        /// this fix the writer overwrote that typed port with the derived one, so the server listened on
+        /// the port the user chose while the config told the agent to dial a different one. Honouring the
+        /// typed port makes the WRITER agree with the BINDER — that agreement is the whole point.</para>
+        ///
+        /// <para>Level 1 still outranks level 2: <c>portOverride</c> is a deliberate per-project marker
+        /// written to pin a project's port, so it beats an incidental port in the host string.</para>
+        /// </summary>
+        public int PinnedHttpPort =>
+            Identity.PortIsOverridden
+                ? ResolvedPort                      // 1. marker portOverride wins outright
+                : ExplicitHostPort ?? ResolvedPort; // 2. user-typed port, else 3. derived v2 port
+
+        /// <summary>
         /// The HTTP <c>url</c> written into configs on the default (credential-free) path: the base
         /// <see cref="Host"/> with the <c>/p/&lt;pin&gt;</c> routing path segment appended, and — for a
-        /// loopback URL in <see cref="ConnectionMode.Local"/> — the port rewritten to
-        /// <see cref="ResolvedPort"/>. The pin rides as a path segment (not a query param) so a lost
+        /// loopback URL in <see cref="ConnectionMode.Local"/> — the port set to
+        /// <see cref="PinnedHttpPort"/>. The pin rides as a path segment (not a query param) so a lost
         /// pin 404s loudly instead of silently degrading to unpinned routing (design 03 Flow F).
         /// </summary>
         public string PinnedHttpUrl => BuildPinnedHttpUrl();
@@ -283,16 +318,66 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
             var pin = ProjectPin;
             if (Uri.TryCreate(Host, UriKind.Absolute, out var uri))
             {
-                // Only the per-project LOCAL loopback port is rewritten from ProjectIdentity; a hosted
-                // (or non-loopback) target keeps its authority verbatim (default ports stay implicit).
+                // Only the per-project LOCAL loopback port is resolved here; a hosted (or non-loopback)
+                // target keeps its authority verbatim (default ports stay implicit). The loopback port
+                // follows PinnedHttpPort's marker > typed > derived precedence, so a port the user typed
+                // into Host survives into the written config instead of being silently overwritten.
                 var authority = ConnectionMode == ConnectionMode.Local && uri.IsLoopback
-                    ? $"{uri.Scheme}://{uri.Host}:{ResolvedPort}"
+                    ? $"{uri.Scheme}://{uri.Host}:{PinnedHttpPort}"
                     : uri.GetLeftPart(UriPartial.Authority);
                 var basePath = uri.AbsolutePath.TrimEnd('/');
                 return $"{authority}{basePath}/p/{pin}{uri.Query}";
             }
             // Non-absolute host (defensive): append the pin segment without a port rewrite.
             return $"{Host.TrimEnd('/')}/p/{pin}";
+        }
+
+        /// <summary>
+        /// Reads an explicitly-typed port out of a host string, or returns <c>null</c> when there is
+        /// none. Returns <c>null</c> for an out-of-range port too, mirroring the engine binder's
+        /// <c>uri.Port &gt; 0 &amp;&amp; uri.Port &lt;= Consts.Hub.MaxPort</c> guard — an unusable port
+        /// falls back to the derived one on BOTH sides rather than diverging.
+        ///
+        /// <para><b>Why the raw string and not <c>Uri.Port</c>:</b> <see cref="Uri"/> synthesises the
+        /// scheme's default port, so <c>http://localhost/mcp</c> and <c>http://localhost:80/mcp</c> both
+        /// report <c>80</c> and become indistinguishable. The first has no user intent behind it and must
+        /// fall through to the derived port; the second is a port the user deliberately typed and must be
+        /// honoured. Only the raw authority preserves that distinction.</para>
+        /// </summary>
+        internal static int? TryGetExplicitPort(string? host)
+        {
+            if (string.IsNullOrWhiteSpace(host))
+                return null;
+
+            // Isolate the authority: after "scheme://" (if present), up to the first '/', '?' or '#'.
+            var schemeEnd = host!.IndexOf("://", StringComparison.Ordinal);
+            var start = schemeEnd >= 0 ? schemeEnd + 3 : 0;
+            var end = host.IndexOfAny(new[] { '/', '?', '#' }, start);
+            var authority = end >= 0 ? host.Substring(start, end - start) : host.Substring(start);
+
+            // Drop any userinfo ("user:pass@host:port") — its colon is not a port separator.
+            var at = authority.LastIndexOf('@');
+            if (at >= 0)
+                authority = authority.Substring(at + 1);
+
+            // For an IPv6 literal the port follows the closing bracket ("[::1]:8080"); the colons inside
+            // the brackets are part of the address. LastIndexOf returns -1 for a normal host, so the
+            // search then starts at 0 and finds a plain "host:port" colon.
+            var colon = authority.IndexOf(':', authority.LastIndexOf(']') + 1);
+            if (colon < 0 || colon == authority.Length - 1)
+                return null;
+
+            var portText = authority.Substring(colon + 1);
+            foreach (var ch in portText)
+            {
+                if (ch < '0' || ch > '9')
+                    return null;
+            }
+
+            if (!int.TryParse(portText, NumberStyles.None, CultureInfo.InvariantCulture, out var port))
+                return null; // overflows int — far beyond MaxPort anyway
+
+            return port > 0 && port <= Consts.Hub.MaxPort ? port : (int?)null;
         }
     }
 }

--- a/McpPlugin/src/AgentConfig/AgentConfiguratorSettings.cs
+++ b/McpPlugin/src/AgentConfig/AgentConfiguratorSettings.cs
@@ -229,14 +229,18 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
         // terminal-written config. Resolved lazily and cached (a marker read is file I/O, and the
         // identity is stable for the settings' <see cref="ProjectRootPath"/>).
         private ProjectIdentity? _identity;
-        private string? _projectPin;
 
         /// <summary>
         /// The project's <see cref="ProjectIdentity"/> — routing pin plus the resolved local port
         /// (the project marker's <c>portOverride</c> wins, else the deterministic hash-derived port).
         /// Read once from the marker at <see cref="ProjectRootPath"/> and cached.
+        ///
+        /// <para>Derived via <see cref="ProjectIdentity.DeriveV2"/>, so the pin and the port come from
+        /// ONE <see cref="ProjectIdentity.NormalizeV2"/> pre-hash string (auth-fixes T1 / defect B).
+        /// <see cref="ProjectPin"/> and <see cref="ResolvedPort"/> both read off this single object,
+        /// which is what makes a v1/v2 mix within one settings instance unrepresentable.</para>
         /// </summary>
-        public ProjectIdentity Identity => _identity ??= ProjectIdentity.Derive(ProjectRootPath, ProjectMarker.Read(ProjectRootPath));
+        public ProjectIdentity Identity => _identity ??= ProjectIdentity.DeriveV2(ProjectRootPath, ProjectMarker.Read(ProjectRootPath));
 
         /// <summary>
         /// The routing pin written into every config (HTTP <c>/p/&lt;pin&gt;</c> segment and stdio
@@ -244,17 +248,24 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
         /// separator-normalized SHA-256, see <see cref="ProjectIdentity.DerivePinV2"/>) so a config
         /// generated from a Windows backslash root matches a plugin whose forward-slash hash it now
         /// equals (auth-fixes T3 / defect B5). Old (v1-pin) configs still route via the plugin's legacy
-        /// hash. Non-secret, safe to commit. The port stays on the v1 derivation (<see cref="ResolvedPort"/>)
-        /// until the engine runtimes adopt the v2 port primitive. Derived once and cached (the pin is
-        /// stable for the settings' <see cref="ProjectRootPath"/>), matching <see cref="Identity"/>.
+        /// hash. Non-secret, safe to commit. Read straight off <see cref="Identity"/>, whose
+        /// <see cref="ResolvedPort"/> shares the same v2 normalization — the engine runtimes already
+        /// adopted the v2 port primitive (<c>UnityMcpPlugin.GeneratePortFromDirectory</c> →
+        /// <see cref="ProjectIdentity.DerivePortV2"/>, defect B10), and this writer now matches them.
         /// </summary>
-        public string ProjectPin => _projectPin ??= ProjectIdentity.DerivePinV2(ProjectRootPath);
+        public string ProjectPin => Identity.Pin;
 
         /// <summary>
         /// The resolved per-project local port: the project marker's <c>portOverride</c> when set,
         /// otherwise the deterministic hash-derived port. This is the port written into configs
         /// (stdio <c>port=</c> arg and the loopback HTTP URL), NOT the raw engine-supplied
         /// <see cref="Port"/> — b6 single-sources the local port from <see cref="ProjectIdentity"/>.
+        ///
+        /// <para>Shares <see cref="Identity"/> — and therefore the exact
+        /// <see cref="ProjectIdentity.NormalizeV2"/> pre-hash string — with <see cref="ProjectPin"/>.
+        /// Before auth-fixes T1 this read a v1 (non-separator-normalized) port while the pin was
+        /// already v2, so on Windows (where <c>ProjectRootPath</c> carries backslashes) the written
+        /// config mixed a v1 port with a v2 pin and pointed at a port the plugin never bound.</para>
         /// </summary>
         public int ResolvedPort => Identity.Port;
 

--- a/McpPlugin/src/AgentConfig/ProjectIdentity.cs
+++ b/McpPlugin/src/AgentConfig/ProjectIdentity.cs
@@ -71,8 +71,11 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
         public string Pin { get; }
 
         /// <summary>
-        /// The resolved local port. Equal to <see cref="DerivePort"/> unless an explicit user port
-        /// override was supplied (from the project marker), in which case the override wins.
+        /// The resolved local port. Equal to the hash-derived port of whichever factory produced this
+        /// identity — <see cref="DerivePort"/> for <see cref="Derive(string, int?)"/>,
+        /// <see cref="DerivePortV2"/> for <see cref="DeriveV2(string, int?)"/> — unless an explicit user
+        /// port override was supplied (from the project marker), in which case the override wins and
+        /// <see cref="PortIsOverridden"/> is true.
         /// </summary>
         public int Port { get; }
 

--- a/McpPlugin/src/AgentConfig/ProjectIdentity.cs
+++ b/McpPlugin/src/AgentConfig/ProjectIdentity.cs
@@ -225,6 +225,45 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
             return PortFromHash(HashOfV2(projectRoot));
         }
 
+        /// <summary>
+        /// Derive the <b>fully v2</b> identity for <paramref name="projectRoot"/>: both the
+        /// <see cref="Pin"/> and the hash-derived <see cref="Port"/> come from the single
+        /// <see cref="NormalizeV2"/> pre-hash string, so one identity object can never mix the v1 and
+        /// v2 normalizations. When <paramref name="portOverride"/> is non-null (the user's explicit
+        /// override from the project marker) it always wins for <see cref="Port"/>; the
+        /// <see cref="Pin"/> is always hash-derived.
+        ///
+        /// <para>This is the factory every configurator path uses (auth-fixes T1 / defect B). The v1
+        /// <see cref="Derive(string, int?)"/> is retained verbatim for legacy consumers and the v1
+        /// golden vectors, but mixing the two within one settings object is exactly the bug this
+        /// method exists to make unrepresentable: on Windows <c>ProjectRootPath</c> carries
+        /// backslashes, so a v1 port and a v2 pin hash <b>different strings</b> and the written
+        /// config points at a port nothing is listening on.</para>
+        /// </summary>
+        /// <param name="projectRoot">The project root path (as the engine reports it — separators are normalized here).</param>
+        /// <param name="portOverride">Optional explicit user port override; wins when set.</param>
+        public static ProjectIdentity DeriveV2(string projectRoot, int? portOverride = null)
+        {
+            if (projectRoot == null)
+                throw new ArgumentNullException(nameof(projectRoot));
+
+            var hash = HashOfV2(projectRoot);
+            var pin = ToHex(hash, PinLength / 2);
+            var derivedPort = PortFromHash(hash);
+
+            if (portOverride.HasValue)
+                return new ProjectIdentity(pin, portOverride.Value, portIsOverridden: true);
+
+            return new ProjectIdentity(pin, derivedPort, portIsOverridden: false);
+        }
+
+        /// <summary>
+        /// Convenience overload of <see cref="DeriveV2(string, int?)"/> that reads the port override
+        /// from a project marker (may be null).
+        /// </summary>
+        public static ProjectIdentity DeriveV2(string projectRoot, ProjectMarker? marker)
+            => DeriveV2(projectRoot, marker?.PortOverride);
+
         internal static byte[] HashOf(string projectRoot)
         {
             var normalized = Normalize(projectRoot);


### PR DESCRIPTION
## Summary

Both defects from the port-mismatch report, in one PR (one file, one library release instead of two).

**Defect B — the written config mixed a v1 port with a v2 pin.** One `AgentConfiguratorSettings`
object derived its **pin** from `DerivePinV2` (separator-normalized) but its **port** from the v1
`ProjectIdentity.Derive` (not normalized). On Windows `ProjectRootPath` carries backslashes, so the
two hashed *different strings* and the agent dialled a port nothing was listening on — on the
**default** path, no custom URL involved, across all 16 configurators.

**Defect A — the writer discarded the port the user typed.** `BuildPinnedHttpUrl()` overwrote an
explicit loopback port in `Host` with the derived port. That was deliberate design (**D15**), and
this PR **deliberately reverses it per an owner ruling of 2026-07-19**: *"The user can enter any
port. The server already uses that port, based on what the user enters. And the Configure button
must use exactly that port, not the standard one."*

The two are the same failure from opposite directions — the config naming a port the plugin never
bound — so they are fixed together.

## Defect B: the two normalizations, and why they diverged

| derivation | pre-hash string | port | pin |
|---|---|---|---|
| v1 (`ProjectIdentity.Derive`) | `c:\tmp\mcpauth-test\test-project` | **29540** | 34e6a562 |
| v2 (`DerivePinV2` / `DerivePortV2`) | `c:/tmp/mcpauth-test/test-project` | **27608** | **a8087ea6** |

v2 adds one step to the normalization — converting `\` to `/` — so a Windows root reported with
backslashes and the same root reported with forward slashes hash identically. The pin adopted v2 in
#164; the port never followed.

**Before:** `http://localhost:29540/p/a8087ea6` — port from v1, pin from v2.
**After:** both from v2 — `http://localhost:27608/p/a8087ea6`.

This was live breakage, not a latent inconsistency: the engine runtimes already adopted the v2 port
primitive (`UnityMcpPlugin.GeneratePortFromDirectory` → `DerivePortV2`, defect B10), so the plugin
**bound the v2 port while the config was written with the v1 port**. The comment at
`AgentConfiguratorSettings.cs:248-249` claimed the runtimes had not adopted v2 yet; they had, and it
is corrected here.

Fixed by adding `ProjectIdentity.DeriveV2`, a whole-identity factory whose pin and hash-derived port
both come from the single `NormalizeV2` pre-hash string. `ProjectPin` and `ResolvedPort` now both
read off one cached `Identity`, so a v1/v2 mix within one settings instance is **unrepresentable**
rather than merely fixed.

## Defect A: the new three-level precedence

The loopback HTTP url's port now resolves by an explicit precedence (new `PinnedHttpPort`):

| # | source | wins over |
|---|---|---|
| 1 | project marker `portOverride` | everything — a deliberate per-project pin |
| 2 | **explicit port in the `Host` URL** — the port the user typed | the derived port |
| 3 | deterministic derived v2 port | — (fallback when `Host` carries no explicit port) |

**Why level 2 is a fix and not a regression:** the engine *already* binds the typed port.
`UnityMcpPluginEditor.Port` returns `uri.Port` whenever `Host` parses as an absolute URI with an
in-range port, and only falls back to the derived port otherwise. So today the server listens on the
typed port while the config is written with the derived one. Honouring the typed port makes the
**writer agree with the binder** — that agreement is the whole point, and it is the same property
defect B restored on the other axis.

**This is a no-op on the default path.** Unity's `UnityConnectionConfig.DefaultHost` is
`http://localhost:{GeneratePortFromDirectory()}` — i.e. `http://localhost:{derived-v2-port}`, an
*explicit* port. Level 2 therefore picks up exactly the value level 3 would have. The change only
bites once the user has actually edited the host, which is precisely the owner's scenario.

The explicit port is read off the **raw** host string, not `Uri.Port`: `Uri` synthesises the scheme
default, making `http://localhost/mcp` and `http://localhost:80/mcp` indistinguishable, though only
the second carries user intent. Out-of-range ports resolve to "no explicit port", mirroring the
binder's `uri.Port > 0 && <= Consts.Hub.MaxPort` guard so both sides fall back together rather than
diverging.

**Scope:** the HTTP url only. `ResolvedPort` — and therefore the stdio `port=` arg — is unchanged,
so defect B's single-v2-normalization fix stands. See the follow-up note below.

## Reach of the change

Wider than the config writer, but only in the direction of consistency:

- `Identity.Pin` moves from v1 to v2. It had **no production consumer** — production read the pin via
  `ProjectPin` (already v2) — so this only removes a way for the two halves to disagree.
- `ResolvedPort` (consumed by `AgentConfigBuilders`, `CodexConfigurator`, `OpenCodeConfigurator`)
  moves from v1 to v2, which is defect B's fix itself.
- `ProjectIdentity.Derive` (v1) and its golden vectors are **untouched** and remain public for legacy
  consumers and the dual-hash transition; after this change it has no production caller in this repo.
- The marker's `portOverride` precedence is preserved exactly, and now explicitly outranks a typed
  host port.
- No version bump, no golden vector added or changed, no engine-repo edits.

## ⚠ Follow-up required in another repo

`Unreal-MCP/bridge/tests/LocalServerPortConsistencyTests.cs` asserts the **old** D15 invariant (that
a typed loopback port is discarded in favour of the derived port). It lives in the Unreal-MCP repo,
so it is **not** editable from here — it will need a matching update in its own repo when that repo
picks up this library version, or it will fail against the new behaviour.

## Other follow-ups (surfaced by review, deliberately not in scope)

- **The stdio transport still has defect A.** `AgentConfigBuilders` writes `port={ResolvedPort}`
  (marker → derived), with no typed-host level. A user who types `http://localhost:50000` and picks
  **stdio** gets a plugin bound to 50000 and a config naming the derived port — the same failure, other
  transport. The owner ruling covered the HTTP url only, so unifying the two rules into one
  "port written into configs" concept needs its own ruling. (Related, pre-existing: the displayed
  `claude mcp add … port={settings.Port}` one-liner uses the *raw engine* port, so it already disagrees
  with the JSON the same command writes.)
- **`TryGetExplicitPort` is `internal`.** Promoting it to public in `McpPlugin.Common` would let the
  engines execute the *identical* parse and close the two residual writer/binder divergences documented
  on `PinnedHttpPort` in code rather than in a comment — the same treatment `ProjectIdentity.NormalizeV2`
  already gets as the B10 primitive. That is a public API change that cascades to Unity-MCP, so it is a
  lead call.
- **`ProjectIdentity` has no normalization discriminator.** `Derive` and `DeriveV2` yield structurally
  identical, silently interchangeable values; the guarantee "a v1/v2 mix is unrepresentable" holds for
  `AgentConfiguratorSettings` by construction, not for the type. Now is the cheapest moment to add one —
  v1 has zero in-repo production consumers after this PR.

## Which test now catches a regression

Verified by reverting each fix independently and re-running.

**Defect B** — reverting `Identity` to the v1 `Derive` fails:
- `PinAndPort_ComeFromTheSameNormalization_ForBackslashRoot` — the identity-level invariant: pin and
  port agree with the v2 primitives *and* with the forward-slash form of the same root, and the port
  is explicitly **not** the v1 derivation.
- `WrittenConfig_UrlPortAndPin_AreBothV2_ForBackslashRoot` — the same invariant end-to-end, through
  what Configure actually writes. Uses a deliberately **portless** host so the url exercises precedence
  level 3; with an explicit port it would (correctly, per defect A) carry that instead and stop
  observing defect B.

**Defect A** — reverting the one-line authority change fails exactly three:
- `ClaudeCode_NewShapes_ExactContent` (the typed `:50000` survives into the written url)
- `LoopbackHttpUrl_HonoursTypedPort_ElseDerivedV2Port` rows `:50000` and `:80`

The portless row of that theory correctly keeps passing — it is level 3, which the revert does not
affect. `MarkerPortOverride_PropagatesToWrittenPort_StdioAndHttp` also passes either way (the marker
wins under both rules) and is now the explicit **level 1 beats level 2** case.

Plus three `DeriveV2` tests in `ProjectIdentityGoldenVectorV2Tests` (every golden vector through the
new factory, backslash/forward-slash agreement on **both** halves, override precedence) — that file is
picked up by the required `golden-vector-parity` CI job.

Why the suite missed defect B originally: every test used a **forward-slash** temp root, where v1 and
v2 coincide and the divergence is invisible. The new tests use hardcoded backslash literals so they
stay deterministic on Linux CI, where `Path.GetTempPath()` is forward-slash.

## Assertions changed (none weakened)

- `NoMarker_UsesDeterministicDerivedPort` now names `DerivePortV2` instead of `DerivePort`. That
  assertion *was* defect B written down — it asserted `ResolvedPort` equals the v1 port.
- `ClaudeCode_NewShapes_ExactContent`'s url now expects the typed `50000` rather than `ResolvedPort`,
  encoding the reversed D15 ruling.
- `WrittenConfig_UrlPortAndPin_AreBothV2_ForBackslashRoot` moved to a portless host (see above).

All three are behaviour-correcting. No assertion was relaxed or deleted, and no golden vector changed.

## Test plan

- [x] Full `dotnet test` gate (profile test.md Suite 1, a 1:1 mirror of the `test` CI job) —
      **2,698 tests, 0 failures** across `McpPlugin.Tests` + `McpPlugin.Server.Tests` on both
      `net8.0` and `net9.0`. `dotnet build --configuration Release`: 0 errors, 0 warnings.
- [x] Negative control run separately for each defect (results above).
- [x] Reported repro arithmetic independently reproduced (v1 → 29540/34e6a562, v2 → 27608/a8087ea6).
- [x] Engine binder behaviour ground-truthed against `UnityMcpPluginEditor.Static.cs` and
      `UnityMcpPlugin.Config.cs` rather than assumed.
- [x] Suite 3 doc audit: `docs/` and `specs/` grepped for the port-rewrite behaviour — the only
      loopback hits describe the server-side auth plane. No drift to repair.
- [ ] `golden-vector-parity` has no local mirror (CI-only) — must be confirmed green on the final HEAD.

Closes #173
