### PR TITLE
fix: honour a user-typed port in the stdio config arg, not just the HTTP url

### DIFF
--- a/McpPlugin.Tests/AgentConfig/ConfigWritersB6Tests.cs
+++ b/McpPlugin.Tests/AgentConfig/ConfigWritersB6Tests.cs
@@ -115,7 +115,10 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
                     var content = c.GetStdioConfig(settings).ExpectedFileContent;
 
                     content.ShouldContain($"{Consts.MCP.Server.Args.Project}={settings.ProjectPin}", customMessage: $"{c.AgentId} stdio must carry project=<pin>");
-                    content.ShouldContain($"{Consts.MCP.Server.Args.Port}={settings.ResolvedPort}", customMessage: $"{c.AgentId} stdio must carry the ProjectIdentity port");
+                    // auth-fixes T1 / defect A (stdio half): the written port is PinnedPort, which for
+                    // this host (an explicit :50000) is the typed port — the one the binder binds.
+                    // This assertion previously named settings.ResolvedPort.
+                    content.ShouldContain($"{Consts.MCP.Server.Args.Port}={settings.PinnedPort}", customMessage: $"{c.AgentId} stdio must carry the pinned port");
                     content.ShouldNotContain($"{Consts.MCP.Server.Args.Authorization}=", customMessage: $"{c.AgentId} stdio must not carry an authorization arg on the default path");
                     content.ShouldNotContain($"{Consts.MCP.Server.Args.Token}=", customMessage: $"{c.AgentId} stdio must not carry a token arg on the default path");
                     content.ShouldNotContain(PatValue, customMessage: $"{c.AgentId} stdio must not embed the token value");
@@ -154,9 +157,13 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
                 var settings = Settings(root); // host "http://localhost:50000/mcp" — an EXPLICIT typed port
                 var pin = settings.ProjectPin;
 
-                // stdio still carries the ProjectIdentity port (marker override, else derived v2).
+                // auth-fixes T1 / defect A, stdio half: the stdio port= arg now honours the port typed
+                // into Host (50000) rather than overwriting it with the derived port — the same fix the
+                // HTTP url got below, and the same port the engine binder binds for BOTH transports.
+                // This assertion previously named settings.ResolvedPort.
                 var stdio = c.GetStdioConfig(settings).ExpectedFileContent;
-                stdio.ShouldContain($"\"{Consts.MCP.Server.Args.Port}={settings.ResolvedPort}\"");
+                stdio.ShouldContain($"\"{Consts.MCP.Server.Args.Port}=50000\"");
+                stdio.ShouldNotContain($"\"{Consts.MCP.Server.Args.Port}={settings.ResolvedPort}\"");
                 stdio.ShouldContain($"\"{Consts.MCP.Server.Args.PluginTimeout}=30000\"");
                 stdio.ShouldContain($"\"{Consts.MCP.Server.Args.ClientTransportMethod}=stdio\"");
                 stdio.ShouldContain($"\"{Consts.MCP.Server.Args.Project}={pin}\"");
@@ -299,10 +306,10 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
         /// the URL authority and the pin in the <c>/p/&lt;pin&gt;</c> segment of one written config must
         /// both come from the v2 normalization. This is the user-visible shape from the bug report.
         ///
-        /// <para>The host is deliberately PORTLESS so the URL exercises precedence level 3 (the derived
-        /// v2 port). With an explicit port in the host the URL would — correctly, per defect A's owner
-        /// ruling — carry that typed port instead, and this test would no longer be observing defect B.
-        /// The stdio half is unaffected by the host either way.</para>
+        /// <para>The host is deliberately PORTLESS so BOTH halves exercise precedence level 3 (the
+        /// derived v2 port). With an explicit port in the host the URL — and, since the stdio half moved
+        /// onto the same precedence, the <c>port=</c> arg too — would correctly carry that typed port per
+        /// defect A's owner ruling, and this test would no longer be observing defect B.</para>
         /// </summary>
         [Fact]
         public void WrittenConfig_UrlPortAndPin_AreBothV2_ForBackslashRoot()
@@ -393,10 +400,15 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
                 settings.ExplicitHostPort.ShouldBe(50000);
                 settings.ResolvedPort.ShouldBe(overridePort);
                 settings.Identity.PortIsOverridden.ShouldBeTrue();
-                settings.PinnedHttpPort.ShouldBe(overridePort);
+                settings.PinnedPort.ShouldBe(overridePort);
 
                 var c = new ClaudeCodeConfigurator();
-                c.GetStdioConfig(settings).ExpectedFileContent.ShouldContain($"{Consts.MCP.Server.Args.Port}={overridePort}");
+                var stdio = c.GetStdioConfig(settings).ExpectedFileContent;
+                stdio.ShouldContain($"{Consts.MCP.Server.Args.Port}={overridePort}");
+                // Level 1 beats level 2 on stdio too — before the stdio half moved onto PinnedPort this
+                // held for the trivial reason that stdio ignored the typed port entirely; now it is a
+                // real precedence assertion.
+                stdio.ShouldNotContain($"{Consts.MCP.Server.Args.Port}=50000");
 
                 var http = c.GetHttpConfig(settings).ExpectedFileContent;
                 http.ShouldContain($"localhost:{overridePort}/");
@@ -440,14 +452,14 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
 
                 settings.Identity.PortIsOverridden.ShouldBeFalse(); // no marker => levels 2/3 only
                 settings.ExplicitHostPort.ShouldBe(typedPort);
-                settings.PinnedHttpPort.ShouldBe(expectedPort);
+                settings.PinnedPort.ShouldBe(expectedPort);
 
                 if (typedPort.HasValue)
                     // The derived port is a DIFFERENT value, so the row genuinely distinguishes the paths
                     // (the derived range is 20000-29999, which neither 50000 nor 80 can collide with).
                     settings.ResolvedPort.ShouldNotBe(typedPort.Value);
                 else
-                    settings.PinnedHttpPort.ShouldBe(ProjectIdentity.DerivePortV2(root));
+                    settings.PinnedPort.ShouldBe(ProjectIdentity.DerivePortV2(root));
 
                 settings.PinnedHttpUrl.ShouldBe($"http://localhost:{expectedPort}/mcp/p/{settings.ProjectPin}");
 
@@ -473,6 +485,105 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
 
                 var lan = Settings(root, host: "http://192.168.1.5:9000/mcp");
                 lan.PinnedHttpUrl.ShouldBe($"http://192.168.1.5:9000/mcp/p/{lan.ProjectPin}");
+            }
+            finally { Directory.Delete(root, recursive: true); }
+        }
+
+        // ---- auth-fixes T1 / defect A, STDIO half (owner ruling extended to stdio 2026-07-19). ----
+        //
+        // The stdio `port=` arg now follows the SAME three-level precedence as the loopback HTTP url:
+        //   1. project marker portOverride   (highest)
+        //   2. explicit port in the Host URL (the port the user typed)
+        //   3. deterministic derived v2 port (fallback)
+        //
+        // Before this, the arg named ResolvedPort, which has no typed-host level — so a user who typed a
+        // custom port and configured over stdio got a config telling the spawned server to dial a port
+        // the plugin was not listening on. The engine binder (UnityMcpPluginEditor.Port) returns uri.Port
+        // for BOTH transports, so stdio was simply the half that had not caught up with the binder.
+
+        /// <summary>
+        /// All three precedence levels, asserted across EVERY real configurator rather than one.
+        ///
+        /// <para>That breadth is the point: THREE different code paths emit this arg —
+        /// <c>AgentConfigBuilders.StdioArgs</c> (most agents), <c>CodexConfigurator</c>'s hand-rolled TOML
+        /// array, and <c>OpenCodeConfigurator</c>'s single <c>command</c> array. A fix applied only to the
+        /// shared builder would silently leave the other two on the old behaviour.</para>
+        /// </summary>
+        [Theory]
+        // Level 3 — no port in Host, so the derived v2 port.
+        [InlineData("http://localhost/mcp", null, null)]
+        // Level 2 — a port typed into Host is honoured, including an explicit scheme-DEFAULT port that
+        // Uri.Port could not distinguish from "no port at all".
+        [InlineData("http://localhost:50000/mcp", null, 50000)]
+        [InlineData("http://localhost:80/mcp", null, 80)]
+        // Level 1 — a marker portOverride beats a typed host port AND the derived port.
+        [InlineData("http://localhost:50000/mcp", 27777, 27777)]
+        [InlineData("http://localhost/mcp", 27777, 27777)]
+        public void StdioPortArg_FollowsTheSameThreeLevelPrecedence_AcrossEveryConfigurator(
+            string host, int? markerOverride, int? expectedPort)
+        {
+            var root = NewTempDir();
+            try
+            {
+                if (markerOverride.HasValue)
+                    new ProjectMarker { PortOverride = markerOverride.Value }.Write(root);
+
+                var derived = ProjectIdentity.DerivePortV2(root);
+                var expected = expectedPort ?? derived;
+                var settings = Settings(root, host: host);
+
+                settings.Identity.PortIsOverridden.ShouldBe(markerOverride.HasValue);
+                settings.PinnedPort.ShouldBe(expected);
+
+                foreach (var c in RealConfigurators())
+                {
+                    var content = c.GetStdioConfig(settings).ExpectedFileContent;
+                    content.ShouldContain($"{Consts.MCP.Server.Args.Port}={expected}",
+                        customMessage: $"{c.AgentId} stdio must carry the pinned port {expected}");
+
+                    // On every row where a higher level applies, the derived port must be ABSENT — this
+                    // is what fails against the old ResolvedPort-based arg. (The derived range is
+                    // 20000-29999, which none of the typed ports above can collide with; the 27777
+                    // override is inside it, hence the guard rather than an unconditional assertion.)
+                    if (expected != derived)
+                        content.ShouldNotContain($"{Consts.MCP.Server.Args.Port}={derived}",
+                            customMessage: $"{c.AgentId} stdio must not fall back to the derived port {derived}");
+                }
+            }
+            finally { Directory.Delete(root, recursive: true); }
+        }
+
+        /// <summary>
+        /// The stdio arg is deliberately NOT gated on loopback / <see cref="ConnectionMode"/>, unlike the
+        /// HTTP url's authority rewrite. Pinned because the asymmetry looks like an oversight and is not.
+        ///
+        /// <para>The gate exists on the HTTP side only because a hosted authority is kept VERBATIM, which
+        /// already preserves whatever port the user typed — so gating there costs nothing. stdio has no
+        /// authority to preserve, and the binder it must agree with (<c>uri.Port</c>) is itself ungated,
+        /// so applying the precedence directly is what keeps writer and binder in step.</para>
+        /// </summary>
+        [Fact]
+        public void StdioPortArg_IsNotGatedOnLoopbackOrConnectionMode()
+        {
+            var root = NewTempDir();
+            try
+            {
+                var c = new ClaudeCodeConfigurator();
+
+                // Non-loopback LAN host: writer and binder both name the typed 9000, and the HTTP url
+                // (authority kept verbatim) independently names it too — all three agree.
+                var lan = Settings(root, host: "http://192.168.1.5:9000/mcp");
+                lan.PinnedPort.ShouldBe(9000);
+                c.GetStdioConfig(lan).ExpectedFileContent.ShouldContain($"{Consts.MCP.Server.Args.Port}=9000");
+                c.GetHttpConfig(lan).ExpectedFileContent.ShouldContain("http://192.168.1.5:9000/mcp/p/");
+
+                // Cloud host with no port: nothing to honour, so stdio falls back to the derived v2 port.
+                // The cloud HTTP url carries no port at all — the local spawn still needs one, so the two
+                // legitimately differ here rather than disagreeing about the same value.
+                var cloud = Settings(root, connectionMode: ConnectionMode.Cloud, host: "https://ai-game.dev/mcp");
+                cloud.PinnedPort.ShouldBe(ProjectIdentity.DerivePortV2(root));
+                c.GetStdioConfig(cloud).ExpectedFileContent
+                    .ShouldContain($"{Consts.MCP.Server.Args.Port}={ProjectIdentity.DerivePortV2(root)}");
             }
             finally { Directory.Delete(root, recursive: true); }
         }

--- a/McpPlugin.Tests/AgentConfig/ConfigWritersB6Tests.cs
+++ b/McpPlugin.Tests/AgentConfig/ConfigWritersB6Tests.cs
@@ -498,16 +498,20 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
         //
         // Before this, the arg named ResolvedPort, which has no typed-host level — so a user who typed a
         // custom port and configured over stdio got a config telling the spawned server to dial a port
-        // the plugin was not listening on. The engine binder (UnityMcpPluginEditor.Port) returns uri.Port
-        // for BOTH transports, so stdio was simply the half that had not caught up with the binder.
+        // the plugin was not listening on. Unity's binder (UnityMcpPluginEditor.Port) returns uri.Port for
+        // BOTH transports, so stdio was simply the half that had not caught up with that binder. (Godot's
+        // and Unreal's binders derive instead on loopback — see AgentConfiguratorSettings.PinnedPort
+        // § "Residual divergence from the binder"; reconciling them is an owner call, not asserted here.)
 
         /// <summary>
         /// All three precedence levels, asserted across EVERY real configurator rather than one.
         ///
-        /// <para>That breadth is the point: THREE different code paths emit this arg —
-        /// <c>AgentConfigBuilders.StdioArgs</c> (most agents), <c>CodexConfigurator</c>'s hand-rolled TOML
-        /// array, and <c>OpenCodeConfigurator</c>'s single <c>command</c> array. A fix applied only to the
-        /// shared builder would silently leave the other two on the old behaviour.</para>
+        /// <para>That breadth is the point. Three emitters put this arg on the wire —
+        /// <c>AgentConfigBuilders.StdioArgs</c> (most agents), <c>CodexConfigurator</c>'s TOML array, and
+        /// <c>OpenCodeConfigurator</c>'s single <c>command</c> array — and they each hand-rolled the list
+        /// independently, which is how the stdio half of defect A survived the HTTP half's fix. They now
+        /// share <c>AgentConfigBuilders.StdioArgValues</c>, so this theory's job is to catch an emitter
+        /// DRIFTING BACK OFF that source of truth (or a fourth one landing that never joined it).</para>
         /// </summary>
         [Theory]
         // Level 3 — no port in Host, so the derived v2 port.
@@ -555,12 +559,8 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
 
         /// <summary>
         /// The stdio arg is deliberately NOT gated on loopback / <see cref="ConnectionMode"/>, unlike the
-        /// HTTP url's authority rewrite. Pinned because the asymmetry looks like an oversight and is not.
-        ///
-        /// <para>The gate exists on the HTTP side only because a hosted authority is kept VERBATIM, which
-        /// already preserves whatever port the user typed — so gating there costs nothing. stdio has no
-        /// authority to preserve, and the binder it must agree with (<c>uri.Port</c>) is itself ungated,
-        /// so applying the precedence directly is what keeps writer and binder in step.</para>
+        /// HTTP url's authority rewrite. Pinned because the asymmetry looks like an oversight and is not —
+        /// <c>AgentConfiguratorSettings.PinnedPort</c> carries the reasoning.
         /// </summary>
         [Fact]
         public void StdioPortArg_IsNotGatedOnLoopbackOrConnectionMode()

--- a/McpPlugin/src/AgentConfig/AgentConfigBuilders.cs
+++ b/McpPlugin/src/AgentConfig/AgentConfigBuilders.cs
@@ -24,14 +24,20 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
     internal static class AgentConfigBuilders
     {
         /// <summary>
-        /// The standard stdio arg array (mcp-authorize b6, design 06): the ProjectIdentity-derived
-        /// per-project <c>port=</c> (marker <c>portOverride</c> wins), plugin-timeout, client-transport,
-        /// and the <c>project=&lt;pin&gt;</c> routing arg. NO auth args — stdio spawns in <c>none</c> mode
-        /// on the default path (the credential-free / anonymous local flow).
+        /// The standard stdio arg array (mcp-authorize b6, design 06): the per-project <c>port=</c>
+        /// (<see cref="AgentConfiguratorSettings.PinnedPort"/> — marker <c>portOverride</c>, else a port
+        /// typed into <c>Host</c>, else the derived v2 port), plugin-timeout, client-transport, and the
+        /// <c>project=&lt;pin&gt;</c> routing arg. NO auth args — stdio spawns in <c>none</c> mode on the
+        /// default path (the credential-free / anonymous local flow).
+        ///
+        /// <para>The <c>port=</c> arg names <see cref="AgentConfiguratorSettings.PinnedPort"/>, not
+        /// <see cref="AgentConfiguratorSettings.ResolvedPort"/>: the engine binder returns <c>uri.Port</c>
+        /// for BOTH transports, so a stdio arg that skipped the typed-host level told the spawned server
+        /// to dial a port the plugin was not listening on (auth-fixes T1 / defect A, stdio half).</para>
         /// </summary>
         public static JsonArray StdioArgs(AgentConfiguratorSettings s) => new()
         {
-            $"{Args.Port}={s.ResolvedPort}",
+            $"{Args.Port}={s.PinnedPort}",
             $"{Args.PluginTimeout}={s.TimeoutMs}",
             $"{Args.ClientTransportMethod}={TransportMethod.stdio}",
             $"{Args.Project}={s.ProjectPin}"

--- a/McpPlugin/src/AgentConfig/AgentConfigBuilders.cs
+++ b/McpPlugin/src/AgentConfig/AgentConfigBuilders.cs
@@ -24,24 +24,42 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
     internal static class AgentConfigBuilders
     {
         /// <summary>
-        /// The standard stdio arg array (mcp-authorize b6, design 06): the per-project <c>port=</c>
-        /// (<see cref="AgentConfiguratorSettings.PinnedPort"/> — marker <c>portOverride</c>, else a port
-        /// typed into <c>Host</c>, else the derived v2 port), plugin-timeout, client-transport, and the
-        /// <c>project=&lt;pin&gt;</c> routing arg. NO auth args — stdio spawns in <c>none</c> mode on the
-        /// default path (the credential-free / anonymous local flow).
+        /// THE single source of truth for the stdio arg values (mcp-authorize b6, design 06): the
+        /// per-project <c>port=</c> (<see cref="AgentConfiguratorSettings.PinnedPort"/> — marker
+        /// <c>portOverride</c>, else a port typed into <c>Host</c>, else the derived v2 port),
+        /// plugin-timeout, client-transport, and the <c>project=&lt;pin&gt;</c> routing arg. NO auth
+        /// args — stdio spawns in <c>none</c> mode on the default path (the credential-free /
+        /// anonymous local flow).
         ///
-        /// <para>The <c>port=</c> arg names <see cref="AgentConfiguratorSettings.PinnedPort"/>, not
-        /// <see cref="AgentConfiguratorSettings.ResolvedPort"/>: the engine binder returns <c>uri.Port</c>
-        /// for BOTH transports, so a stdio arg that skipped the typed-host level told the spawned server
-        /// to dial a port the plugin was not listening on (auth-fixes T1 / defect A, stdio half).</para>
+        /// <para>Returned as plain strings rather than a <see cref="JsonArray"/> because the emitters
+        /// need different containers: <see cref="StdioArgs"/> wraps them in a JSON <c>args</c> array,
+        /// <c>CodexConfigurator</c> passes them to a TOML array, and <c>OpenCodeConfigurator</c> prepends
+        /// its executable to that same array. Those three used to hand-roll this list independently,
+        /// which is exactly how the stdio half of defect A survived the HTTP half's fix — route every new
+        /// emitter through here instead.</para>
+        ///
+        /// <para>The <c>port=</c> arg names <see cref="AgentConfiguratorSettings.PinnedPort"/>, NOT
+        /// <see cref="AgentConfiguratorSettings.ResolvedPort"/> — see <c>PinnedPort</c> for the precedence
+        /// and for why the writer has to agree with the binder (auth-fixes T1 / defect A, stdio half).</para>
         /// </summary>
-        public static JsonArray StdioArgs(AgentConfiguratorSettings s) => new()
+        public static string[] StdioArgValues(AgentConfiguratorSettings s) => new[]
         {
             $"{Args.Port}={s.PinnedPort}",
             $"{Args.PluginTimeout}={s.TimeoutMs}",
             $"{Args.ClientTransportMethod}={TransportMethod.stdio}",
             $"{Args.Project}={s.ProjectPin}"
         };
+
+        /// <summary>
+        /// <see cref="StdioArgValues"/> as the JSON <c>args</c> array most agents write.
+        /// </summary>
+        public static JsonArray StdioArgs(AgentConfiguratorSettings s)
+        {
+            var args = new JsonArray();
+            foreach (var arg in StdioArgValues(s))
+                args.Add(arg);
+            return args;
+        }
 
         /// <summary>
         /// Standard JSON stdio entry: <c>type=stdio</c>, <c>command</c> (path comparison),

--- a/McpPlugin/src/AgentConfig/AgentConfiguratorSettings.cs
+++ b/McpPlugin/src/AgentConfig/AgentConfiguratorSettings.cs
@@ -85,9 +85,9 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
 
         /// <summary>
         /// The raw engine-supplied port (the port the engine's own binder resolved). NOT what the
-        /// config writers emit: the stdio <c>port=</c> arg uses <see cref="ResolvedPort"/> and the
-        /// loopback HTTP url uses <see cref="PinnedHttpPort"/>. This value backs the Docker container
-        /// name / port mapping and the displayed copy-paste <c>mcp add</c> one-liners.
+        /// config writers emit: both the stdio <c>port=</c> arg and the loopback HTTP url use
+        /// <see cref="PinnedPort"/>. This value backs the Docker container name / port mapping and
+        /// the displayed copy-paste <c>mcp add</c> one-liners.
         /// </summary>
         public int Port { get; }
 
@@ -260,12 +260,14 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
         public string ProjectPin => Identity.Pin;
 
         /// <summary>
-        /// The resolved per-project local port: the project marker's <c>portOverride</c> when set,
-        /// otherwise the deterministic hash-derived port. This is the port written into the stdio
-        /// <c>port=</c> arg, NOT the raw engine-supplied <see cref="Port"/> — b6 single-sources the
-        /// local port from <see cref="ProjectIdentity"/>. The loopback HTTP URL uses
-        /// <see cref="PinnedHttpPort"/>, which additionally honours a port the user typed into
-        /// <see cref="Host"/> (defect A) — a level that only exists on the HTTP path.
+        /// The marker-resolved per-project local port: the project marker's <c>portOverride</c> when
+        /// set, otherwise the deterministic v2 hash-derived port — b6 single-sources the local port
+        /// from <see cref="ProjectIdentity"/> rather than the raw engine-supplied <see cref="Port"/>.
+        ///
+        /// <para>This is NOT what the config writers emit. Both transports write
+        /// <see cref="PinnedPort"/>, which layers a port the user typed into <see cref="Host"/>
+        /// BETWEEN this property's two cases (defect A). <see cref="ResolvedPort"/> therefore supplies
+        /// precedence levels 1 and 3; see <see cref="PinnedPort"/> for the full ordering.</para>
         ///
         /// <para>Shares the single cached <see cref="Identity"/> — and therefore the exact
         /// <see cref="ProjectIdentity.NormalizeV2"/> pre-hash string — with <see cref="ProjectPin"/>
@@ -281,8 +283,9 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
         public int? ExplicitHostPort => TryGetExplicitPort(Host);
 
         /// <summary>
-        /// The port written into the loopback HTTP <c>url</c> (<see cref="PinnedHttpUrl"/>), resolved by
-        /// a three-level precedence (auth-fixes T1 / defect A, owner ruling 2026-07-19):
+        /// The per-project local port the config writers emit — the stdio <c>port=</c> arg AND the
+        /// loopback HTTP <c>url</c> (<see cref="PinnedHttpUrl"/>) — resolved by a three-level precedence
+        /// (auth-fixes T1 / defect A, owner ruling 2026-07-19, extended to stdio 2026-07-19):
         /// <list type="number">
         ///   <item>the project marker's <c>portOverride</c> — an explicit per-project pin, wins outright;</item>
         ///   <item>an explicit port in the <see cref="Host"/> URL — the port the USER typed;</item>
@@ -296,6 +299,16 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
         /// this fix the writer overwrote that typed port with the derived one, so the server listened on
         /// the port the user chose while the config told the agent to dial a different one. Honouring the
         /// typed port makes the WRITER agree with the BINDER — that agreement is the whole point.</para>
+        ///
+        /// <para><b>Why this is transport-neutral</b> (it was named <c>PinnedHttpPort</c> when only the
+        /// HTTP url consumed it): that binder property is not transport-scoped — it resolves the ONE port
+        /// the plugin binds, and the stdio server the config spawns dials that same port. So a stdio
+        /// <c>port=</c> arg on the old two-level precedence disagreed with the binder in exactly the way
+        /// the HTTP url used to. The per-transport difference lives at the CALL SITE, not here:
+        /// <see cref="BuildPinnedHttpUrl"/> applies this port only to a <see cref="ConnectionMode.Local"/>
+        /// loopback authority (a hosted target keeps its authority verbatim, which already preserved any
+        /// typed port), whereas stdio has no authority to preserve and applies the precedence directly.
+        /// Both end up naming the port the binder actually binds.</para>
         ///
         /// <para>Level 1 still outranks level 2: <c>portOverride</c> is a deliberate per-project marker
         /// written to pin a project's port, so it beats an incidental port in the host string.</para>
@@ -314,7 +327,7 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
         ///   production today.</item>
         /// </list></para>
         /// </summary>
-        public int PinnedHttpPort =>
+        public int PinnedPort =>
             // marker override (1) else typed host port (2) else derived v2 port (3) — see the list above.
             Identity.PortIsOverridden ? ResolvedPort : ExplicitHostPort ?? ResolvedPort;
 
@@ -322,7 +335,7 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
         /// The HTTP <c>url</c> written into configs on the default (credential-free) path: the base
         /// <see cref="Host"/> with the <c>/p/&lt;pin&gt;</c> routing path segment appended, and — for a
         /// loopback URL in <see cref="ConnectionMode.Local"/> — the port set to
-        /// <see cref="PinnedHttpPort"/>. The pin rides as a path segment (not a query param) so a lost
+        /// <see cref="PinnedPort"/>. The pin rides as a path segment (not a query param) so a lost
         /// pin 404s loudly instead of silently degrading to unpinned routing (design 03 Flow F).
         /// </summary>
         public string PinnedHttpUrl => BuildPinnedHttpUrl();
@@ -334,10 +347,10 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
             {
                 // Only the per-project LOCAL loopback port is resolved here; a hosted (or non-loopback)
                 // target keeps its authority verbatim (default ports stay implicit). The loopback port
-                // follows PinnedHttpPort's marker > typed > derived precedence, so a port the user typed
+                // follows PinnedPort's marker > typed > derived precedence, so a port the user typed
                 // into Host survives into the written config instead of being silently overwritten.
                 var authority = ConnectionMode == ConnectionMode.Local && uri.IsLoopback
-                    ? $"{uri.Scheme}://{uri.Host}:{PinnedHttpPort}"
+                    ? $"{uri.Scheme}://{uri.Host}:{PinnedPort}"
                     : uri.GetLeftPart(UriPartial.Authority);
                 var basePath = uri.AbsolutePath.TrimEnd('/');
                 return $"{authority}{basePath}/p/{pin}{uri.Query}";

--- a/McpPlugin/src/AgentConfig/AgentConfiguratorSettings.cs
+++ b/McpPlugin/src/AgentConfig/AgentConfiguratorSettings.cs
@@ -301,8 +301,8 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
         /// typed port makes the WRITER agree with the BINDER — that agreement is the whole point.</para>
         ///
         /// <para><b>Why this is transport-neutral</b> (it was named <c>PinnedHttpPort</c> when only the
-        /// HTTP url consumed it): that binder property is not transport-scoped — it resolves the ONE port
-        /// the plugin binds, and the stdio server the config spawns dials that same port. So a stdio
+        /// HTTP url consumed it): Unity's binder property is not transport-scoped — it resolves the ONE
+        /// port the plugin binds, and the stdio server the config spawns dials that same port. So a stdio
         /// <c>port=</c> arg on the old two-level precedence disagreed with the binder in exactly the way
         /// the HTTP url used to. The per-transport difference lives at the CALL SITE, not here:
         /// <see cref="BuildPinnedHttpUrl"/> applies this port only to a <see cref="ConnectionMode.Local"/>
@@ -325,6 +325,19 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
         ///   <c>portOverride</c> combined with an explicit port in <see cref="Host"/> resolves to the
         ///   override here and to the typed port there. Latent: nothing writes <c>portOverride</c> in
         ///   production today.</item>
+        ///   <item><b>Level 2 is a UNITY-shaped rule.</b> The claim above that the binder honours a typed
+        ///   port holds for Unity's binder; the other two engine consumers deliberately do the OPPOSITE
+        ///   on loopback. Godot's <c>GodotProjectIdentity.ResolveLocalServerBindPort</c> ignores a
+        ///   loopback host's own explicit port and binds the derived port ("a loopback port override goes
+        ///   through the marker <c>portOverride</c>"), and Unreal's bridge asserts the written config port
+        ///   is never the raw engine-supplied host port. So on a <see cref="ConnectionMode.Local"/>
+        ///   loopback <see cref="Host"/> carrying a typed port, level 2 makes this writer disagree with
+        ///   BOTH of those binders — the inverse of the Unity case it was introduced for. Each pins the
+        ///   old invariant in a test that fails on their next McpPlugin bump
+        ///   (<c>ResolveLocalServerBindPort_LoopbackExplicitPort_StillDerives_MatchingTheWriter</c>,
+        ///   <c>WrittenConfigPort_EqualsServerBindPort_OnDefaultLocalPath</c>). Whether the right
+        ///   resolution is a per-engine policy seam here or a binder change there is an OWNER call and
+        ///   deliberately out of scope for this writer-side change.</item>
         /// </list></para>
         /// </summary>
         public int PinnedPort =>

--- a/McpPlugin/src/AgentConfig/Impl/CodexConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/Impl/CodexConfigurator.cs
@@ -38,16 +38,9 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Impl
             => new TomlAiAgentConfig(AgentName, LocalConfigPath(settings), bodyPath: "mcp_servers", logger: logger)
                 .SetProperty("enabled", true, requiredForConfiguration: true)
                 .SetProperty("command", settings.ExecutableFullPath.Replace('\\', '/'), requiredForConfiguration: true, comparison: ValueComparisonMode.Path)
-                // Codex is TOML-only, so it hand-rolls the arg list AgentConfigBuilders.StdioArgs builds
-                // for the JSON agents. Keep it in lockstep — notably the PinnedPort precedence
-                // (marker portOverride > port typed into Host > derived v2), auth-fixes T1 / defect A.
-                .SetProperty("args", new[]
-                {
-                    $"{Args.Port}={settings.PinnedPort}",
-                    $"{Args.PluginTimeout}={settings.TimeoutMs}",
-                    $"{Args.ClientTransportMethod}={TransportMethod.stdio}",
-                    $"{Args.Project}={settings.ProjectPin}"
-                }, requiredForConfiguration: true)
+                // Codex is TOML-only, so the args land in a TOML array rather than the JSON one
+                // AgentConfigBuilders.StdioArgs builds — but the VALUES come from the same source of truth.
+                .SetProperty("args", AgentConfigBuilders.StdioArgValues(settings), requiredForConfiguration: true)
                 .SetProperty("tool_timeout_sec", 300, requiredForConfiguration: false)
                 .SetPropertyToRemove("url")
                 .SetPropertyToRemove("type")

--- a/McpPlugin/src/AgentConfig/Impl/CodexConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/Impl/CodexConfigurator.cs
@@ -38,9 +38,12 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Impl
             => new TomlAiAgentConfig(AgentName, LocalConfigPath(settings), bodyPath: "mcp_servers", logger: logger)
                 .SetProperty("enabled", true, requiredForConfiguration: true)
                 .SetProperty("command", settings.ExecutableFullPath.Replace('\\', '/'), requiredForConfiguration: true, comparison: ValueComparisonMode.Path)
+                // Codex is TOML-only, so it hand-rolls the arg list AgentConfigBuilders.StdioArgs builds
+                // for the JSON agents. Keep it in lockstep — notably the PinnedPort precedence
+                // (marker portOverride > port typed into Host > derived v2), auth-fixes T1 / defect A.
                 .SetProperty("args", new[]
                 {
-                    $"{Args.Port}={settings.ResolvedPort}",
+                    $"{Args.Port}={settings.PinnedPort}",
                     $"{Args.PluginTimeout}={settings.TimeoutMs}",
                     $"{Args.ClientTransportMethod}={TransportMethod.stdio}",
                     $"{Args.Project}={settings.ProjectPin}"

--- a/McpPlugin/src/AgentConfig/Impl/OpenCodeConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/Impl/OpenCodeConfigurator.cs
@@ -34,19 +34,11 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Impl
 
         protected override AiAgentConfig CreateStdioConfig(AgentConfiguratorSettings settings, ILogger? logger)
         {
-            // mcp-authorize b6: credential-free, pinned stdio command array — the PinnedPort precedence
-            // (marker portOverride > port typed into Host > derived v2, auth-fixes T1 / defect A) +
-            // project=<pin>, no auth args (spawns in `none` mode, Flow D). OpenCode folds the executable
-            // and its args into ONE array, so it hand-rolls what AgentConfigBuilders.StdioArgs builds for
-            // the other JSON agents — keep the two in lockstep.
-            var commandArray = new JsonArray
-            {
-                settings.ExecutableFullPath.Replace('\\', '/'),
-                $"{Args.Port}={settings.PinnedPort}",
-                $"{Args.PluginTimeout}={settings.TimeoutMs}",
-                $"{Args.ClientTransportMethod}={TransportMethod.stdio}",
-                $"{Args.Project}={settings.ProjectPin}"
-            };
+            // mcp-authorize b6: credential-free stdio command array — no auth args, so the spawned server
+            // starts in `none` mode (Flow D). The args themselves come from the shared builder; OpenCode's
+            // only difference is that they follow the executable in ONE array instead of a separate `args`.
+            var commandArray = AgentConfigBuilders.StdioArgs(settings);
+            commandArray.Insert(0, JsonValue.Create(settings.ExecutableFullPath.Replace('\\', '/')));
 
             return new JsonAiAgentConfig(AgentName, LocalConfigPath(settings), bodyPath: "mcp", logger: logger)
                 .SetProperty("type", JsonValue.Create("local")!, requiredForConfiguration: true)

--- a/McpPlugin/src/AgentConfig/Impl/OpenCodeConfigurator.cs
+++ b/McpPlugin/src/AgentConfig/Impl/OpenCodeConfigurator.cs
@@ -34,12 +34,15 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Impl
 
         protected override AiAgentConfig CreateStdioConfig(AgentConfiguratorSettings settings, ILogger? logger)
         {
-            // mcp-authorize b6: credential-free, pinned stdio command array — ProjectIdentity port
-            // (marker override wins) + project=<pin>, no auth args (spawns in `none` mode, Flow D).
+            // mcp-authorize b6: credential-free, pinned stdio command array — the PinnedPort precedence
+            // (marker portOverride > port typed into Host > derived v2, auth-fixes T1 / defect A) +
+            // project=<pin>, no auth args (spawns in `none` mode, Flow D). OpenCode folds the executable
+            // and its args into ONE array, so it hand-rolls what AgentConfigBuilders.StdioArgs builds for
+            // the other JSON agents — keep the two in lockstep.
             var commandArray = new JsonArray
             {
                 settings.ExecutableFullPath.Replace('\\', '/'),
-                $"{Args.Port}={settings.ResolvedPort}",
+                $"{Args.Port}={settings.PinnedPort}",
                 $"{Args.PluginTimeout}={settings.TimeoutMs}",
                 $"{Args.ClientTransportMethod}={TransportMethod.stdio}",
                 $"{Args.Project}={settings.ProjectPin}"

--- a/docs/architecture-transport-auth.md
+++ b/docs/architecture-transport-auth.md
@@ -44,7 +44,7 @@
 > **Written config port precedence (auth-fixes T1, defect A).** The port a configurator writes —
 > the stdio `port=` arg and the loopback HTTP `url` alike — is `AgentConfiguratorSettings.PinnedPort`,
 > resolved by three levels: **1.** the project marker's `portOverride`, **2.** an explicit port the
-> user typed into `Host`, **3.** the deterministic v2 derived port. Level 2 exists because the engine
+> user typed into `Host`, **3.** the deterministic v2 derived port. Level 2 exists because **Unity's**
 > binder already binds the typed port (`UnityMcpPluginEditor.Port` returns `uri.Port` whenever `Host`
 > parses with an in-range port) for **both** transports; writing a different port there told the agent
 > to dial one nothing was listening on. `ResolvedPort` supplies levels 1 and 3 only and is **not** what
@@ -52,6 +52,14 @@
 > url applies the port only to a `Local` **loopback** authority (a hosted target keeps its authority —
 > and therefore any typed port — verbatim), while stdio has no authority to preserve and applies the
 > precedence directly, matching the ungated binder.
+>
+> ⚠ **Level 2 is not yet engine-neutral.** Godot's and Unreal's binders deliberately do the OPPOSITE on
+> a loopback host — they ignore a typed loopback port and bind the *derived* port, routing a loopback
+> override through the marker's `portOverride` instead. On a `Local` loopback `Host` carrying a typed
+> port this writer therefore disagrees with both, and each pins the old invariant in a test that fails
+> on their next McpPlugin bump. Reconciling that (a per-engine policy seam here vs. a binder change
+> there) is an owner call, tracked separately from this writer-side change — see
+> `AgentConfiguratorSettings.PinnedPort` § "Residual divergence from the binder".
 
 ## Overview
 

--- a/docs/architecture-transport-auth.md
+++ b/docs/architecture-transport-auth.md
@@ -41,6 +41,18 @@
 > legacy hash; the v2 vectors live alongside in `ProjectIdentity.GoldenVectors.v2.json` (the shared
 > cross-language artifact the engine-CLI ports reproduce). Configurators now emit the v2 pin.
 
+> **Written config port precedence (auth-fixes T1, defect A).** The port a configurator writes —
+> the stdio `port=` arg and the loopback HTTP `url` alike — is `AgentConfiguratorSettings.PinnedPort`,
+> resolved by three levels: **1.** the project marker's `portOverride`, **2.** an explicit port the
+> user typed into `Host`, **3.** the deterministic v2 derived port. Level 2 exists because the engine
+> binder already binds the typed port (`UnityMcpPluginEditor.Port` returns `uri.Port` whenever `Host`
+> parses with an in-range port) for **both** transports; writing a different port there told the agent
+> to dial one nothing was listening on. `ResolvedPort` supplies levels 1 and 3 only and is **not** what
+> the writers emit. The per-transport difference is at the call site, not in the precedence: the HTTP
+> url applies the port only to a `Local` **loopback** authority (a hosted target keeps its authority —
+> and therefore any typed port — verbatim), while stdio has no authority to preserve and applies the
+> precedence directly, matching the ungated binder.
+
 ## Overview
 
 The MCP Plugin Server is configured through **two independent axes**: **Transport** and **Auth**.


### PR DESCRIPTION
## Summary

- PR #174 taught the written **HTTP** url the owner's port precedence but left **stdio** on the old two-level precedence, so a user who typed a custom port and configured over stdio still got a config naming a port the plugin was not listening on. This closes that half.
- The stdio `port=` arg now follows the same three levels: **1.** marker `portOverride` → **2.** explicit port typed into `Host` → **3.** deterministic v2 derived port.
- Renamed `PinnedHttpPort` → `PinnedPort` (transport-neutral) and moved **all three** stdio emitters onto it.

## The stdio precedence now implemented

| level | source | wins over |
|---|---|---|
| 1 | project marker `portOverride` | everything |
| 2 | explicit port typed into `Host` | the derived port |
| 3 | deterministic v2 derived port (`ResolvedPort`) | — (fallback) |

`ResolvedPort` supplies levels 1 and 3 only; it is no longer what any writer emits.

## Why this is a fix, not a regression

The engine binder is **transport-agnostic**: `UnityMcpPluginEditor.Port` returns `uri.Port`
whenever `Host` parses as an absolute URI with an in-range port, and falls back to the derived
port otherwise — for **both** transports (verified at
`UnityMcpPluginEditor.Static.cs:149-158`; there is no loopback or `ConnectionMode` gate on it).

So the server was already listening on the typed port while the **stdio writer** emitted a
different one. The writer was the side that disagreed with the binder; making them agree is the
fix — the same justification as the HTTP half in #174.

## On the rename (`PinnedHttpPort` → `PinnedPort`)

Judgment call, taken deliberately rather than for cosmetics:

- The property's **body was already transport-neutral**. The per-transport difference lives at
  the call site: `BuildPinnedHttpUrl` applies the port only to a `Local` **loopback** authority
  (a hosted target keeps its authority — and therefore any typed port — verbatim), while stdio
  has no authority to preserve and applies the precedence directly, matching the ungated binder.
- It is **unreleased**. `7.2.0` is the latest published version and `PinnedHttpPort` landed
  after it, so no consumer can be referencing it — the rename costs zero compatibility.
- The imminent **7.3.0 cascade** would otherwise freeze a transport-specific name onto a concept
  three stdio emitters now read. A property named `...HttpPort` read by the stdio writers is
  exactly the kind of misleading scoping that let `ResolvedPort` get mixed in the first place.

If you would rather keep the old name, the revert is a pure rename — no behaviour rides on it.

## All three stdio emitters moved, not just `StdioArgs`

The brief named `AgentConfigBuilders.StdioArgs`, but it is **not** the only emitter of the
stdio `port=` arg. Two configurators hand-roll the same arg list and were on the same defect:

- `CodexConfigurator.cs` — TOML-only, so it builds its own `args` array.
- `OpenCodeConfigurator.cs` — folds executable + args into one `command` array.

Fixing only the shared builder would have shipped a half fix leaving Codex and OpenCode users
broken. Both moved, and the new test asserts across **every** real configurator so a future
hand-rolled emitter cannot silently drift.

## `ResolvedPort` / `Port` consumers deliberately left alone

| site | why left alone |
|---|---|
| `CustomConfigurator.cs:72` — displayed stdio JSON snippet uses raw `settings.Port` | Pre-existing, **broader** divergence: that snippet also omits `project=<pin>` entirely. Moving only its port would half-fix it. Squarely task **T3**. |
| `ClaudeCodeConfigurator.cs:53`, `CodexConfigurator.cs:85` — displayed `mcp add` one-liners use raw `settings.Port` | The known **T3** consistency defect (UI shows the user's real port while the button writes another). Out of scope here; flagged, not touched. |
| `DockerCommands.cs:28,36,39` — container name + port mapping use raw `settings.Port` | Docker maps the engine-supplied port; not a written agent-config surface. |
| `ServerLaunchArguments.cs:62` — `port={port}` | Server-launch subsystem, takes an explicit parameter; unrelated to config writing. |

## Cascade follow-up (do not lose)

`Unreal-MCP/bridge/tests/LocalServerPortConsistencyTests.cs:43-86` asserts the **OLD** invariant
(that the written port always equals the derived port). It lives in another repo, was left
untouched per this task's constraints, and **will fail the Unreal release** unless updated in its
own repo during the cascade.

## On the tests named in the brief

Per the lesson carried forward from #174, the named tests were treated as hypotheses:

- **`MarkerPortOverride_PropagatesToWrittenPort_StdioAndHttp` needed no correction** — the marker
  override still wins, so it passed unchanged. It was *strengthened* instead: it now also asserts
  the stdio arg does **not** carry the typed `:50000`. Before this change that held trivially
  (stdio ignored the typed port outright); now it is a real level-1-beats-level-2 assertion.
- **Two assertions did have to change**, because they encoded the stdio defect itself
  (`AllConfigurators_DefaultStdio_...` and `ClaudeCode_NewShapes_ExactContent` both asserted the
  stdio port equals `ResolvedPort` against a host carrying an explicit `:50000`). Both were
  updated to the new precedence and annotated, not weakened.
- One doc comment claimed "the stdio half is unaffected by the host either way" — no longer true,
  corrected.

## Test plan

- [x] Full local gate: `dotnet test` — **553 + 802 tests, both TFMs (net8.0/net9.0), 0 failures**.
- [x] New `StdioPortArg_FollowsTheSameThreeLevelPrecedence_AcrossEveryConfigurator` theory: all
      three levels, including marker `portOverride` **and** a typed `Host` port both present.
- [x] New `StdioPortArg_IsNotGatedOnLoopbackOrConnectionMode` pins the deliberate HTTP/stdio
      gating asymmetry.
- [x] **Negative control**: reverted the three emitters and confirmed the new rows genuinely fail
      (3/6 fail — exactly the typed-port rows; the level-1 and level-3 rows correctly still pass).
- [x] HTTP behaviour from #174 not regressed — its tests pass unchanged apart from the rename.

Closes #175