### PR TITLE
chore(ci): upgrade Node20-deprecated actions to Node24-capable versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,7 +139,7 @@ jobs:
           echo "success=true" >> $GITHUB_OUTPUT
 
       - name: Create Tag and Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.check-version-tag.outputs.version }}
           name: ${{ needs.check-version-tag.outputs.version }}


### PR DESCRIPTION
softprops/action-gh-release: @v2 -> @v3 (1 occurrence, release.yml)

v2 is the last Node20-based release; v3 is a pure runtime bump with no
input/output changes.

All other actions in this repo already sit at or above the sweep targets
(checkout@v5, setup-dotnet@v5, upload-artifact@v7) and were deliberately
left untouched — never downgrade. NuGet/login@v1 and
mukunku/tag-exists-action@v1.7.0 are already Node24.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012WxMrEo6Nk4RCQZjA4LkFC
