### PR TITLE
feat(api): pinned REST tool routes for deterministic multi-project dispatch

### DIFF
--- a/McpPlugin.Server.Tests/PinnedDirectToolAuthGatingTests.cs
+++ b/McpPlugin.Server.Tests/PinnedDirectToolAuthGatingTests.cs
@@ -1,0 +1,323 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.Common;
+using com.IvanMurzak.McpPlugin.Common.Hub.Client;
+using com.IvanMurzak.McpPlugin.Common.Model;
+using com.IvanMurzak.McpPlugin.Common.Utils;
+using com.IvanMurzak.McpPlugin.Server.Api;
+using com.IvanMurzak.McpPlugin.Server.Auth;
+using com.IvanMurzak.McpPlugin.Server.Auth.OAuth;
+using com.IvanMurzak.McpPlugin.Server.Tests.OAuth;
+using com.IvanMurzak.McpPlugin.Server.Webhooks.Services;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.Server.Tests
+{
+    /// <summary>
+    /// 🔒 Auth-gate PARITY for the pinned REST tool routes (design 06 / zero-config-engine-connect b1):
+    /// the pinned group <c>/p/{pin}/api/tools</c> gates IDENTICALLY to the unpinned group
+    /// <c>/api/tools</c> and to the MCP transport — the pin is routing only, never identity. Every
+    /// assertion probes the pinned AND the unpinned route and requires the SAME outcome:
+    /// <list type="bullet">
+    ///   <item>401 when unauthenticated in every credential-bearing mode (oauth / token / required);
+    ///   open only in none mode.</item>
+    ///   <item>A wrong-audience JWT is rejected (the shared <see cref="AccessTokenValidator"/> agent-plane
+    ///   audience check applies to the pinned surface too).</item>
+    ///   <item>A valid PAT via the opaque-token introspection path is accepted.</item>
+    /// </list>
+    /// Because the two groups share the same auth pipeline (<c>UseAuthentication</c> + endpoint
+    /// <c>RequireAuthorization</c>) and the same <see cref="AuthGating"/> decision, the pinned surface can
+    /// never be an unauthenticated bypass — these tests pin that guarantee against regressions.
+    /// </summary>
+    [Collection("McpPlugin.Server")]
+    public sealed class PinnedDirectToolAuthGatingTests
+    {
+        const string Secret = "pinned-rest-gate-secret";
+        const string Pin = "aabbccdd";
+
+        static string PinnedTools => $"/p/{Pin}/api/tools";
+        const string UnpinnedTools = "/api/tools";
+
+        // OAuth resource-server config for the real-validator tests (mirrors AccessTokenValidatorTests).
+        const string Issuer = "https://as.example";
+        const string Resource = "http://localhost:23471";
+        const string Kid = "key-1";
+        static readonly DateTimeOffset Now = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+
+        // ─────────────── 401 parity across credential-bearing modes (no token) ───────────────
+
+        [Fact]
+        public async Task OAuthMode_WithoutToken_PinnedAndUnpinned_Return401()
+        {
+            await using var host = await StartTokenSchemeHostAsync(Consts.MCP.Server.AuthOption.oauth);
+            using var client = NewClient(host);
+
+            (await GetStatusAsync(client, PinnedTools)).ShouldBe(HttpStatusCode.Unauthorized);
+            (await GetStatusAsync(client, UnpinnedTools)).ShouldBe(HttpStatusCode.Unauthorized);
+        }
+
+        [Fact]
+        public async Task TokenMode_WithoutToken_PinnedAndUnpinned_Return401()
+        {
+            await using var host = await StartTokenSchemeHostAsync(Consts.MCP.Server.AuthOption.token);
+            using var client = NewClient(host);
+
+            (await GetStatusAsync(client, PinnedTools)).ShouldBe(HttpStatusCode.Unauthorized);
+            (await GetStatusAsync(client, UnpinnedTools)).ShouldBe(HttpStatusCode.Unauthorized);
+        }
+
+        [Fact]
+        public async Task RequiredAliasMode_WithoutToken_PinnedAndUnpinned_Return401()
+        {
+            await using var host = await StartTokenSchemeHostAsync(Consts.MCP.Server.AuthOption.required);
+            using var client = NewClient(host);
+
+            (await GetStatusAsync(client, PinnedTools)).ShouldBe(HttpStatusCode.Unauthorized);
+            (await GetStatusAsync(client, UnpinnedTools)).ShouldBe(HttpStatusCode.Unauthorized);
+        }
+
+        [Fact]
+        public async Task TokenMode_WithValidToken_PinnedAndUnpinned_AreReachable()
+        {
+            await using var host = await StartTokenSchemeHostAsync(Consts.MCP.Server.AuthOption.token);
+            using var client = NewClient(host);
+
+            (await GetStatusAsync(client, PinnedTools, bearer: Secret)).ShouldBe(HttpStatusCode.OK);
+            (await GetStatusAsync(client, UnpinnedTools, bearer: Secret)).ShouldBe(HttpStatusCode.OK);
+        }
+
+        [Fact]
+        public async Task NoneMode_WithoutToken_PinnedAndUnpinned_AreOpen()
+        {
+            await using var host = await StartTokenSchemeHostAsync(Consts.MCP.Server.AuthOption.none);
+            using var client = NewClient(host);
+
+            (await GetStatusAsync(client, PinnedTools)).ShouldBe(HttpStatusCode.OK);
+            (await GetStatusAsync(client, UnpinnedTools)).ShouldBe(HttpStatusCode.OK);
+        }
+
+        // ─────────────── OAuth real-validator parity: wrong-audience JWT + PAT introspection ───────────────
+
+        [Fact]
+        public async Task OAuthMode_WrongAudienceJwt_PinnedAndUnpinned_Rejected401()
+        {
+            using var key = TestJwt.CreateKey();
+            var validator = new AccessTokenValidator(
+                new OAuthResourceServerConfig(Issuer, Resource),
+                new FakeJwksKeyProvider().Add(Kid, key),
+                FakeIntrospectionClient.AlwaysInactive,
+                () => Now);
+            await using var host = await StartOAuthHostAsync(validator, new OAuthResourceServerConfig(Issuer, Resource));
+            using var client = NewClient(host);
+
+            // Correctly signed, unexpired ES256 JWT — but audienced to the WRONG resource → rejected.
+            var wrongAud = TestJwt.SignEs256(key, Kid, TestJwt.Claims(Issuer, "http://localhost:59999", Now.AddHours(1)));
+
+            (await GetStatusAsync(client, PinnedTools, bearer: wrongAud)).ShouldBe(HttpStatusCode.Unauthorized);
+            (await GetStatusAsync(client, UnpinnedTools, bearer: wrongAud)).ShouldBe(HttpStatusCode.Unauthorized);
+        }
+
+        [Fact]
+        public async Task OAuthMode_ValidJwt_PinnedAndUnpinned_AreReachable()
+        {
+            // Positive control: a JWT audienced to the canonical resource is accepted on BOTH surfaces.
+            using var key = TestJwt.CreateKey();
+            var validator = new AccessTokenValidator(
+                new OAuthResourceServerConfig(Issuer, Resource),
+                new FakeJwksKeyProvider().Add(Kid, key),
+                FakeIntrospectionClient.AlwaysInactive,
+                () => Now);
+            await using var host = await StartOAuthHostAsync(validator, new OAuthResourceServerConfig(Issuer, Resource));
+            using var client = NewClient(host);
+
+            var goodJwt = TestJwt.SignEs256(key, Kid, TestJwt.Claims(Issuer, Resource, Now.AddHours(1)));
+
+            (await GetStatusAsync(client, PinnedTools, bearer: goodJwt)).ShouldBe(HttpStatusCode.OK);
+            (await GetStatusAsync(client, UnpinnedTools, bearer: goodJwt)).ShouldBe(HttpStatusCode.OK);
+        }
+
+        [Fact]
+        public async Task OAuthMode_ValidPatViaIntrospection_PinnedAndUnpinned_AreReachable()
+        {
+            using var key = TestJwt.CreateKey();
+            const string Pat = "agd_pat_abc";
+            var introspection = new FakeIntrospectionClient(t =>
+                t == Pat ? new IntrospectionResult(true, "pat-user", "mcp:agent", Now.AddHours(1)) : IntrospectionResult.Inactive);
+            var validator = new AccessTokenValidator(
+                new OAuthResourceServerConfig(Issuer, Resource),
+                new FakeJwksKeyProvider().Add(Kid, key),
+                introspection,
+                () => Now);
+            await using var host = await StartOAuthHostAsync(validator, new OAuthResourceServerConfig(Issuer, Resource));
+            using var client = NewClient(host);
+
+            (await GetStatusAsync(client, PinnedTools, bearer: Pat)).ShouldBe(HttpStatusCode.OK);
+            (await GetStatusAsync(client, UnpinnedTools, bearer: Pat)).ShouldBe(HttpStatusCode.OK);
+        }
+
+        [Fact]
+        public async Task OAuthMode_InactivePat_PinnedAndUnpinned_Rejected401()
+        {
+            using var key = TestJwt.CreateKey();
+            var validator = new AccessTokenValidator(
+                new OAuthResourceServerConfig(Issuer, Resource),
+                new FakeJwksKeyProvider().Add(Kid, key),
+                FakeIntrospectionClient.AlwaysInactive, // every opaque token introspects as inactive
+                () => Now);
+            await using var host = await StartOAuthHostAsync(validator, new OAuthResourceServerConfig(Issuer, Resource));
+            using var client = NewClient(host);
+
+            (await GetStatusAsync(client, PinnedTools, bearer: "agd_pat_unknown")).ShouldBe(HttpStatusCode.Unauthorized);
+            (await GetStatusAsync(client, UnpinnedTools, bearer: "agd_pat_unknown")).ShouldBe(HttpStatusCode.Unauthorized);
+        }
+
+        // ───────────────────────────────── helpers ─────────────────────────────────
+
+        static HttpClient NewClient(RunningHost host) => new HttpClient { BaseAddress = new Uri(host.BaseUrl) };
+
+        static async Task<HttpStatusCode> GetStatusAsync(HttpClient client, string route, string? bearer = null)
+        {
+            using var req = new HttpRequestMessage(HttpMethod.Get, route);
+            if (bearer != null)
+                req.Headers.TryAddWithoutValidation("Authorization", $"Bearer {bearer}");
+            using var resp = await client.SendAsync(req);
+            return resp.StatusCode;
+        }
+
+        // Token-scheme host — mirrors DirectToolEndpointsAuthGatingTests but ALSO maps the pinned group.
+        static async Task<RunningHost> StartTokenSchemeHostAsync(Consts.MCP.Server.AuthOption authOption)
+        {
+            var builder = WebApplication.CreateBuilder();
+            builder.Logging.ClearProviders();
+
+            var dataArguments = Mock.Of<IDataArguments>(d => d.Authorization == authOption);
+            builder.Services.AddSingleton(dataArguments);
+            builder.Services.AddSingleton<IClientToolHub>(new StubToolHub());
+            builder.Services.AddSingleton<IClientSystemToolHub>(new StubSystemToolHub());
+            builder.Services.AddSingleton(Mock.Of<IAuthorizationWebhookService>());
+
+            var localTokenMode = authOption == Consts.MCP.Server.AuthOption.token
+                || authOption == Consts.MCP.Server.AuthOption.required;
+
+            builder.Services
+                .AddAuthentication(TokenAuthenticationHandler.SchemeName)
+                .AddScheme<TokenAuthenticationOptions, TokenAuthenticationHandler>(
+                    TokenAuthenticationHandler.SchemeName,
+                    options =>
+                    {
+                        options.OAuthMode = authOption == Consts.MCP.Server.AuthOption.oauth;
+                        options.LocalTokenMode = localTokenMode;
+                        if (localTokenMode)
+                            options.LocalToken = Secret;
+                    });
+            builder.Services.AddAuthorization();
+
+            var app = builder.Build();
+            app.Urls.Add("http://127.0.0.1:0");
+            app.UseAuthentication();
+            app.UseAuthorization();
+            app.MapDirectToolCallApi(dataArguments);
+            app.MapPinnedDirectToolCallApi(dataArguments);
+
+            await app.StartAsync();
+            return new RunningHost(app, app.Urls.First());
+        }
+
+        // OAuth host wired with a REAL AccessTokenValidator (hermetic JWKS + introspection fakes), so the
+        // wrong-audience / PAT-introspection behavior on the pinned surface is the genuine production path.
+        static async Task<RunningHost> StartOAuthHostAsync(IOAuthTokenValidator validator, OAuthResourceServerConfig config)
+        {
+            var builder = WebApplication.CreateBuilder();
+            builder.Logging.ClearProviders();
+
+            var dataArguments = Mock.Of<IDataArguments>(d => d.Authorization == Consts.MCP.Server.AuthOption.oauth);
+            builder.Services.AddSingleton(dataArguments);
+            builder.Services.AddSingleton<IClientToolHub>(new StubToolHub());
+            builder.Services.AddSingleton<IClientSystemToolHub>(new StubSystemToolHub());
+            // The OAuth auth path calls IAuthorizationWebhookService.AuthorizeAiAgentAsync after a valid token;
+            // use the NoOp (returns true) — a bare Moq mock returns a null Task, which would throw on await.
+            builder.Services.AddSingleton<IAuthorizationWebhookService>(new NoOpAuthorizationWebhookService());
+            builder.Services.AddSingleton(validator);
+            builder.Services.AddSingleton(config);
+
+            builder.Services
+                .AddAuthentication(TokenAuthenticationHandler.SchemeName)
+                .AddScheme<TokenAuthenticationOptions, TokenAuthenticationHandler>(
+                    TokenAuthenticationHandler.SchemeName,
+                    options => { options.OAuthMode = true; });
+            builder.Services.AddAuthorization();
+
+            var app = builder.Build();
+            app.Urls.Add("http://127.0.0.1:0");
+            app.UseAuthentication();
+            app.UseAuthorization();
+            app.MapDirectToolCallApi(dataArguments);
+            app.MapPinnedDirectToolCallApi(dataArguments);
+
+            await app.StartAsync();
+            return new RunningHost(app, app.Urls.First());
+        }
+
+        sealed class RunningHost : IAsyncDisposable
+        {
+            readonly WebApplication _app;
+            public string BaseUrl { get; }
+
+            public RunningHost(WebApplication app, string baseUrl)
+            {
+                _app = app;
+                BaseUrl = baseUrl;
+            }
+
+            public async ValueTask DisposeAsync()
+            {
+                await _app.StopAsync();
+                await _app.DisposeAsync();
+            }
+        }
+
+        sealed class StubToolHub : IClientToolHub
+        {
+            public Task<ResponseData<ResponseCallTool>> RunCallTool(RequestCallTool request)
+                => Task.FromResult(ResponseData<ResponseCallTool>.Success(request.RequestID));
+
+            public Task<ResponseData<ResponseListTool[]>> RunListTool(RequestListTool request, CancellationToken cancellationToken = default)
+                => Task.FromResult(new ResponseData<ResponseListTool[]>(request.RequestID, ResponseStatus.Success)
+                {
+                    Value = Array.Empty<ResponseListTool>()
+                });
+        }
+
+        sealed class StubSystemToolHub : IClientSystemToolHub
+        {
+            public Task<ResponseData<ResponseCallTool>> RunSystemTool(RequestCallTool request, CancellationToken cancellationToken = default)
+                => Task.FromResult(ResponseData<ResponseCallTool>.Success(request.RequestID));
+
+            public Task<ResponseData<ResponseListTool[]>> RunListSystemTool(RequestListTool request, CancellationToken cancellationToken = default)
+                => Task.FromResult(new ResponseData<ResponseListTool[]>(request.RequestID, ResponseStatus.Success)
+                {
+                    Value = Array.Empty<ResponseListTool>()
+                });
+        }
+    }
+}

--- a/McpPlugin.Server.Tests/PinnedDirectToolRoutingTests.cs
+++ b/McpPlugin.Server.Tests/PinnedDirectToolRoutingTests.cs
@@ -1,0 +1,312 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.Common;
+using com.IvanMurzak.McpPlugin.Common.Hub.Client;
+using com.IvanMurzak.McpPlugin.Common.Model;
+using com.IvanMurzak.McpPlugin.Common.Utils;
+using com.IvanMurzak.McpPlugin.Server.Api;
+using com.IvanMurzak.McpPlugin.Server.Auth;
+using com.IvanMurzak.McpPlugin.Server.Strategy;
+using com.IvanMurzak.McpPlugin.Server.Webhooks.Services;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.Server.Tests
+{
+    /// <summary>
+    /// 📌 Pinned REST tool routes (design 06 / zero-config-engine-connect b1). The pinned group
+    /// <c>GET /p/{pin}/api/tools</c> + <c>POST /p/{pin}/api/tools/{name}</c> resolves the (account, pin)
+    /// bucket STRICTLY by pin: a pin never falls through — a wrong pin returns <c>NoMatchPinned</c> even
+    /// when the account HAS sibling instances (never MRU-routed), and an empty account returns
+    /// <c>AccountEmpty</c>. The UNPINNED group is byte-identical wiring but still falls to MRU (the
+    /// contrast that proves the pinned group is strict). There is deliberately NO pinned system-tools
+    /// route (design 06 D15). These drive a REAL loopback host through the production
+    /// <see cref="McpSessionTokenMiddleware"/> so the pin is captured live from the pinned request path
+    /// exactly as in prod; the tool hub reports the outcome of the real <see cref="AccountInstances.Resolve"/>.
+    /// </summary>
+    [Collection("McpPlugin.Server")]
+    public sealed class PinnedDirectToolRoutingTests
+    {
+        // pin = leading hex prefix of the project-path SHA-256 (McpSessionTokenMiddleware validates 1–64 hex).
+        const string HashA = "aabbccdd11223344556677889900aabbccddeeff00112233445566778899aabb";
+        const string PinA = "aabbccdd";
+        const string HashB = "11223344aabbccdd556677889900aabbccddeeff00112233445566778899aabb";
+        const string PinB = "11223344";
+        const string WrongPin = "deadbeef";
+        const string Account = "acc-pinned";
+        const string InstanceA = "instance-A";
+        const string InstanceB = "instance-B";
+
+        // ─────────────────── GET list path — strict pin → the pinned project's instance ───────────────────
+
+        [Fact]
+        public async Task PinnedList_ResolvesStrictlyToTheMatchingInstance()
+        {
+            var instances = TwoInstanceRegistry();
+            await using var host = await StartHostAsync(instances);
+            using var client = NewClient(host);
+
+            // Each pin resolves ONLY to its own project's instance — never the sibling.
+            (await ListOutcomeAsync(client, $"/p/{PinA}/api/tools")).ShouldBe(InstanceA);
+            (await ListOutcomeAsync(client, $"/p/{PinB}/api/tools")).ShouldBe(InstanceB);
+        }
+
+        [Fact]
+        public async Task PinnedList_WrongPinWithSiblingsPresent_NoMatchPinned_NeverMru()
+        {
+            // The account HAS two live instances, but neither matches the pin. A pin NEVER falls through to
+            // a sibling (never MRU): the strict outcome is NoMatchPinned, not a routed instance id.
+            var instances = TwoInstanceRegistry();
+            await using var host = await StartHostAsync(instances);
+            using var client = NewClient(host);
+
+            (await ListOutcomeAsync(client, $"/p/{WrongPin}/api/tools")).ShouldBe("NoMatchPinned");
+        }
+
+        [Fact]
+        public async Task PinnedList_EmptyAccount_AccountEmpty()
+        {
+            var instances = new AccountInstances(); // account has NO live instances at all
+            await using var host = await StartHostAsync(instances);
+            using var client = NewClient(host);
+
+            (await ListOutcomeAsync(client, $"/p/{PinA}/api/tools")).ShouldBe("AccountEmpty");
+        }
+
+        [Fact]
+        public async Task UnpinnedList_MultipleInstances_FallsToMru_ProvesPinnedStrictnessContrast()
+        {
+            // Regression / contrast: the UNPINNED group carries no pin, so it resolves to MRU (one of the
+            // live instances) — NEVER NoMatchPinned/AccountEmpty. This is exactly the ambiguity the pinned
+            // group removes; the pinned tests above prove the pinned group does NOT do this.
+            var instances = TwoInstanceRegistry();
+            await using var host = await StartHostAsync(instances);
+            using var client = NewClient(host);
+
+            var outcome = await ListOutcomeAsync(client, "/api/tools");
+            new[] { InstanceA, InstanceB }.ShouldContain(outcome);
+        }
+
+        // ─────────────────── POST call path — outcome → deterministic HTTP status ───────────────────
+
+        [Fact]
+        public async Task PinnedCall_MatchingPin_Resolves_200()
+        {
+            var instances = TwoInstanceRegistry();
+            await using var host = await StartHostAsync(instances);
+            using var client = NewClient(host);
+
+            using var resp = await CallAsync(client, $"/p/{PinA}/api/tools/ping");
+            resp.StatusCode.ShouldBe(HttpStatusCode.OK);
+        }
+
+        [Fact]
+        public async Task PinnedCall_WrongPinWithSiblingsPresent_NoMatchPinned_404_NeverMru()
+        {
+            var instances = TwoInstanceRegistry();
+            await using var host = await StartHostAsync(instances);
+            using var client = NewClient(host);
+
+            using var resp = await CallAsync(client, $"/p/{WrongPin}/api/tools/ping");
+            resp.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+            (await resp.Content.ReadAsStringAsync()).ShouldContain("NoMatchPinned");
+        }
+
+        [Fact]
+        public async Task PinnedCall_EmptyAccount_AccountEmpty_503()
+        {
+            var instances = new AccountInstances();
+            await using var host = await StartHostAsync(instances);
+            using var client = NewClient(host);
+
+            using var resp = await CallAsync(client, $"/p/{PinA}/api/tools/ping");
+            resp.StatusCode.ShouldBe(HttpStatusCode.ServiceUnavailable);
+            (await resp.Content.ReadAsStringAsync()).ShouldContain("AccountEmpty");
+        }
+
+        // ─────────────────── Route set (design 06 D15) — no pinned system-tools analog ───────────────────
+
+        [Fact]
+        public async Task NoPinnedSystemToolsRoute_Exists()
+        {
+            var instances = TwoInstanceRegistry();
+            await using var host = await StartHostAsync(instances);
+            using var client = NewClient(host);
+
+            // Control: the UNPINNED system-tools route IS mapped (reachable, not 404, in none mode).
+            (await client.GetAsync("/api/system-tools")).StatusCode.ShouldNotBe(HttpStatusCode.NotFound);
+
+            // The pinned surface has NO system-tools analog — both list and call 404 (the route is not mapped).
+            (await client.GetAsync($"/p/{PinA}/api/system-tools")).StatusCode.ShouldBe(HttpStatusCode.NotFound);
+            using var post = await CallAsync(client, $"/p/{PinA}/api/system-tools/ping");
+            post.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+        }
+
+        // ───────────────────────────────── helpers ─────────────────────────────────
+
+        static AccountInstances TwoInstanceRegistry()
+        {
+            var instances = new AccountInstances();
+            instances.Register(Account, new PluginInstanceMetadata(InstanceA, "unity", "GameA", HashA, "PC-1"), "conn-A");
+            instances.Register(Account, new PluginInstanceMetadata(InstanceB, "godot", "GameB", HashB, "PC-2"), "conn-B");
+            return instances;
+        }
+
+        static HttpClient NewClient(RunningHost host) => new HttpClient { BaseAddress = new Uri(host.BaseUrl) };
+
+        /// <summary>GET the (pinned or unpinned) list route and read back the single reported outcome name.</summary>
+        static async Task<string?> ListOutcomeAsync(HttpClient client, string route)
+        {
+            using var resp = await client.GetAsync(route);
+            resp.StatusCode.ShouldBe(HttpStatusCode.OK, $"{route} must reach the list handler (mapped route)");
+            using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+            doc.RootElement.GetArrayLength().ShouldBe(1);
+            return doc.RootElement[0].GetProperty("name").GetString();
+        }
+
+        static Task<HttpResponseMessage> CallAsync(HttpClient client, string route)
+            => client.PostAsync(route, new StringContent("{}", Encoding.UTF8, "application/json"));
+
+        // ── Minimal in-memory host: the pin-capture middleware + both tool-call groups + system-tools. ──
+
+        static async Task<RunningHost> StartHostAsync(AccountInstances instances)
+        {
+            var builder = WebApplication.CreateBuilder();
+            builder.Logging.ClearProviders();
+
+            // none mode: no auth gate — this suite isolates the ROUTING/RESOLUTION behavior (auth parity
+            // is covered by PinnedDirectToolAuthGatingTests).
+            var dataArguments = Mock.Of<IDataArguments>(d => d.Authorization == Consts.MCP.Server.AuthOption.none);
+            builder.Services.AddSingleton(dataArguments);
+            builder.Services.AddSingleton<IClientToolHub>(new ResolutionReportingToolHub(instances, Account));
+            builder.Services.AddSingleton<IClientSystemToolHub>(new StubSystemToolHub());
+            builder.Services.AddSingleton(Mock.Of<IAuthorizationWebhookService>());
+
+            var app = builder.Build();
+            app.Urls.Add("http://127.0.0.1:0"); // OS-assigned loopback port
+            // Production pin-capture middleware: parses /p/<pin> out of the request path into the ambient
+            // McpSessionTokenContext, exactly as UseMcpPluginServer wires it in prod.
+            app.UseMiddleware<McpSessionTokenMiddleware>();
+            app.MapDirectToolCallApi(dataArguments);       // unpinned group
+            app.MapPinnedDirectToolCallApi(dataArguments); // pinned group (under test)
+            app.MapSystemToolApi(dataArguments);           // to prove there is NO pinned system-tools analog
+
+            await app.StartAsync();
+            return new RunningHost(app, app.Urls.First());
+        }
+
+        sealed class RunningHost : IAsyncDisposable
+        {
+            readonly WebApplication _app;
+            public string BaseUrl { get; }
+
+            public RunningHost(WebApplication app, string baseUrl)
+            {
+                _app = app;
+                BaseUrl = baseUrl;
+            }
+
+            public async ValueTask DisposeAsync()
+            {
+                await _app.StopAsync();
+                await _app.DisposeAsync();
+            }
+        }
+
+        /// <summary>
+        /// A tool hub that, instead of invoking a live plugin over SignalR, resolves the CURRENT request
+        /// against the real <see cref="AccountInstances"/> using the pin the middleware captured from the
+        /// path, and reports the resolution outcome (resolved instance id, or <c>NoMatchPinned</c>/
+        /// <c>AccountEmpty</c>) as the tool result. This exercises the exact production seam the pinned
+        /// routes wire up: pinned URL → <see cref="McpSessionTokenMiddleware"/> → ambient
+        /// <see cref="McpSessionTokenContext.CurrentProjectPin"/> → strict <see cref="AccountInstances.Resolve"/>.
+        /// </summary>
+        sealed class ResolutionReportingToolHub : IClientToolHub
+        {
+            readonly AccountInstances _instances;
+            readonly string _account;
+
+            public ResolutionReportingToolHub(AccountInstances instances, string account)
+            {
+                _instances = instances;
+                _account = account;
+            }
+
+            InstanceResolution Resolve() => _instances.Resolve(
+                _account,
+                McpSessionTokenContext.CurrentProjectPin,
+                McpSessionTokenContext.CurrentSelectedInstanceId);
+
+            static string OutcomeName(InstanceResolution r) => r.Kind switch
+            {
+                InstanceResolutionKind.Resolved => r.Instance!.InstanceId,
+                InstanceResolutionKind.NoMatchPinned => "NoMatchPinned",
+                _ => "AccountEmpty"
+            };
+
+            public Task<ResponseData<ResponseListTool[]>> RunListTool(RequestListTool request, CancellationToken cancellationToken = default)
+                => Task.FromResult(new ResponseData<ResponseListTool[]>(request.RequestID, ResponseStatus.Success)
+                {
+                    Value = new[]
+                    {
+                        new ResponseListTool
+                        {
+                            Name = OutcomeName(Resolve()),
+                            Enabled = true,
+                            InputSchema = Consts.MCP.EmptyInputSchema
+                        }
+                    }
+                });
+
+            public Task<ResponseData<ResponseCallTool>> RunCallTool(RequestCallTool request)
+            {
+                var resolution = Resolve();
+                return Task.FromResult(resolution.Kind switch
+                {
+                    InstanceResolutionKind.Resolved =>
+                        ResponseData<ResponseCallTool>.Success(request.RequestID)
+                            .SetData(ResponseCallTool.Success(resolution.Instance!.InstanceId)),
+                    InstanceResolutionKind.NoMatchPinned =>
+                        ResponseData<ResponseCallTool>.Error(request.RequestID, "NoMatchPinned", ResponseErrorKind.NotFound)
+                            .SetData(ResponseCallTool.Error("NoMatchPinned", ResponseErrorKind.NotFound)),
+                    _ =>
+                        ResponseData<ResponseCallTool>.Error(request.RequestID, "AccountEmpty", ResponseErrorKind.Unavailable)
+                            .SetData(ResponseCallTool.Error("AccountEmpty", ResponseErrorKind.Unavailable)),
+                });
+            }
+        }
+
+        sealed class StubSystemToolHub : IClientSystemToolHub
+        {
+            public Task<ResponseData<ResponseCallTool>> RunSystemTool(RequestCallTool request, CancellationToken cancellationToken = default)
+                => Task.FromResult(ResponseData<ResponseCallTool>.Success(request.RequestID));
+
+            public Task<ResponseData<ResponseListTool[]>> RunListSystemTool(RequestListTool request, CancellationToken cancellationToken = default)
+                => Task.FromResult(new ResponseData<ResponseListTool[]>(request.RequestID, ResponseStatus.Success)
+                {
+                    Value = Array.Empty<ResponseListTool>()
+                });
+        }
+    }
+}

--- a/McpPlugin.Server/src/Api/DirectToolCallEndpoints.cs
+++ b/McpPlugin.Server/src/Api/DirectToolCallEndpoints.cs
@@ -29,16 +29,39 @@ namespace com.IvanMurzak.McpPlugin.Server.Api
     /// Provides a direct HTTP API for calling MCP tools without going through the full MCP protocol.
     /// This enables AI agents and automation scripts to invoke tools using standard HTTP/JSON (e.g., curl).
     ///
-    /// Endpoints:
+    /// Endpoints (unpinned group):
     ///   GET  /api/tools           — list all available tools with schemas
     ///   POST /api/tools/{name}    — execute a named tool with JSON arguments
+    ///
+    /// Endpoints (project-pinned group — design 06 / zero-config-engine-connect b1):
+    ///   GET  /p/{pin}/api/tools        — list tools for the pinned project's engine instance
+    ///   POST /p/{pin}/api/tools/{name} — execute a named tool against the pinned project's instance
+    ///
+    /// The pinned group makes multi-project tool dispatch deterministic: with 2+ engine instances on one
+    /// account the unpinned group resolves via <c>sticky → single → MRU</c> (<c>AccountInstances.Resolve</c>)
+    /// and can bind the agent to the wrong project, while the pinned group resolves STRICTLY by pin (a pin
+    /// never falls through to another project — an unmatched pin yields <c>NoMatchPinned</c>/<c>AccountEmpty</c>,
+    /// never MRU). The pin is a route token only; its value is captured from the ORIGINAL request path by
+    /// <see cref="Auth.McpSessionTokenMiddleware"/> and flows through the ambient session context to
+    /// <c>AccountMcpStrategy.ResolveCurrentSession</c> — so the two groups share the SAME handlers and
+    /// resolution mechanism, differing only in whether a pin is present on the path. There is deliberately
+    /// NO pinned system-tools route (design 06 D15). The public <c>/mcp/p/{pin}/…</c> form is served by the
+    /// same routes after nginx strips the <c>/mcp</c> prefix (mirroring the existing unpinned convention,
+    /// where nginx strips <c>/mcp</c> ahead of <c>/api/tools</c>).
     /// </summary>
     public static class DirectToolCallEndpoints
     {
         const string RoutePrefix = "/api/tools";
 
+        // The project-pinned variant of RoutePrefix. {pin} is a route token only so the endpoint matches;
+        // the pin VALUE is captured from the original path by McpSessionTokenMiddleware, exactly like the
+        // pinned MCP routes (StreamableHttpTransportLayer.MapPinnedMcp). No route constraint on {pin} — the
+        // middleware validates it loosely (1–64 hex) and ignores a malformed segment, matching the MCP path.
+        const string PinnedRoutePrefix = "/p/{pin}" + RoutePrefix;
+
         /// <summary>
-        /// Maps the direct tool call API endpoints onto the given <see cref="WebApplication"/>.
+        /// Maps the UNPINNED direct tool call API endpoints (<c>/api/tools</c>) onto the given
+        /// <see cref="WebApplication"/>.
         /// Authorization is required in every credential-bearing mode — <see cref="Consts.MCP.Server.AuthOption.oauth"/>,
         /// the offline <see cref="Consts.MCP.Server.AuthOption.token"/> (mcp-authorize g6), and the deprecated
         /// <see cref="Consts.MCP.Server.AuthOption.required"/> alias — so the REST tool surface (which can EXECUTE
@@ -48,6 +71,35 @@ namespace com.IvanMurzak.McpPlugin.Server.Api
         /// </summary>
         public static WebApplication MapDirectToolCallApi(this WebApplication app, IDataArguments dataArguments)
         {
+            MapToolCallGroup(app, dataArguments, RoutePrefix);
+            return app;
+        }
+
+        /// <summary>
+        /// Maps the PROJECT-PINNED direct tool call API endpoints (<c>/p/{pin}/api/tools</c>) onto the given
+        /// <see cref="WebApplication"/> (design 06 / zero-config-engine-connect b1). Registered alongside — and
+        /// byte-identical in behavior to — the unpinned group (both delegate to <see cref="MapToolCallGroup"/>
+        /// with the SAME handlers and the SAME auth gate); the ONLY difference is the route prefix carries a
+        /// <c>{pin}</c> segment, which <see cref="Auth.McpSessionTokenMiddleware"/> captures from the request path
+        /// so tool resolution is pinned STRICTLY to that project's engine instance (never MRU-routed to a sibling).
+        /// There is deliberately no pinned system-tools analog (design 06 D15).
+        /// </summary>
+        public static WebApplication MapPinnedDirectToolCallApi(this WebApplication app, IDataArguments dataArguments)
+        {
+            MapToolCallGroup(app, dataArguments, PinnedRoutePrefix);
+            return app;
+        }
+
+        /// <summary>
+        /// Shared registrar for a direct tool-call route group. Both the unpinned (<c>/api/tools</c>) and the
+        /// project-pinned (<c>/p/{pin}/api/tools</c>) groups route through this ONE method with the SAME list/call
+        /// handlers and the SAME <see cref="AuthGating"/> decision, so they are byte-identical in behavior by
+        /// construction — the pinned group differs only by the <c>{pin}</c> path token (captured by the middleware,
+        /// not read here). Keeping the auth gate in lockstep guarantees a credential-bearing mode can never leave
+        /// one group gated and the other open.
+        /// </summary>
+        static void MapToolCallGroup(WebApplication app, IDataArguments dataArguments, string routePrefix)
+        {
             if (app == null)
                 throw new ArgumentNullException(nameof(app));
 
@@ -55,12 +107,12 @@ namespace com.IvanMurzak.McpPlugin.Server.Api
                 throw new ArgumentNullException(nameof(dataArguments));
 
             var requireAuth = AuthGating.RequiresAuthorization(dataArguments.Authorization);
-            var group = app.MapGroup(RoutePrefix);
+            var group = app.MapGroup(routePrefix);
 
-            // GET /api/tools — list all registered tools
+            // GET <prefix> — list all registered tools
             var listEndpoint = group.MapGet("/", ListToolsHandler);
 
-            // POST /api/tools/{name} — invoke a tool by name
+            // POST <prefix>/{name} — invoke a tool by name
             var callEndpoint = group.MapPost("/{name}", CallToolHandler);
 
             if (requireAuth)
@@ -68,8 +120,6 @@ namespace com.IvanMurzak.McpPlugin.Server.Api
                 listEndpoint.RequireAuthorization();
                 callEndpoint.RequireAuthorization();
             }
-
-            return app;
         }
 
         /// <summary>

--- a/McpPlugin.Server/src/Extension/ExtensionsWebApplication.cs
+++ b/McpPlugin.Server/src/Extension/ExtensionsWebApplication.cs
@@ -70,6 +70,11 @@ namespace com.IvanMurzak.McpPlugin.Server
 
             // Setup direct tool call API (POST /api/tools/{name}, GET /api/tools)
             app.MapDirectToolCallApi(dataArguments);
+            // Setup project-pinned direct tool call API (POST /p/{pin}/api/tools/{name}, GET /p/{pin}/api/tools) —
+            // deterministic multi-project dispatch (design 06 / zero-config-engine-connect b1). Same handlers +
+            // auth gate as the unpinned group; the pin (captured by McpSessionTokenMiddleware) makes resolution
+            // strict-by-project. No pinned system-tools analog (design 06 D15) — the system-tools mapping below is untouched.
+            app.MapPinnedDirectToolCallApi(dataArguments);
             // Setup system tool API (POST /api/system-tools/{name}) — internal tools not exposed to MCP
             app.MapSystemToolApi(dataArguments);
 

--- a/docs/architecture-transport-auth.md
+++ b/docs/architecture-transport-auth.md
@@ -19,6 +19,19 @@
 > previously gated on the deleted `required` mode and were unintentionally never gated), and stay
 > open in `none` mode.
 
+> **Pinned REST tool routes (zero-config-engine-connect b1).** The direct-tool REST surface gained a
+> project-pinned variant registered ALONGSIDE the unpinned group:
+> `GET /p/{pin}/api/tools` + `POST /p/{pin}/api/tools/{name}`
+> (`DirectToolCallEndpoints.MapPinnedDirectToolCallApi`, mapped in `ExtensionsWebApplication`). With 2+
+> engine instances on one account the unpinned group resolves `sticky → single → MRU` and can bind an
+> agent to the wrong project; the pinned group resolves **strictly by pin** — a pin never falls through, so
+> an unmatched pin yields `NoMatchPinned`/`AccountEmpty` (never MRU). The pin is routing only: captured from
+> the request path by `McpSessionTokenMiddleware` and flowed to `AccountMcpStrategy.ResolveCurrentSession`,
+> so the pinned group shares the SAME handlers and the SAME auth gate as the unpinned one (identical
+> `oauth`/`token`/`required` gating; open only in `none`). There is deliberately **no pinned system-tools
+> route**. The public `/mcp/p/{pin}/…` form is served by these same routes after nginx strips the `/mcp`
+> prefix (mirroring the existing unpinned convention where nginx strips `/mcp` ahead of `/api/tools`).
+
 > **Offline token mode (mcp-authorize g6).** A third auth mode, **`token`**, is the OFFLINE
 > counterpart of `oauth`: a loopback single-project server gates BOTH the SignalR plugin connection
 > and the streamableHttp MCP endpoint on a single static bearer secret (`--token` /


### PR DESCRIPTION
## Summary
- Add a project-pinned variant of the direct-tool REST API alongside the unpinned group: `GET /p/{pin}/api/tools` (list) + `POST /p/{pin}/api/tools/{name}` (call), registered in `ExtensionsWebApplication`.
- Both groups route through one shared `MapToolCallGroup` helper (same handlers + same `AuthGating` decision), so the unpinned group is byte-identical by construction; the pinned group differs only by the `{pin}` path token that `McpSessionTokenMiddleware` captures, making tool resolution strict-by-project (`NoMatchPinned`/`AccountEmpty`, **never** MRU) via `AccountMcpStrategy`.
- No pinned system-tools route (design 06 D15). The public `/mcp/p/{pin}/…` form is served by these same routes after nginx strips `/mcp` (mirroring the existing unpinned convention).
- Doc: `architecture-transport-auth.md` gains a pinned-routes callout.

## Test plan
- [x] Target-specific local tests passed (see profile test.md): full xUnit suite green — 570 `McpPlugin.Server.Tests` + 802 `McpPlugin.Tests`, on **both** `net8.0` and `net9.0`, 0 failures.
- [x] Strict-pin resolution: matched pin → the pinned instance; wrong pin with siblings → `NoMatchPinned` (never MRU); empty account → `AccountEmpty`; unpinned group still falls to MRU (contrast).
- [x] Auth-gate parity (pinned == unpinned): 401 unauthenticated in oauth/token/required; wrong-audience JWT rejected; valid PAT via introspection reachable (real `AccessTokenValidator` with hermetic JWKS/introspection fakes).
- [x] No pinned system-tools route (`/p/{pin}/api/system-tools` → 404); unpinned system-tools untouched.
- [x] Unpinned group byte-identical — existing `DirectToolEndpoints*` tests remain green.

Closes #179