### PR TITLE
feat(agent-config): emit v1 ports for the Unreal local plane (D21)

### DIFF
--- a/McpPlugin.Tests/AgentConfig/AgentConfiguratorSettingsPortDerivationTests.cs
+++ b/McpPlugin.Tests/AgentConfig/AgentConfiguratorSettingsPortDerivationTests.cs
@@ -1,0 +1,278 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using com.IvanMurzak.McpPlugin.AgentConfig.Impl;
+using com.IvanMurzak.McpPlugin.Common;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
+{
+    /// <summary>
+    /// zero-config-engine-connect b3 (design 02 § D21 / OQ3) — the shared config writer pins its
+    /// deterministic-port emission to the <b>v1</b> derivation for the Unreal local plane (so the written
+    /// port matches the v1 port the Unreal .NET sidecar binds via <c>ProjectConnectionResolver</c>) while
+    /// keeping the routing <b>pin</b> (registration hash) on v2 for EVERY engine. Non-Unreal engines'
+    /// emission is byte-identical to before (Unity / Godot stay on v2).
+    ///
+    /// <para>The interesting case is a Windows <b>backslash</b> project root, where v1 and v2 diverge.
+    /// Every backslash root here is a hardcoded literal built from <c>(char)92</c> — never
+    /// <c>Path.GetTempPath()</c> — so the divergence is real on Linux CI too (a temp path is forward-slash,
+    /// where v1 == v2 and the whole point of this task would hide). The roots are HASH INPUTS only; they
+    /// are never created on disk, so identity resolution reads no marker and stays on the derived-port
+    /// branch.</para>
+    /// </summary>
+    public class AgentConfiguratorSettingsPortDerivationTests
+    {
+        // A literal backslash, built from its char code so no escaping subtlety can alter it.
+        private static string Bs => ((char)92).ToString();
+
+        // C:\Users\user\my-game — the committed golden-vector backslash root (both golden files carry it):
+        //   v1 (ProjectIdentity.GoldenVectors.json)     -> pin 8ef72cf7, port 29310  (the Unreal binder)
+        //   v2 (ProjectIdentity.GoldenVectors.v2.json)  -> pin 5a87324e, port 24298  (Unity / Godot + the pin)
+        private static string BackslashRoot => "C:" + Bs + "Users" + Bs + "user" + Bs + "my-game";
+
+        private static AgentConfiguratorSettings Settings(
+            string root,
+            LocalPortDerivation localPortDerivation,
+            string host = "http://localhost/mcp",
+            ConnectionMode connectionMode = ConnectionMode.Local) => new(
+                operatingSystem: OperatingSystemKind.Windows,
+                projectRootPath: root,
+                executableFullPath: "C:/Tools/ai-game-developer-mcp-server.exe",
+                port: 50000,
+                timeoutMs: 30000,
+                host: host,
+                connectionMode: connectionMode,
+                localPortDerivation: localPortDerivation);
+
+        private static string NewTempDir()
+        {
+            var root = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(root);
+            return root;
+        }
+
+        // ---- DoD 1: the writer emits v1 ports for Unreal; writer == the v1 binder for a backslash root. ----
+
+        /// <summary>
+        /// The headline D21 assertion: on <see cref="LocalPortDerivation.V1"/> (Unreal) the writer emits the
+        /// v1-derived port — byte-equal to what the Unreal sidecar binder (<c>ProjectConnectionResolver</c>,
+        /// v1 <see cref="ProjectIdentity.Derive"/>) resolves — and NOT the v2 port; the routing pin stays v2.
+        /// The v1/v2 port divergence is only visible on a backslash root.
+        /// </summary>
+        [Fact]
+        public void Unreal_WriterEmitsV1DerivedPort_MatchingTheV1Binder_AndKeepsV2Pin_ForBackslashRoot()
+        {
+            var settings = Settings(BackslashRoot, LocalPortDerivation.V1);
+
+            settings.LocalPortDerivation.ShouldBe(LocalPortDerivation.V1);
+            settings.Identity.PortIsOverridden.ShouldBeFalse(); // no marker on disk => the derived branch
+
+            // Port == the v1 binder derivation == the committed v1 golden vector value.
+            settings.ResolvedPort.ShouldBe(ProjectIdentity.Derive(BackslashRoot).Port);
+            settings.ResolvedPort.ShouldBe(ProjectIdentity.DerivePort(BackslashRoot));
+            settings.ResolvedPort.ShouldBe(29310); // ProjectIdentity.GoldenVectors.json, C:\Users\user\my-game
+
+            // ...and NOT the v2 port the default (Unity/Godot) writer would emit.
+            settings.ResolvedPort.ShouldNotBe(ProjectIdentity.DerivePortV2(BackslashRoot));
+
+            // The routing pin (registration hash) stays v2 for Unreal too (DoD 3, previewed here).
+            settings.ProjectPin.ShouldBe(ProjectIdentity.DerivePinV2(BackslashRoot));
+            settings.ProjectPin.ShouldBe("5a87324e"); // ProjectIdentity.GoldenVectors.v2.json
+            settings.ProjectPin.ShouldNotBe(ProjectIdentity.DerivePin(BackslashRoot)); // != the v1 pin
+
+            // Portless host => PinnedPort falls through to the (v1) derived port, and it reaches the file.
+            settings.PinnedPort.ShouldBe(ProjectIdentity.Derive(BackslashRoot).Port);
+
+            var c = new ClaudeCodeConfigurator();
+            var http = c.GetHttpConfig(settings).ExpectedFileContent;
+            http.ShouldContain($"\"url\": \"http://localhost:{ProjectIdentity.DerivePort(BackslashRoot)}/mcp/p/{ProjectIdentity.DerivePinV2(BackslashRoot)}\"");
+            http.ShouldNotContain($"localhost:{ProjectIdentity.DerivePortV2(BackslashRoot)}"); // never the v2 port
+
+            var stdio = c.GetStdioConfig(settings).ExpectedFileContent;
+            stdio.ShouldContain($"{Consts.MCP.Server.Args.Port}={ProjectIdentity.DerivePort(BackslashRoot)}");
+            stdio.ShouldContain($"{Consts.MCP.Server.Args.Project}={ProjectIdentity.DerivePinV2(BackslashRoot)}");
+        }
+
+        /// <summary>
+        /// The same writer==binder property, but anchored to the committed cross-language golden-vector
+        /// files rather than hardcoded numbers: for EVERY backslash vector in the golden files, the Unreal
+        /// (v1) writer reproduces the v1 golden port (== the v1 binder), the default (v2) writer reproduces
+        /// the v2 golden port, and both reproduce the v2 golden pin. This is the "golden-vector test covers
+        /// backslash roots writer==binder" DoD item.
+        /// </summary>
+        [Fact]
+        public void WriterVsBinder_ForEveryBackslashGoldenVector_UnrealIsV1_OthersAreV2_PinStaysV2()
+        {
+            var v1 = LoadGoldenVectors("ProjectIdentity.GoldenVectors.json");
+            var v2 = LoadGoldenVectors("ProjectIdentity.GoldenVectors.v2.json");
+
+            var backslashPaths = v1.Keys.Where(p => p.IndexOf(Bs, StringComparison.Ordinal) >= 0).ToList();
+            backslashPaths.ShouldNotBeEmpty("the committed golden files must carry at least one backslash vector");
+
+            foreach (var path in backslashPaths)
+            {
+                var (_, v1Port) = v1[path];
+                var (v2Pin, v2Port) = v2[path];
+
+                // The golden files themselves must disagree on the port for a backslash root — that
+                // divergence (v1 binder vs v2 writer) is the entire reason this task exists.
+                v1Port.ShouldNotBe(v2Port);
+
+                var unreal = Settings(path, LocalPortDerivation.V1);
+                var others = Settings(path, LocalPortDerivation.V2);
+
+                // Unreal writer == v1 golden port == the v1 binder derivation.
+                unreal.ResolvedPort.ShouldBe(v1Port, customMessage: $"Unreal writer must emit the v1 port for '{path}'");
+                unreal.ResolvedPort.ShouldBe(ProjectIdentity.Derive(path).Port);
+
+                // Non-Unreal writer == the v2 golden port (unchanged emission).
+                others.ResolvedPort.ShouldBe(v2Port, customMessage: $"non-Unreal writer must emit the v2 port for '{path}'");
+
+                // Both keep the v2 registration pin.
+                unreal.ProjectPin.ShouldBe(v2Pin);
+                others.ProjectPin.ShouldBe(v2Pin);
+            }
+        }
+
+        // ---- DoD 2: non-Unreal engines' emission is byte-identical (Unity / Godot regression). ----
+
+        /// <summary>
+        /// The default (no <c>localPortDerivation</c> argument) is <see cref="LocalPortDerivation.V2"/> and
+        /// emits exactly what an explicit V2 emits — the same v2 port and the same written config bytes —
+        /// so existing Unity / Godot callers are entirely unaffected by the new knob.
+        /// </summary>
+        [Fact]
+        public void NonUnreal_DefaultEqualsExplicitV2_AndEmitsUnchangedV2Port_ForBackslashRoot()
+        {
+            var byDefault = new AgentConfiguratorSettings(
+                operatingSystem: OperatingSystemKind.Windows,
+                projectRootPath: BackslashRoot,
+                executableFullPath: "C:/Tools/ai-game-developer-mcp-server.exe",
+                port: 50000,
+                timeoutMs: 30000,
+                host: "http://localhost/mcp"); // NO localPortDerivation arg => defaults to V2
+
+            var explicitV2 = Settings(BackslashRoot, LocalPortDerivation.V2);
+
+            byDefault.LocalPortDerivation.ShouldBe(LocalPortDerivation.V2);
+
+            // Byte-identical resolution between the default and an explicit V2.
+            byDefault.ResolvedPort.ShouldBe(explicitV2.ResolvedPort);
+            byDefault.PinnedPort.ShouldBe(explicitV2.PinnedPort);
+            byDefault.ProjectPin.ShouldBe(explicitV2.ProjectPin);
+
+            // ...and it is the v2 derivation, unchanged from before this task.
+            byDefault.ResolvedPort.ShouldBe(ProjectIdentity.DerivePortV2(BackslashRoot));
+            byDefault.ResolvedPort.ShouldBe(24298); // ProjectIdentity.GoldenVectors.v2.json
+            byDefault.ProjectPin.ShouldBe(ProjectIdentity.DerivePinV2(BackslashRoot));
+
+            // The written config bytes are identical for the default and the explicit-V2 settings.
+            var c = new ClaudeCodeConfigurator();
+            c.GetHttpConfig(byDefault).ExpectedFileContent.ShouldBe(c.GetHttpConfig(explicitV2).ExpectedFileContent);
+            c.GetStdioConfig(byDefault).ExpectedFileContent.ShouldBe(c.GetStdioConfig(explicitV2).ExpectedFileContent);
+        }
+
+        // ---- DoD 3: the registration hash / pin path is untouched (v2) regardless of port derivation. ----
+
+        /// <summary>
+        /// For one and the same backslash root the v1 (Unreal) and v2 (default) writers emit DIFFERENT
+        /// ports but the SAME v2 routing pin — the registration hash / pin path stays v2 for every engine.
+        /// </summary>
+        [Fact]
+        public void RegistrationPin_StaysV2_WhilePortDiverges_BetweenV1AndV2_ForBackslashRoot()
+        {
+            var v1 = Settings(BackslashRoot, LocalPortDerivation.V1);
+            var v2 = Settings(BackslashRoot, LocalPortDerivation.V2);
+
+            // The routing pin (registration hash) is the SAME v2 value for both engines.
+            v1.ProjectPin.ShouldBe(v2.ProjectPin);
+            v1.ProjectPin.ShouldBe(ProjectIdentity.DerivePinV2(BackslashRoot));
+
+            // ...but the emitted PORT diverges: v1 for Unreal, v2 for the rest.
+            v1.ResolvedPort.ShouldNotBe(v2.ResolvedPort);
+            v1.ResolvedPort.ShouldBe(ProjectIdentity.DerivePort(BackslashRoot));   // v1
+            v2.ResolvedPort.ShouldBe(ProjectIdentity.DerivePortV2(BackslashRoot)); // v2
+
+            // The /p/<pin> routing segment in BOTH written configs is the v2 pin (registration path untouched).
+            var c = new ClaudeCodeConfigurator();
+            c.GetHttpConfig(v1).ExpectedFileContent.ShouldContain($"/p/{ProjectIdentity.DerivePinV2(BackslashRoot)}");
+            c.GetHttpConfig(v2).ExpectedFileContent.ShouldContain($"/p/{ProjectIdentity.DerivePinV2(BackslashRoot)}");
+            c.GetStdioConfig(v1).ExpectedFileContent.ShouldContain($"{Consts.MCP.Server.Args.Project}={ProjectIdentity.DerivePinV2(BackslashRoot)}");
+        }
+
+        // ---- The v1 (Unreal) path preserves the 3-level precedence — only level 3's derivation changed. ----
+
+        /// <summary>
+        /// Level 1 (marker <c>portOverride</c>) still wins outright on the v1 path — over both the typed
+        /// host port (level 2) and the v1 derivation (level 3). The override is not hash-dependent, so this
+        /// is unchanged by the engine-aware derivation. Uses a real on-disk marker (temp dir).
+        /// </summary>
+        [Fact]
+        public void Unreal_MarkerPortOverride_StillWins_OverV1Derivation_AndTypedHostPort()
+        {
+            var root = NewTempDir();
+            try
+            {
+                const int overridePort = 27777;
+                new ProjectMarker { PortOverride = overridePort }.Write(root);
+
+                var settings = Settings(root, LocalPortDerivation.V1, host: "http://localhost:50000/mcp");
+
+                settings.ExplicitHostPort.ShouldBe(50000);
+                settings.Identity.PortIsOverridden.ShouldBeTrue();
+                settings.ResolvedPort.ShouldBe(overridePort); // level 1 beats the v1 derivation
+                settings.PinnedPort.ShouldBe(overridePort);   // level 1 beats the typed host port too
+
+                var stdio = new ClaudeCodeConfigurator().GetStdioConfig(settings).ExpectedFileContent;
+                stdio.ShouldContain($"{Consts.MCP.Server.Args.Port}={overridePort}");
+                stdio.ShouldNotContain($"{Consts.MCP.Server.Args.Port}=50000");
+            }
+            finally { Directory.Delete(root, recursive: true); }
+        }
+
+        /// <summary>
+        /// Level 2 (a port typed into a loopback <see cref="AgentConfiguratorSettings.Host"/>) is honoured
+        /// on the v1 path exactly as on the v2 path — only the level-3 derived FALLBACK switched version.
+        /// So an explicit host port beats the v1 derivation just as it beats the v2 one.
+        /// </summary>
+        [Fact]
+        public void Unreal_TypedHostPort_IsHonoured_OverTheV1Derivation()
+        {
+            var settings = Settings(BackslashRoot, LocalPortDerivation.V1, host: "http://localhost:50000/mcp");
+
+            settings.Identity.PortIsOverridden.ShouldBeFalse();
+            settings.ExplicitHostPort.ShouldBe(50000);
+            settings.PinnedPort.ShouldBe(50000); // the typed port, not the v1 derived fallback
+            settings.PinnedPort.ShouldNotBe(ProjectIdentity.DerivePort(BackslashRoot));
+            settings.PinnedHttpUrl.ShouldBe($"http://localhost:50000/mcp/p/{ProjectIdentity.DerivePinV2(BackslashRoot)}");
+        }
+
+        // --- helpers ---
+
+        private static Dictionary<string, (string Pin, int Port)> LoadGoldenVectors(string fileName)
+        {
+            var filePath = Path.Combine(AppContext.BaseDirectory, fileName);
+            using var doc = JsonDocument.Parse(File.ReadAllText(filePath));
+            var map = new Dictionary<string, (string, int)>();
+            foreach (var v in doc.RootElement.GetProperty("vectors").EnumerateArray())
+            {
+                map[v.GetProperty("path").GetString()!] =
+                    (v.GetProperty("pin").GetString()!, v.GetProperty("port").GetInt32());
+            }
+            return map;
+        }
+    }
+}

--- a/McpPlugin/src/AgentConfig/AgentConfiguratorSettings.cs
+++ b/McpPlugin/src/AgentConfig/AgentConfiguratorSettings.cs
@@ -66,6 +66,29 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
     }
 
     /// <summary>
+    /// Which <see cref="ProjectIdentity"/> derivation backs the deterministic LOCAL port the config
+    /// writers emit (the stdio <c>port=</c> arg and the loopback HTTP url). This is the engine-scoped
+    /// policy seam design 02 § D21 (OQ3) codifies: the routing <b>pin</b> stays v2 for EVERY engine
+    /// regardless of this value — only the hash-derived port fallback differs.
+    ///
+    /// <list type="bullet">
+    ///   <item><see cref="V2"/> (default) — the separator-normalized derivation Unity and Godot bind.</item>
+    ///   <item><see cref="V1"/> — the legacy derivation the <b>Unreal</b> .NET sidecar binds (its
+    ///   <c>ProjectConnectionResolver</c> resolves the local port via v1 <see cref="ProjectIdentity.Derive"/>).
+    ///   Pinned for the Unreal local plane by owner ruling D21 so the written port matches what the sidecar
+    ///   actually binds; a later migration may realign it to <see cref="V2"/>.</item>
+    /// </list>
+    /// </summary>
+    public enum LocalPortDerivation
+    {
+        /// <summary>v2 separator-normalized derivation (<see cref="ProjectIdentity.DeriveV2"/>). Unity + Godot. The default.</summary>
+        V2,
+
+        /// <summary>v1 legacy derivation (<see cref="ProjectIdentity.Derive"/>). The Unreal local plane (design 02 § D21).</summary>
+        V1
+    }
+
+    /// <summary>
     /// All the engine-supplied values a configurator needs to build an MCP config entry.
     /// Replaces the Unity statics (<c>UnityMcpPluginEditor.Port</c>, <c>.Host</c>,
     /// <c>.Token</c>, …, and <c>McpServerManager.ExecutableFullPath</c>) the original
@@ -126,6 +149,15 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
         /// </summary>
         public string DockerImage { get; }
 
+        /// <summary>
+        /// The <see cref="ProjectIdentity"/> derivation used for the deterministic LOCAL port the config
+        /// writers emit. Defaults to <see cref="LocalPortDerivation.V2"/> (Unity / Godot); the Unreal
+        /// sidecar consumer passes <see cref="LocalPortDerivation.V1"/> so the written port matches the v1
+        /// port its bridge binds (design 02 § D21). Never affects the routing <see cref="ProjectPin"/>,
+        /// which stays v2 for every engine.
+        /// </summary>
+        public LocalPortDerivation LocalPortDerivation { get; }
+
         public AgentConfiguratorSettings(
             OperatingSystemKind operatingSystem,
             string projectRootPath,
@@ -138,7 +170,8 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
             Consts.MCP.Server.AuthOption authOption = Consts.MCP.Server.AuthOption.none,
             string serverExecutableName = "gamedev-mcp-server",
             string serverVersion = "8.0.0",
-            string dockerImage = "aigamedeveloper/mcp-server")
+            string dockerImage = "aigamedeveloper/mcp-server",
+            LocalPortDerivation localPortDerivation = LocalPortDerivation.V2)
         {
             OperatingSystem = operatingSystem;
             ProjectRootPath = projectRootPath;
@@ -152,6 +185,7 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
             ServerExecutableName = serverExecutableName;
             ServerVersion = serverVersion;
             DockerImage = dockerImage;
+            LocalPortDerivation = localPortDerivation;
         }
 
         /// <summary>
@@ -172,7 +206,8 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
             Consts.MCP.Server.AuthOption authOption = Consts.MCP.Server.AuthOption.none,
             string serverExecutableName = "gamedev-mcp-server",
             string serverVersion = "8.0.0",
-            string dockerImage = "aigamedeveloper/mcp-server")
+            string dockerImage = "aigamedeveloper/mcp-server",
+            LocalPortDerivation localPortDerivation = LocalPortDerivation.V2)
         {
             return new AgentConfiguratorSettings(
                 operatingSystem: HostOperatingSystem.Detect(),
@@ -186,7 +221,8 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
                 authOption: authOption,
                 serverExecutableName: serverExecutableName,
                 serverVersion: serverVersion,
-                dockerImage: dockerImage);
+                dockerImage: dockerImage,
+                localPortDerivation: localPortDerivation);
         }
 
         /// <summary>
@@ -235,18 +271,58 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
         // terminal-written config. Resolved lazily and cached (a marker read is file I/O, and the
         // identity is stable for the settings' <see cref="ProjectRootPath"/>).
         private ProjectIdentity? _identity;
+        private ProjectIdentity? _portIdentity;
+        private ProjectMarker? _marker;
+        private bool _markerRead;
 
         /// <summary>
-        /// The project's <see cref="ProjectIdentity"/> — routing pin plus the resolved local port
-        /// (the project marker's <c>portOverride</c> wins, else the deterministic hash-derived port).
-        /// Read once from the marker at <see cref="ProjectRootPath"/> and cached.
-        ///
-        /// <para>Derived via <see cref="ProjectIdentity.DeriveV2"/>, so the pin and the port come from
-        /// ONE <see cref="ProjectIdentity.NormalizeV2"/> pre-hash string (auth-fixes T1 / defect B).
-        /// <see cref="ProjectPin"/> and <see cref="ResolvedPort"/> both read off this single object,
-        /// which is what makes a v1/v2 mix within one settings instance unrepresentable.</para>
+        /// The project marker at <see cref="ProjectRootPath"/>, read once (a marker read is file I/O) and
+        /// cached — <c>null</c> when the project has no marker. The pin identity and the engine-aware port
+        /// identity both read off this single result, so an override or target is read from disk exactly
+        /// once. The <see cref="_markerRead"/> flag distinguishes "not read yet" from "read, was null".
         /// </summary>
-        public ProjectIdentity Identity => _identity ??= ProjectIdentity.DeriveV2(ProjectRootPath, ProjectMarker.Read(ProjectRootPath));
+        private ProjectMarker? Marker
+        {
+            get
+            {
+                if (!_markerRead)
+                {
+                    _marker = ProjectMarker.Read(ProjectRootPath);
+                    _markerRead = true;
+                }
+                return _marker;
+            }
+        }
+
+        /// <summary>
+        /// The project's <b>v2</b> <see cref="ProjectIdentity"/> — the source of the routing
+        /// <see cref="ProjectPin"/> (the registration hash stays v2 for EVERY engine, design 02 § D21) and,
+        /// on the default <see cref="LocalPortDerivation.V2"/> path, of the emitted port too. Read once from
+        /// the marker at <see cref="ProjectRootPath"/> and cached.
+        ///
+        /// <para>Derived via <see cref="ProjectIdentity.DeriveV2"/>, so <see cref="ProjectPin"/> and — on
+        /// the v2 path — <see cref="ResolvedPort"/> come from ONE <see cref="ProjectIdentity.NormalizeV2"/>
+        /// pre-hash string (auth-fixes T1 / defect B). The single sanctioned exception is an engine on
+        /// <see cref="LocalPortDerivation.V1"/> (Unreal): its port comes from a separate v1
+        /// <see cref="PortIdentity"/> while the pin stays on this v2 object — the controlled v2-pin /
+        /// v1-port split D21 authorizes so the written port matches the Unreal v1 sidecar binder.</para>
+        /// </summary>
+        public ProjectIdentity Identity => _identity ??= ProjectIdentity.DeriveV2(ProjectRootPath, Marker);
+
+        /// <summary>
+        /// The <see cref="ProjectIdentity"/> whose hash-derived <see cref="ProjectIdentity.Port"/> backs
+        /// <see cref="ResolvedPort"/>. Engine-aware per <see cref="LocalPortDerivation"/> (design 02 § D21):
+        /// <see cref="LocalPortDerivation.V1"/> (Unreal) derives via the legacy v1
+        /// <see cref="ProjectIdentity.Derive"/> to match its sidecar binder; every other engine REUSES the
+        /// v2 <see cref="Identity"/> object, so the default path is byte-identical to before. The marker
+        /// <c>portOverride</c> wins on both derivations (it is not hash-dependent), so
+        /// <see cref="PinnedPort"/>'s three-level precedence is unchanged — only the derived fallback
+        /// (level 3) switches derivation version.
+        /// </summary>
+        private ProjectIdentity PortIdentity => _portIdentity ??=
+            LocalPortDerivation == LocalPortDerivation.V1
+                ? ProjectIdentity.Derive(ProjectRootPath, Marker)
+                : Identity;
 
         /// <summary>
         /// The routing pin written into every config (HTTP <c>/p/&lt;pin&gt;</c> segment and stdio
@@ -261,19 +337,24 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
 
         /// <summary>
         /// The marker-resolved per-project local port: the project marker's <c>portOverride</c> when
-        /// set, otherwise the deterministic v2 hash-derived port — b6 single-sources the local port
-        /// from <see cref="ProjectIdentity"/> rather than the raw engine-supplied <see cref="Port"/>.
+        /// set, otherwise the deterministic hash-derived port — b6 single-sources the local port
+        /// from <see cref="ProjectIdentity"/> rather than the raw engine-supplied <see cref="Port"/>. The
+        /// derivation is engine-aware (<see cref="LocalPortDerivation"/>): v2 by default (Unity / Godot),
+        /// v1 for the Unreal local plane (design 02 § D21) so the emitted port matches the v1 port the
+        /// Unreal sidecar binds. The routing <see cref="ProjectPin"/> stays v2 regardless.
         ///
         /// <para>This is NOT what the config writers emit. Both transports write
         /// <see cref="PinnedPort"/>, which layers a port the user typed into <see cref="Host"/>
         /// BETWEEN this property's two cases (defect A). <see cref="ResolvedPort"/> therefore supplies
         /// precedence levels 1 and 3; see <see cref="PinnedPort"/> for the full ordering.</para>
         ///
-        /// <para>Shares the single cached <see cref="Identity"/> — and therefore the exact
-        /// <see cref="ProjectIdentity.NormalizeV2"/> pre-hash string — with <see cref="ProjectPin"/>
-        /// (auth-fixes T1 / defect B; see <see cref="ProjectIdentity.DeriveV2"/>).</para>
+        /// <para>Reads off <see cref="PortIdentity"/> (a v1 identity for Unreal, else the shared v2
+        /// <see cref="Identity"/>). On the default v2 path it and <see cref="ProjectPin"/> still share the
+        /// exact <see cref="ProjectIdentity.NormalizeV2"/> pre-hash string (auth-fixes T1 / defect B; see
+        /// <see cref="ProjectIdentity.DeriveV2"/>); on the Unreal v1 path only the port switches derivation,
+        /// the pin stays v2.</para>
         /// </summary>
-        public int ResolvedPort => Identity.Port;
+        public int ResolvedPort => PortIdentity.Port;
 
         /// <summary>
         /// The port the user explicitly typed into <see cref="Host"/>, or <c>null</c> when
@@ -289,8 +370,9 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
         /// <list type="number">
         ///   <item>the project marker's <c>portOverride</c> — an explicit per-project pin, wins outright;</item>
         ///   <item>an explicit port in the <see cref="Host"/> URL — the port the USER typed;</item>
-        ///   <item>the deterministic v2 hash-derived port (<see cref="ResolvedPort"/>) — the fallback
-        ///         when <see cref="Host"/> carries no explicit port.</item>
+        ///   <item>the deterministic hash-derived port (<see cref="ResolvedPort"/>) — the fallback
+        ///         when <see cref="Host"/> carries no explicit port; v2 by default, v1 for the Unreal
+        ///         local plane (<see cref="LocalPortDerivation"/>, design 02 § D21).</item>
         /// </list>
         ///
         /// <para>Level 2 exists because the engine runtime ALREADY binds the typed port: Unity's
@@ -335,14 +417,19 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
         ///   BOTH of those binders — the inverse of the Unity case it was introduced for. Each pins the
         ///   old invariant in a test that fails on their next McpPlugin bump
         ///   (<c>ResolveLocalServerBindPort_LoopbackExplicitPort_StillDerives_MatchingTheWriter</c>,
-        ///   <c>WrittenConfigPort_EqualsServerBindPort_OnDefaultLocalPath</c>). Whether the right
-        ///   resolution is a per-engine policy seam here or a binder change there is an OWNER call and
-        ///   deliberately out of scope for this writer-side change.</item>
+        ///   <c>WrittenConfigPort_EqualsServerBindPort_OnDefaultLocalPath</c>). D21 has since codified the
+        ///   per-engine policy seam HERE for a DIFFERENT axis — the level-3 derivation VERSION, v1 for the
+        ///   Unreal local plane via <see cref="LocalPortDerivation"/> — so the writer's derived fallback now
+        ///   matches the Unreal v1 binder. That is orthogonal to the level-2 typed-host divergence this
+        ///   bullet describes, whose cross-engine reconciliation stays an OWNER call out of scope for this
+        ///   writer-side change.</item>
         /// </list></para>
         /// </summary>
         public int PinnedPort =>
-            // marker override (1) else typed host port (2) else derived v2 port (3) — see the list above.
-            Identity.PortIsOverridden ? ResolvedPort : ExplicitHostPort ?? ResolvedPort;
+            // marker override (1) else typed host port (2) else derived port (3, v2 or v1 for Unreal) — see
+            // the list above. The override flag reads off PortIdentity so it agrees with ResolvedPort on the
+            // v1 (Unreal) path; on the v2 default PortIdentity IS Identity, so this is byte-identical.
+            PortIdentity.PortIsOverridden ? ResolvedPort : ExplicitHostPort ?? ResolvedPort;
 
         /// <summary>
         /// The HTTP <c>url</c> written into configs on the default (credential-free) path: the base


### PR DESCRIPTION
## Summary
- The shared config writer (`AgentConfiguratorSettings`) emitted the deterministic local port from the **v2** `ProjectIdentity` derivation for every engine, but the Unreal .NET sidecar **binds v1** (`ProjectConnectionResolver`, `ProjectIdentity.Derive`). On a Windows backslash root v1 ≠ v2, so an Unreal config pointed the agent at a port nothing was listening on (`zero-config-engine-connect` OQ3 → owner ruling D21).
- Add an engine-scoped `LocalPortDerivation` knob (`V2` default / `V1`). For `V1` (Unreal) the emitted **port** derives from the legacy v1 `ProjectIdentity.Derive` (matching its binder); the routing **pin** stays **v2** for every engine (registration hash untouched). Non-Unreal callers are byte-identical — the port identity reuses the shared v2 `Identity` object.
- The marker `portOverride` → typed-host-port → derived three-level precedence is unchanged; only the level-3 derivation version switches for Unreal.

## Test plan
- [x] Target-specific local tests passed (see profile test.md): full xUnit suite green — `McpPlugin.Tests` 808/808 + `McpPlugin.Server.Tests` 570/570, on **both** `net8.0` and `net9.0`, 0 failures.
- [x] Writer emits v1 ports for Unreal and equals the v1 binder derivation for backslash roots — anchored to the committed v1/v2 golden-vector files.
- [x] Non-Unreal engines' emission byte-identical (default == explicit V2; written-config bytes equal).
- [x] Registration hash / pin path untouched (v2) regardless of port derivation.

Closes #181