### PR TITLE
feat(api): pinned system-tools REST routes (reverses design 06 D15)

### DIFF
--- a/McpPlugin.Server.Tests/PinnedSystemToolAuthGatingTests.cs
+++ b/McpPlugin.Server.Tests/PinnedSystemToolAuthGatingTests.cs
@@ -1,0 +1,334 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.Common;
+using com.IvanMurzak.McpPlugin.Common.Hub.Client;
+using com.IvanMurzak.McpPlugin.Common.Model;
+using com.IvanMurzak.McpPlugin.Common.Utils;
+using com.IvanMurzak.McpPlugin.Server.Api;
+using com.IvanMurzak.McpPlugin.Server.Auth;
+using com.IvanMurzak.McpPlugin.Server.Auth.OAuth;
+using com.IvanMurzak.McpPlugin.Server.Tests.OAuth;
+using com.IvanMurzak.McpPlugin.Server.Webhooks.Services;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.Server.Tests
+{
+    /// <summary>
+    /// 🔒 Auth-gate PARITY for the pinned REST SYSTEM-tool routes (owner ruling 2026-07-25, reversing design
+    /// 06 D15). The pinned group <c>/p/{pin}/api/system-tools</c> gates IDENTICALLY to the unpinned group
+    /// <c>/api/system-tools</c> — the pin is routing only, never identity. Every assertion probes the pinned
+    /// AND the unpinned route and requires the SAME outcome:
+    /// <list type="bullet">
+    ///   <item>401 when unauthenticated in every credential-bearing mode (oauth / token / required);
+    ///   open only in none mode.</item>
+    ///   <item>A wrong-audience JWT is rejected (the shared <see cref="AccessTokenValidator"/> agent-plane
+    ///   audience check applies to the pinned system-tools surface too).</item>
+    ///   <item>A valid PAT via the opaque-token introspection path is accepted.</item>
+    /// </list>
+    /// Both groups register through the one <c>SystemToolEndpoints.MapSystemToolGroup</c> registrar with the
+    /// same <see cref="AuthGating"/> decision, so adding the pinned surface can never open an unauthenticated
+    /// bypass of the system-tool surface (which can EXECUTE tools) — these tests pin that against regressions.
+    /// Mirrors <see cref="PinnedDirectToolAuthGatingTests"/>.
+    /// </summary>
+    [Collection("McpPlugin.Server")]
+    public sealed class PinnedSystemToolAuthGatingTests
+    {
+        const string Secret = "pinned-system-rest-gate-secret";
+        const string Pin = "aabbccdd";
+
+        static string PinnedSystemTools => $"/p/{Pin}/api/system-tools";
+        const string UnpinnedSystemTools = "/api/system-tools";
+
+        // OAuth resource-server config for the real-validator tests (mirrors AccessTokenValidatorTests).
+        const string Issuer = "https://as.example";
+        const string Resource = "http://localhost:23471";
+        const string Kid = "key-1";
+        static readonly DateTimeOffset Now = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+
+        // ─────────────── 401 parity across credential-bearing modes (no token) ───────────────
+
+        [Fact]
+        public async Task OAuthMode_WithoutToken_PinnedAndUnpinned_Return401()
+        {
+            await using var host = await StartTokenSchemeHostAsync(Consts.MCP.Server.AuthOption.oauth);
+            using var client = NewClient(host);
+
+            (await GetStatusAsync(client, PinnedSystemTools)).ShouldBe(HttpStatusCode.Unauthorized);
+            (await GetStatusAsync(client, UnpinnedSystemTools)).ShouldBe(HttpStatusCode.Unauthorized);
+        }
+
+        [Fact]
+        public async Task TokenMode_WithoutToken_PinnedAndUnpinned_Return401()
+        {
+            await using var host = await StartTokenSchemeHostAsync(Consts.MCP.Server.AuthOption.token);
+            using var client = NewClient(host);
+
+            (await GetStatusAsync(client, PinnedSystemTools)).ShouldBe(HttpStatusCode.Unauthorized);
+            (await GetStatusAsync(client, UnpinnedSystemTools)).ShouldBe(HttpStatusCode.Unauthorized);
+        }
+
+        [Fact]
+        public async Task RequiredAliasMode_WithoutToken_PinnedAndUnpinned_Return401()
+        {
+            await using var host = await StartTokenSchemeHostAsync(Consts.MCP.Server.AuthOption.required);
+            using var client = NewClient(host);
+
+            (await GetStatusAsync(client, PinnedSystemTools)).ShouldBe(HttpStatusCode.Unauthorized);
+            (await GetStatusAsync(client, UnpinnedSystemTools)).ShouldBe(HttpStatusCode.Unauthorized);
+        }
+
+        [Fact]
+        public async Task TokenMode_WithoutToken_PinnedCall_Returns401_NotExecuted()
+        {
+            // The POST surface EXECUTES a system tool, so its gate matters most: an unauthenticated pinned
+            // call must be rejected before the hub is ever reached.
+            await using var host = await StartTokenSchemeHostAsync(Consts.MCP.Server.AuthOption.token);
+            using var client = NewClient(host);
+
+            (await PostStatusAsync(client, $"{PinnedSystemTools}/ping")).ShouldBe(HttpStatusCode.Unauthorized);
+            (await PostStatusAsync(client, $"{UnpinnedSystemTools}/ping")).ShouldBe(HttpStatusCode.Unauthorized);
+        }
+
+        [Fact]
+        public async Task TokenMode_WithValidToken_PinnedAndUnpinned_AreReachable()
+        {
+            await using var host = await StartTokenSchemeHostAsync(Consts.MCP.Server.AuthOption.token);
+            using var client = NewClient(host);
+
+            (await GetStatusAsync(client, PinnedSystemTools, bearer: Secret)).ShouldBe(HttpStatusCode.OK);
+            (await GetStatusAsync(client, UnpinnedSystemTools, bearer: Secret)).ShouldBe(HttpStatusCode.OK);
+        }
+
+        [Fact]
+        public async Task NoneMode_WithoutToken_PinnedAndUnpinned_AreOpen()
+        {
+            await using var host = await StartTokenSchemeHostAsync(Consts.MCP.Server.AuthOption.none);
+            using var client = NewClient(host);
+
+            (await GetStatusAsync(client, PinnedSystemTools)).ShouldBe(HttpStatusCode.OK);
+            (await GetStatusAsync(client, UnpinnedSystemTools)).ShouldBe(HttpStatusCode.OK);
+        }
+
+        // ─────────────── OAuth real-validator parity: wrong-audience JWT + PAT introspection ───────────────
+
+        [Fact]
+        public async Task OAuthMode_WrongAudienceJwt_PinnedAndUnpinned_Rejected401()
+        {
+            using var key = TestJwt.CreateKey();
+            var validator = new AccessTokenValidator(
+                new OAuthResourceServerConfig(Issuer, Resource),
+                new FakeJwksKeyProvider().Add(Kid, key),
+                FakeIntrospectionClient.AlwaysInactive,
+                () => Now);
+            await using var host = await StartOAuthHostAsync(validator, new OAuthResourceServerConfig(Issuer, Resource));
+            using var client = NewClient(host);
+
+            // Correctly signed, unexpired ES256 JWT — but audienced to the WRONG resource → rejected.
+            var wrongAud = TestJwt.SignEs256(key, Kid, TestJwt.Claims(Issuer, "http://localhost:59999", Now.AddHours(1)));
+
+            (await GetStatusAsync(client, PinnedSystemTools, bearer: wrongAud)).ShouldBe(HttpStatusCode.Unauthorized);
+            (await GetStatusAsync(client, UnpinnedSystemTools, bearer: wrongAud)).ShouldBe(HttpStatusCode.Unauthorized);
+        }
+
+        [Fact]
+        public async Task OAuthMode_ValidJwt_PinnedAndUnpinned_AreReachable()
+        {
+            // Positive control: a JWT audienced to the canonical resource is accepted on BOTH surfaces.
+            using var key = TestJwt.CreateKey();
+            var validator = new AccessTokenValidator(
+                new OAuthResourceServerConfig(Issuer, Resource),
+                new FakeJwksKeyProvider().Add(Kid, key),
+                FakeIntrospectionClient.AlwaysInactive,
+                () => Now);
+            await using var host = await StartOAuthHostAsync(validator, new OAuthResourceServerConfig(Issuer, Resource));
+            using var client = NewClient(host);
+
+            var goodJwt = TestJwt.SignEs256(key, Kid, TestJwt.Claims(Issuer, Resource, Now.AddHours(1)));
+
+            (await GetStatusAsync(client, PinnedSystemTools, bearer: goodJwt)).ShouldBe(HttpStatusCode.OK);
+            (await GetStatusAsync(client, UnpinnedSystemTools, bearer: goodJwt)).ShouldBe(HttpStatusCode.OK);
+        }
+
+        [Fact]
+        public async Task OAuthMode_ValidPatViaIntrospection_PinnedAndUnpinned_AreReachable()
+        {
+            using var key = TestJwt.CreateKey();
+            const string Pat = "agd_pat_abc";
+            var introspection = new FakeIntrospectionClient(t =>
+                t == Pat ? new IntrospectionResult(true, "pat-user", "mcp:agent", Now.AddHours(1)) : IntrospectionResult.Inactive);
+            var validator = new AccessTokenValidator(
+                new OAuthResourceServerConfig(Issuer, Resource),
+                new FakeJwksKeyProvider().Add(Kid, key),
+                introspection,
+                () => Now);
+            await using var host = await StartOAuthHostAsync(validator, new OAuthResourceServerConfig(Issuer, Resource));
+            using var client = NewClient(host);
+
+            (await GetStatusAsync(client, PinnedSystemTools, bearer: Pat)).ShouldBe(HttpStatusCode.OK);
+            (await GetStatusAsync(client, UnpinnedSystemTools, bearer: Pat)).ShouldBe(HttpStatusCode.OK);
+        }
+
+        [Fact]
+        public async Task OAuthMode_InactivePat_PinnedAndUnpinned_Rejected401()
+        {
+            using var key = TestJwt.CreateKey();
+            var validator = new AccessTokenValidator(
+                new OAuthResourceServerConfig(Issuer, Resource),
+                new FakeJwksKeyProvider().Add(Kid, key),
+                FakeIntrospectionClient.AlwaysInactive, // every opaque token introspects as inactive
+                () => Now);
+            await using var host = await StartOAuthHostAsync(validator, new OAuthResourceServerConfig(Issuer, Resource));
+            using var client = NewClient(host);
+
+            (await GetStatusAsync(client, PinnedSystemTools, bearer: "agd_pat_unknown")).ShouldBe(HttpStatusCode.Unauthorized);
+            (await GetStatusAsync(client, UnpinnedSystemTools, bearer: "agd_pat_unknown")).ShouldBe(HttpStatusCode.Unauthorized);
+        }
+
+        // ───────────────────────────────── helpers ─────────────────────────────────
+
+        static HttpClient NewClient(RunningHost host) => new HttpClient { BaseAddress = new Uri(host.BaseUrl) };
+
+        static async Task<HttpStatusCode> GetStatusAsync(HttpClient client, string route, string? bearer = null)
+        {
+            using var req = new HttpRequestMessage(HttpMethod.Get, route);
+            if (bearer != null)
+                req.Headers.TryAddWithoutValidation("Authorization", $"Bearer {bearer}");
+            using var resp = await client.SendAsync(req);
+            return resp.StatusCode;
+        }
+
+        static async Task<HttpStatusCode> PostStatusAsync(HttpClient client, string route, string? bearer = null)
+        {
+            using var req = new HttpRequestMessage(HttpMethod.Post, route)
+            {
+                Content = new System.Net.Http.StringContent("{}", System.Text.Encoding.UTF8, "application/json")
+            };
+            if (bearer != null)
+                req.Headers.TryAddWithoutValidation("Authorization", $"Bearer {bearer}");
+            using var resp = await client.SendAsync(req);
+            return resp.StatusCode;
+        }
+
+        // Token-scheme host — mirrors PinnedDirectToolAuthGatingTests but maps the SYSTEM-tool groups.
+        static async Task<RunningHost> StartTokenSchemeHostAsync(Consts.MCP.Server.AuthOption authOption)
+        {
+            var builder = WebApplication.CreateBuilder();
+            builder.Logging.ClearProviders();
+
+            var dataArguments = Mock.Of<IDataArguments>(d => d.Authorization == authOption);
+            builder.Services.AddSingleton(dataArguments);
+            builder.Services.AddSingleton<IClientSystemToolHub>(new StubSystemToolHub());
+            builder.Services.AddSingleton(Mock.Of<IAuthorizationWebhookService>());
+
+            var localTokenMode = authOption == Consts.MCP.Server.AuthOption.token
+                || authOption == Consts.MCP.Server.AuthOption.required;
+
+            builder.Services
+                .AddAuthentication(TokenAuthenticationHandler.SchemeName)
+                .AddScheme<TokenAuthenticationOptions, TokenAuthenticationHandler>(
+                    TokenAuthenticationHandler.SchemeName,
+                    options =>
+                    {
+                        options.OAuthMode = authOption == Consts.MCP.Server.AuthOption.oauth;
+                        options.LocalTokenMode = localTokenMode;
+                        if (localTokenMode)
+                            options.LocalToken = Secret;
+                    });
+            builder.Services.AddAuthorization();
+
+            var app = builder.Build();
+            app.Urls.Add("http://127.0.0.1:0");
+            app.UseAuthentication();
+            app.UseAuthorization();
+            app.MapSystemToolApi(dataArguments);
+            app.MapPinnedSystemToolApi(dataArguments);
+
+            await app.StartAsync();
+            return new RunningHost(app, app.Urls.First());
+        }
+
+        // OAuth host wired with a REAL AccessTokenValidator (hermetic JWKS + introspection fakes), so the
+        // wrong-audience / PAT-introspection behavior on the pinned surface is the genuine production path.
+        static async Task<RunningHost> StartOAuthHostAsync(IOAuthTokenValidator validator, OAuthResourceServerConfig config)
+        {
+            var builder = WebApplication.CreateBuilder();
+            builder.Logging.ClearProviders();
+
+            var dataArguments = Mock.Of<IDataArguments>(d => d.Authorization == Consts.MCP.Server.AuthOption.oauth);
+            builder.Services.AddSingleton(dataArguments);
+            builder.Services.AddSingleton<IClientSystemToolHub>(new StubSystemToolHub());
+            // The OAuth auth path calls IAuthorizationWebhookService.AuthorizeAiAgentAsync after a valid token;
+            // use the NoOp (returns true) — a bare Moq mock returns a null Task, which would throw on await.
+            builder.Services.AddSingleton<IAuthorizationWebhookService>(new NoOpAuthorizationWebhookService());
+            builder.Services.AddSingleton(validator);
+            builder.Services.AddSingleton(config);
+
+            builder.Services
+                .AddAuthentication(TokenAuthenticationHandler.SchemeName)
+                .AddScheme<TokenAuthenticationOptions, TokenAuthenticationHandler>(
+                    TokenAuthenticationHandler.SchemeName,
+                    options => { options.OAuthMode = true; });
+            builder.Services.AddAuthorization();
+
+            var app = builder.Build();
+            app.Urls.Add("http://127.0.0.1:0");
+            app.UseAuthentication();
+            app.UseAuthorization();
+            app.MapSystemToolApi(dataArguments);
+            app.MapPinnedSystemToolApi(dataArguments);
+
+            await app.StartAsync();
+            return new RunningHost(app, app.Urls.First());
+        }
+
+        sealed class RunningHost : IAsyncDisposable
+        {
+            readonly WebApplication _app;
+            public string BaseUrl { get; }
+
+            public RunningHost(WebApplication app, string baseUrl)
+            {
+                _app = app;
+                BaseUrl = baseUrl;
+            }
+
+            public async ValueTask DisposeAsync()
+            {
+                await _app.StopAsync();
+                await _app.DisposeAsync();
+            }
+        }
+
+        sealed class StubSystemToolHub : IClientSystemToolHub
+        {
+            public Task<ResponseData<ResponseCallTool>> RunSystemTool(RequestCallTool request, CancellationToken cancellationToken = default)
+                => Task.FromResult(ResponseData<ResponseCallTool>.Success(request.RequestID));
+
+            public Task<ResponseData<ResponseListTool[]>> RunListSystemTool(RequestListTool request, CancellationToken cancellationToken = default)
+                => Task.FromResult(new ResponseData<ResponseListTool[]>(request.RequestID, ResponseStatus.Success)
+                {
+                    Value = Array.Empty<ResponseListTool>()
+                });
+        }
+    }
+}

--- a/McpPlugin.Server.Tests/PinnedSystemToolAuthGatingTests.cs
+++ b/McpPlugin.Server.Tests/PinnedSystemToolAuthGatingTests.cs
@@ -13,6 +13,7 @@ using System;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using com.IvanMurzak.McpPlugin.Common;
@@ -221,7 +222,7 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
         {
             using var req = new HttpRequestMessage(HttpMethod.Post, route)
             {
-                Content = new System.Net.Http.StringContent("{}", System.Text.Encoding.UTF8, "application/json")
+                Content = new StringContent("{}", Encoding.UTF8, "application/json")
             };
             if (bearer != null)
                 req.Headers.TryAddWithoutValidation("Authorization", $"Bearer {bearer}");

--- a/McpPlugin.Server.Tests/PinnedSystemToolRoutingTests.cs
+++ b/McpPlugin.Server.Tests/PinnedSystemToolRoutingTests.cs
@@ -24,7 +24,6 @@ using com.IvanMurzak.McpPlugin.Common.Utils;
 using com.IvanMurzak.McpPlugin.Server.Api;
 using com.IvanMurzak.McpPlugin.Server.Auth;
 using com.IvanMurzak.McpPlugin.Server.Strategy;
-using com.IvanMurzak.McpPlugin.Server.Webhooks.Services;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -132,6 +131,14 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
         }
 
         // ─────────────── POST call path — outcome → deterministic HTTP status ───────────────
+        //
+        // FIDELITY NOTE: the 404-vs-503 split below is produced by ResolutionReportingSystemToolHub's OWN
+        // chosen ResponseErrorKinds (see the hub, bottom of this file). It pins the shared handler's
+        // DirectHttpErrorMapper wiring — NOT the production status. In production AccountMcpStrategy
+        // .ResolveConnectionId returns null for BOTH NoMatchPinned and AccountEmpty (the kind is discarded),
+        // so ClientUtils.InvokeAsync exhausts its retries and yields Unavailable → 503 for either case.
+        // Failing FAST on a known-unresolvable pin is a cross-cutting ClientUtils/strategy change affecting
+        // all four REST groups, so it is deliberately out of scope for this PR.
 
         [Fact]
         public async Task PinnedCall_MatchingPin_Resolves_200()
@@ -254,7 +261,6 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
             var dataArguments = Mock.Of<IDataArguments>(d => d.Authorization == Consts.MCP.Server.AuthOption.none);
             builder.Services.AddSingleton(dataArguments);
             builder.Services.AddSingleton<IClientSystemToolHub>(new ResolutionReportingSystemToolHub(instances, Account));
-            builder.Services.AddSingleton(Mock.Of<IAuthorizationWebhookService>());
 
             var app = builder.Build();
             app.Urls.Add("http://127.0.0.1:0"); // OS-assigned loopback port

--- a/McpPlugin.Server.Tests/PinnedSystemToolRoutingTests.cs
+++ b/McpPlugin.Server.Tests/PinnedSystemToolRoutingTests.cs
@@ -35,19 +35,25 @@ using Xunit;
 namespace com.IvanMurzak.McpPlugin.Server.Tests
 {
     /// <summary>
-    /// 📌 Pinned REST tool routes (design 06 / zero-config-engine-connect b1). The pinned group
-    /// <c>GET /p/{pin}/api/tools</c> + <c>POST /p/{pin}/api/tools/{name}</c> resolves the (account, pin)
-    /// bucket STRICTLY by pin: a pin never falls through — a wrong pin returns <c>NoMatchPinned</c> even
-    /// when the account HAS sibling instances (never MRU-routed), and an empty account returns
-    /// <c>AccountEmpty</c>. The UNPINNED group is byte-identical wiring but still falls to MRU (the
-    /// contrast that proves the pinned group is strict). The system-tools surface has the SAME pinned
-    /// pairing since the owner ruling of 2026-07-25 reversed design 06 D15 (see
-    /// <see cref="PinnedSystemToolRoutingTests"/>). These drive a REAL loopback host through the production
-    /// <see cref="McpSessionTokenMiddleware"/> so the pin is captured live from the pinned request path
-    /// exactly as in prod; the tool hub reports the outcome of the real <see cref="AccountInstances.Resolve"/>.
+    /// 📌 Pinned REST SYSTEM-tool routes (owner ruling 2026-07-25 — REVERSES design 06 D15). The pinned group
+    /// <c>GET /p/{pin}/api/system-tools</c> + <c>POST /p/{pin}/api/system-tools/{name}</c> is the system-tool
+    /// twin of the pinned <c>/api/tools</c> group: both prefixes register through ONE shared registrar
+    /// (<c>SystemToolEndpoints.MapSystemToolGroup</c>), so they share handlers and the auth gate, and the pin
+    /// is captured live from the request path by <see cref="McpSessionTokenMiddleware"/> and resolved STRICTLY
+    /// (a wrong pin yields <c>NoMatchPinned</c> even with sibling instances present — never MRU; an empty
+    /// account yields <c>AccountEmpty</c>).
+    ///
+    /// <para><b>Why this exists.</b> D15 declined a pinned system-tools route on the premise that "no engine
+    /// registers a system <c>ping</c> tool" — false: Unity declares <c>ping</c> as
+    /// <c>ToolType = McpToolType.System</c>. The cloud golden path is pinned (<c>/mcp/p/&lt;pin&gt;/…</c>), so
+    /// without this group an engine-liveness probe over the system-tools surface was impossible there. Every
+    /// route assertion below 404s without the pinned mapping — these are the tests that fail without the change.</para>
+    ///
+    /// Mirrors <see cref="PinnedDirectToolRoutingTests"/>, driving a REAL loopback host through the production
+    /// middleware; the system-tool hub reports the outcome of the real <see cref="AccountInstances.Resolve"/>.
     /// </summary>
     [Collection("McpPlugin.Server")]
-    public sealed class PinnedDirectToolRoutingTests
+    public sealed class PinnedSystemToolRoutingTests
     {
         // pin = leading hex prefix of the project-path SHA-256 (McpSessionTokenMiddleware validates 1–64 hex).
         const string HashA = "aabbccdd11223344556677889900aabbccddeeff00112233445566778899aabb";
@@ -55,81 +61,97 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
         const string HashB = "11223344aabbccdd556677889900aabbccddeeff00112233445566778899aabb";
         const string PinB = "11223344";
         const string WrongPin = "deadbeef";
-        const string Account = "acc-pinned";
+        const string Account = "acc-pinned-system";
         const string InstanceA = "instance-A";
         const string InstanceB = "instance-B";
 
-        // ─────────────────── GET list path — strict pin → the pinned project's instance ───────────────────
+        static string PinnedSystemTools(string pin) => $"/p/{pin}/api/system-tools";
+        const string UnpinnedSystemTools = "/api/system-tools";
+
+        // ─────────── Route existence — the D15 reversal (these 404 without the pinned mapping) ───────────
+
+        [Fact]
+        public async Task PinnedSystemToolsRoutes_AreMapped()
+        {
+            await using var host = await StartHostAsync(TwoInstanceRegistry());
+            using var client = NewClient(host);
+
+            // Control: the unpinned group is (and stays) mapped.
+            (await client.GetAsync(UnpinnedSystemTools)).StatusCode.ShouldNotBe(HttpStatusCode.NotFound);
+
+            // The pinned analog now exists — list AND call reach a handler instead of the route table's 404.
+            (await client.GetAsync(PinnedSystemTools(PinA))).StatusCode.ShouldBe(HttpStatusCode.OK);
+            using var post = await CallAsync(client, $"{PinnedSystemTools(PinA)}/ping");
+            post.StatusCode.ShouldBe(HttpStatusCode.OK);
+        }
+
+        // ─────────────── GET list path — strict pin → the pinned project's instance ───────────────
 
         [Fact]
         public async Task PinnedList_ResolvesStrictlyToTheMatchingInstance()
         {
-            var instances = TwoInstanceRegistry();
-            await using var host = await StartHostAsync(instances);
+            await using var host = await StartHostAsync(TwoInstanceRegistry());
             using var client = NewClient(host);
 
             // Each pin resolves ONLY to its own project's instance — never the sibling.
-            (await ListOutcomeAsync(client, $"/p/{PinA}/api/tools")).ShouldBe(InstanceA);
-            (await ListOutcomeAsync(client, $"/p/{PinB}/api/tools")).ShouldBe(InstanceB);
+            (await ListOutcomeAsync(client, PinnedSystemTools(PinA))).ShouldBe(InstanceA);
+            (await ListOutcomeAsync(client, PinnedSystemTools(PinB))).ShouldBe(InstanceB);
         }
 
         [Fact]
         public async Task PinnedList_WrongPinWithSiblingsPresent_NoMatchPinned_NeverMru()
         {
-            // The account HAS two live instances, but neither matches the pin. A pin NEVER falls through to
-            // a sibling (never MRU): the strict outcome is NoMatchPinned, not a routed instance id.
-            var instances = TwoInstanceRegistry();
-            await using var host = await StartHostAsync(instances);
+            // The account HAS two live instances, but neither matches the pin. A pin NEVER falls through to a
+            // sibling (never MRU): the strict outcome is NoMatchPinned, not a routed instance id.
+            await using var host = await StartHostAsync(TwoInstanceRegistry());
             using var client = NewClient(host);
 
-            (await ListOutcomeAsync(client, $"/p/{WrongPin}/api/tools")).ShouldBe("NoMatchPinned");
+            (await ListOutcomeAsync(client, PinnedSystemTools(WrongPin))).ShouldBe("NoMatchPinned");
         }
 
         [Fact]
         public async Task PinnedList_EmptyAccount_AccountEmpty()
         {
-            var instances = new AccountInstances(); // account has NO live instances at all
-            await using var host = await StartHostAsync(instances);
+            await using var host = await StartHostAsync(new AccountInstances()); // no live instances at all
             using var client = NewClient(host);
 
-            (await ListOutcomeAsync(client, $"/p/{PinA}/api/tools")).ShouldBe("AccountEmpty");
+            (await ListOutcomeAsync(client, PinnedSystemTools(PinA))).ShouldBe("AccountEmpty");
         }
 
         [Fact]
         public async Task UnpinnedList_MultipleInstances_FallsToMru_ProvesPinnedStrictnessContrast()
         {
-            // Regression / contrast: the UNPINNED group carries no pin, so it resolves to MRU (one of the
-            // live instances) — NEVER NoMatchPinned/AccountEmpty. This is exactly the ambiguity the pinned
-            // group removes; the pinned tests above prove the pinned group does NOT do this.
-            var instances = TwoInstanceRegistry();
-            await using var host = await StartHostAsync(instances);
+            // Contrast: the UNPINNED system-tools group carries no pin, so it resolves to MRU (one of the live
+            // instances) — never NoMatchPinned/AccountEmpty. That ambiguity is exactly what the pinned group
+            // removes, and it is why a cloud (pinned-path) client needs the pinned group to probe a KNOWN project.
+            await using var host = await StartHostAsync(TwoInstanceRegistry());
             using var client = NewClient(host);
 
-            var outcome = await ListOutcomeAsync(client, "/api/tools");
+            var outcome = await ListOutcomeAsync(client, UnpinnedSystemTools);
             new[] { InstanceA, InstanceB }.ShouldContain(outcome);
         }
 
-        // ─────────────────── POST call path — outcome → deterministic HTTP status ───────────────────
+        // ─────────────── POST call path — outcome → deterministic HTTP status ───────────────
 
         [Fact]
         public async Task PinnedCall_MatchingPin_Resolves_200()
         {
-            var instances = TwoInstanceRegistry();
-            await using var host = await StartHostAsync(instances);
+            await using var host = await StartHostAsync(TwoInstanceRegistry());
             using var client = NewClient(host);
 
-            using var resp = await CallAsync(client, $"/p/{PinA}/api/tools/ping");
+            // The motivating case: a liveness probe of a KNOWN project over the pinned cloud path.
+            using var resp = await CallAsync(client, $"{PinnedSystemTools(PinA)}/ping");
             resp.StatusCode.ShouldBe(HttpStatusCode.OK);
+            (await resp.Content.ReadAsStringAsync()).ShouldContain(InstanceA);
         }
 
         [Fact]
         public async Task PinnedCall_WrongPinWithSiblingsPresent_NoMatchPinned_404_NeverMru()
         {
-            var instances = TwoInstanceRegistry();
-            await using var host = await StartHostAsync(instances);
+            await using var host = await StartHostAsync(TwoInstanceRegistry());
             using var client = NewClient(host);
 
-            using var resp = await CallAsync(client, $"/p/{WrongPin}/api/tools/ping");
+            using var resp = await CallAsync(client, $"{PinnedSystemTools(WrongPin)}/ping");
             resp.StatusCode.ShouldBe(HttpStatusCode.NotFound);
             (await resp.Content.ReadAsStringAsync()).ShouldContain("NoMatchPinned");
         }
@@ -137,39 +159,59 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
         [Fact]
         public async Task PinnedCall_EmptyAccount_AccountEmpty_503()
         {
-            var instances = new AccountInstances();
-            await using var host = await StartHostAsync(instances);
+            await using var host = await StartHostAsync(new AccountInstances());
             using var client = NewClient(host);
 
-            using var resp = await CallAsync(client, $"/p/{PinA}/api/tools/ping");
+            using var resp = await CallAsync(client, $"{PinnedSystemTools(PinA)}/ping");
             resp.StatusCode.ShouldBe(HttpStatusCode.ServiceUnavailable);
             (await resp.Content.ReadAsStringAsync()).ShouldContain("AccountEmpty");
         }
 
-        // ────────────── Route set — the pinned system-tools analog EXISTS (D15 reversed) ──────────────
+        // ─────────────── Handler parity: pinned and unpinned run the SAME handlers ───────────────
 
         [Fact]
-        public async Task PinnedSystemToolsRoute_IsMapped_AlongsideThePinnedToolRoutes()
+        public async Task MalformedJsonBody_PinnedAndUnpinned_Both400()
         {
-            // Design 06 D15 declined a pinned system-tools route on the false premise that no engine
-            // registers a system `ping` tool (Unity does). The owner ruling of 2026-07-25 reversed it, so the
-            // pinned surface now carries BOTH groups. This asserts the two coexist on one host; the strict-pin
-            // behavior of the system-tools group itself is covered by PinnedSystemToolRoutingTests.
-            var instances = TwoInstanceRegistry();
+            // Body handling lives in the shared CallSystemToolHandler; identical outcomes on both prefixes is
+            // the observable proof the pinned group did not fork the logic.
+            await using var host = await StartHostAsync(TwoInstanceRegistry());
+            using var client = NewClient(host);
+
+            using var pinned = await PostRawAsync(client, $"{PinnedSystemTools(PinA)}/ping", "{ not json");
+            using var unpinned = await PostRawAsync(client, $"{UnpinnedSystemTools}/ping", "{ not json");
+
+            pinned.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+            unpinned.StatusCode.ShouldBe(pinned.StatusCode);
+        }
+
+        [Fact]
+        public async Task NonObjectJsonBody_PinnedAndUnpinned_Both400()
+        {
+            await using var host = await StartHostAsync(TwoInstanceRegistry());
+            using var client = NewClient(host);
+
+            using var pinned = await PostRawAsync(client, $"{PinnedSystemTools(PinA)}/ping", "[1,2,3]");
+            using var unpinned = await PostRawAsync(client, $"{UnpinnedSystemTools}/ping", "[1,2,3]");
+
+            pinned.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+            unpinned.StatusCode.ShouldBe(pinned.StatusCode);
+        }
+
+        [Fact]
+        public async Task ListPayloadShape_PinnedAndUnpinned_AreIdenticalForOneInstance()
+        {
+            // A single-instance account resolves identically with or without a pin, so the two groups must
+            // return byte-identical list payloads — they are the same handler over the same hub.
+            var instances = new AccountInstances();
+            instances.Register(Account, new PluginInstanceMetadata(InstanceA, "unity", "GameA", HashA, "PC-1"), "conn-A");
+
             await using var host = await StartHostAsync(instances);
             using var client = NewClient(host);
 
-            // Control: the UNPINNED system-tools route IS mapped (reachable, not 404, in none mode).
-            (await client.GetAsync("/api/system-tools")).StatusCode.ShouldNotBe(HttpStatusCode.NotFound);
+            var pinned = await client.GetStringAsync(PinnedSystemTools(PinA));
+            var unpinned = await client.GetStringAsync(UnpinnedSystemTools);
 
-            // The pinned system-tools analog is mapped too — both list and call resolve to a handler.
-            (await client.GetAsync($"/p/{PinA}/api/system-tools")).StatusCode.ShouldBe(HttpStatusCode.OK);
-            using var post = await CallAsync(client, $"/p/{PinA}/api/system-tools/ping");
-            post.StatusCode.ShouldBe(HttpStatusCode.OK);
-
-            // …and the pinned TOOL routes still work on the same host (no route-table shadowing between the
-            // two pinned groups, which share the same /p/{pin} prefix).
-            (await ListOutcomeAsync(client, $"/p/{PinA}/api/tools")).ShouldBe(InstanceA);
+            pinned.ShouldBe(unpinned);
         }
 
         // ───────────────────────────────── helpers ─────────────────────────────────
@@ -197,19 +239,21 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
         static Task<HttpResponseMessage> CallAsync(HttpClient client, string route)
             => client.PostAsync(route, new StringContent("{}", Encoding.UTF8, "application/json"));
 
-        // ── Minimal in-memory host: pin-capture middleware + both tool-call groups + both system-tool groups. ──
+        static Task<HttpResponseMessage> PostRawAsync(HttpClient client, string route, string body)
+            => client.PostAsync(route, new StringContent(body, Encoding.UTF8, "application/json"));
+
+        // ── Minimal in-memory host: the pin-capture middleware + both system-tool groups. ──
 
         static async Task<RunningHost> StartHostAsync(AccountInstances instances)
         {
             var builder = WebApplication.CreateBuilder();
             builder.Logging.ClearProviders();
 
-            // none mode: no auth gate — this suite isolates the ROUTING/RESOLUTION behavior (auth parity
-            // is covered by PinnedDirectToolAuthGatingTests).
+            // none mode: no auth gate — this suite isolates the ROUTING/RESOLUTION behavior (auth parity is
+            // covered by PinnedSystemToolAuthGatingTests).
             var dataArguments = Mock.Of<IDataArguments>(d => d.Authorization == Consts.MCP.Server.AuthOption.none);
             builder.Services.AddSingleton(dataArguments);
-            builder.Services.AddSingleton<IClientToolHub>(new ResolutionReportingToolHub(instances, Account));
-            builder.Services.AddSingleton<IClientSystemToolHub>(new StubSystemToolHub());
+            builder.Services.AddSingleton<IClientSystemToolHub>(new ResolutionReportingSystemToolHub(instances, Account));
             builder.Services.AddSingleton(Mock.Of<IAuthorizationWebhookService>());
 
             var app = builder.Build();
@@ -217,10 +261,8 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
             // Production pin-capture middleware: parses /p/<pin> out of the request path into the ambient
             // McpSessionTokenContext, exactly as UseMcpPluginServer wires it in prod.
             app.UseMiddleware<McpSessionTokenMiddleware>();
-            app.MapDirectToolCallApi(dataArguments);       // unpinned group
-            app.MapPinnedDirectToolCallApi(dataArguments); // pinned group (under test)
-            app.MapSystemToolApi(dataArguments);           // unpinned system-tools (control)
-            app.MapPinnedSystemToolApi(dataArguments);     // pinned system-tools analog (D15 reversed)
+            app.MapSystemToolApi(dataArguments);       // unpinned group
+            app.MapPinnedSystemToolApi(dataArguments); // pinned group (under test)
 
             await app.StartAsync();
             return new RunningHost(app, app.Urls.First());
@@ -245,19 +287,19 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
         }
 
         /// <summary>
-        /// A tool hub that, instead of invoking a live plugin over SignalR, resolves the CURRENT request
-        /// against the real <see cref="AccountInstances"/> using the pin the middleware captured from the
-        /// path, and reports the resolution outcome (resolved instance id, or <c>NoMatchPinned</c>/
-        /// <c>AccountEmpty</c>) as the tool result. This exercises the exact production seam the pinned
-        /// routes wire up: pinned URL → <see cref="McpSessionTokenMiddleware"/> → ambient
+        /// A SYSTEM tool hub that, instead of invoking a live plugin over SignalR, resolves the CURRENT request
+        /// against the real <see cref="AccountInstances"/> using the pin the middleware captured from the path,
+        /// and reports the resolution outcome (resolved instance id, or <c>NoMatchPinned</c>/<c>AccountEmpty</c>)
+        /// as the tool result. This exercises the exact production seam the pinned system-tools routes wire up:
+        /// pinned URL → <see cref="McpSessionTokenMiddleware"/> → ambient
         /// <see cref="McpSessionTokenContext.CurrentProjectPin"/> → strict <see cref="AccountInstances.Resolve"/>.
         /// </summary>
-        sealed class ResolutionReportingToolHub : IClientToolHub
+        sealed class ResolutionReportingSystemToolHub : IClientSystemToolHub
         {
             readonly AccountInstances _instances;
             readonly string _account;
 
-            public ResolutionReportingToolHub(AccountInstances instances, string account)
+            public ResolutionReportingSystemToolHub(AccountInstances instances, string account)
             {
                 _instances = instances;
                 _account = account;
@@ -275,7 +317,7 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
                 _ => "AccountEmpty"
             };
 
-            public Task<ResponseData<ResponseListTool[]>> RunListTool(RequestListTool request, CancellationToken cancellationToken = default)
+            public Task<ResponseData<ResponseListTool[]>> RunListSystemTool(RequestListTool request, CancellationToken cancellationToken = default)
                 => Task.FromResult(new ResponseData<ResponseListTool[]>(request.RequestID, ResponseStatus.Success)
                 {
                     Value = new[]
@@ -289,7 +331,7 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
                     }
                 });
 
-            public Task<ResponseData<ResponseCallTool>> RunCallTool(RequestCallTool request)
+            public Task<ResponseData<ResponseCallTool>> RunSystemTool(RequestCallTool request, CancellationToken cancellationToken = default)
             {
                 var resolution = Resolve();
                 return Task.FromResult(resolution.Kind switch
@@ -305,18 +347,6 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
                             .SetData(ResponseCallTool.Error("AccountEmpty", ResponseErrorKind.Unavailable)),
                 });
             }
-        }
-
-        sealed class StubSystemToolHub : IClientSystemToolHub
-        {
-            public Task<ResponseData<ResponseCallTool>> RunSystemTool(RequestCallTool request, CancellationToken cancellationToken = default)
-                => Task.FromResult(ResponseData<ResponseCallTool>.Success(request.RequestID));
-
-            public Task<ResponseData<ResponseListTool[]>> RunListSystemTool(RequestListTool request, CancellationToken cancellationToken = default)
-                => Task.FromResult(new ResponseData<ResponseListTool[]>(request.RequestID, ResponseStatus.Success)
-                {
-                    Value = Array.Empty<ResponseListTool>()
-                });
         }
     }
 }

--- a/McpPlugin.Server/src/Api/DirectToolCallEndpoints.cs
+++ b/McpPlugin.Server/src/Api/DirectToolCallEndpoints.cs
@@ -44,8 +44,12 @@ namespace com.IvanMurzak.McpPlugin.Server.Api
     /// never MRU). The pin is a route token only; its value is captured from the ORIGINAL request path by
     /// <see cref="Auth.McpSessionTokenMiddleware"/> and flows through the ambient session context to
     /// <c>AccountMcpStrategy.ResolveCurrentSession</c> — so the two groups share the SAME handlers and
-    /// resolution mechanism, differing only in whether a pin is present on the path. There is deliberately
-    /// NO pinned system-tools route (design 06 D15). The public <c>/mcp/p/{pin}/…</c> form is served by the
+    /// resolution mechanism, differing only in whether a pin is present on the path. The system-tools surface
+    /// now has the SAME pinned/unpinned pairing — see <see cref="SystemToolEndpoints"/>: design 06 D15
+    /// ("no pinned system-tools route") was REVERSED by the owner ruling of 2026-07-25 because its premise
+    /// ("no engine registers a system <c>ping</c> tool") was false — Unity declares <c>ping</c> as
+    /// <c>ToolType = McpToolType.System</c>, and the cloud golden path is pinned, so a liveness probe over the
+    /// system-tools surface was impossible there. The public <c>/mcp/p/{pin}/…</c> form is served by the
     /// same routes after nginx strips the <c>/mcp</c> prefix (mirroring the existing unpinned convention,
     /// where nginx strips <c>/mcp</c> ahead of <c>/api/tools</c>).
     /// </summary>
@@ -82,7 +86,9 @@ namespace com.IvanMurzak.McpPlugin.Server.Api
         /// with the SAME handlers and the SAME auth gate); the ONLY difference is the route prefix carries a
         /// <c>{pin}</c> segment, which <see cref="Auth.McpSessionTokenMiddleware"/> captures from the request path
         /// so tool resolution is pinned STRICTLY to that project's engine instance (never MRU-routed to a sibling).
-        /// There is deliberately no pinned system-tools analog (design 06 D15).
+        /// The system-tools surface has the matching pinned analog
+        /// (<see cref="SystemToolEndpoints.MapPinnedSystemToolApi"/>) — design 06 D15 was reversed by the owner
+        /// ruling of 2026-07-25 (its "no engine registers a system <c>ping</c> tool" premise was false).
         /// </summary>
         public static WebApplication MapPinnedDirectToolCallApi(this WebApplication app, IDataArguments dataArguments)
         {

--- a/McpPlugin.Server/src/Api/DirectToolCallEndpoints.cs
+++ b/McpPlugin.Server/src/Api/DirectToolCallEndpoints.cs
@@ -45,11 +45,8 @@ namespace com.IvanMurzak.McpPlugin.Server.Api
     /// <see cref="Auth.McpSessionTokenMiddleware"/> and flows through the ambient session context to
     /// <c>AccountMcpStrategy.ResolveCurrentSession</c> — so the two groups share the SAME handlers and
     /// resolution mechanism, differing only in whether a pin is present on the path. The system-tools surface
-    /// now has the SAME pinned/unpinned pairing — see <see cref="SystemToolEndpoints"/>: design 06 D15
-    /// ("no pinned system-tools route") was REVERSED by the owner ruling of 2026-07-25 because its premise
-    /// ("no engine registers a system <c>ping</c> tool") was false — Unity declares <c>ping</c> as
-    /// <c>ToolType = McpToolType.System</c>, and the cloud golden path is pinned, so a liveness probe over the
-    /// system-tools surface was impossible there. The public <c>/mcp/p/{pin}/…</c> form is served by the
+    /// now has the SAME pinned/unpinned pairing — see <see cref="SystemToolEndpoints"/>, whose docblock carries
+    /// the design 06 D15 reversal and its rationale. The public <c>/mcp/p/{pin}/…</c> form is served by the
     /// same routes after nginx strips the <c>/mcp</c> prefix (mirroring the existing unpinned convention,
     /// where nginx strips <c>/mcp</c> ahead of <c>/api/tools</c>).
     /// </summary>
@@ -87,8 +84,7 @@ namespace com.IvanMurzak.McpPlugin.Server.Api
         /// <c>{pin}</c> segment, which <see cref="Auth.McpSessionTokenMiddleware"/> captures from the request path
         /// so tool resolution is pinned STRICTLY to that project's engine instance (never MRU-routed to a sibling).
         /// The system-tools surface has the matching pinned analog
-        /// (<see cref="SystemToolEndpoints.MapPinnedSystemToolApi"/>) — design 06 D15 was reversed by the owner
-        /// ruling of 2026-07-25 (its "no engine registers a system <c>ping</c> tool" premise was false).
+        /// (<see cref="SystemToolEndpoints.MapPinnedSystemToolApi"/>) — see that type for the design 06 D15 reversal.
         /// </summary>
         public static WebApplication MapPinnedDirectToolCallApi(this WebApplication app, IDataArguments dataArguments)
         {

--- a/McpPlugin.Server/src/Api/SystemToolEndpoints.cs
+++ b/McpPlugin.Server/src/Api/SystemToolEndpoints.cs
@@ -42,8 +42,11 @@ namespace com.IvanMurzak.McpPlugin.Server.Api
     /// the SAME <see cref="MapSystemToolGroup"/> registrar (same handlers, same <see cref="AuthGating"/>
     /// decision), and the pin is a route token only — its value is captured from the ORIGINAL request path by
     /// <see cref="Auth.McpSessionTokenMiddleware"/> and flows through the ambient session context to
-    /// <c>AccountMcpStrategy.ResolveCurrentSession</c>, making resolution STRICT by project (an unmatched pin
-    /// yields <c>NoMatchPinned</c>/<c>AccountEmpty</c>, never MRU).
+    /// <c>AccountMcpStrategy.ResolveCurrentSession</c>, making resolution STRICT by project (an unmatched
+    /// WELL-FORMED pin yields <c>NoMatchPinned</c>/<c>AccountEmpty</c>, never MRU). Note the <c>{pin}</c> token
+    /// carries no route constraint, so a segment the route accepts but the middleware rejects as malformed
+    /// (non-hex, or longer than 64 chars) is treated as ABSENT and falls back to <c>sticky → single → MRU</c> —
+    /// the same pre-existing behavior as the pinned tool routes and the pinned MCP path.
     ///
     /// <para><b>Why the pinned group exists (D15 reversed).</b> Design 06 D15 declined a pinned system-tools
     /// route on the premise that "no engine registers a system <c>ping</c> tool". That premise was FALSE: the

--- a/McpPlugin.Server/src/Api/SystemToolEndpoints.cs
+++ b/McpPlugin.Server/src/Api/SystemToolEndpoints.cs
@@ -30,16 +30,47 @@ namespace com.IvanMurzak.McpPlugin.Server.Api
     /// Provides HTTP API endpoints for system tools — internal tools that are NOT exposed
     /// to MCP clients or AI agents. These are only accessible via direct HTTP calls.
     ///
-    /// Endpoints:
+    /// Endpoints (unpinned group):
     ///   GET  /api/system-tools        — list all available system tools with schemas
     ///   POST /api/system-tools/{name} — execute a named system tool with JSON arguments
+    ///
+    /// Endpoints (project-pinned group — owner ruling 2026-07-25, REVERSES design 06 D15):
+    ///   GET  /p/{pin}/api/system-tools        — list system tools for the pinned project's engine instance
+    ///   POST /p/{pin}/api/system-tools/{name} — execute a system tool against the pinned project's instance
+    ///
+    /// The pinned group mirrors <see cref="DirectToolCallEndpoints"/> exactly: both prefixes register through
+    /// the SAME <see cref="MapSystemToolGroup"/> registrar (same handlers, same <see cref="AuthGating"/>
+    /// decision), and the pin is a route token only — its value is captured from the ORIGINAL request path by
+    /// <see cref="Auth.McpSessionTokenMiddleware"/> and flows through the ambient session context to
+    /// <c>AccountMcpStrategy.ResolveCurrentSession</c>, making resolution STRICT by project (an unmatched pin
+    /// yields <c>NoMatchPinned</c>/<c>AccountEmpty</c>, never MRU).
+    ///
+    /// <para><b>Why the pinned group exists (D15 reversed).</b> Design 06 D15 declined a pinned system-tools
+    /// route on the premise that "no engine registers a system <c>ping</c> tool". That premise was FALSE: the
+    /// 2026-07-20 review surveyed Godot/Unreal (where the defect was filed) and missed Unity, which declares
+    /// <c>ping</c> as <c>ToolType = McpToolType.System</c>. Since the cloud golden path is pinned
+    /// (<c>/mcp/p/&lt;pin&gt;/…</c>), without this group a client cannot probe engine liveness over the
+    /// system-tools surface on the cloud path at all. The owner ruling of 2026-07-25 ("<c>ping</c> MUST be a
+    /// system tool on every engine") therefore reverses D15 deliberately.</para>
+    ///
+    /// The public <c>/mcp/p/{pin}/…</c> form is served by the same routes after nginx strips the <c>/mcp</c>
+    /// prefix (mirroring the existing unpinned convention, where nginx strips <c>/mcp</c> ahead of
+    /// <c>/api/system-tools</c>).
     /// </summary>
     public static class SystemToolEndpoints
     {
         const string RoutePrefix = "/api/system-tools";
 
+        // The project-pinned variant of RoutePrefix. {pin} is a route token only so the endpoint matches;
+        // the pin VALUE is captured from the original path by McpSessionTokenMiddleware, exactly like the
+        // pinned tool routes (DirectToolCallEndpoints.PinnedRoutePrefix) and the pinned MCP routes
+        // (StreamableHttpTransportLayer.MapPinnedMcp). No route constraint on {pin} — the middleware
+        // validates it loosely (1–64 hex) and ignores a malformed segment, matching the MCP path.
+        const string PinnedRoutePrefix = "/p/{pin}" + RoutePrefix;
+
         /// <summary>
-        /// Maps the system tool API endpoints onto the given <see cref="WebApplication"/>.
+        /// Maps the UNPINNED system tool API endpoints (<c>/api/system-tools</c>) onto the given
+        /// <see cref="WebApplication"/>.
         /// Authorization follows the same rules as the direct tool call endpoints: required in every
         /// credential-bearing mode — <see cref="Consts.MCP.Server.AuthOption.oauth"/>, the offline
         /// <see cref="Consts.MCP.Server.AuthOption.token"/> (mcp-authorize g6), and the deprecated
@@ -49,6 +80,35 @@ namespace com.IvanMurzak.McpPlugin.Server.Api
         /// </summary>
         public static WebApplication MapSystemToolApi(this WebApplication app, IDataArguments dataArguments)
         {
+            MapSystemToolGroup(app, dataArguments, RoutePrefix);
+            return app;
+        }
+
+        /// <summary>
+        /// Maps the PROJECT-PINNED system tool API endpoints (<c>/p/{pin}/api/system-tools</c>) onto the given
+        /// <see cref="WebApplication"/> (owner ruling 2026-07-25, reversing design 06 D15 — see the type
+        /// docblock). Registered alongside — and byte-identical in behavior to — the unpinned group (both
+        /// delegate to <see cref="MapSystemToolGroup"/> with the SAME handlers and the SAME auth gate); the
+        /// ONLY difference is the route prefix carries a <c>{pin}</c> segment, which
+        /// <see cref="Auth.McpSessionTokenMiddleware"/> captures from the request path so system-tool
+        /// resolution is pinned STRICTLY to that project's engine instance (never MRU-routed to a sibling).
+        /// </summary>
+        public static WebApplication MapPinnedSystemToolApi(this WebApplication app, IDataArguments dataArguments)
+        {
+            MapSystemToolGroup(app, dataArguments, PinnedRoutePrefix);
+            return app;
+        }
+
+        /// <summary>
+        /// Shared registrar for a system-tool route group. Both the unpinned (<c>/api/system-tools</c>) and the
+        /// project-pinned (<c>/p/{pin}/api/system-tools</c>) groups route through this ONE method with the SAME
+        /// list/call handlers and the SAME <see cref="AuthGating"/> decision, so they are byte-identical in
+        /// behavior by construction — the pinned group differs only by the <c>{pin}</c> path token (captured by
+        /// the middleware, not read here). Keeping the auth gate in lockstep guarantees a credential-bearing
+        /// mode can never leave one group gated and the other open.
+        /// </summary>
+        static void MapSystemToolGroup(WebApplication app, IDataArguments dataArguments, string routePrefix)
+        {
             if (app == null)
                 throw new ArgumentNullException(nameof(app));
 
@@ -56,12 +116,12 @@ namespace com.IvanMurzak.McpPlugin.Server.Api
                 throw new ArgumentNullException(nameof(dataArguments));
 
             var requireAuth = AuthGating.RequiresAuthorization(dataArguments.Authorization);
-            var group = app.MapGroup(RoutePrefix);
+            var group = app.MapGroup(routePrefix);
 
-            // GET /api/system-tools — list all registered system tools
+            // GET <prefix> — list all registered system tools
             var listEndpoint = group.MapGet("/", ListSystemToolsHandler);
 
-            // POST /api/system-tools/{name} — invoke a system tool by name
+            // POST <prefix>/{name} — invoke a system tool by name
             var callEndpoint = group.MapPost("/{name}", CallSystemToolHandler);
 
             if (requireAuth)
@@ -69,8 +129,6 @@ namespace com.IvanMurzak.McpPlugin.Server.Api
                 listEndpoint.RequireAuthorization();
                 callEndpoint.RequireAuthorization();
             }
-
-            return app;
         }
 
         /// <summary>

--- a/McpPlugin.Server/src/Extension/ExtensionsWebApplication.cs
+++ b/McpPlugin.Server/src/Extension/ExtensionsWebApplication.cs
@@ -73,10 +73,16 @@ namespace com.IvanMurzak.McpPlugin.Server
             // Setup project-pinned direct tool call API (POST /p/{pin}/api/tools/{name}, GET /p/{pin}/api/tools) —
             // deterministic multi-project dispatch (design 06 / zero-config-engine-connect b1). Same handlers +
             // auth gate as the unpinned group; the pin (captured by McpSessionTokenMiddleware) makes resolution
-            // strict-by-project. No pinned system-tools analog (design 06 D15) — the system-tools mapping below is untouched.
+            // strict-by-project.
             app.MapPinnedDirectToolCallApi(dataArguments);
             // Setup system tool API (POST /api/system-tools/{name}) — internal tools not exposed to MCP
             app.MapSystemToolApi(dataArguments);
+            // Setup project-pinned system tool API (POST /p/{pin}/api/system-tools/{name}, GET /p/{pin}/api/system-tools).
+            // Same pinned/unpinned pairing as the tool routes above. This REVERSES design 06 D15 (owner ruling
+            // 2026-07-25): D15's premise "no engine registers a system ping tool" was false (Unity's `ping` is
+            // ToolType = McpToolType.System), and the cloud golden path is pinned — so without this group a client
+            // cannot probe engine liveness over the system-tools surface on the cloud path at all.
+            app.MapPinnedSystemToolApi(dataArguments);
 
             return app;
         }

--- a/McpPlugin.Server/src/Extension/ExtensionsWebApplication.cs
+++ b/McpPlugin.Server/src/Extension/ExtensionsWebApplication.cs
@@ -77,11 +77,8 @@ namespace com.IvanMurzak.McpPlugin.Server
             app.MapPinnedDirectToolCallApi(dataArguments);
             // Setup system tool API (POST /api/system-tools/{name}) — internal tools not exposed to MCP
             app.MapSystemToolApi(dataArguments);
-            // Setup project-pinned system tool API (POST /p/{pin}/api/system-tools/{name}, GET /p/{pin}/api/system-tools).
-            // Same pinned/unpinned pairing as the tool routes above. This REVERSES design 06 D15 (owner ruling
-            // 2026-07-25): D15's premise "no engine registers a system ping tool" was false (Unity's `ping` is
-            // ToolType = McpToolType.System), and the cloud golden path is pinned — so without this group a client
-            // cannot probe engine liveness over the system-tools surface on the cloud path at all.
+            // Setup project-pinned system tool API (POST /p/{pin}/api/system-tools/{name}, GET /p/{pin}/api/system-tools) —
+            // same pinned/unpinned pairing as the tool routes above; reverses design 06 D15 (see SystemToolEndpoints).
             app.MapPinnedSystemToolApi(dataArguments);
 
             return app;

--- a/docs/architecture-transport-auth.md
+++ b/docs/architecture-transport-auth.md
@@ -36,10 +36,13 @@
 > surface now has the same pinned/unpinned pairing:
 > `GET /p/{pin}/api/system-tools` + `POST /p/{pin}/api/system-tools/{name}`
 > (`SystemToolEndpoints.MapPinnedSystemToolApi`, mapped in `ExtensionsWebApplication`). Both prefixes register
-> through one shared `MapSystemToolGroup` registrar, so the pinned group is byte-identical to the unpinned one
+> through one shared registrar, so the pinned group is byte-identical to the unpinned one
 > by construction — same handlers, same `AuthGating` decision, same `McpSessionTokenMiddleware` pin capture and
-> strict-by-pin resolution (`NoMatchPinned`/`AccountEmpty`, never MRU) — differing only by the `{pin}` path
-> token.
+> strict-by-pin resolution (an unmatched **well-formed** pin yields `NoMatchPinned`/`AccountEmpty`, never MRU)
+> — differing only by the `{pin}` path token. As on the pinned tool routes and the pinned MCP path, `{pin}`
+> carries no route constraint, so a segment the route accepts but `McpSessionTokenMiddleware` rejects as
+> malformed (non-hex, or longer than 64 chars) is treated as **absent** and falls back to `sticky → single →
+> MRU`.
 >
 > Design 06 **D15** had deliberately declined this route on the premise that *"no engine registers a system
 > `ping` tool"*. **That premise was false**: the 2026-07-20 review surveyed Godot/Unreal (where the defect was

--- a/docs/architecture-transport-auth.md
+++ b/docs/architecture-transport-auth.md
@@ -28,9 +28,25 @@
 > an unmatched pin yields `NoMatchPinned`/`AccountEmpty` (never MRU). The pin is routing only: captured from
 > the request path by `McpSessionTokenMiddleware` and flowed to `AccountMcpStrategy.ResolveCurrentSession`,
 > so the pinned group shares the SAME handlers and the SAME auth gate as the unpinned one (identical
-> `oauth`/`token`/`required` gating; open only in `none`). There is deliberately **no pinned system-tools
-> route**. The public `/mcp/p/{pin}/…` form is served by these same routes after nginx strips the `/mcp`
-> prefix (mirroring the existing unpinned convention where nginx strips `/mcp` ahead of `/api/tools`).
+> `oauth`/`token`/`required` gating; open only in `none`). The public `/mcp/p/{pin}/…` form is served by these
+> same routes after nginx strips the `/mcp` prefix (mirroring the existing unpinned convention where nginx
+> strips `/mcp` ahead of `/api/tools`).
+
+> **Pinned REST system-tool routes (owner ruling 2026-07-25 — REVERSES design 06 D15).** The system-tool
+> surface now has the same pinned/unpinned pairing:
+> `GET /p/{pin}/api/system-tools` + `POST /p/{pin}/api/system-tools/{name}`
+> (`SystemToolEndpoints.MapPinnedSystemToolApi`, mapped in `ExtensionsWebApplication`). Both prefixes register
+> through one shared `MapSystemToolGroup` registrar, so the pinned group is byte-identical to the unpinned one
+> by construction — same handlers, same `AuthGating` decision, same `McpSessionTokenMiddleware` pin capture and
+> strict-by-pin resolution (`NoMatchPinned`/`AccountEmpty`, never MRU) — differing only by the `{pin}` path
+> token.
+>
+> Design 06 **D15** had deliberately declined this route on the premise that *"no engine registers a system
+> `ping` tool"*. **That premise was false**: the 2026-07-20 review surveyed Godot/Unreal (where the defect was
+> filed) and missed Unity, which declares `ping` as `ToolType = McpToolType.System`. Because the cloud golden
+> path is pinned (`/mcp/p/<pin>/…`), the absence of this group made an engine-liveness probe over the
+> system-tools surface **impossible on the cloud path**; the local/self-host path was unaffected (unpinned
+> `/api/system-tools` already existed). D15 is therefore reversed deliberately, with the owner ruling behind it.
 
 > **Offline token mode (mcp-authorize g6).** A third auth mode, **`token`**, is the OFFLINE
 > counterpart of `oauth`: a loopback single-project server gates BOTH the SignalR plugin connection


### PR DESCRIPTION
## Summary
- Add the **project-pinned** system-tools route group alongside the unpinned one: `GET /p/{pin}/api/system-tools` (list) + `POST /p/{pin}/api/system-tools/{name}` (call), registered in `ExtensionsWebApplication`.
- Both prefixes route through ONE shared `MapSystemToolGroup` registrar (same list/call handlers, same `AuthGating` decision), so the unpinned group is byte-identical by construction; the pinned group differs only by the `{pin}` path token that `McpSessionTokenMiddleware` captures, making system-tool resolution strict-by-project (`NoMatchPinned`/`AccountEmpty`, **never** MRU) via `AccountMcpStrategy`. This mirrors exactly how `DirectToolCallEndpoints` pairs its own prefixes — no forked logic, no second pin mechanism.
- **Reverses design 06 D15.** D15 declined a pinned system-tools route on the premise that *"no engine registers a system `ping` tool"* — false: the 2026-07-20 review surveyed Godot/Unreal (where the defect was filed) and missed Unity, which declares `ping` as `ToolType = McpToolType.System`. The cloud golden path is pinned (`/mcp/p/<pin>/…`), so an engine-liveness probe over the system-tools surface was impossible there; the local/self-host path was unaffected (unpinned `/api/system-tools` already existed). Owner ruling 2026-07-25.
- Docs: the stale D15 assertions in `DirectToolCallEndpoints`, `ExtensionsWebApplication`, `PinnedDirectToolRoutingTests` and `docs/architecture-transport-auth.md` are corrected (and state *why* D15 was reversed) rather than left contradicting the code.
- The public `/mcp/p/{pin}/…` form is served by these same routes after nginx strips `/mcp`, matching the existing convention.

## Test plan
- [x] Target-specific local tests passed (see profile test.md): `McpPlugin.Server.Tests` **591/591** on **both** `net8.0` and `net9.0`, 0 failures.
- [x] **21 tests fail without this change** (verified by neutering `MapPinnedSystemToolApi` and re-running).
- [x] Routing + pin capture (`PinnedSystemToolRoutingTests`, real loopback host through the production `McpSessionTokenMiddleware` + real `AccountInstances.Resolve`): pinned routes are mapped; matched pin → that project's instance; wrong pin with siblings present → `NoMatchPinned` (never MRU); empty account → `AccountEmpty`; call path maps those outcomes to 200 / 404 / 503; unpinned still falls to MRU (contrast).
- [x] Shared-handler parity: malformed and non-object JSON bodies produce identical 400s on both prefixes; single-instance list payloads are byte-identical pinned vs unpinned.
- [x] Auth-gate parity (`PinnedSystemToolAuthGatingTests`, mirroring the pinned `/api/tools` standard): 401 unauthenticated in `oauth`/`token`/`required` (list AND the executing POST), open in `none`, valid local token reachable; with a REAL `AccessTokenValidator` — wrong-audience JWT rejected, valid JWT reachable, valid PAT via introspection reachable, inactive PAT rejected.
- [x] Existing pinned/unpinned `/api/tools` suites remain green (no route-table shadowing between the two `/p/{pin}` groups).

No `<Version>` bump, no ReflectorNet pin change, no NuGet publish — the release chain is owner-gated.

Closes #184