### PR TITLE
fix(security): malformed project pin fails closed + origin-guard the REST tool routes

### DIFF
--- a/McpPlugin.Server.Tests/ConnectionIdentityAndPinTests.cs
+++ b/McpPlugin.Server.Tests/ConnectionIdentityAndPinTests.cs
@@ -70,15 +70,40 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
         [InlineData("/mcp/p/aabbccdd", "aabbccdd")]
         [InlineData("/p/aabbccdd", "aabbccdd")]
         [InlineData("/mcp/p/AABBCCDD", "aabbccdd")]              // lowercased
-        [InlineData("/mcp", null)]                                // no /p/ segment
-        [InlineData("/mcp/p/", null)]                             // empty pin
-        [InlineData("/mcp/p/not-a-pin!", null)]                   // non-hex ignored
+        [InlineData("/p/aabbccdd/api/tools", "aabbccdd")]        // pinned REST tool route
+        [InlineData("/p/aabbccdd/api/system-tools/ping", "aabbccdd")]
         [InlineData("/p/11112222/p/33334444", "33334444")]        // last wins (config URL suffix)
-        [InlineData(null, null)]
-        [InlineData("", null)]
-        public void TryExtractProjectPin_ParsesTrailingPinSegment(string? path, string? expected)
+        public void TryExtractProjectPin_WellFormedPin_IsCaptured(string path, string expected)
         {
-            McpSessionTokenMiddleware.TryExtractProjectPin(path).ShouldBe(expected);
+            McpSessionTokenMiddleware.TryExtractProjectPin(path, out var pin).ShouldBe(ProjectPinParse.Valid);
+            pin.ShouldBe(expected);
+        }
+
+        [Theory]
+        [InlineData("/mcp")]                                      // no /p/ marker
+        [InlineData("/api/tools")]                                // the genuinely-unpinned REST surface
+        [InlineData("/api/tools/p")]                              // trailing "p" is not a marker (nothing follows)
+        [InlineData(null)]
+        [InlineData("")]
+        public void TryExtractProjectPin_NoMarker_IsAbsentNotMalformed(string? path)
+        {
+            // ABSENT ≠ MALFORMED: an unpinned request is a supported mode and must NOT be rejected.
+            McpSessionTokenMiddleware.TryExtractProjectPin(path, out var pin).ShouldBe(ProjectPinParse.Absent);
+            pin.ShouldBeNull();
+        }
+
+        [Theory]
+        [InlineData("/mcp/p/not-a-pin!")]                         // non-hex
+        [InlineData("/p/zzzz/api/tools")]                         // non-hex on a pinned REST route
+        [InlineData("/mcp/p/")]                                   // marker with an empty value
+        [InlineData("/p/aabbccdd0011223344556677889900aabbccdd0011223344556677889900aabbc")] // 65 hex chars (over the 64 cap)
+        [InlineData("/p/11112222/p/nothex")]                      // a later bad marker never inherits an earlier good pin
+        public void TryExtractProjectPin_PresentButUnparseable_IsMalformed(string path)
+        {
+            // Previously these all returned null — indistinguishable from "unpinned" — which silently
+            // re-enabled MRU fallthrough. They must now be reported as malformed so the caller rejects.
+            McpSessionTokenMiddleware.TryExtractProjectPin(path, out var pin).ShouldBe(ProjectPinParse.Malformed);
+            pin.ShouldBeNull();
         }
 
         // ─────────────────────────── stdio project=<pin> arg ───────────────────────────

--- a/McpPlugin.Server.Tests/ConnectionIdentityAndPinTests.cs
+++ b/McpPlugin.Server.Tests/ConnectionIdentityAndPinTests.cs
@@ -72,6 +72,10 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
         [InlineData("/mcp/p/AABBCCDD", "aabbccdd")]              // lowercased
         [InlineData("/p/aabbccdd/api/tools", "aabbccdd")]        // pinned REST tool route
         [InlineData("/p/aabbccdd/api/system-tools/ping", "aabbccdd")]
+        // Routing matches the literal "p" segment case-insensitively, so an upper-case marker REACHES the
+        // pinned endpoints; parsing it as unpinned would re-open the very downgrade this gate closes.
+        [InlineData("/P/aabbccdd/api/tools", "aabbccdd")]
+        [InlineData("/mcp/P/AABBCCDD", "aabbccdd")]
         [InlineData("/p/11112222/p/33334444", "33334444")]        // last wins (config URL suffix)
         public void TryExtractProjectPin_WellFormedPin_IsCaptured(string path, string expected)
         {
@@ -98,6 +102,7 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
         [InlineData("/mcp/p/")]                                   // marker with an empty value
         [InlineData("/p/aabbccdd0011223344556677889900aabbccdd0011223344556677889900aabbc")] // 65 hex chars (over the 64 cap)
         [InlineData("/p/11112222/p/nothex")]                      // a later bad marker never inherits an earlier good pin
+        [InlineData("/P/not-a-pin/api/tools")]                    // upper-case marker: routed as pinned ⇒ parsed as pinned
         public void TryExtractProjectPin_PresentButUnparseable_IsMalformed(string path)
         {
             // Previously these all returned null — indistinguishable from "unpinned" — which silently

--- a/McpPlugin.Server.Tests/PinnedPathRoutingTests.cs
+++ b/McpPlugin.Server.Tests/PinnedPathRoutingTests.cs
@@ -84,6 +84,26 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
             unmapped.StatusCode.ShouldBe(HttpStatusCode.NotFound);
         }
 
+        // ───────────────── a malformed pin on the MCP plane fails closed ─────────────────
+
+        [Theory]
+        [InlineData("/p/not-a-pin")]
+        [InlineData("/mcp/p/not-a-pin")]
+        public async Task NoneMode_MalformedPin_FailsClosed_NoSessionEstablished(string path)
+        {
+            // The pinned MCP routes carry no constraint on {pin}, so a malformed segment still MATCHES the
+            // endpoint. Before the fix the middleware silently nulled the pin and the request established a
+            // normal (unpinned) MCP session that resolves sticky → single → MRU — i.e. a caller that believed
+            // it was pinned got a session bound to an arbitrary sibling project. It must be rejected instead.
+            await using var host = await StartHostAsync(Consts.MCP.Server.AuthOption.none);
+            using var client = NewClient(host);
+
+            using var resp = await client.SendAsync(InitializeRequest(path), HttpCompletionOption.ResponseHeadersRead);
+
+            resp.StatusCode.ShouldBe(HttpStatusCode.BadRequest, $"{path} carries a malformed pin and must fail closed");
+            resp.Headers.Contains("Mcp-Session-Id").ShouldBeFalse($"{path} must not establish an MCP session");
+        }
+
         // ───────────────── pin capture is live during the request on the pinned paths ─────────────────
 
         [Theory]

--- a/McpPlugin.Server.Tests/Security/MalformedProjectPinFailClosedTests.cs
+++ b/McpPlugin.Server.Tests/Security/MalformedProjectPinFailClosedTests.cs
@@ -142,6 +142,48 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests.Security
             host.SystemToolHub.Invocations.ShouldBeEmpty();
         }
 
+        // ───────── The same hole via an UPPER-CASE marker (routing is case-insensitive) ─────────
+
+        [Theory]
+        [MemberData(nameof(MalformedPins))]
+        public async Task UpperCaseMarker_MalformedPin_Rejected_AndNeverReachesAnyProject(string malformed)
+        {
+            // ASP.NET Core matches the literal "p" segment of "/p/{pin}/api/tools/{name}" case-INSENSITIVELY,
+            // so "/P/<malformed>/…" reaches the PINNED endpoint. If the pin parser matched the marker
+            // ordinally it would see no marker, report ABSENT, and hand the request to the unpinned
+            // sticky → single → MRU path — i.e. the whole fail-closed gate bypassed by one capital letter.
+            await using var host = await StartHostAsync(TwoInstanceRegistry());
+            using var client = NewClient(host);
+
+            using var resp = await CallAsync(client, $"/P/{malformed}/api/tools/ping");
+
+            resp.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+            (await resp.Content.ReadAsStringAsync()).ShouldContain(McpSessionTokenMiddleware.InvalidProjectPinError);
+            host.ToolHub.Invocations.ShouldBeEmpty("an upper-case marker must not bypass the pin gate");
+        }
+
+        [Fact]
+        public async Task UpperCaseMarker_WrongButHexPin_StillFailsClosed_NeverMru()
+        {
+            // The dangerous shape: a WELL-FORMED pin behind an upper-case marker. Ordinal marker matching
+            // made this resolve as unpinned and execute against a SIBLING project (observed: instance-B).
+            await using var host = await StartHostAsync(TwoInstanceRegistry());
+            using var client = NewClient(host);
+
+            (await ListOutcomeAsync(client, $"/P/{WrongButHexPin}/api/tools")).ShouldBe("NoMatchPinned");
+            (await ListOutcomeAsync(client, $"/P/{WrongButHexPin}/api/system-tools")).ShouldBe("NoMatchPinned");
+        }
+
+        [Fact]
+        public async Task UpperCaseMarker_MatchingPin_ResolvesStrictlyToItsOwnProject()
+        {
+            await using var host = await StartHostAsync(TwoInstanceRegistry());
+            using var client = NewClient(host);
+
+            (await ListOutcomeAsync(client, $"/P/{PinA}/api/tools")).ShouldBe(InstanceA);
+            (await ListOutcomeAsync(client, $"/P/{PinB}/api/system-tools")).ShouldBe(InstanceB);
+        }
+
         // ───────── Guarding the behaviour that was ALREADY correct (must not regress) ─────────
 
         [Fact]

--- a/McpPlugin.Server.Tests/Security/MalformedProjectPinFailClosedTests.cs
+++ b/McpPlugin.Server.Tests/Security/MalformedProjectPinFailClosedTests.cs
@@ -1,0 +1,417 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.Common;
+using com.IvanMurzak.McpPlugin.Common.Hub.Client;
+using com.IvanMurzak.McpPlugin.Common.Model;
+using com.IvanMurzak.McpPlugin.Common.Utils;
+using com.IvanMurzak.McpPlugin.Server.Api;
+using com.IvanMurzak.McpPlugin.Server.Auth;
+using com.IvanMurzak.McpPlugin.Server.Strategy;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.Server.Tests.Security
+{
+    /// <summary>
+    /// 🔒 A project pin that is PRESENT but MALFORMED must fail CLOSED.
+    ///
+    /// <para><b>The defect.</b> The pinned routes carry no route constraint on <c>{pin}</c>, so
+    /// <c>/p/&lt;non-hex&gt;/api/tools/{name}</c> still matched an endpoint.
+    /// <c>McpSessionTokenMiddleware</c> then validated the segment loosely and, on failure, set the ambient
+    /// pin to <c>null</c> — indistinguishable from a genuinely unpinned request. <c>AccountInstances.Resolve</c>
+    /// therefore skipped its strict pinned branch entirely and fell through to
+    /// <c>sticky → single → MRU</c>, so a caller that believed it was pinned to project A silently EXECUTED
+    /// its tool call against an arbitrary sibling project B.</para>
+    ///
+    /// <para>The failure was asymmetric, which is what made it dangerous:
+    /// a wrong-but-HEX pin failed closed (<c>NoMatchPinned</c>, never MRU) — only a MALFORMED one failed open.
+    /// Pinning exists precisely to stop cross-project mis-routing, so a silent downgrade to "unpinned"
+    /// defeated the control it was built for.</para>
+    ///
+    /// <para><b>ABSENT ≠ MALFORMED.</b> The genuinely-unpinned surfaces (<c>/api/tools</c>,
+    /// <c>/api/system-tools</c>) are unpinned BY DESIGN and must keep working exactly as before — the
+    /// no-collateral-damage tests below pin that.</para>
+    ///
+    /// Drives a REAL loopback host through the production <see cref="McpSessionTokenMiddleware"/> and all four
+    /// REST groups; the tool hubs report the outcome of the real <see cref="AccountInstances.Resolve"/> AND
+    /// record every invocation, so "the sibling project never executed anything" is asserted directly rather
+    /// than inferred from a status code.
+    /// </summary>
+    [Collection("McpPlugin.Server")]
+    public sealed class MalformedProjectPinFailClosedTests
+    {
+        // pin = leading hex prefix of the project-path SHA-256 (validated as 1–64 hex chars).
+        const string HashA = "aabbccdd11223344556677889900aabbccddeeff00112233445566778899aabb";
+        const string PinA = "aabbccdd";
+        const string HashB = "11223344aabbccdd556677889900aabbccddeeff00112233445566778899aabb";
+        const string PinB = "11223344";
+        const string WrongButHexPin = "deadbeef";
+        const string MalformedPin = "not-a-pin";
+        const string Account = "acc-malformed-pin";
+        const string InstanceA = "instance-A";
+        const string InstanceB = "instance-B";
+
+        /// <summary>Every shape the route accepts but the pin grammar (1–64 hex) rejects.</summary>
+        public static TheoryData<string> MalformedPins() => new TheoryData<string>
+        {
+            "not-a-pin",   // punctuation
+            "zzzz",        // out-of-alphabet letters
+            "1234g",       // one bad nibble in an otherwise-hex value
+            "aabbccdd0011223344556677889900aabbccdd0011223344556677889900aabbc", // 65 hex chars (over the cap)
+        };
+
+        // ───────── The regression: a malformed pin must not execute against a sibling project ─────────
+
+        [Theory]
+        [MemberData(nameof(MalformedPins))]
+        public async Task MalformedPin_ToolCall_Rejected_AndNeverReachesAnyProject(string malformed)
+        {
+            // TWO live instances, so an unpinned/downgraded resolution HAS a sibling to mis-route to.
+            await using var host = await StartHostAsync(TwoInstanceRegistry());
+            using var client = NewClient(host);
+
+            using var resp = await CallAsync(client, $"/p/{malformed}/api/tools/ping");
+
+            resp.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+            (await resp.Content.ReadAsStringAsync()).ShouldContain(McpSessionTokenMiddleware.InvalidProjectPinError);
+            // The decisive assertion: no project executed the call. Before the fix this recorded a routed
+            // instance id (whichever was most-recently-active) — cross-project execution.
+            host.ToolHub.Invocations.ShouldBeEmpty("a malformed pin must never execute a tool anywhere");
+        }
+
+        [Theory]
+        [MemberData(nameof(MalformedPins))]
+        public async Task MalformedPin_SystemToolCall_Rejected_AndNeverReachesAnyProject(string malformed)
+        {
+            await using var host = await StartHostAsync(TwoInstanceRegistry());
+            using var client = NewClient(host);
+
+            using var resp = await CallAsync(client, $"/p/{malformed}/api/system-tools/ping");
+
+            resp.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+            (await resp.Content.ReadAsStringAsync()).ShouldContain(McpSessionTokenMiddleware.InvalidProjectPinError);
+            host.SystemToolHub.Invocations.ShouldBeEmpty("a malformed pin must never execute a system tool anywhere");
+        }
+
+        [Fact]
+        public async Task MalformedPin_ToolList_Rejected_AndNeverReachesAnyProject()
+        {
+            // The list surface leaks the sibling project's tool inventory, so it must fail closed too.
+            await using var host = await StartHostAsync(TwoInstanceRegistry());
+            using var client = NewClient(host);
+
+            using var resp = await client.GetAsync($"/p/{MalformedPin}/api/tools");
+
+            resp.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+            host.ToolHub.Invocations.ShouldBeEmpty();
+        }
+
+        [Fact]
+        public async Task MalformedPin_SystemToolList_Rejected_AndNeverReachesAnyProject()
+        {
+            await using var host = await StartHostAsync(TwoInstanceRegistry());
+            using var client = NewClient(host);
+
+            using var resp = await client.GetAsync($"/p/{MalformedPin}/api/system-tools");
+
+            resp.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+            host.SystemToolHub.Invocations.ShouldBeEmpty();
+        }
+
+        // ───────── Guarding the behaviour that was ALREADY correct (must not regress) ─────────
+
+        [Fact]
+        public async Task WrongButHexPin_StillFailsClosed_NoMatchPinned_NeverMru()
+        {
+            // A well-formed pin that matches no live instance is a DIFFERENT case: the request is valid,
+            // strict resolution runs, and it yields NoMatchPinned — never a sibling. Unchanged by this fix.
+            await using var host = await StartHostAsync(TwoInstanceRegistry());
+            using var client = NewClient(host);
+
+            (await ListOutcomeAsync(client, $"/p/{WrongButHexPin}/api/tools")).ShouldBe("NoMatchPinned");
+            (await ListOutcomeAsync(client, $"/p/{WrongButHexPin}/api/system-tools")).ShouldBe("NoMatchPinned");
+        }
+
+        [Fact]
+        public async Task MatchingPin_StillResolvesStrictlyToItsOwnProject()
+        {
+            await using var host = await StartHostAsync(TwoInstanceRegistry());
+            using var client = NewClient(host);
+
+            (await ListOutcomeAsync(client, $"/p/{PinA}/api/tools")).ShouldBe(InstanceA);
+            (await ListOutcomeAsync(client, $"/p/{PinB}/api/tools")).ShouldBe(InstanceB);
+            (await ListOutcomeAsync(client, $"/p/{PinA}/api/system-tools")).ShouldBe(InstanceA);
+            (await ListOutcomeAsync(client, $"/p/{PinB}/api/system-tools")).ShouldBe(InstanceB);
+        }
+
+        // ───────── No collateral damage: absent ≠ malformed ─────────
+
+        [Fact]
+        public async Task GenuinelyUnpinnedRequest_StillSucceeds()
+        {
+            // /api/tools carries no /p/ marker at all. It is unpinned BY DESIGN and must keep resolving
+            // (sticky → single → MRU) exactly as before — rejecting it would be the collateral damage.
+            await using var host = await StartHostAsync(TwoInstanceRegistry());
+            using var client = NewClient(host);
+
+            var live = new[] { InstanceA, InstanceB };
+            live.ShouldContain(await ListOutcomeAsync(client, "/api/tools"));
+            live.ShouldContain(await ListOutcomeAsync(client, "/api/system-tools"));
+
+            using var call = await CallAsync(client, "/api/tools/ping");
+            call.StatusCode.ShouldBe(HttpStatusCode.OK);
+            host.ToolHub.Invocations.ShouldNotBeEmpty("an unpinned call must still reach a project");
+        }
+
+        [Fact]
+        public async Task UnpinnedRoutesAreUntouched_WhenNoPinnedGroupIsInvolved()
+        {
+            // A path segment that merely LOOKS pin-adjacent (a tool literally named "p") is not a pin
+            // marker — nothing follows it — so the request stays unpinned rather than being rejected.
+            await using var host = await StartHostAsync(TwoInstanceRegistry());
+            using var client = NewClient(host);
+
+            using var resp = await CallAsync(client, "/api/tools/p");
+            resp.StatusCode.ShouldBe(HttpStatusCode.OK);
+        }
+
+        // ───────── Middleware-level: the rejection is terminal and leaks no ambient state ─────────
+
+        [Theory]
+        [MemberData(nameof(MalformedPins))]
+        public async Task Middleware_MalformedPin_ShortCircuits_AndSetsNoAmbientPin(string malformed)
+        {
+            var nextCalled = false;
+            string? pinSeenDownstream = "<unset>";
+            var middleware = new McpSessionTokenMiddleware(_ =>
+            {
+                nextCalled = true;
+                pinSeenDownstream = McpSessionTokenContext.CurrentProjectPin;
+                return Task.CompletedTask;
+            });
+
+            var ctx = new DefaultHttpContext { RequestServices = EmptyProvider };
+            ctx.Request.Path = new PathString($"/p/{malformed}/api/tools/ping");
+            ctx.Response.Body = new System.IO.MemoryStream();
+
+            await middleware.InvokeAsync(ctx);
+
+            ctx.Response.StatusCode.ShouldBe(StatusCodes.Status400BadRequest);
+            nextCalled.ShouldBeFalse("the pipeline must not continue past a malformed pin");
+            pinSeenDownstream.ShouldBe("<unset>");
+            McpSessionTokenContext.CurrentProjectPin.ShouldBeNull();
+        }
+
+        [Fact]
+        public async Task Middleware_AbsentPin_PassesThrough()
+        {
+            var nextCalled = false;
+            var middleware = new McpSessionTokenMiddleware(_ => { nextCalled = true; return Task.CompletedTask; });
+
+            var ctx = new DefaultHttpContext { RequestServices = EmptyProvider };
+            ctx.Request.Path = new PathString("/api/tools/ping");
+            ctx.Response.Body = new System.IO.MemoryStream();
+
+            await middleware.InvokeAsync(ctx);
+
+            nextCalled.ShouldBeTrue("an unpinned request must be untouched");
+        }
+
+        // ───────────────────────────────── helpers ─────────────────────────────────
+
+        static readonly IServiceProvider EmptyProvider = new ServiceCollection().BuildServiceProvider();
+
+        static AccountInstances TwoInstanceRegistry()
+        {
+            var instances = new AccountInstances();
+            instances.Register(Account, new PluginInstanceMetadata(InstanceA, "unity", "GameA", HashA, "PC-1"), "conn-A");
+            instances.Register(Account, new PluginInstanceMetadata(InstanceB, "godot", "GameB", HashB, "PC-2"), "conn-B");
+            return instances;
+        }
+
+        static HttpClient NewClient(RunningHost host) => new HttpClient { BaseAddress = new Uri(host.BaseUrl) };
+
+        static Task<HttpResponseMessage> CallAsync(HttpClient client, string route)
+            => client.PostAsync(route, new StringContent("{}", Encoding.UTF8, "application/json"));
+
+        /// <summary>GET a list route and read back the single reported resolution outcome.</summary>
+        static async Task<string?> ListOutcomeAsync(HttpClient client, string route)
+        {
+            using var resp = await client.GetAsync(route);
+            resp.StatusCode.ShouldBe(HttpStatusCode.OK, $"{route} must reach the list handler");
+            using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+            doc.RootElement.GetArrayLength().ShouldBe(1);
+            return doc.RootElement[0].GetProperty("name").GetString();
+        }
+
+        // ── Minimal in-memory host: the production pin-capture middleware + all four REST groups. ──
+
+        static async Task<RunningHost> StartHostAsync(AccountInstances instances)
+        {
+            var builder = WebApplication.CreateBuilder();
+            builder.Logging.ClearProviders();
+
+            // none mode: no auth gate — this suite isolates PIN handling. (Auth parity lives in the
+            // Pinned*AuthGatingTests suites.) none is also the worst case: an unauthenticated caller.
+            var dataArguments = Mock.Of<IDataArguments>(d => d.Authorization == Consts.MCP.Server.AuthOption.none);
+            var toolHub = new RecordingToolHub(instances, Account);
+            var systemToolHub = new RecordingSystemToolHub(instances, Account);
+
+            builder.Services.AddSingleton(dataArguments);
+            builder.Services.AddSingleton<IClientToolHub>(toolHub);
+            builder.Services.AddSingleton<IClientSystemToolHub>(systemToolHub);
+
+            var app = builder.Build();
+            app.Urls.Add("http://127.0.0.1:0"); // OS-assigned loopback port
+            app.UseMiddleware<McpSessionTokenMiddleware>();
+            app.MapDirectToolCallApi(dataArguments);
+            app.MapPinnedDirectToolCallApi(dataArguments);
+            app.MapSystemToolApi(dataArguments);
+            app.MapPinnedSystemToolApi(dataArguments);
+
+            await app.StartAsync();
+            return new RunningHost(app, app.Urls.First(), toolHub, systemToolHub);
+        }
+
+        sealed class RunningHost : IAsyncDisposable
+        {
+            readonly WebApplication _app;
+            public string BaseUrl { get; }
+            public RecordingToolHub ToolHub { get; }
+            public RecordingSystemToolHub SystemToolHub { get; }
+
+            public RunningHost(WebApplication app, string baseUrl, RecordingToolHub toolHub, RecordingSystemToolHub systemToolHub)
+            {
+                _app = app;
+                BaseUrl = baseUrl;
+                ToolHub = toolHub;
+                SystemToolHub = systemToolHub;
+            }
+
+            public async ValueTask DisposeAsync()
+            {
+                await _app.StopAsync();
+                await _app.DisposeAsync();
+            }
+        }
+
+        /// <summary>
+        /// Resolves the CURRENT request against the real <see cref="AccountInstances"/> using the pin the
+        /// middleware captured, records WHICH project each invocation landed on, and reports the outcome as
+        /// the tool result. The recording is what turns "fails closed" into a directly observable property:
+        /// an empty record proves no sibling project was ever driven.
+        /// </summary>
+        abstract class RecordingHubBase
+        {
+            readonly AccountInstances _instances;
+            readonly string _account;
+            readonly ConcurrentQueue<string> _invocations = new ConcurrentQueue<string>();
+
+            protected RecordingHubBase(AccountInstances instances, string account)
+            {
+                _instances = instances;
+                _account = account;
+            }
+
+            /// <summary>The resolution outcome of every request that reached this hub, in order.</summary>
+            public IReadOnlyCollection<string> Invocations => _invocations.ToArray();
+
+            protected string RecordAndResolve(out InstanceResolution resolution)
+            {
+                resolution = _instances.Resolve(
+                    _account,
+                    McpSessionTokenContext.CurrentProjectPin,
+                    McpSessionTokenContext.CurrentSelectedInstanceId);
+
+                var outcome = resolution.Kind switch
+                {
+                    InstanceResolutionKind.Resolved => resolution.Instance!.InstanceId,
+                    InstanceResolutionKind.NoMatchPinned => "NoMatchPinned",
+                    _ => "AccountEmpty"
+                };
+                _invocations.Enqueue(outcome);
+                return outcome;
+            }
+
+            protected ResponseData<ResponseListTool[]> ListResponse(RequestListTool request)
+            {
+                var outcome = RecordAndResolve(out _);
+                return new ResponseData<ResponseListTool[]>(request.RequestID, ResponseStatus.Success)
+                {
+                    Value = new[]
+                    {
+                        new ResponseListTool
+                        {
+                            Name = outcome,
+                            Enabled = true,
+                            InputSchema = Consts.MCP.EmptyInputSchema
+                        }
+                    }
+                };
+            }
+
+            protected ResponseData<ResponseCallTool> CallResponse(RequestCallTool request)
+            {
+                RecordAndResolve(out var resolution);
+                return resolution.Kind switch
+                {
+                    InstanceResolutionKind.Resolved =>
+                        ResponseData<ResponseCallTool>.Success(request.RequestID)
+                            .SetData(ResponseCallTool.Success(resolution.Instance!.InstanceId)),
+                    InstanceResolutionKind.NoMatchPinned =>
+                        ResponseData<ResponseCallTool>.Error(request.RequestID, "NoMatchPinned", ResponseErrorKind.NotFound)
+                            .SetData(ResponseCallTool.Error("NoMatchPinned", ResponseErrorKind.NotFound)),
+                    _ =>
+                        ResponseData<ResponseCallTool>.Error(request.RequestID, "AccountEmpty", ResponseErrorKind.Unavailable)
+                            .SetData(ResponseCallTool.Error("AccountEmpty", ResponseErrorKind.Unavailable)),
+                };
+            }
+        }
+
+        sealed class RecordingToolHub : RecordingHubBase, IClientToolHub
+        {
+            public RecordingToolHub(AccountInstances instances, string account) : base(instances, account) { }
+
+            public Task<ResponseData<ResponseListTool[]>> RunListTool(RequestListTool request, CancellationToken cancellationToken = default)
+                => Task.FromResult(ListResponse(request));
+
+            public Task<ResponseData<ResponseCallTool>> RunCallTool(RequestCallTool request)
+                => Task.FromResult(CallResponse(request));
+        }
+
+        sealed class RecordingSystemToolHub : RecordingHubBase, IClientSystemToolHub
+        {
+            public RecordingSystemToolHub(AccountInstances instances, string account) : base(instances, account) { }
+
+            public Task<ResponseData<ResponseListTool[]>> RunListSystemTool(RequestListTool request, CancellationToken cancellationToken = default)
+                => Task.FromResult(ListResponse(request));
+
+            public Task<ResponseData<ResponseCallTool>> RunSystemTool(RequestCallTool request, CancellationToken cancellationToken = default)
+                => Task.FromResult(CallResponse(request));
+        }
+    }
+}

--- a/McpPlugin.Server.Tests/Security/OriginPolicyTests.cs
+++ b/McpPlugin.Server.Tests/Security/OriginPolicyTests.cs
@@ -44,7 +44,10 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests.Security
         [InlineData("/p/3fa9c1e2/api/tools/ping", true)]
         [InlineData("/p/3fa9c1e2/api/system-tools", true)]
         [InlineData("/p/3fa9c1e2/api/system-tools/ping", true)]
+        // Routing accepts an upper-case marker, so the guard must too (matches the pin parser).
+        [InlineData("/P/3fa9c1e2/api/tools/ping", true)]
         // Segment-boundary precision: a path that merely SHARES a prefix is not a tool surface.
+        [InlineData("/mcpx", false)]
         [InlineData("/api/toolsets", false)]
         [InlineData("/api/system-toolsets", false)]
         [InlineData("/api", false)]

--- a/McpPlugin.Server.Tests/Security/OriginPolicyTests.cs
+++ b/McpPlugin.Server.Tests/Security/OriginPolicyTests.cs
@@ -30,7 +30,26 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests.Security
         [InlineData("/help", false)]
         [InlineData("/.well-known/oauth-protected-resource", false)]
         [InlineData("/oauth/token", false)]
-        [InlineData("/api/tools", false)]
+        // ── The tool-EXECUTING REST surfaces (2026-07-25). `/api/tools` asserted FALSE here until this
+        //    change: `OriginValidationMiddleware` never ran on it, so a hostile page could drive the local
+        //    server's tool routes from the victim's browser (DNS rebinding). Tightened, never loosened.
+        [InlineData("/api/tools", true)]
+        [InlineData("/api/tools/ping", true)]
+        [InlineData("/api/system-tools", true)]
+        [InlineData("/api/system-tools/ping", true)]
+        // The pinned family — including the bare nginx-stripped pinned MCP endpoint, whose /mcp/p/{pin}
+        // twin was already guarded by the /mcp/ prefix.
+        [InlineData("/p/3fa9c1e2", true)]
+        [InlineData("/p/3fa9c1e2/api/tools", true)]
+        [InlineData("/p/3fa9c1e2/api/tools/ping", true)]
+        [InlineData("/p/3fa9c1e2/api/system-tools", true)]
+        [InlineData("/p/3fa9c1e2/api/system-tools/ping", true)]
+        // Segment-boundary precision: a path that merely SHARES a prefix is not a tool surface.
+        [InlineData("/api/toolsets", false)]
+        [InlineData("/api/system-toolsets", false)]
+        [InlineData("/api", false)]
+        [InlineData("/api/other", false)]
+        [InlineData("/pricing", false)]
         public void IsGuardedPath(string path, bool expected)
             => OriginPolicy.IsGuardedPath(new PathString(path), Hub).ShouldBe(expected);
 

--- a/McpPlugin.Server.Tests/Security/OriginValidationMiddlewareTests.cs
+++ b/McpPlugin.Server.Tests/Security/OriginValidationMiddlewareTests.cs
@@ -95,5 +95,51 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests.Security
             var result = await Run(OAuthMode(), "/.well-known/oauth-protected-resource", "https://evil.example");
             result.nextCalled.ShouldBeTrue();
         }
+
+        // ── REST tool surfaces + the pinned family (2026-07-25) ──────────────────────────────────────
+        //
+        // These routes can EXECUTE tools, and before this change IsGuardedPath excluded them, so
+        // OriginValidationMiddleware never ran its check there: a page on a hostile origin could drive
+        // the local server's tool routes straight from the victim's browser (DNS rebinding), and in
+        // `none` mode without any credential at all. Every assertion below fails without the fix.
+
+        const string Pin = "3fa9c1e2";
+
+        public static TheoryData<string> RestToolPaths() => new TheoryData<string>
+        {
+            "/api/tools",
+            "/api/tools/ping",
+            "/api/system-tools",
+            "/api/system-tools/ping",
+            $"/p/{Pin}",                            // bare pinned MCP endpoint (nginx-stripped form)
+            $"/p/{Pin}/api/tools",
+            $"/p/{Pin}/api/tools/ping",
+            $"/p/{Pin}/api/system-tools",
+            $"/p/{Pin}/api/system-tools/ping",
+        };
+
+        [Theory]
+        [MemberData(nameof(RestToolPaths))]
+        public async Task RebindingShapedOrigin_OnRestToolPaths_Returns403_InBothModes(string path)
+        {
+            // A rebinding attack arrives from a page the user is visiting, so it carries that page's Origin.
+            var none = await Run(NoneMode(), path, "https://evil.example");
+            none.status.ShouldBe(403, $"{path} must reject a hostile Origin");
+            none.nextCalled.ShouldBeFalse($"{path} must never reach the tool handler");
+
+            var oauth = await Run(OAuthMode(), path, "https://evil.example");
+            oauth.status.ShouldBe(403, $"{path} must reject a hostile Origin");
+            oauth.nextCalled.ShouldBeFalse($"{path} must never reach the tool handler");
+        }
+
+        [Theory]
+        [MemberData(nameof(RestToolPaths))]
+        public async Task NativeAndLoopbackCallers_OnRestToolPaths_StillPass(string path)
+        {
+            // No collateral damage: curl / the CLI / the desktop app send no Origin at all, and a local
+            // browser tool UI sends a loopback one. Both must keep working on every guarded REST path.
+            (await Run(NoneMode(), path, null)).nextCalled.ShouldBeTrue($"{path} must stay open to native clients");
+            (await Run(NoneMode(), path, "http://localhost:6123")).nextCalled.ShouldBeTrue($"{path} must stay open to loopback");
+        }
     }
 }

--- a/McpPlugin.Server/src/Api/DirectToolCallEndpoints.cs
+++ b/McpPlugin.Server/src/Api/DirectToolCallEndpoints.cs
@@ -57,7 +57,9 @@ namespace com.IvanMurzak.McpPlugin.Server.Api
         // The project-pinned variant of RoutePrefix. {pin} is a route token only so the endpoint matches;
         // the pin VALUE is captured from the original path by McpSessionTokenMiddleware, exactly like the
         // pinned MCP routes (StreamableHttpTransportLayer.MapPinnedMcp). No route constraint on {pin} — the
-        // middleware validates it loosely (1–64 hex) and ignores a malformed segment, matching the MCP path.
+        // middleware validates it (1–64 hex) and REJECTS a malformed segment with 400 invalid_project_pin
+        // before this group's handlers run, matching the MCP path. It is never downgraded to "unpinned":
+        // that downgrade re-enabled MRU fallthrough and executed the call against a sibling project.
         const string PinnedRoutePrefix = "/p/{pin}" + RoutePrefix;
 
         /// <summary>

--- a/McpPlugin.Server/src/Api/SystemToolEndpoints.cs
+++ b/McpPlugin.Server/src/Api/SystemToolEndpoints.cs
@@ -44,9 +44,11 @@ namespace com.IvanMurzak.McpPlugin.Server.Api
     /// <see cref="Auth.McpSessionTokenMiddleware"/> and flows through the ambient session context to
     /// <c>AccountMcpStrategy.ResolveCurrentSession</c>, making resolution STRICT by project (an unmatched
     /// WELL-FORMED pin yields <c>NoMatchPinned</c>/<c>AccountEmpty</c>, never MRU). Note the <c>{pin}</c> token
-    /// carries no route constraint, so a segment the route accepts but the middleware rejects as malformed
-    /// (non-hex, or longer than 64 chars) is treated as ABSENT and falls back to <c>sticky → single → MRU</c> —
-    /// the same pre-existing behavior as the pinned tool routes and the pinned MCP path.
+    /// carries no route constraint, so a segment the route accepts may still be malformed (non-hex, over 64
+    /// chars, or empty) — the middleware then REJECTS the request with <c>400 invalid_project_pin</c> before any
+    /// handler runs, rather than treating it as ABSENT and falling back to <c>sticky → single → MRU</c>. That
+    /// downgrade was a cross-project execution hole; the same fail-closed rule now covers the pinned tool
+    /// routes and the pinned MCP path.
     ///
     /// <para><b>Why the pinned group exists (D15 reversed).</b> Design 06 D15 declined a pinned system-tools
     /// route on the premise that "no engine registers a system <c>ping</c> tool". That premise was FALSE: the
@@ -68,7 +70,8 @@ namespace com.IvanMurzak.McpPlugin.Server.Api
         // the pin VALUE is captured from the original path by McpSessionTokenMiddleware, exactly like the
         // pinned tool routes (DirectToolCallEndpoints.PinnedRoutePrefix) and the pinned MCP routes
         // (StreamableHttpTransportLayer.MapPinnedMcp). No route constraint on {pin} — the middleware
-        // validates it loosely (1–64 hex) and ignores a malformed segment, matching the MCP path.
+        // validates it (1–64 hex) and REJECTS a malformed segment with 400 invalid_project_pin before
+        // this group's handlers run, matching the MCP path. Never downgraded to "unpinned".
         const string PinnedRoutePrefix = "/p/{pin}" + RoutePrefix;
 
         /// <summary>

--- a/McpPlugin.Server/src/Auth/McpSessionTokenMiddleware.cs
+++ b/McpPlugin.Server/src/Auth/McpSessionTokenMiddleware.cs
@@ -18,6 +18,27 @@ using Microsoft.Extensions.DependencyInjection;
 namespace com.IvanMurzak.McpPlugin.Server.Auth
 {
     /// <summary>
+    /// The outcome of parsing the project pin out of a request path (design 04 D14).
+    /// The three states are deliberately distinct because <b>absent is not malformed</b>:
+    /// an unpinned request is a supported, unprivileged mode, while a present-but-unparseable
+    /// pin is a rejected request.
+    /// </summary>
+    public enum ProjectPinParse
+    {
+        /// <summary>No <c>/p/&lt;pin&gt;</c> marker on the path — the request is genuinely unpinned.</summary>
+        Absent = 0,
+
+        /// <summary>A well-formed pin (1–64 hex chars) was captured.</summary>
+        Valid = 1,
+
+        /// <summary>
+        /// A <c>/p/</c> marker is present but its value is not a well-formed pin. The request MUST be
+        /// rejected — downgrading it to <see cref="Absent"/> would silently re-enable MRU fallthrough.
+        /// </summary>
+        Malformed = 2,
+    }
+
+    /// <summary>
     /// Propagates the bearer token into <see cref="McpSessionTokenContext.CurrentToken"/>
     /// so downstream services (e.g. RemoteToolRunner) can route calls to the correct plugin.
     ///
@@ -29,11 +50,22 @@ namespace com.IvanMurzak.McpPlugin.Server.Auth
     ///      but the caller still sends a token for plugin routing.
     ///
     /// Must run after <c>UseAuthentication()</c> and before endpoint handlers.
+    ///
+    /// <para><b>Fail-closed pin gate.</b> The <c>/p/&lt;pin&gt;</c> segment is parsed FIRST, and a pin that is
+    /// PRESENT but unparseable short-circuits the pipeline with <c>400 invalid_project_pin</c> — see
+    /// <see cref="TryExtractProjectPin(string?, out string?)"/> for why that is a security boundary and not a
+    /// convenience.</para>
     /// </summary>
     public class McpSessionTokenMiddleware
     {
         /// <summary>The MCP Streamable-HTTP session header (case-insensitive lookup).</summary>
         public const string SessionIdHeader = "Mcp-Session-Id";
+
+        /// <summary>The path segment that marks the following segment as a project pin (<c>/p/&lt;pin&gt;</c>).</summary>
+        const string PinMarkerSegment = "p";
+
+        /// <summary>Machine-readable error code returned when a present pin cannot be parsed.</summary>
+        public const string InvalidProjectPinError = "invalid_project_pin";
 
         private readonly RequestDelegate _next;
 
@@ -41,6 +73,19 @@ namespace com.IvanMurzak.McpPlugin.Server.Auth
 
         public async Task InvokeAsync(HttpContext context)
         {
+            // ── Project-pin gate (design 04 D14) — runs BEFORE any ambient session state is set. ──
+            // A pin that is PRESENT on the path but unparseable is REJECTED, never downgraded to
+            // "unpinned": the downgrade made AccountInstances.Resolve skip its strict pinned branch and
+            // fall back to sticky → single → MRU, so a caller that believed it was pinned to project A
+            // silently executed tool calls against an arbitrary sibling project B. ABSENT ≠ MALFORMED —
+            // a path carrying no /p/ marker stays genuinely unpinned and is unaffected.
+            var pinParse = TryExtractProjectPin(context.Request.Path.Value, out var projectPin);
+            if (pinParse == ProjectPinParse.Malformed)
+            {
+                await WriteInvalidProjectPinAsync(context).ConfigureAwait(false);
+                return;
+            }
+
             var tokenClaim = context.User?.FindFirst(TokenAuthenticationHandler.TokenClaimType);
             if (tokenClaim != null)
             {
@@ -60,8 +105,8 @@ namespace com.IvanMurzak.McpPlugin.Server.Auth
             // Null-safe in legacy modes — no sub claim ⇒ null identity ⇒ token-equality routing unchanged.
             McpSessionTokenContext.CurrentIdentity = ConnectionIdentity.FromPrincipal(context.User);
 
-            // Capture the project pin from the config URL's trailing /p/<pin> segment (design 04 D14).
-            McpSessionTokenContext.CurrentProjectPin = TryExtractProjectPin(context.Request.Path.Value);
+            // Publish the project pin captured above (null when the path carried no /p/ marker at all).
+            McpSessionTokenContext.CurrentProjectPin = projectPin;
 
             // Capture the MCP session id (mcp-authorize b4) and reload this session's sticky
             // engine-instance selection so account routing honors it (design 04 step 2). The store is
@@ -106,27 +151,66 @@ namespace com.IvanMurzak.McpPlugin.Server.Auth
         }
 
         /// <summary>
-        /// Extracts the project pin from a request path whose config URL ends in a
-        /// <c>/p/&lt;pin&gt;</c> segment (design 04 D14). Returns the LAST such <c>&lt;pin&gt;</c>
-        /// (the config URL suffix), or null when absent. The pin is the first 8 hex chars of the
-        /// project SHA-256; validated loosely as 1–64 hex chars so a malformed segment is ignored.
+        /// Parses the project pin out of a request path whose config URL ends in a <c>/p/&lt;pin&gt;</c>
+        /// segment (design 04 D14). The pin is the leading hex prefix of the project SHA-256, validated as
+        /// 1–64 hex chars; when several well-formed markers appear the LAST one wins (the config URL suffix).
+        ///
+        /// <para><b>Tri-state on purpose — fail closed.</b> This used to return <c>null</c> for BOTH "no
+        /// <c>/p/</c> marker" and "marker present, value unparseable", which made the two indistinguishable
+        /// to the caller. Because the pinned routes carry no route constraint on <c>{pin}</c>, a request
+        /// like <c>/p/not-a-pin/api/tools/{name}</c> still matched an endpoint, arrived with a null pin, and
+        /// was resolved as UNPINNED — <see cref="Strategy.AccountInstances.Resolve"/> skipped its strict
+        /// pinned branch and fell through to <c>sticky → single → MRU</c>, executing the call against an
+        /// arbitrary sibling project. The failure was asymmetric: a wrong-but-HEX pin failed closed
+        /// (<c>NoMatchPinned</c>), only a MALFORMED one failed open. Callers must now distinguish
+        /// <see cref="ProjectPinParse.Absent"/> (supported, unpinned) from
+        /// <see cref="ProjectPinParse.Malformed"/> (reject the request).</para>
         /// </summary>
-        public static string? TryExtractProjectPin(string? path)
+        /// <param name="path">The ORIGINAL request path (route-parameter matching preserves it).</param>
+        /// <param name="pin">The lower-cased pin when the result is <see cref="ProjectPinParse.Valid"/>; else null.</param>
+        /// <returns>Whether the path carried no pin, a well-formed pin, or an unparseable one.</returns>
+        public static ProjectPinParse TryExtractProjectPin(string? path, out string? pin)
         {
+            pin = null;
             if (string.IsNullOrEmpty(path))
-                return null;
+                return ProjectPinParse.Absent;
 
             var segments = path!.Split('/');
-            string? pin = null;
+            var sawMarker = false;
             for (var i = 0; i + 1 < segments.Length; i++)
             {
-                if (!string.Equals(segments[i], "p", StringComparison.Ordinal))
+                if (!string.Equals(segments[i], PinMarkerSegment, StringComparison.Ordinal))
                     continue;
+
+                sawMarker = true;
                 var candidate = segments[i + 1];
-                if (IsHex(candidate))
-                    pin = candidate.ToLowerInvariant();
+                if (!IsHex(candidate))
+                {
+                    // Present but unparseable (incl. an empty segment such as "/mcp/p/") ⇒ fail closed.
+                    // Never keep an earlier well-formed pin either: the caller's intent is ambiguous.
+                    pin = null;
+                    return ProjectPinParse.Malformed;
+                }
+
+                pin = candidate.ToLowerInvariant();
             }
-            return pin;
+
+            return sawMarker ? ProjectPinParse.Valid : ProjectPinParse.Absent;
+        }
+
+        /// <summary>
+        /// Rejects a request whose path carries an unparseable project pin. Deliberately terminal — the
+        /// pipeline is NOT continued, so no handler, hub, or tool ever observes the request.
+        /// </summary>
+        static Task WriteInvalidProjectPinAsync(HttpContext context)
+        {
+            context.Response.StatusCode = StatusCodes.Status400BadRequest;
+            context.Response.ContentType = "application/json";
+            return context.Response.WriteAsJsonAsync(new
+            {
+                error = InvalidProjectPinError,
+                message = "The project pin path segment is malformed; expected 1-64 hexadecimal characters."
+            });
         }
 
         static bool IsHex(string? s)

--- a/McpPlugin.Server/src/Auth/McpSessionTokenMiddleware.cs
+++ b/McpPlugin.Server/src/Auth/McpSessionTokenMiddleware.cs
@@ -61,7 +61,12 @@ namespace com.IvanMurzak.McpPlugin.Server.Auth
         /// <summary>The MCP Streamable-HTTP session header (case-insensitive lookup).</summary>
         public const string SessionIdHeader = "Mcp-Session-Id";
 
-        /// <summary>The path segment that marks the following segment as a project pin (<c>/p/&lt;pin&gt;</c>).</summary>
+        /// <summary>
+        /// The path segment that marks the following segment as a project pin (<c>/p/&lt;pin&gt;</c>).
+        /// Matched CASE-INSENSITIVELY, because ASP.NET Core matches the literal <c>p</c> segment of the
+        /// pinned route templates case-insensitively too: an Ordinal match here would let <c>/P/&lt;pin&gt;</c>
+        /// route as PINNED while parsing as unpinned — the exact downgrade this gate exists to stop.
+        /// </summary>
         const string PinMarkerSegment = "p";
 
         /// <summary>Machine-readable error code returned when a present pin cannot be parsed.</summary>
@@ -154,6 +159,8 @@ namespace com.IvanMurzak.McpPlugin.Server.Auth
         /// Parses the project pin out of a request path whose config URL ends in a <c>/p/&lt;pin&gt;</c>
         /// segment (design 04 D14). The pin is the leading hex prefix of the project SHA-256, validated as
         /// 1–64 hex chars; when several well-formed markers appear the LAST one wins (the config URL suffix).
+        /// The <c>p</c> marker is matched CASE-INSENSITIVELY to stay in lockstep with routing (see
+        /// <see cref="PinMarkerSegment"/>); the pin VALUE may be upper- or lower-case hex and is lower-cased.
         ///
         /// <para><b>Tri-state on purpose — fail closed.</b> This used to return <c>null</c> for BOTH "no
         /// <c>/p/</c> marker" and "marker present, value unparseable", which made the two indistinguishable
@@ -179,7 +186,9 @@ namespace com.IvanMurzak.McpPlugin.Server.Auth
             var sawMarker = false;
             for (var i = 0; i + 1 < segments.Length; i++)
             {
-                if (!string.Equals(segments[i], PinMarkerSegment, StringComparison.Ordinal))
+                // Case-INSENSITIVE: routing matches the literal "p" segment that way, so "/P/<pin>" reaches
+                // the pinned endpoints and must be parsed as pinned (see PinMarkerSegment).
+                if (!string.Equals(segments[i], PinMarkerSegment, StringComparison.OrdinalIgnoreCase))
                     continue;
 
                 sawMarker = true;
@@ -205,12 +214,11 @@ namespace com.IvanMurzak.McpPlugin.Server.Auth
         static Task WriteInvalidProjectPinAsync(HttpContext context)
         {
             context.Response.StatusCode = StatusCodes.Status400BadRequest;
-            context.Response.ContentType = "application/json";
             return context.Response.WriteAsJsonAsync(new
             {
                 error = InvalidProjectPinError,
                 message = "The project pin path segment is malformed; expected 1-64 hexadecimal characters."
-            });
+            }, context.RequestAborted);
         }
 
         static bool IsHex(string? s)

--- a/McpPlugin.Server/src/Security/OriginPolicy.cs
+++ b/McpPlugin.Server/src/Security/OriginPolicy.cs
@@ -21,10 +21,33 @@ namespace com.IvanMurzak.McpPlugin.Server.Security
     /// </summary>
     public static class OriginPolicy
     {
+        /// <summary>The project-pinned route family root — <c>/p/{pin}</c> and everything beneath it.</summary>
+        const string PinnedRoot = "/p";
+
         /// <summary>
-        /// True when the request path is one the transport MUST guard: the MCP endpoints
-        /// (<c>/</c>, <c>/mcp</c>, <c>/mcp/*</c>) and the SignalR hub (incl. <c>/negotiate</c>).
+        /// The UNPINNED REST tool surfaces. They can EXECUTE tools, so they need exactly the same
+        /// rebinding defense as the MCP endpoint (their pinned twins are covered by <see cref="PinnedRoot"/>).
+        /// </summary>
+        static readonly string[] RestToolSurfaces = { "/api/tools", "/api/system-tools" };
+
+        /// <summary>
+        /// True when the request path is one the transport MUST guard:
+        /// <list type="bullet">
+        ///   <item>the MCP endpoints (<c>/</c>, <c>/mcp</c>, <c>/mcp/*</c>) and the SignalR hub (incl. <c>/negotiate</c>);</item>
+        ///   <item>every project-pinned route (<c>/p</c>, <c>/p/{pin}</c>, <c>/p/{pin}/…</c>) — that family covers the
+        ///   nginx-stripped pinned MCP endpoint <b>and</b> both pinned REST tool groups;</item>
+        ///   <item>the unpinned REST tool surfaces <c>/api/tools[/…]</c> and <c>/api/system-tools[/…]</c>.</item>
+        /// </list>
         /// Discovery paths (<c>/.well-known/*</c>, <c>/oauth/*</c>) are intentionally NOT guarded.
+        ///
+        /// <para><b>Why the REST/pinned families are guarded (2026-07-25).</b> Guarding only <c>/mcp*</c> left every
+        /// tool-EXECUTING REST route outside the DNS-rebinding defense: a hostile page could drive
+        /// <c>POST /api/tools/{name}</c>, <c>POST /api/system-tools/{name}</c> or their <c>/p/{pin}/…</c> variants from
+        /// the victim's own browser — unauthenticated in <c>none</c> mode. The bare pinned MCP endpoint <c>/p/{pin}</c>
+        /// (what the server receives after nginx strips <c>/mcp</c>) was unguarded for the same reason, while its
+        /// <c>/mcp/p/{pin}</c> twin was guarded by the <c>/mcp/</c> prefix — an incoherence this closes. Only
+        /// <c>/api/tools</c> and <c>/api/system-tools</c> are added from <c>/api/*</c>: guarding <c>/api/*</c>
+        /// wholesale would capture a hosting application's own unrelated endpoints.</para>
         /// </summary>
         public static bool IsGuardedPath(PathString path, string hubPath)
         {
@@ -42,7 +65,30 @@ namespace com.IvanMurzak.McpPlugin.Server.Security
             if (value.StartsWith("/mcp/", StringComparison.OrdinalIgnoreCase))
                 return true;
 
+            // Project-pinned family: /p, /p/{pin}, /p/{pin}/api/tools[/…], /p/{pin}/api/system-tools[/…].
+            // Guarded as a whole so a future pinned route is covered by construction, never by a later edit.
+            if (IsSegmentPrefix(value, PinnedRoot))
+                return true;
+
+            foreach (var surface in RestToolSurfaces)
+            {
+                if (IsSegmentPrefix(value, surface))
+                    return true;
+            }
+
             return false;
+        }
+
+        /// <summary>
+        /// True when <paramref name="value"/> equals <paramref name="prefix"/> exactly, or extends it at a
+        /// SEGMENT boundary (<c>/api/tools</c> and <c>/api/tools/x</c> match; <c>/api/toolsX</c> does not).
+        /// </summary>
+        static bool IsSegmentPrefix(string value, string prefix)
+        {
+            if (!value.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                return false;
+
+            return value.Length == prefix.Length || value[prefix.Length] == '/';
         }
 
         /// <summary>

--- a/McpPlugin.Server/src/Security/OriginPolicy.cs
+++ b/McpPlugin.Server/src/Security/OriginPolicy.cs
@@ -21,6 +21,9 @@ namespace com.IvanMurzak.McpPlugin.Server.Security
     /// </summary>
     public static class OriginPolicy
     {
+        /// <summary>The MCP endpoint root — <c>/mcp</c> and everything beneath it (incl. <c>/mcp/p/{pin}</c>).</summary>
+        const string McpRoot = "/mcp";
+
         /// <summary>The project-pinned route family root — <c>/p/{pin}</c> and everything beneath it.</summary>
         const string PinnedRoot = "/p";
 
@@ -60,9 +63,9 @@ namespace com.IvanMurzak.McpPlugin.Server.Security
 
             if (string.Equals(value, "/", StringComparison.Ordinal))
                 return true;
-            if (string.Equals(value, "/mcp", StringComparison.OrdinalIgnoreCase))
-                return true;
-            if (value.StartsWith("/mcp/", StringComparison.OrdinalIgnoreCase))
+            // MCP endpoint family: /mcp, /mcp/…, /mcp/p/{pin}/… — the same segment-boundary rule the
+            // families below use, so "/mcpx" is still NOT the MCP endpoint.
+            if (IsSegmentPrefix(value, McpRoot))
                 return true;
 
             // Project-pinned family: /p, /p/{pin}, /p/{pin}/api/tools[/…], /p/{pin}/api/system-tools[/…].

--- a/McpPlugin.Server/src/Transport/StreamableHttpTransportLayer.cs
+++ b/McpPlugin.Server/src/Transport/StreamableHttpTransportLayer.cs
@@ -203,6 +203,11 @@ namespace com.IvanMurzak.McpPlugin.Server.Transport
         /// request path by the middleware (route-parameter matching preserves the path, unlike a
         /// pre-routing rewrite, which would strip the pin before capture). Served in BOTH auth modes so
         /// the pinned URL behaves exactly like <c>/mcp</c> (401 in oauth, anonymous session in none).
+        ///
+        /// <para>Because <c>{pin}</c> carries no route constraint, a MALFORMED segment still matches these
+        /// routes; <see cref="Auth.McpSessionTokenMiddleware"/> rejects it with <c>400 invalid_project_pin</c>
+        /// so no MCP session is ever established for it — it is never downgraded to an unpinned session,
+        /// which would resolve <c>sticky → single → MRU</c> onto an arbitrary sibling project.</para>
         /// </summary>
         static void MapPinnedMcp(WebApplication app, bool requireAuthorization)
         {

--- a/docs/architecture-transport-auth.md
+++ b/docs/architecture-transport-auth.md
@@ -66,6 +66,13 @@
 > isolation is exactly the control that stops cross-project mis-routing (design 04 D14 / design 06), so a
 > silent downgrade defeated it.
 >
+> The `/p/` **marker** is matched **case-insensitively**, in lockstep with routing: ASP.NET Core matches the
+> literal `p` segment of `/p/{pin}/…` case-insensitively, so `/P/<pin>/…` reaches the pinned endpoints. An
+> ordinal marker match would parse those requests as *unpinned* and hand them straight back to
+> `sticky → single → MRU` — the same downgrade, bypassable with one capital letter. (The pin VALUE may be
+> upper- or lower-case hex; it is lower-cased before resolution.) `OriginPolicy` matches the same family
+> case-insensitively for the same reason.
+>
 > `TryExtractProjectPin` is therefore **tri-state** (`ProjectPinParse.Absent` / `Valid` / `Malformed`) rather
 > than "pin or null" — a signature change on `McpPlugin.Server`'s public surface, because the two `null`
 > meanings had to become distinguishable at the call site. **Absent ≠ malformed:** a request carrying no `/p/`

--- a/docs/architecture-transport-auth.md
+++ b/docs/architecture-transport-auth.md
@@ -40,9 +40,9 @@
 > by construction — same handlers, same `AuthGating` decision, same `McpSessionTokenMiddleware` pin capture and
 > strict-by-pin resolution (an unmatched **well-formed** pin yields `NoMatchPinned`/`AccountEmpty`, never MRU)
 > — differing only by the `{pin}` path token. As on the pinned tool routes and the pinned MCP path, `{pin}`
-> carries no route constraint, so a segment the route accepts but `McpSessionTokenMiddleware` rejects as
-> malformed (non-hex, or longer than 64 chars) is treated as **absent** and falls back to `sticky → single →
-> MRU`.
+> carries no route constraint, so a segment the route accepts may still be rejected by
+> `McpSessionTokenMiddleware` as malformed — see the fail-closed callout below; such a request is **rejected**,
+> never downgraded to unpinned.
 >
 > Design 06 **D15** had deliberately declined this route on the premise that *"no engine registers a system
 > `ping` tool"*. **That premise was false**: the 2026-07-20 review surveyed Godot/Unreal (where the defect was
@@ -50,6 +50,37 @@
 > path is pinned (`/mcp/p/<pin>/…`), the absence of this group made an engine-liveness probe over the
 > system-tools surface **impossible on the cloud path**; the local/self-host path was unaffected (unpinned
 > `/api/system-tools` already existed). D15 is therefore reversed deliberately, with the owner ruling behind it.
+
+> **A malformed project pin FAILS CLOSED (2026-07-25, security).** A `/p/<pin>` segment that is **present but
+> unparseable** (non-hex, over 64 chars, or empty) is now **rejected** with `400 invalid_project_pin` by
+> `McpSessionTokenMiddleware`, before any ambient session state is set and before any handler, hub, or tool
+> observes the request. It is no longer treated as *absent*.
+>
+> The previous behaviour — documented here as intended, and shared by the pinned MCP path and both pinned REST
+> groups — silently downgraded such a request to **unpinned**: `McpSessionTokenMiddleware.TryExtractProjectPin`
+> returned `null`, so `AccountInstances.Resolve` skipped its strict pinned branch and fell back to
+> `sticky → single → MRU`. Because `{pin}` carries no route constraint, `/p/<non-hex>/api/tools/{name}` still
+> matched an endpoint — so a caller that believed it was pinned to project A silently **executed tool calls
+> against an arbitrary sibling project B**. The failure was asymmetric, which is what made it dangerous: a
+> **wrong-but-hex** pin failed closed (`NoMatchPinned`, never MRU); only a **malformed** one failed open. Pin
+> isolation is exactly the control that stops cross-project mis-routing (design 04 D14 / design 06), so a
+> silent downgrade defeated it.
+>
+> `TryExtractProjectPin` is therefore **tri-state** (`ProjectPinParse.Absent` / `Valid` / `Malformed`) rather
+> than "pin or null" — a signature change on `McpPlugin.Server`'s public surface, because the two `null`
+> meanings had to become distinguishable at the call site. **Absent ≠ malformed:** a request carrying no `/p/`
+> marker at all (`/api/tools/…`, `/mcp`) is unpinned BY DESIGN and is completely unaffected.
+
+> **Origin guarding covers the REST tool surfaces (2026-07-25, security).** `OriginPolicy.IsGuardedPath` now
+> also guards the tool-EXECUTING REST routes — `/api/tools[/…]`, `/api/system-tools[/…]` — and the whole
+> project-pinned family `/p[/…]`, which covers both pinned REST groups **and** the bare pinned MCP endpoint
+> `/p/{pin}` (the form the server receives after nginx strips `/mcp`; only its `/mcp/p/{pin}` twin was guarded
+> before, via the `/mcp/` prefix). Previously `IsGuardedPath` matched only `/`, `/mcp`, `/mcp/*` and the hub
+> path, so `OriginValidationMiddleware` never ran its check on the REST surfaces: a hostile page could drive
+> the local server's tool routes from the victim's own browser (**DNS rebinding**) — unauthenticated in `none`
+> mode. Only those two `/api/*` prefixes are added, deliberately: guarding `/api/*` wholesale would capture a
+> hosting application's own unrelated endpoints. Native clients (no `Origin`) and loopback origins are
+> unaffected.
 
 > **Offline token mode (mcp-authorize g6).** A third auth mode, **`token`**, is the OFFLINE
 > counterpart of `oauth`: a loopback single-project server gates BOTH the SignalR plugin connection


### PR DESCRIPTION
## Summary

Two **pre-existing** security defects on the pinned / REST surfaces, surfaced by the review of #185 and deliberately left out of scope there. **Neither was introduced by #185** — both also affect the existing unpinned `/api/tools` surface.

### 1. A present-but-MALFORMED project pin failed OPEN → cross-project execution

The pinned routes carry **no route constraint** on `{pin}` (`DirectToolCallEndpoints.PinnedRoutePrefix`, `SystemToolEndpoints.PinnedRoutePrefix`, `StreamableHttpTransportLayer.MapPinnedMcp`), so `/p/<non-hex>/api/tools/{name}` still matched an endpoint. `McpSessionTokenMiddleware.TryExtractProjectPin` then validated the segment loosely and, on failure, returned `null` — indistinguishable from "no pin at all". `AccountInstances.Resolve` therefore skipped its strict pinned branch and fell back to `sticky → single → MRU`, so a caller that believed it was pinned to project A silently **executed tool calls against an arbitrary sibling project B**.

The failure was asymmetric, which is what made it dangerous:

| pin shape | before | after |
|---|---|---|
| wrong but **hex** | ✅ fails closed (`NoMatchPinned`) | unchanged |
| **malformed / non-hex** | ❌ **fails open**, silently MRU-routes | ✅ `400 invalid_project_pin` |
| genuinely **absent** (`/api/tools/…`) | unpinned by design | unchanged |

- `TryExtractProjectPin` is now **tri-state** — `ProjectPinParse.Absent` / `Valid` / `Malformed` — because the two `null` meanings had to become distinguishable at the call site.
- `McpSessionTokenMiddleware` rejects a malformed pin with `400 invalid_project_pin` **first**, before any ambient session state is set and before any handler, hub or tool observes the request. A malformed segment is never downgraded to "unpinned".
- **ABSENT ≠ MALFORMED.** A request carrying no `/p/` marker (`/api/tools/…`, `/mcp`) is unpinned by design and is completely unaffected — asserted explicitly.
- An empty marker value (`/mcp/p/`) and a value over the 64-char cap are treated as malformed (fail closed).

### 2. `OriginPolicy.IsGuardedPath` did not guard the REST tool routes

`IsGuardedPath` matched only `/`, `/mcp`, `/mcp/*` and the hub path, so `OriginValidationMiddleware` never ran its check on the tool-**executing** REST routes — a **DNS-rebinding** exposure: a hostile page could drive the local server's tool routes from the victim's own browser, unauthenticated in `none` mode. Now guarded:

- `/api/tools[/…]` and `/api/system-tools[/…]` (segment-boundary matching — `/api/toolsets` is *not* captured);
- the whole project-pinned family `/p[/…]`, covering both pinned REST groups **and** the bare pinned MCP endpoint `/p/{pin}`.

Native clients (no `Origin`) and loopback origins are unaffected — asserted on every newly-guarded path.

## ⚠ Deviations from the brief — please read

- **A third gap, not in the brief.** The brief named `/api/tools`, `/api/system-tools` and their `/p/{pin}/…` variants. Ground truth showed the **bare pinned MCP endpoint `/p/{pin}` was also unguarded** — it is the form the server receives in production after nginx strips `/mcp`, while its `/mcp/p/{pin}` twin *was* guarded via the `/mcp/` prefix. Guarding one and not the other is incoherent, so the fix covers the `/p` family as a whole (which subsumes the pinned REST variants and covers future pinned routes by construction).
- **Only two `/api/*` prefixes are guarded, not `/api/*`.** Guarding `/api/*` wholesale would capture a hosting application's own unrelated endpoints. Recorded deliberately.
- **One existing expectation was flipped**: `OriginPolicyTests` asserted `IsGuardedPath("/api/tools") == false`. That encoded the defect. It is now `true` — a tightening; **no existing check was loosened**.
- **A fourth gap, found in refine — the fail-closed gate was bypassable with one capital letter.** ASP.NET Core matches the literal `p` segment of `/p/{pin}/…` **case-insensitively**, so `/P/<pin>/…` reaches the pinned endpoint — but `TryExtractProjectPin` compared the marker with `StringComparison.Ordinal`, saw no marker, reported `Absent`, and handed the request straight back to `sticky → single → MRU`. Verified against the real loopback host BEFORE fixing: `/P/deadbeef/api/tools` returned `200` with `pin=<null>` resolved to sibling `instance-B` (its lower-case twin correctly returned `NoMatchPinned`), and `/P/not-a-pin/api/tools` skipped the new `400` entirely. The marker is now matched `OrdinalIgnoreCase`, in lockstep with routing — `OriginPolicy` already matched the family that way, so the two halves of this PR now agree. Covered by 7 new assertions; re-planting the `Ordinal` compare fails 9 of them.
- **Public API change on `McpPlugin.Server`**: `TryExtractProjectPin(string?)` → `TryExtractProjectPin(string?, out string?)` returning `ProjectPinParse`. In-repo the only callers are the middleware and its tests. Keeping a "pin or null" overload would have preserved the exact footgun this PR removes, so it was replaced rather than added to.

## Test plan

- [x] Target-specific local tests passed (see profile `test.md`): full solution gate green — `McpPlugin.Server.Tests` **650/650** + `McpPlugin.Tests` **808/808**, on **both** `net8.0` and `net9.0`, **0 failures** (`dotnet restore` → `build --configuration Release` → `test --no-build --configuration Release`, mirroring `test-pull-request.yml`).
- [x] **34 tests fail without these changes**, verified by neutering both fixes on the same tree (middleware rejection short-circuited + `IsGuardedPath` reverted): 14 `MalformedProjectPinFailClosedTests` + 2 `PinnedPathRoutingTests` (finding 1), 9 `OriginPolicyTests` + 9 `OriginValidationMiddlewareTests` (finding 2).
- [x] **The required "must fail against today's code" test**: `MalformedProjectPinFailClosedTests` drives a REAL loopback host through the production `McpSessionTokenMiddleware` and all four REST groups with **two live instances registered** (so a downgraded resolution *has* a sibling to mis-route to). The recording hubs assert `Invocations.ShouldBeEmpty()` — i.e. *no project executed anything* — rather than inferring safety from a status code. Before the fix this recorded a routed instance id.
- [x] Wrong-but-hex pin still fails closed (`NoMatchPinned`, never MRU) on both tool and system-tool groups — guarded, unchanged.
- [x] Matching pin still resolves strictly to its own project; genuinely unpinned `/api/tools` + `/api/system-tools` still resolve and still execute (no collateral damage); a tool literally named `p` is still not read as a pin marker.
- [x] MCP plane: `/p/not-a-pin` and `/mcp/p/not-a-pin` now `400` and establish **no** `Mcp-Session-Id`.
- [x] Rebinding-shaped `Origin` (`https://evil.example`) → `403` on `/api/tools`, `/api/tools/ping`, `/api/system-tools`, `/api/system-tools/ping`, `/p/{pin}`, and all four pinned variants, in **both** `none` and `oauth` allow-sets; absent and loopback origins still pass on every one of them.
- [x] Docs: `docs/architecture-transport-auth.md` documented the fail-open downgrade **as intended behaviour** — corrected, with the two new callouts explaining why. Stale in-code comments in `DirectToolCallEndpoints`, `SystemToolEndpoints` and `StreamableHttpTransportLayer` corrected likewise.

No `<Version>` bump, no ReflectorNet pin change, no NuGet publish, no consumer pin bumps — the release chain is owned separately.

Closes #186
