### PR TITLE
fix(strategy): honor a session's engine-instance selection when routing

### DIFF
--- a/McpPlugin.Server.Tests/IsolationMatrix/Phase2GateIsolationMatrixTests.cs
+++ b/McpPlugin.Server.Tests/IsolationMatrix/Phase2GateIsolationMatrixTests.cs
@@ -83,8 +83,13 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests.IsolationMatrix
         public Phase2GateIsolationMatrixTests()
         {
             _registry = new AccountInstances();
-            _strategy = new AccountMcpStrategy(_registry);
             _selections = new SessionSelectionStore();
+            // Hand the SAME store to both sides, exactly as production wiring does (issue #195):
+            // ExtensionsMcpServerBuilder registers strategy.Selections as the ISessionSelectionStore
+            // singleton, so the selection tool writes the map the router reads. Constructing the
+            // strategy without it would give it a private second store and reproduce here the very
+            // writer/reader split that made select_engine_instance a silent no-op.
+            _strategy = new AccountMcpStrategy(_registry, _selections);
             _tools = new ServerNativeTools(_registry, _selections, new NoOpEnrollment());
 
             // Register the 2 accounts × their plugin instances — the "two fake plugin instances" per

--- a/McpPlugin.Server.Tests/SelectionRoutingOverHttpTests.cs
+++ b/McpPlugin.Server.Tests/SelectionRoutingOverHttpTests.cs
@@ -1,0 +1,389 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Sockets;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.Common.Utils;
+using com.IvanMurzak.McpPlugin.Server.Auth;
+using com.IvanMurzak.McpPlugin.Server.Auth.OAuth;
+using com.IvanMurzak.McpPlugin.Server.Strategy;
+using com.IvanMurzak.McpPlugin.Server.Tests.OAuth;
+using com.IvanMurzak.McpPlugin.Server.Tools;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.Server.Tests
+{
+    /// <summary>
+    /// End-to-end regression cover for sticky engine-instance routing (issue #195).
+    ///
+    /// <para>These tests drive a REAL loopback Kestrel host running the REAL <c>WithMcpServer</c> +
+    /// <c>WithMcpPluginServer</c> oauth wiring over the REAL Streamable HTTP transport, and reach the
+    /// routing decision the only way production does: an actual MCP <c>initialize</c> handshake, an
+    /// actual <c>select_engine_instance</c> call, and then an actual proxied <c>tools/call</c> whose
+    /// routing is observed. Every other selection test in this suite hand-builds a
+    /// <see cref="SelectionToolContext"/>, and a hand-built context CANNOT observe this defect by
+    /// construction — the suite was fully green while the selection had no effect whatsoever.</para>
+    ///
+    /// <para><b>The defect.</b> <c>HttpServerTransportOptions.PerSessionExecutionContext</c> is
+    /// <c>true</c>, so a session's request handlers run on the <see cref="System.Threading.ExecutionContext"/>
+    /// captured once inside <c>RunSessionHandler</c>. <c>McpSessionTokenMiddleware</c> reloads the
+    /// sticky selection into <c>McpSessionTokenContext.CurrentSelectedInstanceId</c> per REQUEST, so
+    /// that write never reaches an MCP handler: the sticky term of
+    /// <see cref="AccountInstances.Resolve"/> was permanently null on this path and routing silently
+    /// fell through to <c>single → MRU</c>. <c>select_engine_instance</c> answered "Selected …" and
+    /// changed nothing.</para>
+    ///
+    /// <para><b>Why TWO instances.</b> With a single registered instance the <c>single</c> auto-pair
+    /// rung of <see cref="AccountInstances.Resolve"/> routes to it regardless of the selection, so a
+    /// one-instance test cannot tell honoured-selection from accidental-routing. Both tests below
+    /// therefore register two instances and deliberately select the one that is NOT most-recently
+    /// active, which is the only arrangement in which the sticky rung and the MRU rung disagree.</para>
+    /// </summary>
+    [Collection("McpPlugin.Server")]
+    public sealed class SelectionRoutingOverHttpTests
+    {
+        const string Kid = "selection-routing-kid";
+        const string Account = "acct-selection-routing";
+
+        const string InstanceA = "instance-alpha";
+        const string ProjectA = "AlphaProject";
+        const string HashA = "aaaaaaaa1111222233334444555566667777888899990000aaaabbbbccccdddd0";
+
+        const string InstanceB = "instance-beta";
+        const string ProjectB = "BetaProject";
+        const string HashB = "bbbbbbbb1111222233334444555566667777888899990000aaaabbbbccccdddd0";
+
+        /// <summary>
+        /// The regression: after <c>select_engine_instance</c> picks A, the NEXT tool call on the same
+        /// MCP session is routed to A — even though B is the most-recently-active instance and would
+        /// win the MRU rung.
+        ///
+        /// <para>The observed artifact is POSITIVE and is produced by the routing code itself:
+        /// <see cref="AccountMcpStrategy.ResolveConnectionId"/> calls
+        /// <see cref="AccountInstances.TouchByConnection"/> on the instance it resolved, so the
+        /// resolved instance — and only the resolved instance — has its <c>LastActiveAt</c> moved
+        /// forward by the proxied call. Asserting that A's timestamp ADVANCED (rather than asserting
+        /// that B's did not) means a call that never reached routing at all cannot satisfy it.</para>
+        /// </summary>
+        [Fact]
+        public async Task SelectedInstance_IsRoutedTo_OnSubsequentToolCall()
+        {
+            await using var host = await StartOAuthHostAsync();
+            host.RegisterInstance(InstanceA, "unity", ProjectA, HashA, "MACHINE-A");
+            await Task.Delay(50);
+            host.RegisterInstance(InstanceB, "unity", ProjectB, HashB, "MACHINE-B");
+
+            // Self-validating setup: with NO selection the account resolves to B (the MRU rung). If this
+            // ever stops holding, the test below would pass for the wrong reason, so pin it here.
+            host.ResolveWithoutSelection().ShouldBe(InstanceB,
+                "setup precondition: B must be the most-recently-active instance, so that routing to A " +
+                "can only be explained by the selection being honoured");
+
+            using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(120) };
+            var sessionId = await host.InitializeAsync(client);
+
+            var select = await host.CallToolAsync(client, sessionId, ServerNativeTools.SelectInstance,
+                new { instance_id = InstanceA });
+            select.IsError.ShouldBeFalse($"select_engine_instance must succeed; got: {select.Text}");
+
+            var beforeA = host.LastActiveAt(InstanceA);
+            var beforeB = host.LastActiveAt(InstanceB);
+
+            var proxied = await host.CallToolAsync(client, sessionId, "any_engine_tool", new { });
+
+            // The call cannot succeed (no live SignalR plugin backs the registered connection ids), but
+            // it MUST have got past resolution — an unresolved session short-circuits in ToolRouter.Call
+            // with the agent-actionable text below and never reaches ResolveConnectionId at all.
+            proxied.Text.ShouldNotContain("No engine instances are connected",
+                Case.Sensitive, "the account has two live instances, so resolution must not fail");
+
+            var afterA = host.LastActiveAt(InstanceA);
+            var afterB = host.LastActiveAt(InstanceB);
+
+            afterA.ShouldBeGreaterThan(beforeA,
+                $"the selected instance {InstanceA} must be the one routing resolved, and routing bumps " +
+                $"its LastActiveAt; A {beforeA:O} -> {afterA:O}, B {beforeB:O} -> {afterB:O}. " +
+                $"Tool result was: {proxied.Text}");
+            afterB.ShouldBe(beforeB,
+                $"the unselected instance {InstanceB} must NOT have been routed to; " +
+                $"B {beforeB:O} -> {afterB:O}");
+        }
+
+        /// <summary>
+        /// The re-selection half: selecting B after A re-routes subsequent calls to B. A fix that
+        /// merely cached the first selection (or that pinned the session to whatever it saw first)
+        /// passes the test above and fails this one.
+        /// </summary>
+        [Fact]
+        public async Task ReSelectingAnotherInstance_ReRoutesSubsequentToolCalls()
+        {
+            await using var host = await StartOAuthHostAsync();
+            host.RegisterInstance(InstanceA, "unity", ProjectA, HashA, "MACHINE-A");
+            await Task.Delay(50);
+            host.RegisterInstance(InstanceB, "unity", ProjectB, HashB, "MACHINE-B");
+
+            using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(120) };
+            var sessionId = await host.InitializeAsync(client);
+
+            // Round 1 — select A (the non-MRU instance) and confirm routing follows it.
+            var selectA = await host.CallToolAsync(client, sessionId, ServerNativeTools.SelectInstance,
+                new { instance_id = InstanceA });
+            selectA.IsError.ShouldBeFalse($"select_engine_instance(A) must succeed; got: {selectA.Text}");
+
+            var beforeA = host.LastActiveAt(InstanceA);
+            await host.CallToolAsync(client, sessionId, "any_engine_tool", new { });
+            host.LastActiveAt(InstanceA).ShouldBeGreaterThan(beforeA,
+                $"round 1: the call after selecting {InstanceA} must route to {InstanceA}");
+
+            // Round 2 — switch the selection to B on the SAME session.
+            var selectB = await host.CallToolAsync(client, sessionId, ServerNativeTools.SelectInstance,
+                new { instance_id = InstanceB });
+            selectB.IsError.ShouldBeFalse($"select_engine_instance(B) must succeed; got: {selectB.Text}");
+
+            var beforeB2 = host.LastActiveAt(InstanceB);
+            var beforeA2 = host.LastActiveAt(InstanceA);
+            await host.CallToolAsync(client, sessionId, "any_engine_tool", new { });
+
+            host.LastActiveAt(InstanceB).ShouldBeGreaterThan(beforeB2,
+                $"round 2: after re-selecting {InstanceB} the call must route to {InstanceB}");
+            host.LastActiveAt(InstanceA).ShouldBe(beforeA2,
+                $"round 2: {InstanceA} is no longer selected and must not be routed to");
+        }
+
+        // ───────────────────────────── real loopback oauth host ─────────────────────────────
+
+        /// <summary>
+        /// Builds the REAL oauth server wiring on a loopback port. Hermetic: the JWKS provider is
+        /// replaced with an in-memory key, so no authorization server is contacted. Modelled on
+        /// <see cref="AmbientSessionIdOverHttpTests"/>, whose harness the target profile's
+        /// <c>test.md</c> § Suite 4 nominates as the cheapest real-session harness to copy.
+        /// </summary>
+        static async Task<OAuthHost> StartOAuthHostAsync()
+        {
+            var port = FreeLoopbackPort();
+            const string issuer = "https://as.example";              // never fetched: the JWKS provider is replaced below
+            var publicUrl = $"http://127.0.0.1:{port}/mcp";
+
+            var key = TestJwt.CreateKey();
+
+            var dataArguments = new DataArguments(new[]
+            {
+                $"port={port}",
+                "client-transport=streamableHttp",
+                "auth=oauth",
+                $"auth-issuer={issuer}",
+                $"public-url={publicUrl}",
+                // The proxied probe call cannot be answered (no live plugin behind the registered
+                // connection ids), so keep ClientUtils' per-attempt wait short. Routing — the thing
+                // under test — has already happened on the first attempt.
+                "plugin-timeout=200",
+            });
+
+            var builder = WebApplication.CreateBuilder();
+            builder.Logging.ClearProviders();
+            builder.Services
+                .WithMcpServer(dataArguments)
+                .WithMcpPluginServer(dataArguments);
+
+            // Hermetic: serve the signing key from memory instead of fetching the AS over HTTP.
+            // Registered AFTER the production wiring so this singleton is the resolved one.
+            builder.Services.AddSingleton<IJwksKeyProvider>(new FakeJwksKeyProvider().Add(Kid, key));
+
+            var app = builder.Build();
+            app.Urls.Add($"http://127.0.0.1:{port}");
+            app.UseMcpPluginServer(dataArguments);
+            await app.StartAsync();
+
+            var token = TestJwt.SignEs256(key, Kid, TestJwt.Claims(
+                issuer, publicUrl, DateTimeOffset.UtcNow.AddHours(1),
+                sub: Account, scope: ConnectionIdentity.ScopeAgent));
+
+            return new OAuthHost(app, $"http://127.0.0.1:{port}", token, key);
+        }
+
+        sealed class OAuthHost : IAsyncDisposable
+        {
+            readonly WebApplication _app;
+            readonly ECDsa _key;
+            readonly string _baseUrl;
+            readonly string _token;
+
+            public OAuthHost(WebApplication app, string baseUrl, string token, ECDsa key)
+            {
+                _app = app;
+                _baseUrl = baseUrl;
+                _token = token;
+                _key = key;
+            }
+
+            public IServiceProvider Services => _app.Services;
+
+            AccountMcpStrategy Strategy
+            {
+                get
+                {
+                    var strategy = _app.Services.GetRequiredService<IMcpConnectionStrategy>() as AccountMcpStrategy;
+                    strategy.ShouldNotBeNull("oauth mode must resolve the AccountMcpStrategy");
+                    return strategy!;
+                }
+            }
+
+            /// <summary>
+            /// Registers a plugin instance exactly as <c>McpServerHub</c> does in oauth mode. Distinct
+            /// project hash + machine per instance so the registry's dedup key (path, engine, machine)
+            /// keeps both alive — identical metadata would silently evict the first.
+            /// </summary>
+            public void RegisterInstance(string instanceId, string engine, string projectName, string projectPathHash, string machineName)
+            {
+                var identity = ConnectionIdentity.Create(Account, ConnectionIdentity.ScopePlugin);
+                identity.ShouldNotBeNull();
+                Strategy.RegisterInstance(
+                    identity!,
+                    new PluginInstanceMetadata(instanceId, engine, projectName, projectPathHash, machineName),
+                    connectionId: "conn-" + instanceId,
+                    logger: NullLogger.Instance);
+            }
+
+            /// <summary>The instance an unpinned, unselected session of this account resolves to (the MRU rung).</summary>
+            public string? ResolveWithoutSelection()
+                => Strategy.Instances.Resolve(Account, projectPin: null, selectedInstanceId: null).Instance?.InstanceId;
+
+            /// <summary>The registry's live activity stamp for an instance — bumped by routing, and by nothing else here.</summary>
+            public DateTimeOffset LastActiveAt(string instanceId)
+                => Strategy.Instances.GetInstances(Account)
+                    .First(i => string.Equals(i.InstanceId, instanceId, StringComparison.Ordinal))
+                    .LastActiveAt;
+
+            /// <summary>Runs the MCP handshake and returns the server-issued <c>Mcp-Session-Id</c>.</summary>
+            public async Task<string> InitializeAsync(HttpClient client)
+            {
+                var (_, sessionId) = await PostAsync(client, null, new
+                {
+                    jsonrpc = "2.0",
+                    id = 1,
+                    method = "initialize",
+                    @params = new
+                    {
+                        protocolVersion = "2024-11-05",
+                        capabilities = new { },
+                        clientInfo = new { name = "selection-routing-test", version = "1.0.0" }
+                    }
+                });
+                sessionId.ShouldNotBeNullOrEmpty("the server must mint an Mcp-Session-Id on initialize");
+                await PostAsync(client, sessionId, new { jsonrpc = "2.0", method = "notifications/initialized" });
+                return sessionId!;
+            }
+
+            public async Task<(bool IsError, string Text)> CallToolAsync(HttpClient client, string sessionId, string toolName, object arguments)
+            {
+                var (body, _) = await PostAsync(client, sessionId, new
+                {
+                    jsonrpc = "2.0",
+                    id = 99,
+                    method = "tools/call",
+                    @params = new { name = toolName, arguments }
+                });
+                return ReadToolResult(body);
+            }
+
+            public async Task<(string Body, string? SessionId)> PostAsync(HttpClient client, string? sessionId, object payload)
+            {
+                using var request = new HttpRequestMessage(HttpMethod.Post, _baseUrl + "/mcp");
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _token);
+                request.Headers.Accept.ParseAdd("application/json");
+                request.Headers.Accept.ParseAdd("text/event-stream");
+                if (!string.IsNullOrEmpty(sessionId))
+                    request.Headers.TryAddWithoutValidation("Mcp-Session-Id", sessionId);
+                request.Content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
+
+                using var response = await client.SendAsync(request);
+                var body = await response.Content.ReadAsStringAsync();
+                // Assert SUCCESS, not merely "not 401": a routing or wiring regression answering 404 /
+                // 405 / 500 would otherwise resurface as a JsonDocument.Parse failure in ReadToolResult,
+                // which reads as a broken harness rather than as the regression it is.
+                // (notifications/initialized answers 202, so this cannot be pinned to 200.)
+                response.IsSuccessStatusCode.ShouldBeTrue(
+                    $"POST /mcp must succeed with the agent token; status {(int)response.StatusCode} {response.StatusCode}, body: {body}");
+                var issued = response.Headers.TryGetValues("Mcp-Session-Id", out var values) ? values.FirstOrDefault() : null;
+                return (body, issued);
+            }
+
+            public async ValueTask DisposeAsync()
+            {
+                await _app.StopAsync();
+                await _app.DisposeAsync();
+                _key.Dispose();
+            }
+        }
+
+        // ───────────────────────────── helpers ─────────────────────────────
+
+        static int FreeLoopbackPort()
+        {
+            var probe = new TcpListener(IPAddress.Loopback, 0);
+            probe.Start();
+            var port = ((IPEndPoint)probe.LocalEndpoint).Port;
+            probe.Stop();
+            return port;
+        }
+
+        /// <summary>The streamable-HTTP reply is an SSE frame; pull the JSON out of its data: lines.</summary>
+        static string Unwrap(string body)
+        {
+            if (!body.Contains("data:", StringComparison.Ordinal))
+                return body;
+            var sb = new StringBuilder();
+            foreach (var line in body.Split('\n'))
+            {
+                var trimmed = line.TrimEnd('\r');
+                if (trimmed.StartsWith("data:", StringComparison.Ordinal))
+                    sb.Append(trimmed.Substring(5).Trim());
+            }
+            return sb.Length > 0 ? sb.ToString() : body;
+        }
+
+        static (bool IsError, string Text) ReadToolResult(string rawBody)
+        {
+            var body = Unwrap(rawBody);
+            using var doc = JsonDocument.Parse(body);
+            var root = doc.RootElement;
+            if (root.TryGetProperty("error", out var error))
+                return (true, "JSON-RPC error: " + error.ToString());
+
+            var result = root.GetProperty("result");
+            var isError = result.TryGetProperty("isError", out var flag) && flag.ValueKind == JsonValueKind.True;
+            var texts = new List<string>();
+            if (result.TryGetProperty("content", out var content) && content.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var block in content.EnumerateArray())
+                {
+                    if (block.TryGetProperty("text", out var text))
+                        texts.Add(text.GetString() ?? string.Empty);
+                }
+            }
+            return (isError, string.Join("\n", texts));
+        }
+    }
+}

--- a/McpPlugin.Server.Tests/SelectionRoutingOverHttpTests.cs
+++ b/McpPlugin.Server.Tests/SelectionRoutingOverHttpTests.cs
@@ -48,18 +48,25 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
     ///
     /// <para><b>The defect.</b> <c>HttpServerTransportOptions.PerSessionExecutionContext</c> is
     /// <c>true</c>, so a session's request handlers run on the <see cref="System.Threading.ExecutionContext"/>
-    /// captured once inside <c>RunSessionHandler</c>. <c>McpSessionTokenMiddleware</c> reloads the
-    /// sticky selection into <c>McpSessionTokenContext.CurrentSelectedInstanceId</c> per REQUEST, so
-    /// that write never reaches an MCP handler: the sticky term of
-    /// <see cref="AccountInstances.Resolve"/> was permanently null on this path and routing silently
-    /// fell through to <c>single → MRU</c>. <c>select_engine_instance</c> answered "Selected …" and
-    /// changed nothing.</para>
+    /// captured once inside <c>RunSessionHandler</c> — during <c>initialize</c>, a request that carries
+    /// no <c>Mcp-Session-Id</c> (the server mints it in that response). <c>McpSessionTokenMiddleware</c>
+    /// reloads the sticky selection into <c>McpSessionTokenContext.CurrentSelectedInstanceId</c> per
+    /// REQUEST, so the value frozen into that context was a store lookup at a null key, and every later
+    /// per-request write landed on a context no handler runs on. The sticky term of
+    /// <see cref="AccountInstances.Resolve"/> was therefore permanently null on this path and routing
+    /// silently fell through to <c>single → MRU</c>. <c>select_engine_instance</c> answered "Selected …"
+    /// and changed nothing.</para>
     ///
     /// <para><b>Why TWO instances.</b> With a single registered instance the <c>single</c> auto-pair
     /// rung of <see cref="AccountInstances.Resolve"/> routes to it regardless of the selection, so a
     /// one-instance test cannot tell honoured-selection from accidental-routing. Both tests below
     /// therefore register two instances and deliberately select the one that is NOT most-recently
-    /// active, which is the only arrangement in which the sticky rung and the MRU rung disagree.</para>
+    /// active, which is the only arrangement in which the sticky rung and the MRU rung disagree.
+    /// <b>Hence the <c>Task.Delay(50)</c> between the two registrations</b>: <c>Resolve</c> breaks a
+    /// <c>LastActiveAt</c> tie by enumeration order rather than by registration order, and the Windows
+    /// clock granularity is ~15.6 ms — so back-to-back registrations could share a timestamp and leave
+    /// both tests nondeterministically unable to discriminate. Each test asserts the resulting MRU
+    /// order explicitly rather than trusting it.</para>
     /// </summary>
     [Collection("McpPlugin.Server")]
     public sealed class SelectionRoutingOverHttpTests
@@ -69,11 +76,11 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
 
         const string InstanceA = "instance-alpha";
         const string ProjectA = "AlphaProject";
-        const string HashA = "aaaaaaaa1111222233334444555566667777888899990000aaaabbbbccccdddd0";
+        const string HashA = "aaaaaaaa1111222233334444555566667777888899990000aaaabbbbccccdddd";
 
         const string InstanceB = "instance-beta";
         const string ProjectB = "BetaProject";
-        const string HashB = "bbbbbbbb1111222233334444555566667777888899990000aaaabbbbccccdddd0";
+        const string HashB = "bbbbbbbb1111222233334444555566667777888899990000aaaabbbbccccdddd";
 
         /// <summary>
         /// The regression: after <c>select_engine_instance</c> picks A, the NEXT tool call on the same
@@ -115,8 +122,11 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
 
             // The call cannot succeed (no live SignalR plugin backs the registered connection ids), but
             // it MUST have got past resolution — an unresolved session short-circuits in ToolRouter.Call
-            // with the agent-actionable text below and never reaches ResolveConnectionId at all.
-            proxied.Text.ShouldNotContain("No engine instances are connected",
+            // with AgentActionableErrors.ForResolution(...) and never reaches ResolveConnectionId at all.
+            // Assert the CONSTANT, never a hand-copied literal: that short-circuit can only emit
+            // AccountEmpty or PinnedNoMatch, and list_engine_instances' own "No engine instances are
+            // connected" wording appears in NEITHER — so a literal here would be unfalsifiable.
+            proxied.Text.ShouldNotContain(AgentActionableErrors.AccountEmpty,
                 Case.Sensitive, "the account has two live instances, so resolution must not fail");
 
             var afterA = host.LastActiveAt(InstanceA);
@@ -144,6 +154,13 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
             await Task.Delay(50);
             host.RegisterInstance(InstanceB, "unity", ProjectB, HashB, "MACHINE-B");
 
+            // Self-validating setup, exactly as in the test above: BOTH rounds below are only
+            // discriminating while the instance being selected is NOT the one MRU would pick, so pin
+            // that arrangement rather than inheriting it from registration order.
+            host.ResolveWithoutSelection().ShouldBe(InstanceB,
+                "round 1 precondition: B must be the most-recently-active instance, so that routing to " +
+                "A can only be explained by the selection being honoured");
+
             using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(120) };
             var sessionId = await host.InitializeAsync(client);
 
@@ -157,7 +174,15 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
             host.LastActiveAt(InstanceA).ShouldBeGreaterThan(beforeA,
                 $"round 1: the call after selecting {InstanceA} must route to {InstanceA}");
 
-            // Round 2 — switch the selection to B on the SAME session.
+            // Round 2 — switch the selection to B on the SAME session. Round 1's routed call moved A to
+            // the front of the MRU order, so B is once again the instance MRU would NOT pick; assert
+            // that before selecting it, or round 2 could pass with the sticky term ignored entirely.
+            // (ResolveWithoutSelection passes selectedInstanceId: null, so it reports the MRU rung and
+            // is unaffected by the selection already sitting in the store.)
+            host.ResolveWithoutSelection().ShouldBe(InstanceA,
+                "round 2 precondition: round 1's routed call made A most-recently-active, so selecting " +
+                "B is again the non-MRU choice");
+
             var selectB = await host.CallToolAsync(client, sessionId, ServerNativeTools.SelectInstance,
                 new { instance_id = InstanceB });
             selectB.IsError.ShouldBeFalse($"select_engine_instance(B) must succeed; got: {selectB.Text}");
@@ -177,8 +202,7 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
         /// <summary>
         /// Builds the REAL oauth server wiring on a loopback port. Hermetic: the JWKS provider is
         /// replaced with an in-memory key, so no authorization server is contacted. Modelled on
-        /// <see cref="AmbientSessionIdOverHttpTests"/>, whose harness the target profile's
-        /// <c>test.md</c> § Suite 4 nominates as the cheapest real-session harness to copy.
+        /// <see cref="AmbientSessionIdOverHttpTests"/>, the cheapest real-session harness in this suite.
         /// </summary>
         static async Task<OAuthHost> StartOAuthHostAsync()
         {
@@ -195,9 +219,11 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
                 "auth=oauth",
                 $"auth-issuer={issuer}",
                 $"public-url={publicUrl}",
-                // The proxied probe call cannot be answered (no live plugin behind the registered
-                // connection ids), so keep ClientUtils' per-attempt wait short. Routing — the thing
-                // under test — has already happened on the first attempt.
+                // Defensive only — it is NOT what bounds these tests. The proxied probe call cannot be
+                // answered (no live plugin behind the registered connection ids), but the invoke fails
+                // immediately rather than pending, so ClientUtils' per-attempt wait is never entered.
+                // Do not reach for this value to speed the suite up; it will not move.
+                // Routing — the thing under test — has already happened on the first attempt.
                 "plugin-timeout=200",
             });
 
@@ -237,8 +263,6 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
                 _token = token;
                 _key = key;
             }
-
-            public IServiceProvider Services => _app.Services;
 
             AccountMcpStrategy Strategy
             {

--- a/McpPlugin.Server/src/Auth/McpSessionTokenContext.cs
+++ b/McpPlugin.Server/src/Auth/McpSessionTokenContext.cs
@@ -62,8 +62,11 @@ namespace com.IvanMurzak.McpPlugin.Server.Auth
         /// <see cref="Tools.ISessionSelectionStore"/>) and by <c>select_engine_instance</c> inside its own
         /// request. On the streamable-HTTP MCP path that per-request reload does NOT reach a request
         /// handler, for the same <c>PerSessionExecutionContext</c> reason documented on
-        /// <see cref="CurrentSessionId"/> — so a handler observes the selection only within the request
-        /// that set it, and cross-request sticky routing there is not yet wired.</para>
+        /// <see cref="CurrentSessionId"/> — so a handler observes this value only within the request
+        /// that set it. It is therefore NOT the authority on "what did this session select":
+        /// <see cref="Strategy.AccountMcpStrategy"/> treats a null here as "ask the store" and looks the
+        /// selection up by <see cref="CurrentSessionId"/>, which is what makes sticky routing work
+        /// across requests on that path (issue #195).</para>
         /// </summary>
         public static string? CurrentSelectedInstanceId
         {

--- a/McpPlugin.Server/src/Extension/ExtensionsMcpServerBuilder.cs
+++ b/McpPlugin.Server/src/Extension/ExtensionsMcpServerBuilder.cs
@@ -161,7 +161,6 @@ namespace com.IvanMurzak.McpPlugin.Server
                 // AccountMcpStrategy consults it to honor a session's sticky selection when routing, so
                 // a separately-registered store would leave select_engine_instance writing to one map
                 // while the router read another — the tool would answer "Selected …" and change nothing.
-                // Same shape as strategy.Instances below.
                 mcpServerBuilder.Services.AddSingleton<ISessionSelectionStore>(sp =>
                 {
                     var strategy = sp.GetRequiredService<IMcpConnectionStrategy>() as AccountMcpStrategy

--- a/McpPlugin.Server/src/Extension/ExtensionsMcpServerBuilder.cs
+++ b/McpPlugin.Server/src/Extension/ExtensionsMcpServerBuilder.cs
@@ -156,7 +156,18 @@ namespace com.IvanMurzak.McpPlugin.Server
 
                 // Server-native tools (mcp-authorize b4) — the account+instance selection + enrollment
                 // surface. Only meaningful in oauth mode (the pairing plane), so registered here.
-                mcpServerBuilder.Services.AddSingleton<ISessionSelectionStore, SessionSelectionStore>();
+                //
+                // Resolve the store OFF the strategy rather than constructing a second one (issue #195):
+                // AccountMcpStrategy consults it to honor a session's sticky selection when routing, so
+                // a separately-registered store would leave select_engine_instance writing to one map
+                // while the router read another — the tool would answer "Selected …" and change nothing.
+                // Same shape as strategy.Instances below.
+                mcpServerBuilder.Services.AddSingleton<ISessionSelectionStore>(sp =>
+                {
+                    var strategy = sp.GetRequiredService<IMcpConnectionStrategy>() as AccountMcpStrategy
+                        ?? throw new InvalidOperationException("ISessionSelectionStore requires the oauth AccountMcpStrategy.");
+                    return strategy.Selections;
+                });
 
                 mcpServerBuilder.Services.AddSingleton<IEnrollmentClient>(sp =>
                 {

--- a/McpPlugin.Server/src/Strategy/AccountMcpStrategy.cs
+++ b/McpPlugin.Server/src/Strategy/AccountMcpStrategy.cs
@@ -131,30 +131,33 @@ namespace com.IvanMurzak.McpPlugin.Server.Strategy
             return _instances.Resolve(
                 identity.AccountId,
                 McpSessionTokenContext.CurrentProjectPin,
-                CurrentSelectedInstanceId());
+                ResolveStickySelection());
         }
 
         /// <summary>
         /// The sticky instance selected by <c>select_engine_instance</c> for the in-flight session
         /// (issue #195), or null when the session has made no selection.
         ///
-        /// <para>TWO sources, and BOTH are required. The ambient
-        /// <see cref="McpSessionTokenContext.CurrentSelectedInstanceId"/> is authoritative when set —
-        /// <see cref="McpSessionTokenMiddleware"/> loads it per request for the direct-tool REST
-        /// surfaces, and <c>select_engine_instance</c> sets it inline so its own request routes to the
-        /// instance it just picked. On the streamable-HTTP MCP path that ambient value is ALWAYS null:
-        /// <c>PerSessionExecutionContext</c> is <c>true</c>, so handlers run on the
-        /// <see cref="System.Threading.ExecutionContext"/> captured once in
-        /// <c>StreamableHttpTransportLayer.RunSessionHandler</c> and the middleware's per-request
-        /// <c>AsyncLocal</c> write never reaches them. Falling back to a store lookup keyed by
-        /// <see cref="McpSessionTokenContext.CurrentSessionId"/> — which IS published on that captured
-        /// context — is what makes a selection survive past the request that made it.</para>
+        /// <para>TWO sources, read ambient-first. <see cref="McpSessionTokenMiddleware"/> loads the
+        /// ambient <see cref="McpSessionTokenContext.CurrentSelectedInstanceId"/> per request for the
+        /// direct-tool REST surfaces, and <c>select_engine_instance</c> sets it inline so its own
+        /// request routes to the instance it just picked. On the streamable-HTTP MCP path the ambient is
+        /// null on every request EXCEPT that one, for the <c>PerSessionExecutionContext</c> reason
+        /// documented on <see cref="McpSessionTokenContext.CurrentSessionId"/> — with one extra step
+        /// specific to the selection: the value frozen into the captured context at <c>initialize</c> is
+        /// a store lookup at a NULL key, that request carrying no <c>Mcp-Session-Id</c> yet. Falling
+        /// back to the store, keyed by the session id (which IS published on that captured context), is
+        /// what makes a selection survive past the request that made it.</para>
+        ///
+        /// <para>The two cannot DISAGREE: the middleware loads the ambient FROM this same store, and
+        /// <c>select_engine_instance</c> writes both. The ambient is a fast path, not an independent
+        /// input.</para>
         ///
         /// <para>This only ever supplies the <c>sticky</c> term of
         /// <see cref="AccountInstances.Resolve"/>: a project pin is still applied first and strictly, so
         /// a selection can narrow a pin but can never route across projects.</para>
         /// </summary>
-        string? CurrentSelectedInstanceId()
+        string? ResolveStickySelection()
             => McpSessionTokenContext.CurrentSelectedInstanceId
                 ?? _selections.Get(McpSessionTokenContext.CurrentSessionId);
 

--- a/McpPlugin.Server/src/Strategy/AccountMcpStrategy.cs
+++ b/McpPlugin.Server/src/Strategy/AccountMcpStrategy.cs
@@ -15,6 +15,7 @@ using com.IvanMurzak.McpPlugin.Common;
 using com.IvanMurzak.McpPlugin.Common.Model;
 using com.IvanMurzak.McpPlugin.Common.Utils;
 using com.IvanMurzak.McpPlugin.Server.Auth;
+using com.IvanMurzak.McpPlugin.Server.Tools;
 using Microsoft.Extensions.Logging;
 
 namespace com.IvanMurzak.McpPlugin.Server.Strategy
@@ -39,17 +40,30 @@ namespace com.IvanMurzak.McpPlugin.Server.Strategy
     public sealed class AccountMcpStrategy : IMcpConnectionStrategy
     {
         readonly AccountInstances _instances;
+        readonly ISessionSelectionStore _selections;
 
         public AccountMcpStrategy() : this(new AccountInstances()) { }
 
         /// <summary>Testable ctor — inject a registry (e.g. with a deterministic clock).</summary>
-        public AccountMcpStrategy(AccountInstances instances)
+        public AccountMcpStrategy(AccountInstances instances) : this(instances, new SessionSelectionStore()) { }
+
+        /// <summary>Testable ctor — inject both the registry and the sticky-selection store.</summary>
+        public AccountMcpStrategy(AccountInstances instances, ISessionSelectionStore selections)
         {
             _instances = instances ?? throw new ArgumentNullException(nameof(instances));
+            _selections = selections ?? throw new ArgumentNullException(nameof(selections));
         }
 
         /// <summary>The account+instance registry backing this strategy.</summary>
         public AccountInstances Instances => _instances;
+
+        /// <summary>
+        /// The per-session sticky-selection store backing this strategy. Owned here — exactly like
+        /// <see cref="Instances"/> — so the selection tool and the router provably share ONE store:
+        /// <c>ExtensionsMcpServerBuilder</c> registers THIS instance as the
+        /// <see cref="ISessionSelectionStore"/> singleton rather than constructing a second one.
+        /// </summary>
+        public ISessionSelectionStore Selections => _selections;
 
         public Consts.MCP.Server.AuthOption AuthOption => Consts.MCP.Server.AuthOption.oauth;
 
@@ -117,8 +131,32 @@ namespace com.IvanMurzak.McpPlugin.Server.Strategy
             return _instances.Resolve(
                 identity.AccountId,
                 McpSessionTokenContext.CurrentProjectPin,
-                McpSessionTokenContext.CurrentSelectedInstanceId);
+                CurrentSelectedInstanceId());
         }
+
+        /// <summary>
+        /// The sticky instance selected by <c>select_engine_instance</c> for the in-flight session
+        /// (issue #195), or null when the session has made no selection.
+        ///
+        /// <para>TWO sources, and BOTH are required. The ambient
+        /// <see cref="McpSessionTokenContext.CurrentSelectedInstanceId"/> is authoritative when set —
+        /// <see cref="McpSessionTokenMiddleware"/> loads it per request for the direct-tool REST
+        /// surfaces, and <c>select_engine_instance</c> sets it inline so its own request routes to the
+        /// instance it just picked. On the streamable-HTTP MCP path that ambient value is ALWAYS null:
+        /// <c>PerSessionExecutionContext</c> is <c>true</c>, so handlers run on the
+        /// <see cref="System.Threading.ExecutionContext"/> captured once in
+        /// <c>StreamableHttpTransportLayer.RunSessionHandler</c> and the middleware's per-request
+        /// <c>AsyncLocal</c> write never reaches them. Falling back to a store lookup keyed by
+        /// <see cref="McpSessionTokenContext.CurrentSessionId"/> — which IS published on that captured
+        /// context — is what makes a selection survive past the request that made it.</para>
+        ///
+        /// <para>This only ever supplies the <c>sticky</c> term of
+        /// <see cref="AccountInstances.Resolve"/>: a project pin is still applied first and strictly, so
+        /// a selection can narrow a pin but can never route across projects.</para>
+        /// </summary>
+        string? CurrentSelectedInstanceId()
+            => McpSessionTokenContext.CurrentSelectedInstanceId
+                ?? _selections.Get(McpSessionTokenContext.CurrentSessionId);
 
         public string? ResolveConnectionId(string? token, int retryOffset)
         {

--- a/McpPlugin.Server/src/Tools/SessionSelectionStore.cs
+++ b/McpPlugin.Server/src/Tools/SessionSelectionStore.cs
@@ -19,13 +19,19 @@ namespace com.IvanMurzak.McpPlugin.Server.Tools
     /// Keyed by the MCP session id (the <c>Mcp-Session-Id</c> header). <c>select_engine_instance</c>
     /// writes here; <see cref="Auth.McpSessionTokenMiddleware"/> reloads the value into
     /// <see cref="Auth.McpSessionTokenContext.CurrentSelectedInstanceId"/> on each subsequent request,
-    /// which is what the direct-tool REST surfaces observe. On the streamable-HTTP MCP path that
-    /// per-request reload does NOT reach a request handler (<c>PerSessionExecutionContext</c> — see
-    /// <see cref="Auth.McpSessionTokenContext.CurrentSessionId"/>), so routing there honors the
-    /// selection only within the request that set it. Selection is per-SESSION, NOT per-account — two agent
-    /// sessions of the same account may independently select different instances (design 04
-    /// multi-tenancy semantics). A selection may narrow a pin but never override it to another
-    /// project (enforced by <c>select_engine_instance</c> before writing here).
+    /// which is what the direct-tool REST surfaces observe.
+    /// <para>On the streamable-HTTP MCP path that per-request reload does NOT reach a request handler
+    /// (<c>PerSessionExecutionContext</c> — see <see cref="Auth.McpSessionTokenContext.CurrentSessionId"/>),
+    /// so <see cref="Strategy.AccountMcpStrategy"/> reads this store DIRECTLY, keyed by the ambient
+    /// session id, when the ambient selection is absent (issue #195). Routing therefore honors a
+    /// selection on every subsequent request of the session, not just the one that set it. The strategy
+    /// OWNS the instance registered as this interface's singleton, so the writer and the reader cannot
+    /// drift onto two different maps.</para>
+    /// <para>Selection is per-SESSION, NOT per-account — two agent sessions of the same account may
+    /// independently select different instances (design 04 multi-tenancy semantics). A selection may
+    /// narrow a pin but never override it to another project (enforced by <c>select_engine_instance</c>
+    /// before writing here, and again by <see cref="Strategy.AccountInstances.Resolve"/>, which applies
+    /// the pin before the sticky term).</para>
     /// </summary>
     public interface ISessionSelectionStore
     {

--- a/McpPlugin.Server/src/Tools/SessionSelectionStore.cs
+++ b/McpPlugin.Server/src/Tools/SessionSelectionStore.cs
@@ -47,8 +47,12 @@ namespace com.IvanMurzak.McpPlugin.Server.Tools
 
     /// <summary>
     /// In-memory <see cref="ISessionSelectionStore"/>. Registered as a singleton only in <c>oauth</c>
-    /// mode (the account+instance pairing plane); the map is small (one entry per live agent session)
-    /// and entries are dropped on <see cref="Clear"/>.
+    /// mode (the account+instance pairing plane); the map holds one small entry per agent session that
+    /// has called <c>select_engine_instance</c>.
+    /// <para><see cref="ISessionSelectionStore.Clear"/> has no production caller yet, so entries are
+    /// reclaimed only at process exit. Harmless — session ids are unique, so a stale entry is
+    /// unreachable, and <see cref="Strategy.AccountInstances.Resolve"/> ignores a sticky id that is no
+    /// longer a live candidate — but unbounded.</para>
     /// </summary>
     public sealed class SessionSelectionStore : ISessionSelectionStore
     {

--- a/README.md
+++ b/README.md
@@ -423,6 +423,14 @@ docker run -p 8080:8080 mcp-bridge port=8080 client-transport=streamableHttp
 - **`DemoConsoleApp`**: A sample client application demonstrating how to expose tools.
 - **`DemoWebApp`**: A sample server application demonstrating how to host the MCP bridge.
 
+## Migration guides
+
+- **[Migrating to 8.0.0](docs/migration-8.0.0.md)** — three methods on `IClientPromptHub` /
+  `IClientResourceHub` gained a `CancellationToken` parameter. Callers keep compiling but MUST be
+  recompiled (the change is binary-breaking); anyone supplying their own implementation of those
+  interfaces has a source change to make. All three packages share one version and must be pinned to
+  `8.0.0` together.
+
 ## License
 
 This project is licensed under the Apache-2.0 License. Copyright - Ivan Murzak.

--- a/docs/architecture-transport-auth.md
+++ b/docs/architecture-transport-auth.md
@@ -144,11 +144,21 @@
 > middleware capture is unchanged and still serves the direct-tool REST surfaces, which run in the
 > request's own execution context.
 >
-> ⚠ The same `PerSessionExecutionContext` reasoning applies to `CurrentSelectedInstanceId`, which the
-> middleware also reloads per request: on the MCP path a sticky selection is therefore observed only
-> within the request that set it, so cross-request sticky routing is **not** yet wired there.
-> `AccountMcpStrategy.ResolveCurrentSession` reads only the ambient value and holds no
-> `ISessionSelectionStore`. Tracked separately from the fix above.
+> The same capture applies to `CurrentSelectedInstanceId`, which the middleware also reloads per
+> request — with one difference. Identity and pin are session-CONSTANT, so freezing them at `initialize`
+> is correct. The selection is session-MUTABLE, and the value frozen for it is a store lookup at the
+> **null** key described above. So on the MCP path a sticky selection used to be observed only within
+> the request that set it, and `select_engine_instance` was a silent no-op across requests.
+>
+> **Fixed in [#195](https://github.com/IvanMurzak/MCP-Plugin-dotnet/issues/195).**
+> `AccountMcpStrategy` now OWNS an `ISessionSelectionStore`, and `ResolveCurrentSession`'s sticky term
+> falls back to `store.Get(CurrentSessionId)` when the ambient value is null — `CurrentSessionId` being
+> the one selection-relevant ambient that IS published on the captured context, by `RunSessionHandler`
+> itself. A selection is therefore honoured on every subsequent request of the session.
+> `ExtensionsMcpServerBuilder` registers `strategy.Selections` as the `ISessionSelectionStore`
+> singleton rather than constructing a second one, so the selection tool and the router provably share
+> one map. The project pin is still applied strictly BEFORE the sticky term
+> (`AccountInstances.Resolve`), so a selection can narrow a pin but can never route across projects.
 >
 > **2. The catalog list paths degrade instead of failing, and are bounded at 15 s.** The two resource
 > `SetError` overloads used to `throw`, which the SDK surfaced as `-32603 "An error occurred."` during

--- a/docs/migration-8.0.0.md
+++ b/docs/migration-8.0.0.md
@@ -1,0 +1,87 @@
+# Migrating to 8.0.0
+
+`8.0.0` is a **major** release: three public `McpPlugin.Common` hub interfaces gained a
+`CancellationToken` parameter. Callers keep compiling (the parameter is defaulted), but
+**implementers do not**, and the change is binary-breaking either way — which is why this is
+`8.0.0` rather than a patch.
+
+> **The version constant is not bumped by this document.** `<Version>` in
+> `McpPlugin/McpPlugin.csproj` is the single source of truth for all three packages, and pushing a
+> new value to `main` is what triggers `release.yml` to publish to NuGet (see
+> `docs/claude/release.md`). The bump to `8.0.0` is therefore made by the release run, via
+> `commands/bump-version.ps1 8.0.0`, not by a feature PR.
+
+## What changed
+
+Introduced in [#194](https://github.com/IvanMurzak/MCP-Plugin-dotnet/pull/194), which bounded the
+prompt/resource list paths with the same linked-CTS timeout the tool path already used. Threading a
+token through those paths required it on the hub contracts:
+
+| Interface | Method |
+|---|---|
+| `IClientPromptHub` | `RunListPrompts` |
+| `IClientResourceHub` | `RunListResources` |
+| `IClientResourceHub` | `RunResourceTemplates` |
+
+All three now end in `CancellationToken cancellationToken = default`:
+
+```csharp
+// McpPlugin.Common/src/Hub/Client/IClientPromptHub.cs
+Task<ResponseData<ResponseListPrompts>> RunListPrompts(
+    RequestListPrompts request, CancellationToken cancellationToken = default);
+
+// McpPlugin.Common/src/Hub/Client/IClientResourceHub.cs
+Task<ResponseData<ResponseListResource[]>> RunListResources(
+    RequestListResources request, CancellationToken cancellationToken = default);
+
+Task<ResponseData<ResponseResourceTemplate[]>> RunResourceTemplates(
+    RequestListResourceTemplates request, CancellationToken cancellationToken = default);
+```
+
+## Who has to change
+
+**Implementers of these interfaces** — the engine plugins (Unity-MCP, Godot-MCP, Unreal-MCP) and any
+downstream host that supplies its own prompt/resource hub. An existing implementation no longer
+satisfies the interface and fails to compile with `CS0535` ("does not implement interface member").
+
+**Callers need no source change.** The parameter is defaulted, so existing call sites still compile.
+They must still be **recompiled** against 8.0.0: a defaulted parameter is baked into the caller at
+compile time, so a binary built against 7.x will `MissingMethodException` at runtime against the
+8.0.0 assembly. Do not mix 7.x and 8.0.0 assemblies in one process.
+
+## How to migrate
+
+Add the parameter to each override and honour it:
+
+```diff
+-public Task<ResponseData<ResponseListPrompts>> RunListPrompts(RequestListPrompts request)
++public Task<ResponseData<ResponseListPrompts>> RunListPrompts(
++    RequestListPrompts request, CancellationToken cancellationToken = default)
+ {
+-    return _promptManager.ListAsync(request);
++    return _promptManager.ListAsync(request, cancellationToken);
+ }
+```
+
+If the underlying work genuinely cannot be cancelled, accept the parameter and ignore it rather than
+omitting it — the signature must match. Pass the token down wherever the call chain already accepts
+one; the repo convention is that every async path threads its `CancellationToken` (see
+`docs/claude/style.md`).
+
+## Also in 8.0.0
+
+- `select_engine_instance` now actually takes effect. Its per-session selection is honoured by
+  routing on every **subsequent** request of that MCP session, not just the request that set it
+  ([#195](https://github.com/IvanMurzak/MCP-Plugin-dotnet/issues/195)). No API change; behaviour
+  only. A session that relied on the previous (broken) behaviour was in practice being routed to the
+  most-recently-active instance, so after upgrading, an agent that called `select_engine_instance`
+  will start reaching the instance it asked for.
+- `resources/list` and `resources/templates/list` degrade to an empty catalog instead of raising a
+  JSON-RPC error when no engine plugin is connected (#194).
+
+## Downstream pins to move in lockstep
+
+`com.IvanMurzak.McpPlugin`, `com.IvanMurzak.McpPlugin.Server` and `com.IvanMurzak.McpPlugin.Common`
+share one `<Version>` and are published together. Consumers that pin more than one of them must move
+**every** pin to `8.0.0` in the same change — a split pin mixes 7.x and 8.0.0 assemblies, which is
+exactly the binary-incompatible combination described above.

--- a/docs/migration-8.0.0.md
+++ b/docs/migration-8.0.0.md
@@ -1,7 +1,7 @@
 # Migrating to 8.0.0
 
-`8.0.0` is a **major** release: three public `McpPlugin.Common` hub interfaces gained a
-`CancellationToken` parameter. Callers keep compiling (the parameter is defaulted), but
+`8.0.0` is a **major** release: three methods across two public `McpPlugin.Common` hub interfaces
+gained a `CancellationToken` parameter. Callers keep compiling (the parameter is defaulted), but
 **implementers do not**, and the change is binary-breaking either way — which is why this is
 `8.0.0` rather than a patch.
 
@@ -40,9 +40,15 @@ Task<ResponseData<ResponseResourceTemplate[]>> RunResourceTemplates(
 
 ## Who has to change
 
-**Implementers of these interfaces** — the engine plugins (Unity-MCP, Godot-MCP, Unreal-MCP) and any
-downstream host that supplies its own prompt/resource hub. An existing implementation no longer
-satisfies the interface and fails to compile with `CS0535` ("does not implement interface member").
+**Implementers of these interfaces** — any downstream host that supplies its OWN `IClientPromptHub` /
+`IClientResourceHub` implementation. Such an implementation no longer satisfies the interface and
+fails to compile with `CS0535` ("does not implement interface member").
+
+**The engine plugins (Unity-MCP, Godot-MCP, Unreal-MCP) are NOT implementers** and will not see a
+`CS0535`. They CONSUME `IPromptManager` / `IResourceManager` from the `McpPlugin` package, and the
+concrete managers behind those already carried the token overload — which is why #194 was able to
+change both interfaces without touching a single implementation in this repository. For the engine
+plugins 8.0.0 is a pin bump plus a recompile (next paragraph), not a source change.
 
 **Callers need no source change.** The parameter is defaulted, so existing call sites still compile.
 They must still be **recompiled** against 8.0.0: a defaulted parameter is baked into the caller at
@@ -51,6 +57,10 @@ compile time, so a binary built against 7.x will `MissingMethodException` at run
 
 ## How to migrate
 
+`CancellationToken` lives in `System.Threading`, and `ImplicitUsings` is **disabled** in every
+project here — so add `using System.Threading;` to any file that does not already have it, or the
+new parameter will not resolve.
+
 Add the parameter to each override and honour it:
 
 ```diff
@@ -58,24 +68,35 @@ Add the parameter to each override and honour it:
 +public Task<ResponseData<ResponseListPrompts>> RunListPrompts(
 +    RequestListPrompts request, CancellationToken cancellationToken = default)
  {
--    return _promptManager.ListAsync(request);
-+    return _promptManager.ListAsync(request, cancellationToken);
+-    return _promptManager.RunListPrompts(request);
++    return _promptManager.RunListPrompts(request, cancellationToken);
  }
 ```
 
 If the underlying work genuinely cannot be cancelled, accept the parameter and ignore it rather than
 omitting it — the signature must match. Pass the token down wherever the call chain already accepts
-one; the repo convention is that every async path threads its `CancellationToken` (see
-`docs/claude/style.md`).
+one.
+
+**Keeping the 1-argument form as an overload is fine, and is what this repo does.** Every in-repo
+implementer declares the 2-argument member plus a 1-argument overload delegating to it, so any
+concrete-typed caller keeps compiling unchanged (`McpPlugin.Server/src/Client/RemotePromptRunner.cs`):
+
+```csharp
+public Task<ResponseData<ResponseListPrompts>> RunListPrompts(RequestListPrompts request)
+    => RunListPrompts(request, default);
+
+public async Task<ResponseData<ResponseListPrompts>> RunListPrompts(
+    RequestListPrompts request, CancellationToken cancellationToken = default) { /* … */ }
+```
 
 ## Also in 8.0.0
 
 - `select_engine_instance` now actually takes effect. Its per-session selection is honoured by
   routing on every **subsequent** request of that MCP session, not just the request that set it
-  ([#195](https://github.com/IvanMurzak/MCP-Plugin-dotnet/issues/195)). No API change; behaviour
-  only. A session that relied on the previous (broken) behaviour was in practice being routed to the
-  most-recently-active instance, so after upgrading, an agent that called `select_engine_instance`
-  will start reaching the instance it asked for.
+  ([#195](https://github.com/IvanMurzak/MCP-Plugin-dotnet/issues/195)). Additive API only
+  (`AccountMcpStrategy.Selections`, plus a two-argument constructor); no existing signature changed,
+  so this part is neither source- nor binary-breaking. A session that relied on the previous (broken)
+  behaviour was in practice being routed to the most-recently-active instance.
 - `resources/list` and `resources/templates/list` degrade to an empty catalog instead of raising a
   JSON-RPC error when no engine plugin is connected (#194).
 


### PR DESCRIPTION
## Summary

- **`select_engine_instance` now actually takes effect.** It previously returned SUCCESS and changed nothing: every subsequent tool call on the same MCP session was still routed by `pin → single → MRU`. `AccountMcpStrategy` now owns the `ISessionSelectionStore` and falls back to a lookup keyed by the ambient session id when `CurrentSelectedInstanceId` is null, so a selection survives past the request that made it.
- **The tool and the router now provably share one store.** `ExtensionsMcpServerBuilder` registers the strategy's store as the `ISessionSelectionStore` singleton instead of constructing a second one — the same shape already used for `strategy.Instances`.
- **Adds `docs/migration-8.0.0.md`** for the implementer-breaking `CancellationToken` parameters #194 added to three `McpPlugin.Common` hub methods.

## Root cause (it was not a missing store)

The sticky term was *already* threaded through `AccountMcpStrategy.ResolveCurrentSession` → `AccountInstances.Resolve`. It simply never carried a value on the streamable-HTTP MCP path:

`HttpServerTransportOptions.PerSessionExecutionContext` is `true`, so a session's request handlers run on the `ExecutionContext` captured **once** inside `RunSessionHandler`. `McpSessionTokenMiddleware` reloads `CurrentSelectedInstanceId` from the store **per request** (`McpSessionTokenMiddleware.cs:121-123`), and that `AsyncLocal` write therefore never reaches a handler. The session id *does* reach handlers — #194 publishes it from `RunSessionHandler` — so the selection was recoverable from the store by that key, which is exactly what this PR does.

`select_engine_instance` set the ambient value inline (`ServerNativeTools.cs:198`) "to take effect within this request too", which is why the tool itself looked correct in isolation.

A project pin is still applied first and strictly: a selection can narrow a pin, never route across projects.

## Before / after (real Streamable HTTP, on this machine)

Two instances registered on one account; **B** is most-recently-active, **A** is selected. Observed artifact is `LastActiveAt`, which `ResolveConnectionId` bumps on the instance it resolved — so only the routed instance moves.

**Before the fix** — `select_engine_instance(A)` succeeded, then the next tool call routed to B:

```
A instance-alpha 19:45:16.7352194 -> 19:45:16.7352194   (unchanged: never routed to)
B instance-beta  19:45:16.7983458 -> 19:45:17.3663285   (moved: MRU won)
Failed: 2, Passed: 0, Total: 2  (net8.0 and net9.0)
```

**After the fix** — routing follows the selection, and re-selecting B re-routes to B:

```
Passed!  - Failed: 0, Passed: 2, Skipped: 0, Total: 2 - McpPlugin.Server.Tests.dll (net8.0)
Passed!  - Failed: 0, Passed: 2, Skipped: 0, Total: 2 - McpPlugin.Server.Tests.dll (net9.0)
```

**Two instances is the discriminator.** With one instance the `single` auto-pair rung routes to it regardless of the selection, so a one-instance test cannot tell an honoured selection from an accidental one. Both tests deliberately select the instance that is *not* MRU — the only arrangement in which the sticky rung and the MRU rung disagree.

## Test plan

- [x] Target-specific local tests passed (see profile test.md) — Suite 1, solution-level: **671 passed × 2 TFMs** (`McpPlugin.Server.Tests`) and **808 passed × 2 TFMs** (`McpPlugin.Tests`), 4/4 test hosts `Test Run Successful`, **0 failures**.
- [x] Suite 4 (live oauth-mode MCP session over real Streamable HTTP) — the new tests *are* a Suite 4 gate.
- [x] Regression tests planted: **6/6 RED, 0 GREEN, restore-failures 0**, each attributed from its own per-plant log.
      (Re-run against the final tree during review: P1/P3 re-anchored for a method rename, P6 added for the new precondition.)

### Plant round

Every RED below is attributed to the *assertion that failed*, not to a suite count. Note that P4 and P5 fail on **different** halves than P1–P3, which is what establishes those halves are independently breakable rather than carried by the first assertion.

| Plant | Mutation | Verdict | Attributed to |
|---|---|---|---|
| P1 | drop the store fallback (the bundled pre-fix revert) | RED | `must be the one routing resolved` / `round 1: the call after selecting instance-alpha must route to instance-alpha` |
| P2 | DI registers a *separate* `SessionSelectionStore` | RED | same half — proves the shared-store wiring is load-bearing, not cosmetic |
| P3 | fallback keyed off `CurrentToken` instead of `CurrentSessionId` | RED | same half — proves the *key* is load-bearing |
| P4 | retry loop fails over to a sibling instance | RED | `the unselected instance instance-beta must NOT have been routed to` — the routing half still **passed**. Reddens the exclusivity half of **both** tests (test 2's `instance-alpha is no longer selected and must not be routed to` too), so that half is plant-covered in both. |
| P5 | store is first-write-wins (`TryAdd`) | RED | `round 2: after re-selecting instance-beta the call must route to instance-beta` — **1 failed / 1 passed**: test 1 stayed green, so this isolates the re-selection half |
| P6 | swap the two registrations, so A (not B) is most-recently-active | RED | `round 1 precondition` — **1 failed / 1 passed**: proves the MRU precondition added during review actually discriminates, rather than being a comment that always passes |

P1 alone would have been the revert the issue's DoD names, and it proves only the *union* of the halves it reverts: P2–P5 exist because each neuters exactly one mechanism.

## Found during review, deliberately NOT fixed here

Each was verified from source and is reported rather than fixed, to keep this PR the size of its issue:

- **`select_engine_instance` re-routes the tool CATALOG too, with no `list_changed` notification.**
  `tools/list` resolves through the same `ResolveConnectionId`, so an agent that cached the catalog
  before selecting can call a tool the newly-selected instance does not have. Pre-existing in class
  (the MRU rung already moved the catalog), but newly reachable on purpose. Needs its own task — a
  session-scoped notification is a design decision, and the existing tools-changed subject is a broadcast.
- **A selection whose instance disconnects is dropped in silence.** `Resolve` falls through to
  `single`/MRU, so a later call can execute against a different project with no signal, and
  `list_engine_instances` keeps printing `(selected)` for an instance that is gone. Related:
  `InstanceResolution.AdvisoryNote` has **no production reader** at all (definition plus six test
  assertions, nothing else), so the advisory that would explain the switch reaches nobody.
- **`ISessionSelectionStore.Clear` has no production caller**, so entries are reclaimed only at process
  exit. Harmless (session ids are unique; `Resolve` ignores a sticky id that is no longer live) but
  unbounded, and this PR makes the map load-bearing for routing. The natural eviction point is the
  existing `finally` in `StreamableHttpTransportLayer.RunSessionHandler`. Out of scope here since it
  reaches into the transport layer; the code comment now states the situation honestly.
- **Session isolation is not covered end-to-end.** Both tests drive one MCP session, so an
  implementation keyed by account id rather than session id would pass them. `SessionSelectionStoreTests`
  covers per-session semantics at unit level and `select_engine_instance` writes `context.SessionId`
  by construction, so the gap is narrow — but it is a gap, stated rather than implied.
- **The oauth-only DI factory can throw where the previous registration could not.** It matches the
  idiom of the `ServerNativeTools` registration beside it, and making it total would silently hand back
  a disconnected store — exactly the failure this PR removes — so failing loudly is the better
  behaviour. Recorded, not changed.
- **~120 lines of the HTTP test harness are duplicated** from `AmbientSessionIdOverHttpTests`
  (`FreeLoopbackPort` is now a third byte-identical copy). Extraction would touch a test file this PR
  does not otherwise own; worth doing when a third real-session test appears.

## Deliberately NOT in this PR: the `<Version>` bump

The dispatching task asked for `<Version>` → `8.0.0`. **It is left at 7.5.2 on purpose**, and this is not a mere convention call:

`.github/workflows/release.yml` triggers on `push: branches: [main]`, reads `<Version>` straight out of `McpPlugin/McpPlugin.csproj`, and publishes when no matching tag exists (`docs/claude/release.md`: "Push to `main` triggers: version check → test → GitHub release → NuGet deploy"). **Merging this PR with `<Version>` = 8.0.0 would publish all three NuGet packages** — contradicting the same task's explicit "do NOT publish or release; land the PR only".

### Operator follow-up (cannot be done by this PR)

1. Run `workflows/release/targets/mcp-plugin-dotnet`, which owns `commands/bump-version.ps1 8.0.0`, to set the version and publish. The migration note this PR adds means that run has nothing left to author.
2. **Only after 8.0.0 is published**, fix the two pins in `shared/GameDev-MCP-Server/com.IvanMurzak.GameDev.MCP.Server.csproj` **together**: `com.IvanMurzak.McpPlugin.Server` (line 60, currently `7.5.2`) and `com.IvanMurzak.McpPlugin` (line 67, currently `7.5.0`). They sit under a comment asserting they are kept "in lockstep", which the file currently violates. A split pin matters more after 8.0.0, whose change is binary-breaking. Out of this repo's scope — reported, not touched.

Closes #195

