### PR TITLE
fix(server): degrade a failed prompts/list to an empty catalog

### DIFF
--- a/McpPlugin.Server.Tests/ListSetErrorDegradationTests.cs
+++ b/McpPlugin.Server.Tests/ListSetErrorDegradationTests.cs
@@ -11,7 +11,6 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using ModelContextProtocol.Protocol;
 using Shouldly;
 using Xunit;
@@ -33,12 +32,12 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
     [Collection("McpPlugin.Server")]
     public class ListSetErrorDegradationTests
     {
-        // What these two cases establish, precisely: SetError does NOT throw (the defect-2 regression
-        // guard) and returns the SAME instance with a non-null catalog. They do NOT establish that the
-        // catalog was emptied — a freshly-constructed List*Result already exposes a non-null EMPTY list,
-        // so the count assertion below holds even for a SetError that clears nothing. The emptying is
-        // pinned by the two *_ClearsAnyAlreadyCollectedEntries cases, which start from a POPULATED
-        // catalog and are the only ones that can observe it.
+        // What the *_ReturnsEmptyCatalog_DoesNotThrow cases establish, precisely: SetError does NOT
+        // throw (the defect-2 regression guard) and returns the SAME instance with a non-null catalog.
+        // They do NOT establish that the catalog was emptied — a freshly-constructed List*Result
+        // already exposes a non-null EMPTY list, so the count assertion below holds even for a SetError
+        // that clears nothing. The emptying is pinned by the *_ClearsAnyAlreadyCollectedEntries cases,
+        // which start from a POPULATED catalog and are the only ones that can observe it.
 
         [Fact]
         public void ListResources_SetError_ReturnsEmptyCatalog_DoesNotThrow()
@@ -101,12 +100,7 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
             result.ResourceTemplates.Count.ShouldBe(0);
         }
 
-        /// <summary>
-        /// The prompt overload no longer fabricates a client-visible entry. A freshly-constructed
-        /// <see cref="ListPromptsResult"/> already exposes an empty list, so this case is deliberately
-        /// paired with <see cref="ListPrompts_SetError_ClearsAnyAlreadyCollectedEntries"/> below —
-        /// that one starts from a POPULATED catalog and is the only one that can observe the emptying.
-        /// </summary>
+        /// <summary>The prompt overload no longer fabricates a client-visible entry.</summary>
         [Fact]
         public void ListPrompts_SetError_ReturnsEmptyCatalog_DoesNotThrow()
         {
@@ -123,8 +117,8 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
         /// The defect this pins: <c>SetError</c> used to REPLACE the catalog with a single synthetic
         /// <c>Prompt { Name = "Error", Description = message }</c>. Starting from a populated catalog
         /// makes both halves observable at once — the stale entry must go, and no fabricated entry
-        /// may take its place. The name set is asserted as EMPTY rather than "does not contain Error",
-        /// so a differently-named fabrication cannot satisfy it either.
+        /// may take its place. Emptiness is asserted rather than "contains nothing named Error", so a
+        /// fabrication under ANY name fails this case.
         /// </summary>
         [Fact]
         public void ListPrompts_SetError_ClearsAnyAlreadyCollectedEntries()
@@ -140,7 +134,6 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
             result.SetError("Invoke 'RunListPrompts': Failed to invoke 'RequestListPrompts' after 10 retries.");
 
             result.Prompts.Count.ShouldBe(0);
-            result.Prompts.Select(p => p.Name).ShouldBeEmpty();
         }
 
         [Fact]

--- a/McpPlugin.Server.Tests/ListSetErrorDegradationTests.cs
+++ b/McpPlugin.Server.Tests/ListSetErrorDegradationTests.cs
@@ -11,6 +11,7 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using ModelContextProtocol.Protocol;
 using Shouldly;
 using Xunit;
@@ -19,13 +20,15 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
 {
     /// <summary>
     /// Every list-shaped <c>SetError</c> overload in the server DEGRADES rather than throwing, so the
-    /// MCP call still succeeds. The two resource overloads return an EMPTY catalog, mirroring
-    /// <see cref="ExtensionsTool.SetError(ListToolsResult, string)"/>; the prompt overload
-    /// (<see cref="ExtensionsPrompt.SetError(ListPromptsResult, string)"/>) is the deliberate odd one
-    /// out and returns a single synthetic <c>Error</c> prompt carrying the message. The resource pair
-    /// used to be the only list-shaped overloads that did NOT degrade: they were implemented as
-    /// <c>throw new Exception(message)</c>, which surfaced to the client as a hard JSON-RPC
-    /// <c>-32603</c> whenever the engine plugin had not attached yet (issue #193, defect 2).
+    /// MCP call still succeeds, and every one of them now returns an EMPTY catalog, mirroring
+    /// <see cref="ExtensionsTool.SetError(ListToolsResult, string)"/>. Two earlier deviations are
+    /// both closed: the resource pair used to <c>throw new Exception(message)</c>, surfacing to the
+    /// client as a hard JSON-RPC <c>-32603</c> whenever the engine plugin had not attached yet
+    /// (issue #193, defect 2); and the prompt overload
+    /// (<see cref="ExtensionsPrompt.SetError(ListPromptsResult, string)"/>) used to fabricate a
+    /// single synthetic prompt named <c>"Error"</c> carrying the internal message, which MCP clients
+    /// rendered as a real, selectable prompt. In every case the message is not lost — the router
+    /// logs it at Warn before degrading.
     /// </summary>
     [Collection("McpPlugin.Server")]
     public class ListSetErrorDegradationTests
@@ -96,6 +99,56 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
             result.SetError("[Error] plugin not connected");
 
             result.ResourceTemplates.Count.ShouldBe(0);
+        }
+
+        /// <summary>
+        /// The prompt overload no longer fabricates a client-visible entry. A freshly-constructed
+        /// <see cref="ListPromptsResult"/> already exposes an empty list, so this case is deliberately
+        /// paired with <see cref="ListPrompts_SetError_ClearsAnyAlreadyCollectedEntries"/> below —
+        /// that one starts from a POPULATED catalog and is the only one that can observe the emptying.
+        /// </summary>
+        [Fact]
+        public void ListPrompts_SetError_ReturnsEmptyCatalog_DoesNotThrow()
+        {
+            var result = new ListPromptsResult();
+
+            var returned = Should.NotThrow(() => result.SetError("[Error] plugin not connected"));
+
+            returned.ShouldBeSameAs(result);
+            returned.Prompts.ShouldNotBeNull();
+            returned.Prompts.Count.ShouldBe(0);
+        }
+
+        /// <summary>
+        /// The defect this pins: <c>SetError</c> used to REPLACE the catalog with a single synthetic
+        /// <c>Prompt { Name = "Error", Description = message }</c>. Starting from a populated catalog
+        /// makes both halves observable at once — the stale entry must go, and no fabricated entry
+        /// may take its place. The name set is asserted as EMPTY rather than "does not contain Error",
+        /// so a differently-named fabrication cannot satisfy it either.
+        /// </summary>
+        [Fact]
+        public void ListPrompts_SetError_ClearsAnyAlreadyCollectedEntries()
+        {
+            var result = new ListPromptsResult
+            {
+                Prompts = new List<Prompt>
+                {
+                    new Prompt { Name = "stale", Description = "collected before the failure" }
+                }
+            };
+
+            result.SetError("Invoke 'RunListPrompts': Failed to invoke 'RequestListPrompts' after 10 retries.");
+
+            result.Prompts.Count.ShouldBe(0);
+            result.Prompts.Select(p => p.Name).ShouldBeEmpty();
+        }
+
+        [Fact]
+        public void ListPrompts_SetError_OnNullTarget_ThrowsArgumentNullException()
+        {
+            ListPromptsResult? target = null;
+
+            Should.Throw<ArgumentNullException>(() => target!.SetError("boom"));
         }
 
         [Fact]

--- a/McpPlugin.Server.Tests/PromptListDegradationOverHttpTests.cs
+++ b/McpPlugin.Server.Tests/PromptListDegradationOverHttpTests.cs
@@ -12,9 +12,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
 using System.Net.Http;
-using System.Net.Sockets;
 using System.Text;
 using System.Text.Json;
 using System.Threading;
@@ -23,10 +21,16 @@ using com.IvanMurzak.McpPlugin.Common.Hub.Client;
 using com.IvanMurzak.McpPlugin.Common.Model;
 using com.IvanMurzak.McpPlugin.Common.Utils;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using NLog;
+using NLog.Config;
+using NLog.Targets;
 using Shouldly;
 using Xunit;
+using NLogLevel = NLog.LogLevel;
 
 namespace com.IvanMurzak.McpPlugin.Server.Tests
 {
@@ -54,15 +58,22 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
     public sealed class PromptListDegradationOverHttpTests
     {
         /// <summary>
+        /// The shared identity of this fixture family: the text the plugin call fails with. It is what
+        /// the client used to see in the synthetic prompt's description, and what the operator log must
+        /// still carry.
+        /// </summary>
+        const string PluginFailureText =
+            "Invoke 'RunListPrompts': Failed to invoke " +
+            "'com.IvanMurzak.McpPlugin.Common.Model.RequestListPrompts' after 10 retries.";
+
+        /// <summary>
         /// The regression. With the plugin call failing, <c>prompts/list</c> answers with an empty
         /// catalog and NO synthetic entry — in particular nothing named <c>"Error"</c>.
         /// </summary>
         [Fact]
         public async Task PromptsList_WhenThePluginCallFails_ReturnsEmptyCatalogWithNoSyntheticErrorPrompt()
         {
-            var hub = FakePromptHub.ThatFailsWith(
-                "Invoke 'RunListPrompts': Failed to invoke " +
-                "'com.IvanMurzak.McpPlugin.Common.Model.RequestListPrompts' after 10 retries.");
+            var hub = FakePromptHub.ThatFailsWith(PluginFailureText);
 
             await using var host = await StartNoneAuthHostAsync(hub);
             using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(60) };
@@ -82,9 +93,10 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
                 .Select(p => p.TryGetProperty("name", out var n) ? n.GetString() : null)
                 .ToList();
 
-            // Asserted as an exact set rather than "does not contain Error": an entry named anything
-            // else would be just as much a fabrication, and an exact-set assertion cannot be satisfied
-            // by a differently-named synthetic element.
+            // Emptiness is asserted rather than "contains nothing named Error": an entry named anything
+            // else would be just as much a fabrication, and emptiness cannot be satisfied by a
+            // differently-named synthetic element. The names are projected rather than counted so a
+            // failure names the fabricated entry instead of only its count.
             names.ShouldBeEmpty($"the failed prompts/list must emit no prompt at all; got: {body}");
 
             // Positive artifact: the call REACHED the plugin seam and failed there. Without this, the
@@ -126,6 +138,30 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
             hub.ListCallCount.ShouldBe(1, "the router must have called the plugin hub exactly once");
         }
 
+        /// <summary>
+        /// The OTHER half of the ruling that produced this change: the client-facing fabrication goes
+        /// away, but the internal failure text must still reach the OPERATOR. Removing the synthetic
+        /// prompt deleted the only client-visible copy of that text, so the router's Warn log is now
+        /// its ONLY carrier — and an unasserted log is one refactor away from silence. This pins it as
+        /// a PRESENCE claim (the text must appear), which no short-circuiting path can satisfy.
+        /// </summary>
+        [Fact]
+        public async Task PromptsList_WhenThePluginCallFails_StillLogsTheInternalFailureTextForOperators()
+        {
+            var hub = FakePromptHub.ThatFailsWith(PluginFailureText);
+
+            using var warnings = CapturedRouterWarnings.Install();
+
+            await using var host = await StartNoneAuthHostAsync(hub);
+            using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(60) };
+
+            var sessionId = await host.HandshakeAsync(client);
+            await host.ListPromptsAsync(client, sessionId);
+
+            warnings.Text.ShouldContain(PluginFailureText, Case.Sensitive,
+                "the failure text the client no longer sees must still reach the operator log at Warn");
+        }
+
         // ───────────────────────────── fake plugin hub ─────────────────────────────
 
         /// <summary>
@@ -135,27 +171,25 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
         /// </summary>
         sealed class FakePromptHub : IClientPromptHub
         {
-            ResponseData<ResponseListPrompts>? _response;
+            readonly ResponseData<ResponseListPrompts> _response;
             int _listCallCount;
+
+            FakePromptHub(ResponseData<ResponseListPrompts> response) => _response = response;
 
             public int ListCallCount => Volatile.Read(ref _listCallCount);
 
-            public static FakePromptHub ThatFailsWith(string message) => new FakePromptHub
-            {
-                _response = ResponseData<ResponseListPrompts>.Error("req-fail", message)
-            };
+            public static FakePromptHub ThatFailsWith(string message)
+                => new FakePromptHub(ResponseData<ResponseListPrompts>.Error("req-fail", message));
 
+            // Packed exactly as the real producer packs it (McpPromptManager.ListAll -> Pack), so the
+            // success envelope this fixture feeds the router carries the same Message the plugin would.
             public static FakePromptHub ThatReturns(params ResponsePrompt[] prompts)
-            {
-                var response = ResponseData<ResponseListPrompts>.Success("req-ok");
-                response.Value = new ResponseListPrompts { Prompts = prompts.ToList() };
-                return new FakePromptHub { _response = response };
-            }
+                => new FakePromptHub(new ResponseListPrompts { Prompts = prompts.ToList() }.Pack("req-ok"));
 
             public Task<ResponseData<ResponseListPrompts>> RunListPrompts(RequestListPrompts request, CancellationToken cancellationToken = default)
             {
                 Interlocked.Increment(ref _listCallCount);
-                return Task.FromResult(_response!);
+                return _response.TaskFromResult();
             }
 
             public Task<ResponseData<ResponseGetPrompt>> RunGetPrompt(RequestGetPrompt request)
@@ -166,11 +200,8 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
 
         static async Task<NoneAuthHost> StartNoneAuthHostAsync(IClientPromptHub promptHub)
         {
-            var port = FreeLoopbackPort();
-
             var dataArguments = new DataArguments(new[]
             {
-                $"port={port}",
                 "client-transport=streamableHttp",
                 "auth=none",
             });
@@ -186,11 +217,19 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
             builder.Services.AddSingleton(promptHub);
 
             var app = builder.Build();
-            app.Urls.Add($"http://127.0.0.1:{port}");
+            app.Urls.Add("http://127.0.0.1:0"); // OS-assigned loopback port
             app.UseMcpPluginServer(dataArguments);
             await app.StartAsync();
 
-            return new NoneAuthHost(app, $"http://127.0.0.1:{port}");
+            // Read the port the OS actually bound, rather than probing a free one and re-binding it
+            // later: that probe-then-rebind leaves a window for another process to take the port.
+            // Same pattern as PinnedPathRoutingTests.StartHostAsync.
+            var address = app.Services
+                .GetRequiredService<IServer>()
+                .Features.Get<IServerAddressesFeature>()!
+                .Addresses.First();
+
+            return new NoneAuthHost(app, address);
         }
 
         sealed class NoneAuthHost : IAsyncDisposable
@@ -263,16 +302,45 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
             }
         }
 
-        // ───────────────────────────── helpers ─────────────────────────────
+        // ───────────────────────────── captured operator log ─────────────────────────────
 
-        static int FreeLoopbackPort()
+        /// <summary>
+        /// Captures what <see cref="PromptRouter"/> writes at Warn. The routers log through NLog's
+        /// static <c>LogManager</c>, which is independent of the host's
+        /// <c>builder.Logging.ClearProviders()</c>, so the capture is installed on the NLog
+        /// configuration and scoped to the router's own logger.
+        ///
+        /// <para>That configuration is process-global, and test parallelism is NOT what makes the swap
+        /// safe: only 43 of this assembly's 62 test classes carry
+        /// <c>[Collection("McpPlugin.Server")]</c>, so the other 19 do run concurrently with these.
+        /// What makes it safe is that the rule is scoped to the router's logger name — concurrent
+        /// tests can neither pollute the capture nor observe it — and that this is the only file in
+        /// the assembly that reads or writes <c>LogManager.Configuration</c>. Before adding a second
+        /// log-asserting test anywhere in this assembly, re-check both of those.</para>
+        /// </summary>
+        sealed class CapturedRouterWarnings : IDisposable
         {
-            var probe = new TcpListener(IPAddress.Loopback, 0);
-            probe.Start();
-            var port = ((IPEndPoint)probe.LocalEndpoint).Port;
-            probe.Stop();
-            return port;
+            readonly LoggingConfiguration? _previous = LogManager.Configuration;
+            readonly MemoryTarget _target = new MemoryTarget("prompt-router-warn-capture") { Layout = "${message}" };
+
+            CapturedRouterWarnings()
+            {
+                var config = new LoggingConfiguration();
+                // Derived from the type, not spelled out: the router's logger name IS its full type
+                // name (LogManager.GetCurrentClassLogger), so a rename cannot silently stop matching.
+                config.AddRule(NLogLevel.Warn, NLogLevel.Fatal, _target, typeof(PromptRouter).FullName!);
+                LogManager.Configuration = config;
+            }
+
+            public string Text => string.Join(Environment.NewLine, _target.Logs);
+
+            /// <summary>Named rather than a bare `new` because constructing it MUTATES global state.</summary>
+            public static CapturedRouterWarnings Install() => new CapturedRouterWarnings();
+
+            public void Dispose() => LogManager.Configuration = _previous;
         }
+
+        // ───────────────────────────── helpers ─────────────────────────────
 
         /// <summary>The streamable-HTTP reply is an SSE frame; pull the JSON out of its data: lines.</summary>
         static string Unwrap(string body)

--- a/McpPlugin.Server.Tests/PromptListDegradationOverHttpTests.cs
+++ b/McpPlugin.Server.Tests/PromptListDegradationOverHttpTests.cs
@@ -1,0 +1,292 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.Common.Hub.Client;
+using com.IvanMurzak.McpPlugin.Common.Model;
+using com.IvanMurzak.McpPlugin.Common.Utils;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.Server.Tests
+{
+    /// <summary>
+    /// End-to-end cover for what a client actually receives from <c>prompts/list</c> when the
+    /// plugin-side call fails — the routine "the engine plugin has not attached yet" window.
+    ///
+    /// <para>The defect: <see cref="ExtensionsPrompt.SetError(ModelContextProtocol.Protocol.ListPromptsResult, string)"/>
+    /// used to fabricate a single synthetic prompt named <c>"Error"</c> whose description carried the
+    /// internal failure text. It never threw, so nothing in the suite went red — but on the wire the
+    /// client saw a REAL, selectable prompt, with internal .NET type names in its description. The
+    /// fix returns an EMPTY catalog instead, matching the tool and resource list paths; the failure
+    /// text stays on the server-side log at Warn (<c>PromptRouter.List</c>), so operators lose
+    /// nothing.</para>
+    ///
+    /// <para>The two cases are one fixture family on purpose. The failure case asserts an EMPTY
+    /// catalog, and an emptiness assertion is satisfied for free by any path that never ran at all —
+    /// so it is paired with <see cref="PromptsList_WhenThePluginReturnsPrompts_EmitsThemOverTheWire"/>,
+    /// which drives the SAME host and the SAME seam and pins the exact prompt names that come back.
+    /// The failure case additionally pins <see cref="FakePromptHub.ListCallCount"/>, so the empty
+    /// catalog is provably the DEGRADATION of a call that reached the plugin seam and failed there,
+    /// not the silence of a request that never arrived.</para>
+    /// </summary>
+    [Collection("McpPlugin.Server")]
+    public sealed class PromptListDegradationOverHttpTests
+    {
+        /// <summary>
+        /// The regression. With the plugin call failing, <c>prompts/list</c> answers with an empty
+        /// catalog and NO synthetic entry — in particular nothing named <c>"Error"</c>.
+        /// </summary>
+        [Fact]
+        public async Task PromptsList_WhenThePluginCallFails_ReturnsEmptyCatalogWithNoSyntheticErrorPrompt()
+        {
+            var hub = FakePromptHub.ThatFailsWith(
+                "Invoke 'RunListPrompts': Failed to invoke " +
+                "'com.IvanMurzak.McpPlugin.Common.Model.RequestListPrompts' after 10 retries.");
+
+            await using var host = await StartNoneAuthHostAsync(hub);
+            using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(60) };
+
+            var sessionId = await host.HandshakeAsync(client);
+            var body = await host.ListPromptsAsync(client, sessionId);
+
+            using var doc = JsonDocument.Parse(body);
+
+            doc.RootElement.TryGetProperty("error", out _).ShouldBeFalse(
+                $"prompts/list must not fail the JSON-RPC call when the plugin call fails; got: {body}");
+
+            doc.RootElement.GetProperty("result").TryGetProperty("prompts", out var prompts).ShouldBeTrue(
+                $"the degraded catalog is empty, not absent; got: {body}");
+
+            var names = prompts.EnumerateArray()
+                .Select(p => p.TryGetProperty("name", out var n) ? n.GetString() : null)
+                .ToList();
+
+            // Asserted as an exact set rather than "does not contain Error": an entry named anything
+            // else would be just as much a fabrication, and an exact-set assertion cannot be satisfied
+            // by a differently-named synthetic element.
+            names.ShouldBeEmpty($"the failed prompts/list must emit no prompt at all; got: {body}");
+
+            // Positive artifact: the call REACHED the plugin seam and failed there. Without this, the
+            // emptiness above would also hold for a request that never got as far as the router.
+            hub.ListCallCount.ShouldBe(1, "the router must have called the plugin hub exactly once");
+        }
+
+        /// <summary>
+        /// The paired positive case: the same host, the same seam, a SUCCESSFUL plugin response — and
+        /// the prompts appear on the wire. This is what makes the empty-catalog assertion above
+        /// meaningful: it proves this fixture is capable of emitting prompts in the first place.
+        /// </summary>
+        [Fact]
+        public async Task PromptsList_WhenThePluginReturnsPrompts_EmitsThemOverTheWire()
+        {
+            var hub = FakePromptHub.ThatReturns(
+                new ResponsePrompt { Name = "alpha", Description = "first", Enabled = true },
+                new ResponsePrompt { Name = "beta", Description = "second", Enabled = true });
+
+            await using var host = await StartNoneAuthHostAsync(hub);
+            using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(60) };
+
+            var sessionId = await host.HandshakeAsync(client);
+            var body = await host.ListPromptsAsync(client, sessionId);
+
+            using var doc = JsonDocument.Parse(body);
+
+            doc.RootElement.TryGetProperty("error", out _).ShouldBeFalse(
+                $"prompts/list must succeed when the plugin answers; got: {body}");
+
+            var names = doc.RootElement.GetProperty("result").GetProperty("prompts")
+                .EnumerateArray()
+                .Select(p => p.GetProperty("name").GetString())
+                .ToList();
+
+            names.ShouldBe(new List<string?> { "alpha", "beta" },
+                $"the plugin's prompts must reach the client verbatim and in order; got: {body}");
+
+            hub.ListCallCount.ShouldBe(1, "the router must have called the plugin hub exactly once");
+        }
+
+        // ───────────────────────────── fake plugin hub ─────────────────────────────
+
+        /// <summary>
+        /// Stands in for <see cref="RemotePromptRunner"/> so both outcomes of the plugin call are
+        /// reachable without a live SignalR plugin: the real runner needs an attached engine plugin,
+        /// and its failure path costs a full retry budget in wall-clock time.
+        /// </summary>
+        sealed class FakePromptHub : IClientPromptHub
+        {
+            ResponseData<ResponseListPrompts>? _response;
+            int _listCallCount;
+
+            public int ListCallCount => Volatile.Read(ref _listCallCount);
+
+            public static FakePromptHub ThatFailsWith(string message) => new FakePromptHub
+            {
+                _response = ResponseData<ResponseListPrompts>.Error("req-fail", message)
+            };
+
+            public static FakePromptHub ThatReturns(params ResponsePrompt[] prompts)
+            {
+                var response = ResponseData<ResponseListPrompts>.Success("req-ok");
+                response.Value = new ResponseListPrompts { Prompts = prompts.ToList() };
+                return new FakePromptHub { _response = response };
+            }
+
+            public Task<ResponseData<ResponseListPrompts>> RunListPrompts(RequestListPrompts request, CancellationToken cancellationToken = default)
+            {
+                Interlocked.Increment(ref _listCallCount);
+                return Task.FromResult(_response!);
+            }
+
+            public Task<ResponseData<ResponseGetPrompt>> RunGetPrompt(RequestGetPrompt request)
+                => throw new NotSupportedException("These tests only drive prompts/list.");
+        }
+
+        // ───────────────────────────── real loopback none-auth host ─────────────────────────────
+
+        static async Task<NoneAuthHost> StartNoneAuthHostAsync(IClientPromptHub promptHub)
+        {
+            var port = FreeLoopbackPort();
+
+            var dataArguments = new DataArguments(new[]
+            {
+                $"port={port}",
+                "client-transport=streamableHttp",
+                "auth=none",
+            });
+
+            var builder = WebApplication.CreateBuilder();
+            builder.Logging.ClearProviders();
+            builder.Services
+                .WithMcpServer(dataArguments)
+                .WithMcpPluginServer(dataArguments);
+
+            // Registered AFTER the production wiring so this singleton is the one the router resolves
+            // (same pattern as AmbientSessionIdOverHttpTests' FakeJwksKeyProvider).
+            builder.Services.AddSingleton(promptHub);
+
+            var app = builder.Build();
+            app.Urls.Add($"http://127.0.0.1:{port}");
+            app.UseMcpPluginServer(dataArguments);
+            await app.StartAsync();
+
+            return new NoneAuthHost(app, $"http://127.0.0.1:{port}");
+        }
+
+        sealed class NoneAuthHost : IAsyncDisposable
+        {
+            readonly WebApplication _app;
+            readonly string _baseUrl;
+
+            public NoneAuthHost(WebApplication app, string baseUrl)
+            {
+                _app = app;
+                _baseUrl = baseUrl;
+            }
+
+            /// <summary>initialize + notifications/initialized; returns the server-minted session id.</summary>
+            public async Task<string> HandshakeAsync(HttpClient client)
+            {
+                var (_, sessionId) = await PostAsync(client, null, new
+                {
+                    jsonrpc = "2.0",
+                    id = 1,
+                    method = "initialize",
+                    @params = new
+                    {
+                        protocolVersion = "2024-11-05",
+                        capabilities = new { },
+                        clientInfo = new { name = "prompt-list-degradation-test", version = "1.0.0" }
+                    }
+                });
+
+                sessionId.ShouldNotBeNullOrEmpty("the server must mint an Mcp-Session-Id on initialize");
+                await PostAsync(client, sessionId, new { jsonrpc = "2.0", method = "notifications/initialized" });
+                return sessionId!;
+            }
+
+            public async Task<string> ListPromptsAsync(HttpClient client, string sessionId)
+            {
+                var (body, _) = await PostAsync(client, sessionId, new
+                {
+                    jsonrpc = "2.0",
+                    id = 2,
+                    method = "prompts/list"
+                });
+                return Unwrap(body);
+            }
+
+            async Task<(string Body, string? SessionId)> PostAsync(HttpClient client, string? sessionId, object payload)
+            {
+                using var request = new HttpRequestMessage(HttpMethod.Post, _baseUrl + "/mcp");
+                request.Headers.Accept.ParseAdd("application/json");
+                request.Headers.Accept.ParseAdd("text/event-stream");
+                if (!string.IsNullOrEmpty(sessionId))
+                    request.Headers.TryAddWithoutValidation("Mcp-Session-Id", sessionId);
+                request.Content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
+
+                using var response = await client.SendAsync(request);
+                var body = await response.Content.ReadAsStringAsync();
+                // Assert SUCCESS rather than merely "not 401": a routing or wiring regression answering
+                // 404 / 405 / 500 would otherwise resurface downstream as a JsonDocument.Parse failure,
+                // which reads as a broken harness instead of the regression it is.
+                response.IsSuccessStatusCode.ShouldBeTrue(
+                    $"POST /mcp must succeed in auth=none mode; status {(int)response.StatusCode} {response.StatusCode}, body: {body}");
+                var issued = response.Headers.TryGetValues("Mcp-Session-Id", out var values) ? values.FirstOrDefault() : null;
+                return (body, issued);
+            }
+
+            public async ValueTask DisposeAsync()
+            {
+                await _app.StopAsync();
+                await _app.DisposeAsync();
+            }
+        }
+
+        // ───────────────────────────── helpers ─────────────────────────────
+
+        static int FreeLoopbackPort()
+        {
+            var probe = new TcpListener(IPAddress.Loopback, 0);
+            probe.Start();
+            var port = ((IPEndPoint)probe.LocalEndpoint).Port;
+            probe.Stop();
+            return port;
+        }
+
+        /// <summary>The streamable-HTTP reply is an SSE frame; pull the JSON out of its data: lines.</summary>
+        static string Unwrap(string body)
+        {
+            if (!body.Contains("data:", StringComparison.Ordinal))
+                return body;
+            var sb = new StringBuilder();
+            foreach (var line in body.Split('\n'))
+            {
+                var trimmed = line.TrimEnd('\r');
+                if (trimmed.StartsWith("data:", StringComparison.Ordinal))
+                    sb.Append(trimmed.Substring(5).Trim());
+            }
+            return sb.Length > 0 ? sb.ToString() : body;
+        }
+    }
+}

--- a/McpPlugin.Server/src/Extension/ExtensionsPrompt.cs
+++ b/McpPlugin.Server/src/Extension/ExtensionsPrompt.cs
@@ -38,6 +38,10 @@ namespace com.IvanMurzak.McpPlugin.Server
         /// <see cref="PromptRouter.List"/>, "the plugin has not connected yet". The failure
         /// message is not dropped: the router logs it as a warning before degrading.
         /// </summary>
+        /// <param name="message">
+        /// INTENTIONALLY UNUSED, exactly as in the three sibling list overloads — putting it back
+        /// into the result is the defect this method was changed to remove.
+        /// </param>
         public static ListPromptsResult SetError(this ListPromptsResult target, string message)
         {
             if (target == null)

--- a/McpPlugin.Server/src/Extension/ExtensionsPrompt.cs
+++ b/McpPlugin.Server/src/Extension/ExtensionsPrompt.cs
@@ -28,19 +28,22 @@ namespace com.IvanMurzak.McpPlugin.Server
             return target;
         }
 
+        /// <summary>
+        /// Degrades a failed <c>prompts/list</c> to an EMPTY catalog, mirroring the tool path
+        /// (<see cref="ExtensionsTool.SetError(ListToolsResult, string)"/>) and the two resource
+        /// list paths. This used to fabricate a single synthetic <c>Prompt</c> named
+        /// <c>"Error"</c> carrying the failure message, which every MCP client rendered as a real,
+        /// selectable prompt whose description leaked internal .NET type names to end users —
+        /// an outcome worse than an empty list on the most common failure branch of
+        /// <see cref="PromptRouter.List"/>, "the plugin has not connected yet". The failure
+        /// message is not dropped: the router logs it as a warning before degrading.
+        /// </summary>
         public static ListPromptsResult SetError(this ListPromptsResult target, string message)
         {
             if (target == null)
                 throw new ArgumentNullException(nameof(target));
 
-            target.Prompts = new List<Prompt>()
-            {
-                new Prompt()
-                {
-                    Name = "Error",
-                    Description = message
-                }
-            };
+            target.Prompts = new List<Prompt>();
 
             return target;
         }

--- a/McpPlugin.Server/src/Mcp/Prompt/PromptRouter.List.cs
+++ b/McpPlugin.Server/src/Mcp/Prompt/PromptRouter.List.cs
@@ -35,7 +35,7 @@ namespace com.IvanMurzak.McpPlugin.Server
 
             if (request.Services == null)
             {
-                logger.Warn("List: 'Services' is null - the server is misconfigured. Returning a degraded prompt list.");
+                logger.Warn("List: 'Services' is null - the server is misconfigured. Returning an empty prompt list.");
                 return new ListPromptsResult().SetError("[Error] 'Services' is null");
             }
 
@@ -60,13 +60,13 @@ namespace com.IvanMurzak.McpPlugin.Server
             {
                 // Defensive only - see ResourceRouter.List: the runner converts every failure, including
                 // cancellation, into an error ResponseData, so a timeout lands on the Error branch below.
-                logger.Warn("List timed out after {0}s: MCP Plugin not yet connected. Returning a degraded prompt list.", _listPromptsTimeout.TotalSeconds);
+                logger.Warn("List timed out after {0}s: MCP Plugin not yet connected. Returning an empty prompt list.", _listPromptsTimeout.TotalSeconds);
                 return new ListPromptsResult().SetError("[Error] Timed out listing prompts");
             }
 
             if (response == null)
             {
-                logger.Warn("List response is null (plugin may not be connected yet). Returning a degraded prompt list.");
+                logger.Warn("List response is null (plugin may not be connected yet). Returning an empty prompt list.");
                 return new ListPromptsResult().SetError($"[Error] '{nameof(response)}' is null");
             }
 
@@ -74,17 +74,17 @@ namespace com.IvanMurzak.McpPlugin.Server
             {
                 if (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
                 {
-                    logger.Warn("List timed out after {0}s: MCP Plugin not yet connected. Returning a degraded prompt list.", _listPromptsTimeout.TotalSeconds);
+                    logger.Warn("List timed out after {0}s: MCP Plugin not yet connected. Returning an empty prompt list.", _listPromptsTimeout.TotalSeconds);
                     return new ListPromptsResult().SetError("[Error] Timed out listing prompts");
                 }
 
-                logger.Warn("List error (plugin may not be connected yet): {0}. Returning a degraded prompt list.", response.Message);
+                logger.Warn("List error (plugin may not be connected yet): {0}. Returning an empty prompt list.", response.Message);
                 return new ListPromptsResult().SetError(response.Message ?? "[Error] Got an error during reading resources");
             }
 
             if (response.Value == null)
             {
-                logger.Warn("List response value is null (plugin may not be connected yet). Returning a degraded prompt list.");
+                logger.Warn("List response value is null (plugin may not be connected yet). Returning an empty prompt list.");
                 return new ListPromptsResult().SetError("[Error] Resource value is null");
             }
 

--- a/McpPlugin.Server/src/Mcp/Prompt/PromptRouter.List.cs
+++ b/McpPlugin.Server/src/Mcp/Prompt/PromptRouter.List.cs
@@ -79,13 +79,13 @@ namespace com.IvanMurzak.McpPlugin.Server
                 }
 
                 logger.Warn("List error (plugin may not be connected yet): {0}. Returning an empty prompt list.", response.Message);
-                return new ListPromptsResult().SetError(response.Message ?? "[Error] Got an error during reading resources");
+                return new ListPromptsResult().SetError(response.Message ?? "[Error] Got an error during listing prompts");
             }
 
             if (response.Value == null)
             {
                 logger.Warn("List response value is null (plugin may not be connected yet). Returning an empty prompt list.");
-                return new ListPromptsResult().SetError("[Error] Resource value is null");
+                return new ListPromptsResult().SetError("[Error] Prompt value is null");
             }
 
             // Trusted internal clients receive the unfiltered catalog — see ToolRouter.ListAll.

--- a/docs/architecture-transport-auth.md
+++ b/docs/architecture-transport-auth.md
@@ -167,9 +167,15 @@
 > `resources/list`, `resources/templates/list` and `prompts/list` additionally pass a linked
 > `CancellationToken` into the runner with a 15 s bound, matching `ToolRouter.ListAll`; previously they
 > called the token-less runner overload, so `ClientUtils.InvokeAsync` ran its full 10-attempt ladder
-> under a token no caller controlled — ~110 s at the default 10 s `plugin-timeout`. Note the prompt
-> degradation is **not** empty: `ExtensionsPrompt.SetError(ListPromptsResult, …)` returns a single
-> synthetic prompt named `Error` carrying the message.
+> under a token no caller controlled — ~110 s at the default 10 s `plugin-timeout`.
+>
+> **Fixed in [#197](https://github.com/IvanMurzak/MCP-Plugin-dotnet/issues/197).** `prompts/list` was
+> the last list path that did not degrade to an empty catalog:
+> `ExtensionsPrompt.SetError(ListPromptsResult, …)` used to return a single synthetic prompt named
+> `Error` carrying the internal message, which every MCP client rendered as a real, selectable prompt.
+> It now empties the catalog like the other three, so `resources/list`,
+> `resources/templates/list`, `prompts/list` and `tools/list` all behave identically. The internal
+> message reaches operators through the router's `Warn` log, which is now its only carrier.
 
 ## Overview
 


### PR DESCRIPTION
## Summary

- `ExtensionsPrompt.SetError(ListPromptsResult, string)` now returns an **empty** prompt catalog instead of fabricating a synthetic `Prompt { Name = "Error", Description = <internal message> }`. That entry never threw — which is why it looked benign next to the two resource overloads fixed in #194 — but on the wire every MCP client rendered it as a real, selectable prompt whose description leaked internal .NET type names to end users.
- Operator visibility is preserved: `PromptRouter.List` already logs the internal failure message at `Warn` on every degrade branch. Its six `Warn` strings now read *"Returning an empty prompt list"* instead of *"a degraded prompt list"*, so the operator log describes what the client actually receives.
- Because this change deletes the only *client-visible* copy of that message, the `Warn` log is now its **only** carrier — so the refine pass added a regression test that pins it. See "Operator visibility is now tested" below.
- Adds a regression test that drives a **real Streamable HTTP MCP session** and pins both directions, plus three unit cases on the overload itself.

This is the last list-shaped `SetError` overload that did not already degrade to an empty catalog.

## Live before/after evidence

Real MCP session (`initialize` → `notifications/initialized` → `prompts/list`) against a Streamable HTTP host in `auth=none` mode with **no engine plugin connected**.

**Before:**

```json
{"result":{"prompts":[{"name":"Error","description":"Invoke 'RunListPrompts': Failed to invoke 'com.IvanMurzak.McpPlugin.Common.Model.RequestListPrompts' after 10 retries."}]},"id":2,"jsonrpc":"2.0"}
```

**After:**

```json
{"result":{"prompts":[]},"id":2,"jsonrpc":"2.0"}
```

**Server log, after the fix** (the internal message is still there, at `Warn`):

```
warn: com.IvanMurzak.McpPlugin.Server.PromptRouter[0]
      List error (plugin may not be connected yet): Invoke 'RunListPrompts': Failed to invoke 'com.IvanMurzak.McpPlugin.Common.Model.RequestListPrompts' after 10 retries.. Returning an empty prompt list.
```

## Operator visibility is now tested

The owner ruling had two halves — the client-facing fabrication goes away, **and** the internal message must still reach operators ("losing operator visibility is NOT acceptable"). The first half had three assertions; the second had none, and the compensating control was measurably unprotected: **deleting the `Warn` on the exercised error branch left the full 676-test server suite green.**

`PromptsList_WhenThePluginCallFails_StillLogsTheInternalFailureTextForOperators` closes that. It captures the router's `Warn` output through an NLog `MemoryTarget` scoped to the router's own logger (the routers log via the static `NLog.LogManager`, so the host's `builder.Logging.ClearProviders()` does not reach them) and asserts the injected failure text is present. Two deliberate properties:

- it is a **presence** claim, so no short-circuiting path can satisfy it;
- it asserts only the fixture-injected failure text, never the surrounding English wording — re-phrasing the log message does not break it.

## `SetError` inventory — every overload under `McpPlugin.Server/src/Extension/`

Audited as requested. Nothing outside the prompt-list overload was changed.

| # | Location | Overload | Current behaviour | Client-facing? |
|---|---|---|---|---|
| 1 | `ExtensionsTool.cs:26` | `CallToolResult` | Sets `IsError = true` and replaces `Content[0]` with a `TextContentBlock` carrying the message | **Yes — and correct.** `tools/call` has a first-class error channel (`isError`); the text is the documented place for the reason. |
| 2 | `ExtensionsTool.cs:47` | `ListToolsResult` | Empties `Tools`; message discarded (router logs it) | No. The reference shape. |
| 3 | `ExtensionsListResources.cs:28` | `ListResourcesResult` | Empties `Resources`; message discarded | No. Fixed in #194. |
| 4 | `ExtensionsListResourceTemplates.cs:28` | `ListResourceTemplatesResult` | Empties `ResourceTemplates`; message discarded | No. Fixed in #194. |
| 5 | `ExtensionsPrompt.cs:20` | `GetPromptResult` | Sets `Description = message`, empties `Messages` | **Yes — flagged below.** |
| 6 | `ExtensionsPrompt.cs:41` | `ListPromptsResult` | **THIS PR:** empties `Prompts`; message discarded | No, now. Was the defect. |
| 7 | `ExtensionsReadResource.cs:21` | `ReadResourceResult` | Clears `Contents`, then adds one `TextResourceContents` with the message as its body | **Yes — flagged below.** |

### Flagged, deliberately NOT changed in this PR

Two overloads still put the internal message somewhere a user can see. Both are **single-item reads**, not catalogs, so neither can inject a phantom entry into a browsable list — the specific harm this PR fixes — and both are arguably load-bearing. Raising them here rather than expanding this PR's scope:

- **#5 `GetPromptResult`** (`ExtensionsPrompt.cs:20`) — puts the internal message in the prompt's `Description` and returns zero messages. Reached from 8 branches of `PromptRouter.Get`, several of which format the internal type name (`$"[Error] '{nameof(response)}' is null"`). A user who selects a prompt during the plugin-attach window gets an empty prompt described by internal text. Unlike the list case they explicitly asked for *this* prompt, so *some* feedback is warranted — but the current wording is not written for them. **Note for whoever takes this ruling:** all eight of those `PromptRouter.Get` branches return with **no server-side `Warn` at all** (only `logger.Trace`), so today the internal text reaches an operator *only* because it is client-visible. Removing the client-facing leak there would leave zero operator record — the exact constraint the owner made non-negotiable for the list path — so a fix must add the log in the same change.
- **#7 `ReadResourceResult`** (`ExtensionsReadResource.cs:21`) — returns the internal message as the resource's actual `text` content. `resources/read` has no error channel of its own, so degrading to empty contents would be indistinguishable from an empty resource; the message may genuinely be the least-bad option. Worth a deliberate ruling, not a silent change.

Also flagged, **not** changed (pre-existing, out of this PR's scope):

- `PromptRouter.List.cs:94` dereferences `response.Value.Prompts` with only the *wrapper* null-checked at `:85`. `SelectVisible` does `source.Where(...)`, which throws `ArgumentNullException` on a null source — escaping `List` as a JSON-RPC `-32603` with no `Warn`, i.e. the failure mode #194/#197 exist to remove. Prompts is the only list router with a **nested** collection (for resources, `response.Value` *is* the collection, so its existing null-check covers it). Not reachable from our own `McpPromptManager`, which always assigns a materialised `.ToList()`; it needs a third-party or malformed plugin payload, since `"Prompts": null` survives STJ deserialisation and overwrites the property initializer. Left alone rather than adding an untested guard on an unreachable path.

Everything else in the table is already consistent.

## Test plan

- [x] `PromptListDegradationOverHttpTests` — drives a real loopback Kestrel host with the production `WithMcpServer` + `WithMcpPluginServer` wiring over real Streamable HTTP, with a fake `IClientPromptHub` standing in for an attached plugin:
  - failure case: `prompts/list` returns an empty catalog, the emitted name set is asserted **empty** (not merely "does not contain `Error`", which a differently-named fabrication would satisfy), and `hub.ListCallCount == 1` proves the empty catalog is the degradation of a call that *reached the plugin seam*, not a request that never arrived;
  - positive case, same fixture family: a **successful** plugin response emits exactly `["alpha", "beta"]` — this is what makes the emptiness assertion above non-vacuous;
  - operator-visibility case (added in refine): the internal failure text still reaches the router's `Warn` log.
- [x] `ListSetErrorDegradationTests` extended with three prompt cases (empty on a fresh result, **clears an already-populated catalog**, throws `ArgumentNullException` on a null target) and its now-stale class doc corrected — it previously documented the prompt overload as "the deliberate odd one out".
- [x] `docs/architecture-transport-auth.md` corrected: its issue-#193 postmortem still stated *"the prompt degradation is **not** empty … returns a single synthetic prompt named `Error`"*, which this PR makes false. It now records the #197 fix and the resulting invariant — all four list paths degrade identically.
- [x] Full solution suite green: `dotnet test --configuration Release` → 4/4 test hosts `Test Run Successful.`, 0 failures (677 × 2 server + 808 × 2 client, both `net8.0` and `net9.0`).

### Plant round — 8/8 RED, each attributed from its own per-plant log

Every claim was mutated independently rather than reverting the fix once, because a single bundled revert reddens through whichever half fires first and leaves the rest unproven. Re-run against the final tree after the refine pass; extended from 5 claims to 8.

| Plant | Mutation | Result |
|---|---|---|
| P1 | Restore the fabricating `SetError` body (the bundled revert) | RED — `PromptsList_WhenThePluginCallFails...` via `names ... should be empty but had`, plus both unit cases |
| P2 | `SetError` leaves an already-populated catalog intact | RED — isolates the clearing half from the fabrication half, via `ListPrompts_SetError_ClearsAnyAlreadyCollectedEntries` |
| P3 | Success path stops emitting the plugin's prompts | RED — via `PromptsList_WhenThePluginReturnsPrompts_EmitsThemOverTheWire`, proving the positive artifact discriminates |
| P4 | Remove the null-target guard | RED — `should throw ArgumentNullException but threw NullReferenceException` |
| P5 | Router degrades *before* ever calling the plugin hub | RED — **within the failure test, only `hub.ListCallCount` fired**; its emptiness assertions stayed satisfied, which is exactly why that artifact exists. (The same short-circuit also reddens the positive case, so the run shows 2 failing tests.) |
| P6 | Router degrades without logging the internal failure text | RED — `PromptsList_WhenThePluginCallFails_StillLogsTheInternalFailureTextForOperators`; nothing else. Before this test, the same mutation left 676 tests green. |
| P7 | `SetError` throws instead of emptying (the pre-#194 resource behaviour) | RED — the JSON-RPC `error`-absent assertion plus both `DoesNotThrow` unit cases |
| P8 | Success path emits the plugin's prompts in reverse order | RED — pins the *"and in order"* half of the positive case, which P3 alone could not (an empty list fails regardless of ordering) |

`SUMMARY 8/8 matched their expect | 8 RED | 0 GREEN | restore-failures 0`, every plant `verify_exit 1` (a real test failure, not a collection error).

P5 and P6 are the load-bearing ones: P5 shows that without the `ListCallCount` assertion the failure-path test would have been satisfiable by a code path that never ran, and P6 shows the operator half of the ruling was entirely unprotected until this PR's refine pass.

No `<Version>` bump — release is handled separately.

Closes #197
