### PR TITLE
test(server): make router log output assertable from McpPlugin.Server.Tests

### DIFF
--- a/McpPlugin.Server.Tests/Infrastructure/CapturedRouterLogs.cs
+++ b/McpPlugin.Server.Tests/Infrastructure/CapturedRouterLogs.cs
@@ -1,0 +1,167 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using NLog;
+using NLog.Config;
+using NLog.Targets;
+using NLogLevel = NLog.LogLevel;
+
+namespace com.IvanMurzak.McpPlugin.Server.Tests.Infrastructure
+{
+    /// <summary>
+    /// Captures what a server-side router writes to the operator log, so a test can assert on it.
+    ///
+    /// <para>Why this exists at all: the routers log through NLog's STATIC
+    /// <see cref="LogManager"/>, not through the host's Microsoft.Extensions.Logging pipeline, so
+    /// they are unaffected by <c>builder.Logging.ClearProviders()</c> AND invisible to any MEL
+    /// provider. <c>McpPlugin.Tests/Infrastructure/TestLoggerFactory</c> is a MEL provider in a
+    /// DIFFERENT assembly and cannot observe these writes — a test wired to it asserts on nothing
+    /// and stays green when the log line under test is deleted. Capture on the NLog side instead:
+    /// that is what this type does.</para>
+    ///
+    /// <para><b>Global state, and how this stays safe under xUnit parallelism.</b>
+    /// <see cref="LogManager.Configuration"/> is process-global, and only about two thirds of this
+    /// assembly's test classes carry <c>[Collection("McpPlugin.Server")]</c> — the rest genuinely
+    /// DO run concurrently — so the collection attribute alone cannot make this safe. Three
+    /// mechanisms do, and none of them is optional:</para>
+    /// <list type="number">
+    /// <item><description><b>Assembly-wide mutual exclusion.</b> Every install passes through the
+    /// static <see cref="_gate"/> semaphore and holds it until <see cref="Dispose"/>. Two captures
+    /// therefore never overlap, so no capture can observe a configuration another one installed,
+    /// and the saved "previous" configuration is never a configuration some other capture is still
+    /// using. Without this, a second install would silently drop the first one's rule (a whole-config
+    /// swap) and the two disposals would restore in an order that leaves the wrong config
+    /// installed.</description></item>
+    /// <item><description><b>Logger-name scoping.</b> The installed rule matches only the router
+    /// type's own logger name (<c>LogManager.GetCurrentClassLogger()</c> names a logger after its
+    /// declaring type), so unrelated concurrent tests can neither pollute the capture nor read
+    /// it.</description></item>
+    /// <item><description><b>Exact restore.</b> <see cref="Dispose"/> puts back the very
+    /// <see cref="LoggingConfiguration"/> instance that was installed beforehand (including
+    /// <c>null</c>, the usual state in this suite) and is idempotent, so a double-dispose cannot
+    /// over-release the gate.</description></item>
+    /// </list>
+    ///
+    /// <para>Callers should ALSO carry <c>[Collection("McpPlugin.Server")]</c>. That is a
+    /// throughput measure rather than a correctness one: it keeps log-asserting classes from
+    /// queueing on the gate and burning xUnit worker threads while they block.</para>
+    ///
+    /// <para>Usage:
+    /// <code>
+    /// using var logs = CapturedRouterLogs.InstallFor(typeof(PromptRouter));
+    /// // ... drive the degraded path ...
+    /// logs.Text.ShouldContain(expectedFailureText, Case.Sensitive);
+    /// </code>
+    /// The argument is a <see cref="Type"/> rather than a generic parameter because the routers are
+    /// STATIC classes, which C# forbids as type arguments.</para>
+    /// </summary>
+    public sealed class CapturedRouterLogs : IDisposable
+    {
+        /// <summary>
+        /// Assembly-wide: at most one capture may own <see cref="LogManager.Configuration"/> at a
+        /// time. Deliberately NOT reentrant — a nested install is a bug, and blocking surfaces it.
+        /// </summary>
+        static readonly SemaphoreSlim _gate = new SemaphoreSlim(1, 1);
+
+        /// <summary>
+        /// How long <see cref="InstallFor(Type)"/> waits for the gate before giving up. Generous
+        /// enough for a slow end-to-end test to finish, short enough that a leaked capture fails
+        /// with a named error instead of hanging the suite until xUnit's own timeout.
+        /// </summary>
+        public static readonly TimeSpan DefaultAcquireTimeout = TimeSpan.FromSeconds(60);
+
+        readonly LoggingConfiguration? _previous;
+        readonly MemoryTarget _target;
+        int _disposed;
+
+        CapturedRouterLogs(Type routerType, NLogLevel minLevel)
+        {
+            _previous = LogManager.Configuration;
+            _target = new MemoryTarget($"router-log-capture-{routerType.Name}") { Layout = "${message}" };
+
+            var config = new LoggingConfiguration();
+            // Derived from the type, not spelled out: a router's logger name IS its full type name
+            // (LogManager.GetCurrentClassLogger), so a rename cannot silently stop matching.
+            config.AddRule(minLevel, NLogLevel.Fatal, _target, routerType.FullName!);
+            LogManager.Configuration = config;
+        }
+
+        /// <summary>
+        /// Installs a capture of everything <paramref name="routerType"/> logs at Warn or above —
+        /// the operator-visible band.
+        /// </summary>
+        /// <param name="routerType">The router whose logger to capture, e.g. <c>typeof(PromptRouter)</c>.</param>
+        public static CapturedRouterLogs InstallFor(Type routerType)
+            => InstallFor(routerType, NLogLevel.Warn);
+
+        /// <summary>Installs a capture from <paramref name="minLevel"/> up to Fatal.</summary>
+        public static CapturedRouterLogs InstallFor(Type routerType, NLogLevel minLevel)
+        {
+            var captured = TryInstallFor(routerType, minLevel, DefaultAcquireTimeout);
+            if (captured == null)
+            {
+                throw new TimeoutException(
+                    $"Timed out after {DefaultAcquireTimeout.TotalSeconds}s waiting for the " +
+                    $"{nameof(CapturedRouterLogs)} gate while installing a capture for " +
+                    $"'{routerType.FullName}'. Another capture is still installed — it was most " +
+                    "likely not disposed (always use `using var`).");
+            }
+
+            return captured;
+        }
+
+        /// <summary>
+        /// Gate-aware install that gives up instead of throwing. Exposed for the tests that pin the
+        /// mutual-exclusion guarantee itself; ordinary callers want <see cref="InstallFor(Type)"/>.
+        /// </summary>
+        internal static CapturedRouterLogs? TryInstallFor(Type routerType, NLogLevel minLevel, TimeSpan acquireTimeout)
+        {
+            if (routerType == null)
+                throw new ArgumentNullException(nameof(routerType));
+            if (minLevel == null)
+                throw new ArgumentNullException(nameof(minLevel));
+
+            if (!_gate.Wait(acquireTimeout))
+                return null;
+
+            try
+            {
+                return new CapturedRouterLogs(routerType, minLevel);
+            }
+            catch
+            {
+                _gate.Release();
+                throw;
+            }
+        }
+
+        /// <summary>Everything captured so far, newest last, one entry per log call.</summary>
+        public IReadOnlyList<string> Lines => _target.Logs.ToArray();
+
+        /// <summary>The captured entries joined into one blob, for substring assertions.</summary>
+        public string Text => string.Join(Environment.NewLine, _target.Logs);
+
+        public void Dispose()
+        {
+            // Idempotent: a second Dispose must not release the gate a second time, which would let
+            // two captures run concurrently and reintroduce exactly the race this type prevents.
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
+                return;
+
+            LogManager.Configuration = _previous;
+            _gate.Release();
+        }
+    }
+}

--- a/McpPlugin.Server.Tests/Infrastructure/NoneAuthMcpHost.cs
+++ b/McpPlugin.Server.Tests/Infrastructure/NoneAuthMcpHost.cs
@@ -1,0 +1,169 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.Common.Utils;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Shouldly;
+
+namespace com.IvanMurzak.McpPlugin.Server.Tests.Infrastructure
+{
+    /// <summary>
+    /// A real loopback Kestrel host running the REAL <c>WithMcpServer</c> + <c>WithMcpPluginServer</c>
+    /// wiring over the REAL Streamable HTTP transport in <c>auth=none</c> mode, plus the JSON-RPC
+    /// plumbing needed to drive an MCP session against it.
+    ///
+    /// <para>This is how a test reaches a router the way production does. Reaching one directly is
+    /// not practical — the handlers take a <c>RequestContext&lt;T&gt;</c> that only the MCP server
+    /// constructs — so an end-to-end host is the seam, and every list-degradation test needs the
+    /// same one.</para>
+    ///
+    /// <para>Note that <c>auth=none</c> is passed EXPLICITLY. <c>DataArguments</c> also reads the
+    /// environment, and a worktree's <c>.worktree.env</c> sets <c>MCP_AUTHORIZATION=required</c>;
+    /// without the explicit argument the host would come up in a different mode.</para>
+    /// </summary>
+    public sealed class NoneAuthMcpHost : IAsyncDisposable
+    {
+        readonly WebApplication _app;
+        readonly string _baseUrl;
+
+        NoneAuthMcpHost(WebApplication app, string baseUrl)
+        {
+            _app = app;
+            _baseUrl = baseUrl;
+        }
+
+        public IServiceProvider Services => _app.Services;
+
+        /// <summary>
+        /// Starts the host. <paramref name="registerFakes"/> runs AFTER the production wiring, so a
+        /// singleton it registers is the one the routers resolve (same pattern as
+        /// <c>AmbientSessionIdOverHttpTests</c>' <c>FakeJwksKeyProvider</c>).
+        /// </summary>
+        public static async Task<NoneAuthMcpHost> StartAsync(Action<IServiceCollection>? registerFakes = null)
+        {
+            var dataArguments = new DataArguments(new[]
+            {
+                "client-transport=streamableHttp",
+                "auth=none",
+            });
+
+            var builder = WebApplication.CreateBuilder();
+            builder.Logging.ClearProviders();
+            builder.Services
+                .WithMcpServer(dataArguments)
+                .WithMcpPluginServer(dataArguments);
+
+            registerFakes?.Invoke(builder.Services);
+
+            var app = builder.Build();
+            app.Urls.Add("http://127.0.0.1:0"); // OS-assigned loopback port
+            app.UseMcpPluginServer(dataArguments);
+            await app.StartAsync();
+
+            // Read the port the OS actually bound, rather than probing a free one and re-binding it
+            // later: that probe-then-rebind leaves a window for another process to take the port.
+            // Same pattern as PinnedPathRoutingTests.StartHostAsync.
+            var address = app.Services
+                .GetRequiredService<IServer>()
+                .Features.Get<IServerAddressesFeature>()!
+                .Addresses.First();
+
+            return new NoneAuthMcpHost(app, address);
+        }
+
+        /// <summary>initialize + notifications/initialized; returns the server-minted session id.</summary>
+        public async Task<string> HandshakeAsync(HttpClient client, string clientName = "mcp-plugin-server-test")
+        {
+            var (_, sessionId) = await PostAsync(client, null, new
+            {
+                jsonrpc = "2.0",
+                id = 1,
+                method = "initialize",
+                @params = new
+                {
+                    protocolVersion = "2024-11-05",
+                    capabilities = new { },
+                    clientInfo = new { name = clientName, version = "1.0.0" }
+                }
+            });
+
+            sessionId.ShouldNotBeNullOrEmpty("the server must mint an Mcp-Session-Id on initialize");
+            await PostAsync(client, sessionId, new { jsonrpc = "2.0", method = "notifications/initialized" });
+            return sessionId!;
+        }
+
+        /// <summary>
+        /// Sends one parameterless JSON-RPC request on an established session and returns the
+        /// response body with the SSE framing removed.
+        /// </summary>
+        public async Task<string> CallAsync(HttpClient client, string sessionId, string method, int id = 2)
+        {
+            var (body, _) = await PostAsync(client, sessionId, new
+            {
+                jsonrpc = "2.0",
+                id,
+                method
+            });
+            return Unwrap(body);
+        }
+
+        public async Task<(string Body, string? SessionId)> PostAsync(HttpClient client, string? sessionId, object payload)
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Post, _baseUrl + "/mcp");
+            request.Headers.Accept.ParseAdd("application/json");
+            request.Headers.Accept.ParseAdd("text/event-stream");
+            if (!string.IsNullOrEmpty(sessionId))
+                request.Headers.TryAddWithoutValidation("Mcp-Session-Id", sessionId);
+            request.Content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
+
+            using var response = await client.SendAsync(request);
+            var body = await response.Content.ReadAsStringAsync();
+            // Assert SUCCESS rather than merely "not 401": a routing or wiring regression answering
+            // 404 / 405 / 500 would otherwise resurface downstream as a JsonDocument.Parse failure,
+            // which reads as a broken harness instead of the regression it is.
+            response.IsSuccessStatusCode.ShouldBeTrue(
+                $"POST /mcp must succeed in auth=none mode; status {(int)response.StatusCode} {response.StatusCode}, body: {body}");
+            var issued = response.Headers.TryGetValues("Mcp-Session-Id", out var values) ? values.FirstOrDefault() : null;
+            return (body, issued);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await _app.StopAsync();
+            await _app.DisposeAsync();
+        }
+
+        /// <summary>The streamable-HTTP reply is an SSE frame; pull the JSON out of its data: lines.</summary>
+        static string Unwrap(string body)
+        {
+            if (!body.Contains("data:", StringComparison.Ordinal))
+                return body;
+            var sb = new StringBuilder();
+            foreach (var line in body.Split('\n'))
+            {
+                var trimmed = line.TrimEnd('\r');
+                if (trimmed.StartsWith("data:", StringComparison.Ordinal))
+                    sb.Append(trimmed.Substring(5).Trim());
+            }
+            return sb.Length > 0 ? sb.ToString() : body;
+        }
+    }
+}

--- a/McpPlugin.Server.Tests/Infrastructure/NoneAuthMcpHost.cs
+++ b/McpPlugin.Server.Tests/Infrastructure/NoneAuthMcpHost.cs
@@ -50,8 +50,6 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests.Infrastructure
             _baseUrl = baseUrl;
         }
 
-        public IServiceProvider Services => _app.Services;
-
         /// <summary>
         /// Starts the host. <paramref name="registerFakes"/> runs AFTER the production wiring, so a
         /// singleton it registers is the one the routers resolve (same pattern as
@@ -151,7 +149,15 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests.Infrastructure
             await _app.DisposeAsync();
         }
 
-        /// <summary>The streamable-HTTP reply is an SSE frame; pull the JSON out of its data: lines.</summary>
+        /// <summary>
+        /// The streamable-HTTP reply is an SSE frame; pull the JSON out of its <c>data:</c> lines.
+        ///
+        /// <para>This assumes ONE JSON document per reply: the <c>data:</c> payloads are concatenated
+        /// with no separator, so a reply carrying a second event — a notification alongside the
+        /// response, or a multi-line data payload — comes back as two documents run together and
+        /// fails to parse. Every caller today sends one request and reads one response. A caller that
+        /// needs more should split the frames here rather than work around the concatenation.</para>
+        /// </summary>
         static string Unwrap(string body)
         {
             if (!body.Contains("data:", StringComparison.Ordinal))

--- a/McpPlugin.Server.Tests/PromptListDegradationOverHttpTests.cs
+++ b/McpPlugin.Server.Tests/PromptListDegradationOverHttpTests.cs
@@ -13,24 +13,16 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
-using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using com.IvanMurzak.McpPlugin.Common.Hub.Client;
 using com.IvanMurzak.McpPlugin.Common.Model;
 using com.IvanMurzak.McpPlugin.Common.Utils;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting.Server;
-using Microsoft.AspNetCore.Hosting.Server.Features;
+using com.IvanMurzak.McpPlugin.Server.Tests.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using NLog;
-using NLog.Config;
-using NLog.Targets;
 using Shouldly;
 using Xunit;
-using NLogLevel = NLog.LogLevel;
 
 namespace com.IvanMurzak.McpPlugin.Server.Tests
 {
@@ -46,13 +38,16 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
     /// text stays on the server-side log at Warn (<c>PromptRouter.List</c>), so operators lose
     /// nothing.</para>
     ///
-    /// <para>The two cases are one fixture family on purpose. The failure case asserts an EMPTY
-    /// catalog, and an emptiness assertion is satisfied for free by any path that never ran at all —
-    /// so it is paired with <see cref="PromptsList_WhenThePluginReturnsPrompts_EmitsThemOverTheWire"/>,
+    /// <para>The two catalog cases are one fixture family on purpose. The failure case asserts an
+    /// EMPTY catalog, and an emptiness assertion is satisfied for free by any path that never ran at
+    /// all — so it is paired with <see cref="PromptsList_WhenThePluginReturnsPrompts_EmitsThemOverTheWire"/>,
     /// which drives the SAME host and the SAME seam and pins the exact prompt names that come back.
     /// The failure case additionally pins <see cref="FakePromptHub.ListCallCount"/>, so the empty
     /// catalog is provably the DEGRADATION of a call that reached the plugin seam and failed there,
     /// not the silence of a request that never arrived.</para>
+    ///
+    /// <para>The operator-log half uses the shared <see cref="CapturedRouterLogs"/> helper; see
+    /// <see cref="RouterLogCaptureTests"/> for the tests that pin the helper's own guarantees.</para>
     /// </summary>
     [Collection("McpPlugin.Server")]
     public sealed class PromptListDegradationOverHttpTests
@@ -75,11 +70,11 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
         {
             var hub = FakePromptHub.ThatFailsWith(PluginFailureText);
 
-            await using var host = await StartNoneAuthHostAsync(hub);
+            await using var host = await NoneAuthMcpHost.StartAsync(services => services.AddSingleton<IClientPromptHub>(hub));
             using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(60) };
 
-            var sessionId = await host.HandshakeAsync(client);
-            var body = await host.ListPromptsAsync(client, sessionId);
+            var sessionId = await host.HandshakeAsync(client, "prompt-list-degradation-test");
+            var body = await host.CallAsync(client, sessionId, "prompts/list");
 
             using var doc = JsonDocument.Parse(body);
 
@@ -116,11 +111,11 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
                 new ResponsePrompt { Name = "alpha", Description = "first", Enabled = true },
                 new ResponsePrompt { Name = "beta", Description = "second", Enabled = true });
 
-            await using var host = await StartNoneAuthHostAsync(hub);
+            await using var host = await NoneAuthMcpHost.StartAsync(services => services.AddSingleton<IClientPromptHub>(hub));
             using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(60) };
 
-            var sessionId = await host.HandshakeAsync(client);
-            var body = await host.ListPromptsAsync(client, sessionId);
+            var sessionId = await host.HandshakeAsync(client, "prompt-list-degradation-test");
+            var body = await host.CallAsync(client, sessionId, "prompts/list");
 
             using var doc = JsonDocument.Parse(body);
 
@@ -150,16 +145,21 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
         {
             var hub = FakePromptHub.ThatFailsWith(PluginFailureText);
 
-            using var warnings = CapturedRouterWarnings.Install();
+            using var logs = CapturedRouterLogs.InstallFor(typeof(PromptRouter));
 
-            await using var host = await StartNoneAuthHostAsync(hub);
+            await using var host = await NoneAuthMcpHost.StartAsync(services => services.AddSingleton<IClientPromptHub>(hub));
             using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(60) };
 
-            var sessionId = await host.HandshakeAsync(client);
-            await host.ListPromptsAsync(client, sessionId);
+            var sessionId = await host.HandshakeAsync(client, "prompt-list-degradation-test");
+            await host.CallAsync(client, sessionId, "prompts/list");
 
-            warnings.Text.ShouldContain(PluginFailureText, Case.Sensitive,
+            logs.Text.ShouldContain(PluginFailureText, Case.Sensitive,
                 "the failure text the client no longer sees must still reach the operator log at Warn");
+
+            // Positive artifact for the capture itself: the router really did reach the failure
+            // branch. Without it, a capture that silently recorded nothing would be indistinguishable
+            // from one whose assertion above simply had not been reached yet.
+            hub.ListCallCount.ShouldBe(1, "the router must have called the plugin hub exactly once");
         }
 
         // ───────────────────────────── fake plugin hub ─────────────────────────────
@@ -194,167 +194,6 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
 
             public Task<ResponseData<ResponseGetPrompt>> RunGetPrompt(RequestGetPrompt request)
                 => throw new NotSupportedException("These tests only drive prompts/list.");
-        }
-
-        // ───────────────────────────── real loopback none-auth host ─────────────────────────────
-
-        static async Task<NoneAuthHost> StartNoneAuthHostAsync(IClientPromptHub promptHub)
-        {
-            var dataArguments = new DataArguments(new[]
-            {
-                "client-transport=streamableHttp",
-                "auth=none",
-            });
-
-            var builder = WebApplication.CreateBuilder();
-            builder.Logging.ClearProviders();
-            builder.Services
-                .WithMcpServer(dataArguments)
-                .WithMcpPluginServer(dataArguments);
-
-            // Registered AFTER the production wiring so this singleton is the one the router resolves
-            // (same pattern as AmbientSessionIdOverHttpTests' FakeJwksKeyProvider).
-            builder.Services.AddSingleton(promptHub);
-
-            var app = builder.Build();
-            app.Urls.Add("http://127.0.0.1:0"); // OS-assigned loopback port
-            app.UseMcpPluginServer(dataArguments);
-            await app.StartAsync();
-
-            // Read the port the OS actually bound, rather than probing a free one and re-binding it
-            // later: that probe-then-rebind leaves a window for another process to take the port.
-            // Same pattern as PinnedPathRoutingTests.StartHostAsync.
-            var address = app.Services
-                .GetRequiredService<IServer>()
-                .Features.Get<IServerAddressesFeature>()!
-                .Addresses.First();
-
-            return new NoneAuthHost(app, address);
-        }
-
-        sealed class NoneAuthHost : IAsyncDisposable
-        {
-            readonly WebApplication _app;
-            readonly string _baseUrl;
-
-            public NoneAuthHost(WebApplication app, string baseUrl)
-            {
-                _app = app;
-                _baseUrl = baseUrl;
-            }
-
-            /// <summary>initialize + notifications/initialized; returns the server-minted session id.</summary>
-            public async Task<string> HandshakeAsync(HttpClient client)
-            {
-                var (_, sessionId) = await PostAsync(client, null, new
-                {
-                    jsonrpc = "2.0",
-                    id = 1,
-                    method = "initialize",
-                    @params = new
-                    {
-                        protocolVersion = "2024-11-05",
-                        capabilities = new { },
-                        clientInfo = new { name = "prompt-list-degradation-test", version = "1.0.0" }
-                    }
-                });
-
-                sessionId.ShouldNotBeNullOrEmpty("the server must mint an Mcp-Session-Id on initialize");
-                await PostAsync(client, sessionId, new { jsonrpc = "2.0", method = "notifications/initialized" });
-                return sessionId!;
-            }
-
-            public async Task<string> ListPromptsAsync(HttpClient client, string sessionId)
-            {
-                var (body, _) = await PostAsync(client, sessionId, new
-                {
-                    jsonrpc = "2.0",
-                    id = 2,
-                    method = "prompts/list"
-                });
-                return Unwrap(body);
-            }
-
-            async Task<(string Body, string? SessionId)> PostAsync(HttpClient client, string? sessionId, object payload)
-            {
-                using var request = new HttpRequestMessage(HttpMethod.Post, _baseUrl + "/mcp");
-                request.Headers.Accept.ParseAdd("application/json");
-                request.Headers.Accept.ParseAdd("text/event-stream");
-                if (!string.IsNullOrEmpty(sessionId))
-                    request.Headers.TryAddWithoutValidation("Mcp-Session-Id", sessionId);
-                request.Content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
-
-                using var response = await client.SendAsync(request);
-                var body = await response.Content.ReadAsStringAsync();
-                // Assert SUCCESS rather than merely "not 401": a routing or wiring regression answering
-                // 404 / 405 / 500 would otherwise resurface downstream as a JsonDocument.Parse failure,
-                // which reads as a broken harness instead of the regression it is.
-                response.IsSuccessStatusCode.ShouldBeTrue(
-                    $"POST /mcp must succeed in auth=none mode; status {(int)response.StatusCode} {response.StatusCode}, body: {body}");
-                var issued = response.Headers.TryGetValues("Mcp-Session-Id", out var values) ? values.FirstOrDefault() : null;
-                return (body, issued);
-            }
-
-            public async ValueTask DisposeAsync()
-            {
-                await _app.StopAsync();
-                await _app.DisposeAsync();
-            }
-        }
-
-        // ───────────────────────────── captured operator log ─────────────────────────────
-
-        /// <summary>
-        /// Captures what <see cref="PromptRouter"/> writes at Warn. The routers log through NLog's
-        /// static <c>LogManager</c>, which is independent of the host's
-        /// <c>builder.Logging.ClearProviders()</c>, so the capture is installed on the NLog
-        /// configuration and scoped to the router's own logger.
-        ///
-        /// <para>That configuration is process-global, and test parallelism is NOT what makes the swap
-        /// safe: only 43 of this assembly's 62 test classes carry
-        /// <c>[Collection("McpPlugin.Server")]</c>, so the other 19 do run concurrently with these.
-        /// What makes it safe is that the rule is scoped to the router's logger name — concurrent
-        /// tests can neither pollute the capture nor observe it — and that this is the only file in
-        /// the assembly that reads or writes <c>LogManager.Configuration</c>. Before adding a second
-        /// log-asserting test anywhere in this assembly, re-check both of those.</para>
-        /// </summary>
-        sealed class CapturedRouterWarnings : IDisposable
-        {
-            readonly LoggingConfiguration? _previous = LogManager.Configuration;
-            readonly MemoryTarget _target = new MemoryTarget("prompt-router-warn-capture") { Layout = "${message}" };
-
-            CapturedRouterWarnings()
-            {
-                var config = new LoggingConfiguration();
-                // Derived from the type, not spelled out: the router's logger name IS its full type
-                // name (LogManager.GetCurrentClassLogger), so a rename cannot silently stop matching.
-                config.AddRule(NLogLevel.Warn, NLogLevel.Fatal, _target, typeof(PromptRouter).FullName!);
-                LogManager.Configuration = config;
-            }
-
-            public string Text => string.Join(Environment.NewLine, _target.Logs);
-
-            /// <summary>Named rather than a bare `new` because constructing it MUTATES global state.</summary>
-            public static CapturedRouterWarnings Install() => new CapturedRouterWarnings();
-
-            public void Dispose() => LogManager.Configuration = _previous;
-        }
-
-        // ───────────────────────────── helpers ─────────────────────────────
-
-        /// <summary>The streamable-HTTP reply is an SSE frame; pull the JSON out of its data: lines.</summary>
-        static string Unwrap(string body)
-        {
-            if (!body.Contains("data:", StringComparison.Ordinal))
-                return body;
-            var sb = new StringBuilder();
-            foreach (var line in body.Split('\n'))
-            {
-                var trimmed = line.TrimEnd('\r');
-                if (trimmed.StartsWith("data:", StringComparison.Ordinal))
-                    sb.Append(trimmed.Substring(5).Trim());
-            }
-            return sb.Length > 0 ? sb.ToString() : body;
         }
     }
 }

--- a/McpPlugin.Server.Tests/PromptListDegradationOverHttpTests.cs
+++ b/McpPlugin.Server.Tests/PromptListDegradationOverHttpTests.cs
@@ -61,6 +61,9 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
             "Invoke 'RunListPrompts': Failed to invoke " +
             "'com.IvanMurzak.McpPlugin.Common.Model.RequestListPrompts' after 10 retries.";
 
+        /// <summary>The client name this fixture family handshakes with.</summary>
+        const string ClientName = "prompt-list-degradation-test";
+
         /// <summary>
         /// The regression. With the plugin call failing, <c>prompts/list</c> answers with an empty
         /// catalog and NO synthetic entry — in particular nothing named <c>"Error"</c>.
@@ -73,7 +76,7 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
             await using var host = await NoneAuthMcpHost.StartAsync(services => services.AddSingleton<IClientPromptHub>(hub));
             using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(60) };
 
-            var sessionId = await host.HandshakeAsync(client, "prompt-list-degradation-test");
+            var sessionId = await host.HandshakeAsync(client, ClientName);
             var body = await host.CallAsync(client, sessionId, "prompts/list");
 
             using var doc = JsonDocument.Parse(body);
@@ -114,7 +117,7 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
             await using var host = await NoneAuthMcpHost.StartAsync(services => services.AddSingleton<IClientPromptHub>(hub));
             using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(60) };
 
-            var sessionId = await host.HandshakeAsync(client, "prompt-list-degradation-test");
+            var sessionId = await host.HandshakeAsync(client, ClientName);
             var body = await host.CallAsync(client, sessionId, "prompts/list");
 
             using var doc = JsonDocument.Parse(body);
@@ -150,7 +153,7 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
             await using var host = await NoneAuthMcpHost.StartAsync(services => services.AddSingleton<IClientPromptHub>(hub));
             using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(60) };
 
-            var sessionId = await host.HandshakeAsync(client, "prompt-list-degradation-test");
+            var sessionId = await host.HandshakeAsync(client, ClientName);
             await host.CallAsync(client, sessionId, "prompts/list");
 
             logs.Text.ShouldContain(PluginFailureText, Case.Sensitive,

--- a/McpPlugin.Server.Tests/RouterLogCaptureTests.cs
+++ b/McpPlugin.Server.Tests/RouterLogCaptureTests.cs
@@ -1,0 +1,268 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.Common.Hub.Client;
+using com.IvanMurzak.McpPlugin.Common.Model;
+using com.IvanMurzak.McpPlugin.Common.Utils;
+using com.IvanMurzak.McpPlugin.Server.Tests.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using NLog;
+using NLog.Config;
+using Shouldly;
+using Xunit;
+using NLogLevel = NLog.LogLevel;
+
+namespace com.IvanMurzak.McpPlugin.Server.Tests
+{
+    /// <summary>
+    /// Cover for <see cref="CapturedRouterLogs"/> — the shared way this assembly asserts on what a
+    /// router told the operator — and for the second consumer that proves it is genuinely shared.
+    ///
+    /// <para>Why this matters more than a normal helper test: an operator-visibility requirement
+    /// ("the operator must still see a warning") used to be UNTESTABLE here. The routers log through
+    /// NLog's static <c>LogManager</c>, so the suite could not observe them, and deleting a router's
+    /// <c>Warn</c> line left all ~676 server tests green. A helper that silently captured nothing
+    /// would restore exactly that failure mode while LOOKING like cover, so the cases below assert
+    /// the capture's POSITIVE artifacts (what it did record, and that it really did install) rather
+    /// than only what it did not record.</para>
+    /// </summary>
+    [Collection("McpPlugin.Server")]
+    public sealed class RouterLogCaptureTests
+    {
+        /// <summary>The text the fake plugin call fails with — the operator's only copy of the cause.</summary>
+        const string PluginFailureText =
+            "Invoke 'RunListResources': Failed to invoke " +
+            "'com.IvanMurzak.McpPlugin.Common.Model.RequestListResources' after 10 retries.";
+
+        // ─────────────────── a SECOND router, through the shared helper ───────────────────
+
+        /// <summary>
+        /// The degraded <c>resources/list</c> path returns an empty catalog to the client, so the
+        /// router's <c>Warn</c> is the only place the cause survives. Asserted as a PRESENCE claim,
+        /// which an empty capture cannot satisfy, and paired with the hub's call count so the text
+        /// is provably the log of a call that reached the plugin seam and failed there.
+        ///
+        /// <para>This case exists on a DIFFERENT router from the prompt one on purpose: it is what
+        /// makes <see cref="CapturedRouterLogs"/> a shared facility rather than one test's local
+        /// workaround.</para>
+        /// </summary>
+        [Fact]
+        public async Task ResourcesList_WhenThePluginCallFails_LogsTheFailureTextForOperators()
+        {
+            var hub = FakeResourceHub.ThatFailsWith(PluginFailureText);
+
+            using var logs = CapturedRouterLogs.InstallFor(typeof(ResourceRouter));
+
+            await using var host = await NoneAuthMcpHost.StartAsync(services => services.AddSingleton<IClientResourceHub>(hub));
+            using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(60) };
+
+            var sessionId = await host.HandshakeAsync(client, "resource-list-log-test");
+            var body = await host.CallAsync(client, sessionId, "resources/list");
+
+            hub.ListCallCount.ShouldBe(1, "the router must have called the plugin hub exactly once");
+
+            logs.Text.ShouldContain(PluginFailureText, Case.Sensitive,
+                $"the degraded resources/list must still tell the operator why; wire body was: {body}");
+        }
+
+        /// <summary>
+        /// The paired half, and the reason the case above is not vacuous: on the SUCCESS path the
+        /// same host and the same seam put the resources on the wire (a positive artifact — this
+        /// fixture can emit) and the operator log stays clean at Warn. Together the pair pins both
+        /// directions: the warning appears exactly when the plugin call fails, and not otherwise.
+        /// </summary>
+        [Fact]
+        public async Task ResourcesList_WhenThePluginReturnsResources_EmitsThemOverTheWireAndLogsNothingAtWarn()
+        {
+            var hub = FakeResourceHub.ThatReturns(
+                new ResponseListResource("res://alpha", "alpha"),
+                new ResponseListResource("res://beta", "beta"));
+
+            using var logs = CapturedRouterLogs.InstallFor(typeof(ResourceRouter));
+
+            await using var host = await NoneAuthMcpHost.StartAsync(services => services.AddSingleton<IClientResourceHub>(hub));
+            using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(60) };
+
+            var sessionId = await host.HandshakeAsync(client, "resource-list-log-test");
+            var body = await host.CallAsync(client, sessionId, "resources/list");
+
+            using var doc = JsonDocument.Parse(body);
+
+            var uris = doc.RootElement.GetProperty("result").GetProperty("resources")
+                .EnumerateArray()
+                .Select(r => r.GetProperty("uri").GetString())
+                .ToList();
+
+            uris.ShouldBe(new List<string?> { "res://alpha", "res://beta" },
+                $"the plugin's resources must reach the client verbatim and in order; got: {body}");
+
+            logs.Lines.ShouldBeEmpty(
+                "a successful resources/list must not warn the operator about anything");
+        }
+
+        // ─────────────────── the helper's own guarantees ───────────────────
+
+        /// <summary>
+        /// The capture is scoped to ONE router's logger, which is what lets it coexist with the test
+        /// classes in this assembly that carry no <c>[Collection]</c> and therefore really do run
+        /// concurrently. Both directions are asserted from the same capture, so neither half can pass
+        /// because nothing was logged at all: the requested router's line MUST be there, and the
+        /// other router's MUST NOT.
+        /// </summary>
+        [Fact]
+        public void Capture_IsScopedToTheRequestedRouter()
+        {
+            const string Wanted = "wanted-line-from-the-prompt-router";
+            const string Unwanted = "unwanted-line-from-the-resource-router";
+
+            using var logs = CapturedRouterLogs.InstallFor(typeof(PromptRouter));
+
+            // Written through the very logger names the routers use: LogManager.GetCurrentClassLogger()
+            // names a logger after its declaring type.
+            LogManager.GetLogger(typeof(PromptRouter).FullName!).Warn(Wanted);
+            LogManager.GetLogger(typeof(ResourceRouter).FullName!).Warn(Unwanted);
+
+            logs.Text.ShouldContain(Wanted, Case.Sensitive,
+                "the capture must record what the router it was installed for logged");
+            logs.Text.ShouldNotContain(Unwanted, Case.Sensitive,
+                "the capture must not record another router's output, or concurrent tests would pollute it");
+        }
+
+        /// <summary>
+        /// Below the Warn floor nothing is captured, so an "operator-visible" assertion cannot be
+        /// satisfied by a Debug/Info line that no operator would see at default verbosity. Paired
+        /// with a Warn written through the same logger, so the emptiness cannot come from a capture
+        /// that records nothing at all.
+        /// </summary>
+        [Fact]
+        public void Capture_TakesWarnAndAbove_NotChatter()
+        {
+            using var logs = CapturedRouterLogs.InstallFor(typeof(PromptRouter));
+
+            var logger = LogManager.GetLogger(typeof(PromptRouter).FullName!);
+            logger.Info("info-chatter");
+            logger.Debug("debug-chatter");
+            logger.Warn("operator-visible-line");
+
+            logs.Lines.ShouldHaveSingleItem().ShouldBe("operator-visible-line");
+        }
+
+        /// <summary>
+        /// Disposal puts back the EXACT <see cref="LoggingConfiguration"/> instance that was installed
+        /// before, so a capture cannot leak into whatever runs next. A sentinel configuration is
+        /// installed first rather than asserting against whatever NLog happened to hold, because the
+        /// interesting claim is identity, and identity needs a known instance to compare against.
+        /// </summary>
+        [Fact]
+        public void Dispose_RestoresTheExactPreviousNLogConfiguration()
+        {
+            var original = LogManager.Configuration;
+            var sentinel = new LoggingConfiguration();
+
+            try
+            {
+                LogManager.Configuration = sentinel;
+
+                using (CapturedRouterLogs.InstallFor(typeof(PromptRouter)))
+                {
+                    // Positive artifact: the capture really did take over. Without it, "restored"
+                    // below would hold just as well for a helper that installed nothing at all.
+                    LogManager.Configuration.ShouldNotBeSameAs(sentinel,
+                        "installing a capture must replace the active NLog configuration");
+                }
+
+                LogManager.Configuration.ShouldBeSameAs(sentinel,
+                    "Dispose must put back the exact configuration instance it found");
+            }
+            finally
+            {
+                LogManager.Configuration = original;
+            }
+        }
+
+        /// <summary>
+        /// The mutual-exclusion guarantee, stated as a test rather than as a comment: while one
+        /// capture is installed, a second cannot be. This is what makes the whole-configuration swap
+        /// safe in an assembly where roughly a third of the test classes carry no
+        /// <c>[Collection]</c> and run in parallel — two overlapping captures would drop each other's
+        /// rules and restore in the wrong order.
+        ///
+        /// <para>The zero timeout keeps this deterministic: no sleeps, no threads, no timing window.
+        /// The second half is what stops the gate from passing this test by simply being permanently
+        /// shut.</para>
+        /// </summary>
+        [Fact]
+        public void Install_WhileAnotherCaptureIsHeld_IsRefusedUntilItIsDisposed()
+        {
+            using (CapturedRouterLogs.InstallFor(typeof(PromptRouter)))
+            {
+                var refused = CapturedRouterLogs.TryInstallFor(typeof(ResourceRouter), NLogLevel.Warn, TimeSpan.Zero);
+                try
+                {
+                    refused.ShouldBeNull(
+                        "a second capture must not be admitted while the first one still owns LogManager.Configuration");
+                }
+                finally
+                {
+                    refused?.Dispose();
+                }
+            }
+
+            using var admitted = CapturedRouterLogs.TryInstallFor(typeof(ResourceRouter), NLogLevel.Warn, TimeSpan.Zero);
+            admitted.ShouldNotBeNull(
+                "the gate must open again once the previous capture is disposed, or every later capture would time out");
+        }
+
+        // ───────────────────────────── fake plugin hub ─────────────────────────────
+
+        /// <summary>
+        /// Stands in for <c>RemoteResourceRunner</c> so both outcomes of the plugin call are reachable
+        /// without a live SignalR plugin: the real runner needs an attached engine plugin, and its
+        /// failure path costs a full retry budget in wall-clock time.
+        /// </summary>
+        sealed class FakeResourceHub : IClientResourceHub
+        {
+            readonly ResponseData<ResponseListResource[]> _response;
+            int _listCallCount;
+
+            FakeResourceHub(ResponseData<ResponseListResource[]> response) => _response = response;
+
+            public int ListCallCount => Volatile.Read(ref _listCallCount);
+
+            public static FakeResourceHub ThatFailsWith(string message)
+                => new FakeResourceHub(ResponseData<ResponseListResource[]>.Error("req-fail", message));
+
+            // Packed exactly as the real producer packs it, so the success envelope this fixture feeds
+            // the router carries the same Message the plugin would.
+            public static FakeResourceHub ThatReturns(params ResponseListResource[] resources)
+                => new FakeResourceHub(resources.Pack("req-ok"));
+
+            public Task<ResponseData<ResponseListResource[]>> RunListResources(RequestListResources request, CancellationToken cancellationToken = default)
+            {
+                Interlocked.Increment(ref _listCallCount);
+                return _response.TaskFromResult();
+            }
+
+            public Task<ResponseData<ResponseResourceContent[]>> RunResourceContent(RequestResourceContent request)
+                => throw new NotSupportedException("These tests only drive resources/list.");
+
+            public Task<ResponseData<ResponseResourceTemplate[]>> RunResourceTemplates(RequestListResourceTemplates request, CancellationToken cancellationToken = default)
+                => throw new NotSupportedException("These tests only drive resources/list.");
+        }
+    }
+}

--- a/McpPlugin.Server.Tests/RouterLogCaptureTests.cs
+++ b/McpPlugin.Server.Tests/RouterLogCaptureTests.cs
@@ -49,6 +49,17 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
             "Invoke 'RunListResources': Failed to invoke " +
             "'com.IvanMurzak.McpPlugin.Common.Model.RequestListResources' after 10 retries.";
 
+        /// <summary>The client name this fixture family handshakes with.</summary>
+        const string ClientName = "resource-list-log-test";
+
+        /// <summary>
+        /// Asks the gate without waiting: <c>null</c> means another capture still holds it. The zero
+        /// timeout is what keeps the gate cases deterministic — no sleeps, no threads, no timing
+        /// window — so it is spelled once here rather than at each call site.
+        /// </summary>
+        static CapturedRouterLogs? TryInstallWithoutWaiting(Type routerType)
+            => CapturedRouterLogs.TryInstallFor(routerType, NLogLevel.Warn, TimeSpan.Zero);
+
         // ─────────────────── a SECOND router, through the shared helper ───────────────────
 
         /// <summary>
@@ -71,7 +82,7 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
             await using var host = await NoneAuthMcpHost.StartAsync(services => services.AddSingleton<IClientResourceHub>(hub));
             using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(60) };
 
-            var sessionId = await host.HandshakeAsync(client, "resource-list-log-test");
+            var sessionId = await host.HandshakeAsync(client, ClientName);
             var body = await host.CallAsync(client, sessionId, "resources/list");
 
             hub.ListCallCount.ShouldBe(1, "the router must have called the plugin hub exactly once");
@@ -98,7 +109,7 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
             await using var host = await NoneAuthMcpHost.StartAsync(services => services.AddSingleton<IClientResourceHub>(hub));
             using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(60) };
 
-            var sessionId = await host.HandshakeAsync(client, "resource-list-log-test");
+            var sessionId = await host.HandshakeAsync(client, ClientName);
             var body = await host.CallAsync(client, sessionId, "resources/list");
 
             using var doc = JsonDocument.Parse(body);
@@ -112,7 +123,7 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
                 $"the plugin's resources must reach the client verbatim and in order; got: {body}");
 
             logs.Lines.ShouldBeEmpty(
-                "a successful resources/list must not warn the operator about anything");
+                "a successful resources/list must not warn the operator from ResourceRouter");
         }
 
         // ─────────────────── the helper's own guarantees ───────────────────
@@ -176,12 +187,20 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
 
             try
             {
+                // This sentinel install and its restore in the finally below are the only writes to
+                // LogManager.Configuration outside the helper, and neither holds the helper's gate —
+                // they cannot, since the point is to plant a known instance for the capture to find.
+                // Safe because both capture-installing classes carry [Collection("McpPlugin.Server")],
+                // so nothing can be mid-capture here. A third writer, or a capture-installing class
+                // without that attribute, breaks that assumption — move these under the gate then.
                 LogManager.Configuration = sentinel;
 
                 using (CapturedRouterLogs.InstallFor(typeof(PromptRouter)))
                 {
-                    // Positive artifact: the capture really did take over. Without it, "restored"
-                    // below would hold just as well for a helper that installed nothing at all.
+                    // Positive artifact: a helper that installed nothing at all would leave `sentinel`
+                    // in place and fail here. That the replacement also ROUTES the router's logger
+                    // into the capture is a separate claim, pinned by
+                    // Capture_IsScopedToTheRequestedRouter.
                     LogManager.Configuration.ShouldNotBeSameAs(sentinel,
                         "installing a capture must replace the active NLog configuration");
                 }
@@ -211,7 +230,7 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
         {
             using (CapturedRouterLogs.InstallFor(typeof(PromptRouter)))
             {
-                var refused = CapturedRouterLogs.TryInstallFor(typeof(ResourceRouter), NLogLevel.Warn, TimeSpan.Zero);
+                var refused = TryInstallWithoutWaiting(typeof(ResourceRouter));
                 try
                 {
                     refused.ShouldBeNull(
@@ -223,9 +242,35 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
                 }
             }
 
-            using var admitted = CapturedRouterLogs.TryInstallFor(typeof(ResourceRouter), NLogLevel.Warn, TimeSpan.Zero);
+            using var admitted = TryInstallWithoutWaiting(typeof(ResourceRouter));
             admitted.ShouldNotBeNull(
                 "the gate must open again once the previous capture is disposed, or every later capture would time out");
+        }
+
+        /// <summary>
+        /// Disposal is idempotent — a guarantee <see cref="CapturedRouterLogs"/> folds into its
+        /// exact-restore mechanism, and the one thing nothing else in this assembly exercises: no
+        /// consumer disposes a capture twice, so without this case the guard could be deleted and
+        /// every test would stay green.
+        ///
+        /// <para>Two claims, and each needs the other. A second <c>Dispose</c> must not throw: the
+        /// gate is a <c>SemaphoreSlim(1, 1)</c>, so releasing it twice raises
+        /// <c>SemaphoreFullException</c> — out of a <c>using</c> block's implicit disposal, where it
+        /// masks whatever the test was really asserting. And the gate must still ADMIT a capture
+        /// afterwards, which is what stops the first claim being satisfied by a <c>Dispose</c> that
+        /// does nothing at all (that one never releases the gate, so the admission below fails).</para>
+        /// </summary>
+        [Fact]
+        public void Dispose_IsIdempotent_AndLeavesTheGateOpen()
+        {
+            var logs = CapturedRouterLogs.InstallFor(typeof(PromptRouter));
+            logs.Dispose();
+
+            Should.NotThrow(() => logs.Dispose());
+
+            using var admitted = TryInstallWithoutWaiting(typeof(PromptRouter));
+            admitted.ShouldNotBeNull(
+                "a double Dispose must leave the gate exactly as one Dispose does — still open for the next capture");
         }
 
         // ───────────────────────────── fake plugin hub ─────────────────────────────

--- a/docs/claude/testing.md
+++ b/docs/claude/testing.md
@@ -52,8 +52,8 @@ logs.Text.ShouldContain(expectedFailureText, Case.Sensitive);
   assembly-wide gate and restores the exact previous configuration on `Dispose` — always use
   `using var`, and prefer `[Collection("McpPlugin.Server")]` on the calling class so log-asserting
   tests do not queue on that gate.
-- Its own guarantees (scoping, level floor, restore, mutual exclusion) are pinned by
-  `McpPlugin.Server.Tests/RouterLogCaptureTests.cs`.
+- Its own guarantees (scoping, level floor, exact restore, mutual exclusion, idempotent disposal) are
+  pinned by `McpPlugin.Server.Tests/RouterLogCaptureTests.cs`.
 - Assert **presence** of the expected text rather than the absence of something else: an absence
   assertion is satisfied for free by a capture that recorded nothing at all, which is the exact
   failure mode this helper exists to rule out.

--- a/docs/claude/testing.md
+++ b/docs/claude/testing.md
@@ -3,8 +3,60 @@
 - xUnit + Shouldly + Moq
 - Arrange-Act-Assert pattern
 - `[Fact]` for single scenarios, `[Theory]` for parameterized
-- `[Collection("McpPlugin")]` for test isolation
-- Custom `TestLoggerFactory` / `XunitTestOutputLoggerProvider` for test logging
+- Collection names are **project-scoped**: `[Collection("McpPlugin")]` in `McpPlugin.Tests`,
+  `[Collection("McpPlugin.Server")]` in `McpPlugin.Server.Tests`. There is no repo-wide name — match
+  the project you are editing. `[Collection]` is also the ONLY serialization mechanism here (no
+  `CollectionDefinition`, no `[assembly: CollectionBehavior]`, no `xunit.runner.json`), and not every
+  class carries it, so classes without it DO run in parallel with yours.
+
+## Logging in tests
+
+The two test projects log through **different** stacks, and a helper from one is useless in the
+other. Pick by project:
+
+### `McpPlugin.Tests` — Microsoft.Extensions.Logging (MEL)
+
+- `TestLoggerFactory` / `XunitTestOutputLoggerProvider` (`McpPlugin.Tests/Infrastructure/`) are MEL
+  providers, and they live in `McpPlugin.Tests`. Use them **there** instead of `NullLogger`, so a
+  failure emits to the test output console.
+- They are **not available in `McpPlugin.Server.Tests`** — different project, no reference — and
+  reaching for them there fails twice over: the type is unreachable, and even if it were reachable a
+  MEL provider cannot observe what the server-side routers write (next section).
+
+### `McpPlugin.Server.Tests` — NLog, via `CapturedRouterLogs`
+
+The server-side routers (`PromptRouter`, `ResourceRouter`, `ToolRouter`) log through NLog's **static
+`LogManager`**, which is independent of the host's MEL pipeline — `builder.Logging.ClearProviders()`
+does not silence them, and no MEL provider ever sees them. A test wired to a MEL logger therefore
+asserts on nothing and stays green even when the log line under test is deleted. That is not
+hypothetical: during PR #198 deleting a router's `Warn` line left all 676 server tests passing.
+
+To assert on what a router told the operator, capture on the **NLog** side with the shared helper
+`McpPlugin.Server.Tests/Infrastructure/CapturedRouterLogs.cs`:
+
+```csharp
+using var logs = CapturedRouterLogs.InstallFor(typeof(PromptRouter));
+
+// ... drive the degraded path over a real host ...
+
+logs.Text.ShouldContain(expectedFailureText, Case.Sensitive);
+```
+
+- Takes a `Type` rather than a generic parameter because the routers are **static** classes, which
+  C# forbids as type arguments. The rule is scoped to `routerType.FullName`, which is exactly the
+  logger name `LogManager.GetCurrentClassLogger()` produces, so renaming a router cannot silently
+  stop the capture matching.
+- Captures **Warn and above** by default (the operator-visible band); pass an explicit
+  `NLog.LogLevel` for a lower floor.
+- `LogManager.Configuration` is process-global, so the helper serializes every capture behind an
+  assembly-wide gate and restores the exact previous configuration on `Dispose` — always use
+  `using var`, and prefer `[Collection("McpPlugin.Server")]` on the calling class so log-asserting
+  tests do not queue on that gate.
+- Its own guarantees (scoping, level floor, restore, mutual exclusion) are pinned by
+  `McpPlugin.Server.Tests/RouterLogCaptureTests.cs`.
+- Assert **presence** of the expected text rather than the absence of something else: an absence
+  assertion is satisfied for free by a capture that recorded nothing at all, which is the exact
+  failure mode this helper exists to rule out.
 
 ## Test commands
 
@@ -16,6 +68,11 @@ dotnet test
 dotnet test McpPlugin.Tests/McpPlugin.Tests.csproj
 
 # Run a specific test class or method
-dotnet test --filter "ClassName=McpBuilderTests"
+dotnet test --filter "FullyQualifiedName~McpBuilderTests"
 dotnet test --filter "FullyQualifiedName~McpBuilderTests.Build_WithoutLogging_ShouldSucceed"
 ```
+
+- `FullyQualifiedName~` (substring match) is the filter to use for a class OR a method. **Do not use
+  `ClassName=`** — it is an MSTest property that the xUnit adapter ignores, so it matches nothing,
+  and `dotnet test` exits **0** on a zero-match filter. A filtered run is only green if its summary
+  line shows a non-zero `Total:`.


### PR DESCRIPTION
## Summary

- **`McpPlugin.Server.Tests` can now assert on router log output.** The server routers log through
  NLog's static `LogManager`, which no `Microsoft.Extensions.Logging` provider observes, so any
  requirement of the form *"the operator must still see a warning"* was untestable in that project —
  measured during #198, where deleting a router's `Warn` line left every server test green. New
  shared helper `McpPlugin.Server.Tests/Infrastructure/CapturedRouterLogs.cs` promotes that PR's
  file-local `CapturedRouterWarnings` `MemoryTarget` workaround, keeping its semantics.
- **Its safety under parallelism is stated and tested, not assumed.** `LogManager.Configuration` is
  process-global and `[Collection("McpPlugin.Server")]` covers only part of this assembly's classes,
  so the collection attribute alone cannot make a whole-config swap safe. Three mechanisms do, each
  with its own test: an assembly-wide gate that admits **one** capture at a time, a rule scoped to
  the router's own logger name, and an exact (idempotent) restore of the previous configuration on
  dispose. `InstallFor` takes a `Type` rather than a generic parameter because the routers are
  **static** classes, which C# forbids as type arguments.
- **One implementation, two consumers.** `PromptListDegradationOverHttpTests` is migrated onto the
  helper; new `RouterLogCaptureTests` drives a **different** router (`ResourceRouter`) through it,
  which is what makes it a shared facility rather than one test's local workaround. The `auth=none`
  loopback Streamable-HTTP harness both need is extracted alongside it as
  `Infrastructure/NoneAuthMcpHost.cs`, so the second consumer does not copy ~110 lines of host
  plumbing.
- **`docs/claude/testing.md` corrected, not caveated.** `TestLoggerFactory` /
  `XunitTestOutputLoggerProvider` are now scoped to `McpPlugin.Tests` (MEL) with an explicit note
  that they are unreachable *and* blind in `McpPlugin.Server.Tests`; the NLog capture is documented
  as the way to assert router logs there. Two adjacent false claims in the same file are fixed while
  it is open: collection names are project-scoped, and the `ClassName=` filter recipe is replaced by
  `FullyQualifiedName~` (`ClassName=` is an MSTest property the xUnit adapter ignores, and
  `dotnet test` exits **0** on a zero-match filter).

No production behaviour changes. No `<Version>` bump (`git diff origin/main -- '*.csproj'
Directory.Build.props` is empty), so this PR is inert with respect to `release.yml`.

## Plant verification

The point of the helper is that it can **fail** when the log line is missing, so every breakable
claim got its own plant through `plant_and_revert.py` (build inside the verify command; each RED
attributed by reading its own per-plant log, not the summary count):

| # | Plant | Expected | Verdict | Test that reddened |
|---|---|---|---|---|
| P1 | delete `PromptRouter.List`'s `Warn` on the plugin-error branch | red | **RED** | `PromptsList_WhenThePluginCallFails_StillLogsTheInternalFailureTextForOperators` |
| P2 | delete `ResourceRouter.List`'s `Warn` on the plugin-error branch | red | **RED** | `ResourcesList_WhenThePluginCallFails_LogsTheFailureTextForOperators` |
| P3 | widen the capture rule from the router's logger name to `*` | red | **RED** | `Capture_IsScopedToTheRequestedRouter` |
| P4 | drop the previous-configuration restore from `Dispose` | red | **RED** | `Dispose_RestoresTheExactPreviousNLogConfiguration` |
| P5 | let the gate admit two captures (`SemaphoreSlim(2, 2)`) | red | **RED** | `Install_WhileAnotherCaptureIsHeld_IsRefusedUntilItIsDisposed` |
| P6 | make the capture report an empty blob | red | **RED** | `PromptsList_WhenThePluginCallFails_StillLogsTheInternalFailureTextForOperators` |
| P7 | make `ResourceRouter.List` warn unconditionally | red | **RED** | `ResourcesList_WhenThePluginReturnsResources_EmitsThemOverTheWireAndLogsNothingAtWarn` |
| P8 | drop the capture's level floor below `Warn` | red | **RED** | `Capture_TakesWarnAndAbove_NotChatter` |
| P9 | make `Dispose`'s idempotency guard never fire | red | **RED** | `Dispose_IsIdempotent_AndLeavesTheGateOpen` |
| P10 | stop `Dispose` releasing the gate (restore kept) | red | **RED** | `Dispose_IsIdempotent_AndLeavesTheGateOpen` |
| P11 | stop `Dispose` releasing the gate (restore kept) | red | **RED** | `Install_WhileAnotherCaptureIsHeld_IsRefusedUntilItIsDisposed` |

`SUMMARY 11/11 matched their expect | 11 RED | 0 GREEN | restore-failures 0`, summed across three
rounds grouped by verify command: P1–P9 over both log-asserting classes, then P10 and P11 each
scoped to their own marker, because a gate that never reopens makes every later install wait out
its 60s timeout. Every log carries `Build succeeded.` and a `Failed! ...` line with a non-zero
`Total:` — a zero-match filter would have scored every plant green.

**P1 is the exact scenario the defect report names**, and **P6 is what stops the assertions being
satisfiable by an empty capture**: with `Text` forced to `string.Empty` the presence assertions go
red, so they are genuine presence claims rather than absences that any short-circuit satisfies.
**P7 is the other direction of the resources claim** — the warning must appear when the plugin call
fails *and not otherwise* — paired in the same fixture family with a positive artifact (the resource
URIs actually arriving on the wire), so the "no warning" half cannot pass merely because nothing was
logged at all.

**P9–P11 were added by the review pass**, which found one guarantee asserted only by a comment:
`Dispose` is idempotent, but nothing in the suite disposed a capture twice, so the guard could have
been deleted with every test still green. `Dispose_IsIdempotent_AndLeavesTheGateOpen` pins it, and
its two halves hold each other up — P9 (the guard never fires) reddens the "must not throw" half,
P10 (the gate is never released) reddens the "gate still admits a capture" half that stops the
first being satisfied by a `Dispose` that does nothing at all. P11 marks that same mutation on the
pre-existing gate-reopen assertion, which until now had no plant of its own.

## Test plan

- [x] Target-specific local tests passed (see profile `test.md`): full solution-level
      `dotnet test --no-build --configuration Release` — **4/4 test hosts `Test Run Successful.`,
      0 `Test Run Failed.`**, 684 passed (`McpPlugin.Server.Tests`) and 808 passed
      (`McpPlugin.Tests`) on **both** `net8.0` and `net9.0`.
- [x] Plant round, re-run against the refined tree: 11/11 RED, 0 GREEN, 0 restore failures; tree byte-clean afterwards.
- [x] `dotnet build --no-restore --configuration Release`: 0 errors, no new warnings.

Closes #199

