### PR TITLE
feat(agent-config): machine credential store v2 — families schema, atomic writes, unreadable state

### DIFF
--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -7,7 +7,14 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    # Cross-platform matrix (design 04 §5): the machine credential store's at-rest protection and
+    # atomic-write behaviour are OS-specific — DPAPI + rename/handle timing on Windows, 0600/0700
+    # permission asserts on the POSIX legs — so the suite runs on all three.
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     permissions:
       checks: write
       pull-requests: write
@@ -36,8 +43,10 @@ jobs:
         run: dotnet test --no-build --verbosity normal --configuration Release --logger "trx;LogFileName=test-results.trx" --results-directory ./TestResults
 
       - name: Publish Test Results
+        # The docker-based action only runs on Linux; the Windows/macOS legs upload their .trx
+        # artifacts below and gate on the test step itself.
         uses: EnricoMi/publish-unit-test-result-action@v2
-        if: always()
+        if: always() && runner.os == 'Linux'
         with:
           files: 'TestResults/**/*.trx'
 
@@ -45,7 +54,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: test-results
+          name: test-results-${{ matrix.os }}
           path: TestResults/**/*.trx
 
   # mcp-authorize Phase-2 gate (design 04/07, task b8): the cross-language golden-vector parity

--- a/McpPlugin.Tests/AgentConfig/MachineCredentialStoreAtomicityTests.cs
+++ b/McpPlugin.Tests/AgentConfig/MachineCredentialStoreAtomicityTests.cs
@@ -1,0 +1,243 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.AgentConfig;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
+{
+    /// <summary>
+    /// The atomic-write contract of the machine credential store (design 04 §1): temp sibling in
+    /// the same directory → fsync → rename, with the Windows rename retry policy (≥4 attempts,
+    /// ≥250 ms backoff on EBUSY/EPERM/EACCES-alike holders). A reader must never observe a
+    /// truncated document, and a writer killed before the rename must leave the destination intact.
+    /// </summary>
+    public sealed class MachineCredentialStoreAtomicityTests : IDisposable
+    {
+        private readonly string _baseDir;
+
+        public MachineCredentialStoreAtomicityTests()
+        {
+            _baseDir = Path.Combine(Path.GetTempPath(), "agd-store-atomic-" + Guid.NewGuid().ToString("N"), ".ai-game-dev");
+        }
+
+        public void Dispose()
+        {
+            var parent = Path.GetDirectoryName(_baseDir);
+            if (parent != null && Directory.Exists(parent))
+                Directory.Delete(parent, recursive: true);
+        }
+
+        private MachineCredentialStore NewStore() => new MachineCredentialStore(_baseDir);
+
+        private static MachineCredentials Credentials(string accessToken, string refreshToken) => new MachineCredentials
+        {
+            Families = new MachineCredentialFamilies
+            {
+                Plugin = new MachineCredentialFamily
+                {
+                    AccessToken = accessToken,
+                    RefreshToken = refreshToken,
+                    ClientId = "unity-mcp-plugin",
+                    Scope = "mcp:plugin",
+                },
+            },
+        };
+
+        [Fact]
+        public void RetryPolicy_MeetsTheStoreContract()
+        {
+            // Part of the v2 store contract (design 04 §1) — not a tunable.
+            MachineCredentialStore.RenameRetryAttempts.ShouldBeGreaterThanOrEqualTo(4);
+            MachineCredentialStore.RenameRetryDelayMs.ShouldBeGreaterThanOrEqualTo(250);
+        }
+
+        [Fact]
+        public void StrayTempSibling_FromAWriterKilledBeforeRename_DoesNotAffectReads()
+        {
+            var store = NewStore();
+            store.Write(Credentials("GOOD-AT", "GOOD-RT"));
+
+            // A writer killed between fsync and rename leaves exactly this: a temp sibling with
+            // arbitrary content, next to an untouched destination.
+            File.WriteAllText(
+                Path.Combine(_baseDir, MachineCredentialStore.CredentialsFileName + ".deadbeef.tmp"),
+                "partial garbage from a killed writer");
+
+            var result = store.TryRead();
+            result.Status.ShouldBe(MachineCredentialStoreStatus.Ok);
+            result.Credentials!.Families!.Plugin!.AccessToken.ShouldBe("GOOD-AT");
+        }
+
+        /// <summary>
+        /// Mandated plant (04 §5, Windows CI leg): the rename retry policy survives a simulated
+        /// destination-handle holder (AV scanner / indexer / reader without FILE_SHARE_DELETE).
+        /// Without the retry loop the write throws immediately while the handle is held — RED.
+        /// The elapsed floor proves a retry actually happened (the first attempt fails at ~0 ms).
+        /// </summary>
+        [Fact]
+        public async Task Write_RetriesUntilDestinationHandleReleased_Windows()
+        {
+            if (!OperatingSystem.IsWindows())
+                return; // FileShare semantics are only enforced by Windows; POSIX rename ignores holders.
+
+            var store = NewStore();
+            store.Write(Credentials("OLD-AT", "OLD-RT"));
+
+            // Hold the destination WITHOUT FileShare.Delete: File.Replace needs delete access on the
+            // destination, so every rename attempt fails with a sharing violation until release.
+            var holder = new FileStream(store.CredentialsPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+            var release = Task.Run(() =>
+            {
+                Thread.Sleep(600);
+                holder.Dispose();
+            });
+
+            var stopwatch = Stopwatch.StartNew();
+            store.Write(Credentials("NEW-AT", "NEW-RT")); // must survive the holder via retries
+            stopwatch.Stop();
+            await release;
+
+            stopwatch.ElapsedMilliseconds.ShouldBeGreaterThanOrEqualTo(400); // ≥1 backoff happened
+            store.Read()!.Families!.Plugin!.AccessToken.ShouldBe("NEW-AT");
+        }
+
+        /// <summary>
+        /// Mandated plant (04 §5): a reader concurrent with writers never observes a truncated
+        /// readable document — it sees the old document or the new one, complete, every time.
+        /// Replacing the atomic temp-sibling+rename write with a direct in-place write
+        /// (<c>File.WriteAllBytes</c>, the pre-v2 behaviour) turns this RED: readers sample the
+        /// truncate-then-write window and decode partial content.
+        /// </summary>
+        [Fact]
+        public async Task ConcurrentReaders_NeverObserveATruncatedDocument()
+        {
+            const int writes = 120;
+            var store = NewStore();
+
+            // Padding widens the on-disk document so an in-place truncate-then-write window is
+            // reliably observable; carried as an unknown field to also exercise preservation.
+            using var padding = JsonDocument.Parse(
+                JsonSerializer.Serialize(new string('x', 64 * 1024)));
+
+            MachineCredentials Payload(int i)
+            {
+                var credentials = Credentials("AT-" + i, "RT-" + i);
+                credentials.ExtensionData = new Dictionary<string, JsonElement>
+                {
+                    ["padding"] = padding.RootElement.Clone(),
+                };
+                return credentials;
+            }
+
+            store.Write(Payload(0));
+
+            var writer = Task.Run(() =>
+            {
+                for (var i = 1; i <= writes; i++)
+                    store.Write(Payload(i));
+            });
+
+            var violations = new List<string>();
+            var successfulReads = 0;
+
+            while (!writer.IsCompleted)
+            {
+                byte[] raw;
+                try
+                {
+                    // FileShare.ReadWrite | Delete: observe the file without ever blocking the
+                    // writer's rename — this reader adds no synchronization of its own.
+                    using var streamRead = new FileStream(
+                        store.CredentialsPath, FileMode.Open, FileAccess.Read,
+                        FileShare.ReadWrite | FileShare.Delete);
+                    using var buffer = new MemoryStream();
+                    streamRead.CopyTo(buffer);
+                    raw = buffer.ToArray();
+                }
+                catch (IOException)
+                {
+                    continue; // transient open failure during a rename — not a torn read
+                }
+
+                try
+                {
+                    if (raw.Length == 0)
+                        throw new InvalidDataException("observed an empty credential file");
+
+                    var json = Encoding.UTF8.GetString(MachineCredentialStore.UnprotectBytes(raw));
+                    using var doc = JsonDocument.Parse(json);
+
+                    var plugin = doc.RootElement.GetProperty("families").GetProperty("plugin");
+                    var accessToken = plugin.GetProperty("accessToken").GetString()!;
+                    var refreshToken = plugin.GetProperty("refreshToken").GetString()!;
+
+                    // Both fields must carry the SAME generation — a mixed pair is a torn document.
+                    accessToken.ShouldStartWith("AT-");
+                    refreshToken.ShouldBe("RT-" + accessToken.Substring(3));
+
+                    doc.RootElement.GetProperty("padding").GetString()!.Length.ShouldBe(64 * 1024);
+                    successfulReads++;
+                }
+                catch (Exception ex)
+                {
+                    violations.Add(ex.GetType().Name + ": " + ex.Message);
+                    if (violations.Count >= 5)
+                        break; // enough evidence
+                }
+
+                Thread.Sleep(1);
+            }
+
+            await writer; // propagate any writer failure
+
+            violations.ShouldBeEmpty();
+            // Anti-vacuity: the assertion above proves nothing if no read ever succeeded.
+            successfulReads.ShouldBeGreaterThanOrEqualTo(25);
+        }
+
+        [Fact]
+        public void AtomicWrite_PreservesPosixPermissions_OnCreateAndOnReplace()
+        {
+            if (OperatingSystem.IsWindows())
+                return; // POSIX-only assertion; exercised on the Linux/macOS CI legs. (CA1416 guard)
+
+            var store = NewStore();
+
+            store.Write(Credentials("FIRST-AT", "FIRST-RT")); // create path (File.Move)
+            File.GetUnixFileMode(store.CredentialsPath)
+                .ShouldBe(UnixFileMode.UserRead | UnixFileMode.UserWrite); // 0600
+            File.GetUnixFileMode(store.BaseDirectory)
+                .ShouldBe(UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute); // 0700
+
+            store.Write(Credentials("SECOND-AT", "SECOND-RT")); // replace path (File.Replace)
+            File.GetUnixFileMode(store.CredentialsPath)
+                .ShouldBe(UnixFileMode.UserRead | UnixFileMode.UserWrite); // 0600 survives the rename
+        }
+
+        [Fact]
+        public void AtomicWrite_LeavesNoTempSiblingBehind_OnSuccess()
+        {
+            var store = NewStore();
+            store.Write(Credentials("AT", "RT"));
+            store.Write(Credentials("AT2", "RT2"));
+
+            Directory.GetFiles(_baseDir, "*.tmp").ShouldBeEmpty();
+        }
+    }
+}

--- a/McpPlugin.Tests/AgentConfig/MachineCredentialStoreTests.cs
+++ b/McpPlugin.Tests/AgentConfig/MachineCredentialStoreTests.cs
@@ -73,7 +73,13 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
             read.ExpiresAt.ShouldBe(new DateTimeOffset(2030, 1, 2, 3, 4, 5, TimeSpan.Zero));
             read.ServerTarget.ShouldBe("https://ai-game.dev");
             read.Subject.ShouldBe("account-uuid-123");
-            read.Version.ShouldBe(1);
+            read.Version.ShouldBe(2); // a top-level-style write is upgraded to the v2 schema on write
+
+            // The old-style top-level token material was adopted as families.legacy (design 04 §1),
+            // and the top-level fields above are its v1 compat mirror.
+            read.Families.ShouldNotBeNull();
+            read.Families!.Legacy!.AccessToken.ShouldBe(SecretAccessToken);
+            read.Families.Legacy.RefreshToken.ShouldBe(SecretRefreshToken);
         }
 
         [Fact]

--- a/McpPlugin.Tests/AgentConfig/MachineCredentialStoreV2Tests.cs
+++ b/McpPlugin.Tests/AgentConfig/MachineCredentialStoreV2Tests.cs
@@ -1,0 +1,452 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using com.IvanMurzak.McpPlugin.AgentConfig;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
+{
+    /// <summary>
+    /// The v2 store contract (design 04 §1): the <c>families.{agent,plugin,legacy}</c> schema with
+    /// per-family <c>clientId</c> + <c>scope</c>, the top-level v1 compat mirror of the plugin
+    /// family, v1 read-compat as <c>families.legacy</c> with first-write upgrade, unknown-field
+    /// preservation across a read→write round-trip, version passthrough, and the structured
+    /// "store unreadable" state (never crash, never delete, never overwrite until explicit re-auth).
+    ///
+    /// <para>Raw-document assertions go through the store's internal plaintext seams so they run on
+    /// Windows (DPAPI at rest) exactly as on POSIX, and compare <b>parsed values, never bytes</b> —
+    /// formatting is codec-specific by design.</para>
+    /// </summary>
+    public sealed class MachineCredentialStoreV2Tests : IDisposable
+    {
+        private static readonly DateTimeOffset AgentExpiry = new DateTimeOffset(2030, 1, 2, 3, 4, 5, TimeSpan.Zero);
+        private static readonly DateTimeOffset PluginExpiry = new DateTimeOffset(2030, 6, 7, 8, 9, 10, TimeSpan.Zero);
+        private static readonly DateTimeOffset LegacyExpiry = new DateTimeOffset(2029, 11, 12, 13, 14, 15, TimeSpan.Zero);
+
+        private readonly string _baseDir;
+
+        public MachineCredentialStoreV2Tests()
+        {
+            _baseDir = Path.Combine(Path.GetTempPath(), "agd-store-v2-" + Guid.NewGuid().ToString("N"), ".ai-game-dev");
+        }
+
+        public void Dispose()
+        {
+            var parent = Path.GetDirectoryName(_baseDir);
+            if (parent != null && Directory.Exists(parent))
+                Directory.Delete(parent, recursive: true);
+        }
+
+        private MachineCredentialStore NewStore() => new MachineCredentialStore(_baseDir);
+
+        private static MachineCredentials FullV2Credentials() => new MachineCredentials
+        {
+            ServerTarget = "https://ai-game.dev",
+            Subject = "usr_full",
+            Families = new MachineCredentialFamilies
+            {
+                Agent = new MachineCredentialFamily
+                {
+                    AccessToken = "AGENT-AT",
+                    RefreshToken = "AGENT-RT",
+                    ExpiresAt = AgentExpiry,
+                    ClientId = "unity-mcp-plugin",
+                    Scope = "mcp:agent",
+                },
+                Plugin = new MachineCredentialFamily
+                {
+                    AccessToken = "PLUGIN-AT",
+                    RefreshToken = "PLUGIN-RT",
+                    ExpiresAt = PluginExpiry,
+                    ClientId = "unity-mcp-plugin",
+                    Scope = "mcp:plugin",
+                },
+                Legacy = new MachineCredentialFamily
+                {
+                    AccessToken = "LEGACY-AT",
+                    RefreshToken = "LEGACY-RT",
+                    ExpiresAt = LegacyExpiry,
+                },
+            },
+        };
+
+        private JsonDocument ReadRawDocument()
+        {
+            var json = NewStore().ReadPlaintextJson();
+            json.ShouldNotBeNull();
+            return JsonDocument.Parse(json!);
+        }
+
+        // ── v2 round-trip ────────────────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void WriteV2_ThenRead_RoundTripsAllFamilies()
+        {
+            var store = NewStore();
+            store.Write(FullV2Credentials());
+
+            var read = store.Read();
+            read.ShouldNotBeNull();
+            read!.Version.ShouldBe(MachineCredentials.CurrentVersion);
+            read.ServerTarget.ShouldBe("https://ai-game.dev");
+            read.Subject.ShouldBe("usr_full");
+
+            var agent = read.Families!.Agent!;
+            agent.AccessToken.ShouldBe("AGENT-AT");
+            agent.RefreshToken.ShouldBe("AGENT-RT");
+            agent.ExpiresAt.ShouldBe(AgentExpiry);
+            agent.ClientId.ShouldBe("unity-mcp-plugin");
+            agent.Scope.ShouldBe("mcp:agent");
+
+            var plugin = read.Families.Plugin!;
+            plugin.AccessToken.ShouldBe("PLUGIN-AT");
+            plugin.RefreshToken.ShouldBe("PLUGIN-RT");
+            plugin.ExpiresAt.ShouldBe(PluginExpiry);
+            plugin.ClientId.ShouldBe("unity-mcp-plugin");
+            plugin.Scope.ShouldBe("mcp:plugin");
+
+            var legacy = read.Families.Legacy!;
+            legacy.AccessToken.ShouldBe("LEGACY-AT");
+            legacy.RefreshToken.ShouldBe("LEGACY-RT");
+            legacy.ExpiresAt.ShouldBe(LegacyExpiry);
+            legacy.ClientId.ShouldBeNull(); // unknown by definition
+            legacy.Scope.ShouldBeNull();
+        }
+
+        // ── v1 compat mirror ─────────────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void Write_MirrorsPluginFamilyTokens_AtTopLevel()
+        {
+            NewStore().Write(FullV2Credentials());
+
+            // Model view: the mirror is what pre-v2 model consumers read.
+            var read = NewStore().Read()!;
+            read.AccessToken.ShouldBe("PLUGIN-AT");
+            read.RefreshToken.ShouldBe("PLUGIN-RT");
+            read.ExpiresAt.ShouldBe(PluginExpiry);
+
+            // Old-reader simulation on the raw document: a v1 reader keys on the top-level fields.
+            using var doc = ReadRawDocument();
+            doc.RootElement.GetProperty("version").GetInt32().ShouldBe(2);
+            doc.RootElement.GetProperty("accessToken").GetString().ShouldBe("PLUGIN-AT");
+            doc.RootElement.GetProperty("refreshToken").GetString().ShouldBe("PLUGIN-RT");
+            DateTimeOffset.Parse(doc.RootElement.GetProperty("expiresAt").GetString()!).ShouldBe(PluginExpiry);
+        }
+
+        [Fact]
+        public void Write_WithoutPluginFamily_MirrorsLegacyFamily()
+        {
+            var credentials = FullV2Credentials();
+            credentials.Families!.Plugin = null;
+
+            NewStore().Write(credentials);
+
+            using var doc = ReadRawDocument();
+            doc.RootElement.GetProperty("accessToken").GetString().ShouldBe("LEGACY-AT");
+            doc.RootElement.GetProperty("refreshToken").GetString().ShouldBe("LEGACY-RT");
+        }
+
+        [Fact]
+        public void Write_AgentOnlyDocument_EmitsNoTopLevelTokenMirror()
+        {
+            var credentials = FullV2Credentials();
+            credentials.Families!.Plugin = null;
+            credentials.Families.Legacy = null;
+            // A stale mirror must never outlive its source: even if a caller left top-level values
+            // behind, an agent-only document has no plugin-plane credential to mirror.
+            credentials.AccessToken = "STALE";
+            credentials.RefreshToken = "STALE";
+
+            NewStore().Write(credentials);
+
+            using var doc = ReadRawDocument();
+            doc.RootElement.TryGetProperty("accessToken", out _).ShouldBeFalse();
+            doc.RootElement.TryGetProperty("refreshToken", out _).ShouldBeFalse();
+            doc.RootElement.TryGetProperty("expiresAt", out _).ShouldBeFalse();
+            doc.RootElement.GetProperty("families").TryGetProperty("agent", out _).ShouldBeTrue();
+        }
+
+        // ── v1 read-compat + first-write upgrade ─────────────────────────────────────────────────
+
+        private const string V1DocumentWithUnknownField = @"{
+            ""version"": 1,
+            ""accessToken"": ""V1-AT"",
+            ""refreshToken"": ""V1-RT"",
+            ""expiresAt"": ""2030-01-02T03:04:05+00:00"",
+            ""serverTarget"": ""https://ai-game.dev"",
+            ""subject"": ""usr_v1"",
+            ""futureField"": { ""nested"": [1, 2, 3] }
+        }";
+
+        [Fact]
+        public void V1Document_IsReadAsLegacyFamily()
+        {
+            NewStore().WritePlaintextJson(V1DocumentWithUnknownField);
+
+            var result = NewStore().TryRead();
+            result.Status.ShouldBe(MachineCredentialStoreStatus.Ok);
+
+            var credentials = result.Credentials!;
+            credentials.Version.ShouldBe(1); // still a v1 document until the first write
+            credentials.ServerTarget.ShouldBe("https://ai-game.dev");
+            credentials.Subject.ShouldBe("usr_v1");
+
+            var legacy = credentials.Families!.Legacy!;
+            legacy.AccessToken.ShouldBe("V1-AT");
+            legacy.RefreshToken.ShouldBe("V1-RT");
+            legacy.ExpiresAt.ShouldBe(new DateTimeOffset(2030, 1, 2, 3, 4, 5, TimeSpan.Zero));
+            legacy.ClientId.ShouldBeNull();
+            legacy.Scope.ShouldBeNull();
+
+            credentials.Families.Agent.ShouldBeNull();
+            credentials.Families.Plugin.ShouldBeNull();
+        }
+
+        [Fact]
+        public void FirstWrite_UpgradesV1DocumentToV2_WithMirror_PreservingUnknownFields()
+        {
+            var store = NewStore();
+            store.WritePlaintextJson(V1DocumentWithUnknownField);
+
+            var credentials = store.Read()!;
+            store.Write(credentials); // first write by updated code → v2 + mirror (design 04 §1)
+
+            using var doc = ReadRawDocument();
+            doc.RootElement.GetProperty("version").GetInt32().ShouldBe(2);
+
+            var legacy = doc.RootElement.GetProperty("families").GetProperty("legacy");
+            legacy.GetProperty("accessToken").GetString().ShouldBe("V1-AT");
+            legacy.GetProperty("refreshToken").GetString().ShouldBe("V1-RT");
+
+            // The adopted legacy family is the only plugin-plane credential → it is the mirror.
+            doc.RootElement.GetProperty("accessToken").GetString().ShouldBe("V1-AT");
+            doc.RootElement.GetProperty("refreshToken").GetString().ShouldBe("V1-RT");
+
+            doc.RootElement.GetProperty("serverTarget").GetString().ShouldBe("https://ai-game.dev");
+            doc.RootElement.GetProperty("subject").GetString().ShouldBe("usr_v1");
+
+            // The unknown v1 field survived the upgrade (parsed-value comparison, never bytes).
+            var future = doc.RootElement.GetProperty("futureField");
+            future.GetProperty("nested").GetArrayLength().ShouldBe(3);
+            future.GetProperty("nested")[2].GetInt32().ShouldBe(3);
+        }
+
+        [Fact]
+        public void Rotate_OnV1Document_RotatesLegacyFamily_AndUpgrades()
+        {
+            var store = NewStore();
+            store.WritePlaintextJson(V1DocumentWithUnknownField);
+
+            store.Rotate("NEW-AT", "NEW-RT", new DateTimeOffset(2031, 1, 1, 0, 0, 0, TimeSpan.Zero));
+
+            using var doc = ReadRawDocument();
+            doc.RootElement.GetProperty("version").GetInt32().ShouldBe(2);
+
+            var legacy = doc.RootElement.GetProperty("families").GetProperty("legacy");
+            legacy.GetProperty("accessToken").GetString().ShouldBe("NEW-AT");
+            legacy.GetProperty("refreshToken").GetString().ShouldBe("NEW-RT");
+
+            doc.RootElement.GetProperty("accessToken").GetString().ShouldBe("NEW-AT");
+
+            // Identity fields and unknown fields survive the rotation.
+            doc.RootElement.GetProperty("subject").GetString().ShouldBe("usr_v1");
+            doc.RootElement.TryGetProperty("futureField", out _).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void Rotate_WithPluginFamily_RotatesPluginFamily_NotAgent()
+        {
+            var store = NewStore();
+            store.Write(FullV2Credentials());
+
+            store.Rotate("ROTATED-AT", "ROTATED-RT");
+
+            var read = store.Read()!;
+            read.Families!.Plugin!.AccessToken.ShouldBe("ROTATED-AT");
+            read.Families.Plugin.RefreshToken.ShouldBe("ROTATED-RT");
+            read.Families.Plugin.ClientId.ShouldBe("unity-mcp-plugin"); // family identity untouched
+            read.Families.Plugin.Scope.ShouldBe("mcp:plugin");
+
+            read.Families.Agent!.AccessToken.ShouldBe("AGENT-AT"); // other families untouched
+            read.Families.Legacy!.AccessToken.ShouldBe("LEGACY-AT");
+
+            read.AccessToken.ShouldBe("ROTATED-AT"); // mirror follows the plugin family
+        }
+
+        // ── Unknown-field preservation (mandated plant: removing [JsonExtensionData] → RED) ──────
+
+        [Fact]
+        public void UnknownFields_SurviveReadWriteRoundTrip_AtEveryLevel()
+        {
+            var store = NewStore();
+            store.WritePlaintextJson(@"{
+                ""version"": 2,
+                ""accessToken"": ""PLUGIN-AT"",
+                ""x-top"": { ""nested"": [1, 2, 3], ""flag"": true },
+                ""families"": {
+                    ""x-unknown-family"": { ""accessToken"": ""FUTURE-AT"" },
+                    ""plugin"": {
+                        ""accessToken"": ""PLUGIN-AT"",
+                        ""refreshToken"": ""PLUGIN-RT"",
+                        ""clientId"": ""unity-mcp-plugin"",
+                        ""scope"": ""mcp:plugin"",
+                        ""x-in-family"": 42
+                    }
+                }
+            }");
+
+            var credentials = store.Read()!;
+            store.Write(credentials); // the round-trip that used to drop unknown fields
+
+            using var doc = ReadRawDocument();
+
+            // Top level.
+            var top = doc.RootElement.GetProperty("x-top");
+            top.GetProperty("nested").GetArrayLength().ShouldBe(3);
+            top.GetProperty("nested")[0].GetInt32().ShouldBe(1);
+            top.GetProperty("flag").GetBoolean().ShouldBeTrue();
+
+            // families container.
+            doc.RootElement.GetProperty("families").GetProperty("x-unknown-family")
+                .GetProperty("accessToken").GetString().ShouldBe("FUTURE-AT");
+
+            // Inside a family.
+            doc.RootElement.GetProperty("families").GetProperty("plugin")
+                .GetProperty("x-in-family").GetInt32().ShouldBe(42);
+        }
+
+        [Fact]
+        public void VersionPassthrough_NewerDocumentKeepsItsVersionOnWrite()
+        {
+            var store = NewStore();
+            store.WritePlaintextJson(@"{
+                ""version"": 3,
+                ""accessToken"": ""V3-AT"",
+                ""families"": { ""plugin"": { ""accessToken"": ""V3-AT"", ""refreshToken"": ""V3-RT"" } },
+                ""v3Only"": ""keep-me""
+            }");
+
+            var credentials = store.Read()!;
+            store.Write(credentials);
+
+            using var doc = ReadRawDocument();
+            doc.RootElement.GetProperty("version").GetInt32().ShouldBe(3); // never downgraded
+            doc.RootElement.GetProperty("v3Only").GetString().ShouldBe("keep-me");
+        }
+
+        // ── Structured "store unreadable" state (mandated plant: corrupted fixture → RED) ────────
+
+        private void PlantCorruptedStore()
+        {
+            Directory.CreateDirectory(_baseDir);
+            // Not a DPAPI blob (Windows: CryptUnprotectData fails) and not valid JSON (POSIX).
+            File.WriteAllBytes(NewStore().CredentialsPath, System.Text.Encoding.UTF8.GetBytes("this-is-not-a-credential-store"));
+        }
+
+        [Fact]
+        public void TryRead_ReturnsMissing_WhenNoFile()
+        {
+            var result = NewStore().TryRead();
+            result.Status.ShouldBe(MachineCredentialStoreStatus.Missing);
+            result.Credentials.ShouldBeNull();
+        }
+
+        [Fact]
+        public void TryRead_ReturnsUnreadable_OnCorruptedContent_NeverCrashes_NeverDeletes()
+        {
+            PlantCorruptedStore();
+            var store = NewStore();
+            var originalBytes = File.ReadAllBytes(store.CredentialsPath);
+
+            MachineCredentialReadResult result = default!;
+            Should.NotThrow(() => result = store.TryRead()); // never crash (design 04 §1)
+
+            result.Status.ShouldBe(MachineCredentialStoreStatus.Unreadable);
+            result.Credentials.ShouldBeNull();
+            result.Error.ShouldNotBeNullOrWhiteSpace();
+
+            // Never delete, never overwrite: the store is preserved byte-for-byte for the user.
+            File.Exists(store.CredentialsPath).ShouldBeTrue();
+            File.ReadAllBytes(store.CredentialsPath).ShouldBe(originalBytes);
+        }
+
+        [Fact]
+        public void TryRead_ReturnsUnreadable_OnEmptyFile()
+        {
+            Directory.CreateDirectory(_baseDir);
+            File.WriteAllBytes(NewStore().CredentialsPath, Array.Empty<byte>());
+
+            NewStore().TryRead().Status.ShouldBe(MachineCredentialStoreStatus.Unreadable);
+        }
+
+        [Fact]
+        public void TryRead_ReturnsUnreadable_OnValidBlobWithCorruptedJson()
+        {
+            // On Windows this is a VALID DPAPI blob whose payload is not JSON — the failure moves
+            // from the unprotect stage to the decode stage; the state must be the same.
+            NewStore().WritePlaintextJson("{ this is not json");
+
+            NewStore().TryRead().Status.ShouldBe(MachineCredentialStoreStatus.Unreadable);
+        }
+
+        [Fact]
+        public void Read_ReturnsNull_ForUnreadableStore_WithoutThrowing()
+        {
+            PlantCorruptedStore();
+
+            MachineCredentials? read = null;
+            Should.NotThrow(() => read = NewStore().Read());
+            read.ShouldBeNull();
+        }
+
+        [Fact]
+        public void Exists_IsTrue_ForUnreadableStore_SoItIsNeverASignedInSignal()
+        {
+            PlantCorruptedStore();
+            var store = NewStore();
+
+            store.Exists.ShouldBeTrue(); // the file exists...
+            store.TryRead().Status.ShouldBe(MachineCredentialStoreStatus.Unreadable); // ...but is no credential
+        }
+
+        [Fact]
+        public void Rotate_OnUnreadableStore_Throws_AndPreservesTheFile()
+        {
+            PlantCorruptedStore();
+            var store = NewStore();
+            var originalBytes = File.ReadAllBytes(store.CredentialsPath);
+
+            // An automated rotation must never overwrite a store the user has not explicitly
+            // re-authorized to replace (design 04 §1).
+            Should.Throw<InvalidOperationException>(() => store.Rotate("NEW-AT", "NEW-RT"));
+
+            File.ReadAllBytes(store.CredentialsPath).ShouldBe(originalBytes);
+        }
+
+        [Fact]
+        public void Write_AfterExplicitReauth_ReplacesUnreadableStore()
+        {
+            PlantCorruptedStore();
+            var store = NewStore();
+
+            // Write is the explicit re-auth surface (login/adopt) — it may replace the store.
+            store.Write(FullV2Credentials());
+
+            var result = store.TryRead();
+            result.Status.ShouldBe(MachineCredentialStoreStatus.Ok);
+            result.Credentials!.Families!.Plugin!.AccessToken.ShouldBe("PLUGIN-AT");
+        }
+    }
+}

--- a/McpPlugin/src/AgentConfig/MachineCredentialFamilies.cs
+++ b/McpPlugin/src/AgentConfig/MachineCredentialFamilies.cs
@@ -1,0 +1,50 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace com.IvanMurzak.McpPlugin.AgentConfig
+{
+    /// <summary>
+    /// The <c>families</c> container of the v2 machine credential document (design 04 §1): one
+    /// credential family per token plane on this machine.
+    /// </summary>
+    public sealed class MachineCredentialFamilies
+    {
+        /// <summary>
+        /// The <c>mcp:agent</c>-scope family — the credential minted by an agent-plane login
+        /// (device flow / browser). Stamped with the <c>clientId</c> it was minted under.
+        /// </summary>
+        [JsonPropertyName("agent")]
+        public MachineCredentialFamily? Agent { get; set; }
+
+        /// <summary>
+        /// The <c>mcp:plugin</c>-scope family — derived from <see cref="Agent"/> via RFC 8693
+        /// token exchange (or minted directly by a tools-only login). Its token material is also
+        /// mirrored at the document's top level for pre-v2 readers.
+        /// </summary>
+        [JsonPropertyName("plugin")]
+        public MachineCredentialFamily? Plugin { get; set; }
+
+        /// <summary>
+        /// The adopted v1 credential (present only after reading a <c>{version: 1}</c> document,
+        /// design F11.1). Carries no <c>clientId</c> / <c>scope</c> — unknown by definition.
+        /// </summary>
+        [JsonPropertyName("legacy")]
+        public MachineCredentialFamily? Legacy { get; set; }
+
+        /// <summary>Unknown JSON fields preserved across a read→write round-trip (e.g. families added by a newer schema).</summary>
+        [JsonExtensionData]
+        public Dictionary<string, JsonElement>? ExtensionData { get; set; }
+    }
+}

--- a/McpPlugin/src/AgentConfig/MachineCredentialFamily.cs
+++ b/McpPlugin/src/AgentConfig/MachineCredentialFamily.cs
@@ -1,0 +1,58 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace com.IvanMurzak.McpPlugin.AgentConfig
+{
+    /// <summary>
+    /// One credential family of the v2 machine credential document (design 04 §1): the token
+    /// triple plus the OAuth <c>clientId</c> the family was minted under and the <c>scope</c> it
+    /// carries. The legacy family (an adopted v1 credential) has neither — they are unknown by
+    /// definition.
+    /// </summary>
+    public sealed class MachineCredentialFamily
+    {
+        /// <summary>The current short-lived ES256 JWT access token of this family.</summary>
+        [JsonPropertyName("accessToken")]
+        public string? AccessToken { get; set; }
+
+        /// <summary>The rotating refresh token used to mint a new access token before <see cref="ExpiresAt"/>.</summary>
+        [JsonPropertyName("refreshToken")]
+        public string? RefreshToken { get; set; }
+
+        /// <summary>Absolute expiry of <see cref="AccessToken"/>; used to schedule proactive refresh.</summary>
+        [JsonPropertyName("expiresAt")]
+        public DateTimeOffset? ExpiresAt { get; set; }
+
+        /// <summary>
+        /// The OAuth client id this family was minted under (design D8) — written from the value
+        /// actually presented at mint/derivation, never inferred. A later refresh must present
+        /// exactly this id. <c>null</c> for the legacy family (unknown by definition).
+        /// </summary>
+        [JsonPropertyName("clientId")]
+        public string? ClientId { get; set; }
+
+        /// <summary>
+        /// The OAuth scope of this family (<c>mcp:agent</c> / <c>mcp:plugin</c>). <c>null</c> for
+        /// the legacy family (unknown by definition).
+        /// </summary>
+        [JsonPropertyName("scope")]
+        public string? Scope { get; set; }
+
+        /// <summary>Unknown JSON fields preserved across a read→write round-trip.</summary>
+        [JsonExtensionData]
+        public Dictionary<string, JsonElement>? ExtensionData { get; set; }
+    }
+}

--- a/McpPlugin/src/AgentConfig/MachineCredentialReadResult.cs
+++ b/McpPlugin/src/AgentConfig/MachineCredentialReadResult.cs
@@ -1,0 +1,79 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+
+namespace com.IvanMurzak.McpPlugin.AgentConfig
+{
+    /// <summary>
+    /// The outcome of <see cref="MachineCredentialStore.TryRead"/>. Distinguishes the three states
+    /// the store contract requires (design 04 §1): no store at all (<see cref="MachineCredentialStoreStatus.Missing"/>),
+    /// a healthy credential (<see cref="MachineCredentialStoreStatus.Ok"/>), and — critically — a
+    /// store that <b>exists but cannot be read</b> (<see cref="MachineCredentialStoreStatus.Unreadable"/>:
+    /// DPAPI unprotect failure after a password reset / roaming profile / service account, or a
+    /// corrupted document). An unreadable store is <b>not</b> an empty store: callers surface
+    /// "sign in required" and must never crash, delete, or overwrite it until the user explicitly
+    /// re-authorizes.
+    /// </summary>
+    public sealed class MachineCredentialReadResult
+    {
+        MachineCredentialReadResult(MachineCredentialStoreStatus status, MachineCredentials? credentials, string? error)
+        {
+            Status = status;
+            Credentials = credentials;
+            Error = error;
+        }
+
+        /// <summary>The read outcome.</summary>
+        public MachineCredentialStoreStatus Status { get; }
+
+        /// <summary>The credentials; non-null exactly when <see cref="Status"/> is <see cref="MachineCredentialStoreStatus.Ok"/>.</summary>
+        public MachineCredentials? Credentials { get; }
+
+        /// <summary>
+        /// Diagnostic detail when <see cref="Status"/> is <see cref="MachineCredentialStoreStatus.Unreadable"/>.
+        /// Never contains token material.
+        /// </summary>
+        public string? Error { get; }
+
+        /// <summary>No credential file exists.</summary>
+        public static MachineCredentialReadResult Missing()
+            => new MachineCredentialReadResult(MachineCredentialStoreStatus.Missing, null, null);
+
+        /// <summary>The store was read and decoded successfully.</summary>
+        public static MachineCredentialReadResult Ok(MachineCredentials credentials)
+            => new MachineCredentialReadResult(
+                MachineCredentialStoreStatus.Ok,
+                credentials ?? throw new ArgumentNullException(nameof(credentials)),
+                null);
+
+        /// <summary>The store exists but could not be read (see <paramref name="error"/>).</summary>
+        public static MachineCredentialReadResult Unreadable(string error)
+            => new MachineCredentialReadResult(MachineCredentialStoreStatus.Unreadable, null, error);
+    }
+
+    /// <summary>The three states of a machine credential store read (see <see cref="MachineCredentialReadResult"/>).</summary>
+    public enum MachineCredentialStoreStatus
+    {
+        /// <summary>No credential file exists (signed out / never signed in).</summary>
+        Missing = 0,
+
+        /// <summary>The store was read and decoded successfully.</summary>
+        Ok = 1,
+
+        /// <summary>
+        /// The store exists but cannot be read (DPAPI unprotect failure, corrupted or truncated
+        /// document). Surface "sign in required"; never crash, never delete, never overwrite until
+        /// the user explicitly re-authorizes.
+        /// </summary>
+        Unreadable = 2,
+    }
+}

--- a/McpPlugin/src/AgentConfig/MachineCredentialStore.cs
+++ b/McpPlugin/src/AgentConfig/MachineCredentialStore.cs
@@ -16,13 +16,15 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Threading;
 
 namespace com.IvanMurzak.McpPlugin.AgentConfig
 {
     /// <summary>
     /// The shared machine credential store at <c>~/.ai-game-dev/</c> — a single per-machine home for
-    /// the ai-game.dev account credential (<c>credentials.json</c>) and the co-located public JWKS
-    /// cache (<c>jwks-cache.json</c>). Engines, CLIs, and the local server all read this store, so
+    /// the ai-game.dev account credential (<c>credentials.json</c>, schema v2 — see
+    /// <see cref="MachineCredentials"/>) and the co-located public JWKS cache
+    /// (<c>jwks-cache.json</c>). Engines, CLIs, and the local server all read this store, so
     /// sign-in happens once per machine.
     ///
     /// <para><b>At-rest protection (security-critical):</b></para>
@@ -33,6 +35,22 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
     ///         user's key (<c>CryptProtectData</c>, <c>CRYPTPROTECT_UI_FORBIDDEN</c>) so the on-disk
     ///         bytes are never plaintext.</item>
     /// </list>
+    ///
+    /// <para><b>Write durability (design 04 §1):</b> credential writes are whole-file and atomic — a
+    /// temp sibling in the same directory is written, fsynced, then renamed over the destination
+    /// (<see cref="File.Replace(string, string, string)"/>, which preserves the destination's DACL on
+    /// Windows, with a move fallback for the create case). The rename retries
+    /// <see cref="RenameRetryAttempts"/> times with <see cref="RenameRetryDelayMs"/> ms backoff to
+    /// survive transient holders (AV scanners, indexers, concurrent readers). A reader therefore
+    /// never observes a truncated document.</para>
+    ///
+    /// <para><b>Unreadable ≠ empty (design 04 §1):</b> a store that exists but cannot be decoded
+    /// (DPAPI unprotect failure after a password reset / roaming profile / service account, or a
+    /// corrupted document) is a distinct <see cref="MachineCredentialStoreStatus.Unreadable"/> state
+    /// surfaced by <see cref="TryRead"/> — never a crash, and never a reason to delete or overwrite
+    /// the file until the user explicitly re-authorizes (an automated
+    /// <see cref="Rotate(string, string, DateTimeOffset?)"/> refuses; an explicit re-auth
+    /// <see cref="Write"/> replaces it).</para>
     ///
     /// <para>The JWKS cache holds only public signing keys, so it is stored plaintext (still inside the
     /// user-only directory). Credentials are NEVER written to a project file / VCS.</para>
@@ -47,6 +65,17 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
 
         /// <summary>File name of the co-located public JWKS cache.</summary>
         public const string JwksCacheFileName = "jwks-cache.json";
+
+        /// <summary>
+        /// Attempts made to rename the fsynced temp sibling over the destination before giving up.
+        /// Contract (design 04 §1): at least 4.
+        /// </summary>
+        public const int RenameRetryAttempts = 5;
+
+        /// <summary>
+        /// Backoff between rename attempts, in milliseconds. Contract (design 04 §1): at least 250.
+        /// </summary>
+        public const int RenameRetryDelayMs = 250;
 
         // 0600 (owner rw) and 0700 (owner rwx) as binary bit-patterns — C# has no octal literals.
         private const uint PosixFilePermissions = 0b110_000_000;      // rw- --- ---
@@ -84,32 +113,103 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
         /// <summary>Absolute path of the public JWKS cache file.</summary>
         public string JwksCachePath => Path.Combine(_baseDirectory, JwksCacheFileName);
 
-        /// <summary>True when a credential file exists in the store.</summary>
+        /// <summary>
+        /// True when a credential file exists in the store. <b>Never a signed-in signal</b> (design
+        /// 04 §1): an existing file may be unreadable — use <see cref="TryRead"/> and check for
+        /// <see cref="MachineCredentialStoreStatus.Ok"/> instead.
+        /// </summary>
         public bool Exists => File.Exists(CredentialsPath);
 
         /// <summary>
         /// Read and decrypt the stored credentials, or <c>null</c> when none are present.
+        /// <para>Compatibility surface: an <b>unreadable</b> store also yields <c>null</c> here (it
+        /// never throws for one) — call <see cref="TryRead"/> to distinguish
+        /// <see cref="MachineCredentialStoreStatus.Missing"/> from
+        /// <see cref="MachineCredentialStoreStatus.Unreadable"/>.</para>
         /// </summary>
-        public MachineCredentials? Read()
+        public MachineCredentials? Read() => TryRead().Credentials;
+
+        /// <summary>
+        /// Read the store with a structured outcome (design 04 §1): <see cref="MachineCredentialStoreStatus.Missing"/>
+        /// when no file exists, <see cref="MachineCredentialStoreStatus.Ok"/> with the decoded
+        /// credentials (a <c>{version: 1}</c> document is adopted in-memory as
+        /// <c>families.legacy</c>), or <see cref="MachineCredentialStoreStatus.Unreadable"/> when the
+        /// file exists but cannot be decoded — which is <b>not</b> signed-out: never crash, never
+        /// delete, never overwrite until the user explicitly re-authorizes.
+        /// </summary>
+        public MachineCredentialReadResult TryRead()
         {
             if (!File.Exists(CredentialsPath))
-                return null;
+                return MachineCredentialReadResult.Missing();
 
-            var raw = File.ReadAllBytes(CredentialsPath);
+            byte[] raw;
+            try
+            {
+                raw = ReadAllBytesWithRetry(CredentialsPath);
+            }
+            catch (FileNotFoundException)
+            {
+                return MachineCredentialReadResult.Missing(); // deleted between the existence check and the open
+            }
+            catch (DirectoryNotFoundException)
+            {
+                return MachineCredentialReadResult.Missing();
+            }
+            catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+            {
+                return MachineCredentialReadResult.Unreadable("credential file could not be opened: " + ex.Message);
+            }
+
             if (raw.Length == 0)
-                return null;
+                return MachineCredentialReadResult.Unreadable("credential file is empty");
 
-            var plaintext = IsWindows ? Unprotect(raw) : raw;
+            byte[] plaintext;
+            if (IsWindows)
+            {
+                try
+                {
+                    plaintext = Unprotect(raw);
+                }
+                catch (CryptographicException ex)
+                {
+                    // Password reset / roaming profile / service account — the DPAPI user key can no
+                    // longer decrypt the blob. Structured state, never a crash (design 04 §1).
+                    return MachineCredentialReadResult.Unreadable("DPAPI unprotect failed: " + ex.Message);
+                }
+            }
+            else
+            {
+                plaintext = raw;
+            }
+
             var json = Encoding.UTF8.GetString(plaintext);
             if (string.IsNullOrWhiteSpace(json))
-                return null;
+                return MachineCredentialReadResult.Unreadable("credential document is blank");
 
-            return JsonSerializer.Deserialize<MachineCredentials>(json, SerializerOptions);
+            MachineCredentials? credentials;
+            try
+            {
+                credentials = JsonSerializer.Deserialize<MachineCredentials>(json, SerializerOptions);
+            }
+            catch (JsonException ex)
+            {
+                return MachineCredentialReadResult.Unreadable("credential document is not valid JSON: " + ex.Message);
+            }
+
+            if (credentials == null)
+                return MachineCredentialReadResult.Unreadable("credential document decodes to null");
+
+            // v1 read-compat: interpret top-level token material as families.legacy (design 04 §1).
+            credentials.AdoptLegacyTokens();
+            return MachineCredentialReadResult.Ok(credentials);
         }
 
         /// <summary>
         /// Encrypt (Windows) / restrict (POSIX) and write <paramref name="credentials"/> to the store,
-        /// creating the store directory with owner-only permissions if needed.
+        /// creating the store directory with owner-only permissions if needed. The document is
+        /// normalized to the v2 write contract first (v1 adoption, version upgrade, and the top-level
+        /// v1 compat mirror of the plugin family — see <see cref="MachineCredentials"/>), then written
+        /// atomically (temp sibling → fsync → rename-with-retry).
         /// </summary>
         public void Write(MachineCredentials credentials)
         {
@@ -118,30 +218,48 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
 
             EnsureBaseDirectory();
 
+            credentials.NormalizeForWrite();
             var json = JsonSerializer.Serialize(credentials, SerializerOptions);
-            var plaintext = Encoding.UTF8.GetBytes(json);
-            var bytes = IsWindows ? Protect(plaintext) : plaintext;
-
-            File.WriteAllBytes(CredentialsPath, bytes);
-            SetPosixPermissions(CredentialsPath, PosixFilePermissions);
+            WriteProtected(json);
         }
 
         /// <summary>
-        /// Replace the token material (access + refresh + expiry) while preserving the stored identity
-        /// fields (<see cref="MachineCredentials.ServerTarget"/> / <see cref="MachineCredentials.Subject"/>),
-        /// then persist. Returns the written credentials.
+        /// Replace the plugin-plane token material (access + refresh + expiry) while preserving every
+        /// other stored field, then persist. In a v2 document this rotates the <c>plugin</c> family
+        /// (falling back to <c>legacy</c>, creating it when the store is empty); the top-level v1
+        /// mirror follows on write. Refuses (throws <see cref="InvalidOperationException"/>) when the
+        /// store exists but is unreadable — an automated rotation must never destroy a store the user
+        /// has not explicitly re-authorized to overwrite (design 04 §1). Returns the written credentials.
         /// </summary>
         public MachineCredentials Rotate(string accessToken, string refreshToken, DateTimeOffset? expiresAt = null)
         {
-            var current = Read() ?? new MachineCredentials();
-            current.AccessToken = accessToken;
-            current.RefreshToken = refreshToken;
-            current.ExpiresAt = expiresAt;
+            var result = TryRead();
+            if (result.Status == MachineCredentialStoreStatus.Unreadable)
+                throw new InvalidOperationException(
+                    "The machine credential store exists but cannot be read (" + result.Error +
+                    "); sign-in is required. Refusing to overwrite it from an automated rotation.");
+
+            var current = result.Credentials ?? new MachineCredentials();
+            var families = current.Families ?? (current.Families = new MachineCredentialFamilies());
+            var family = families.Plugin ?? families.Legacy;
+            if (family == null)
+            {
+                family = new MachineCredentialFamily();
+                families.Legacy = family;
+            }
+
+            family.AccessToken = accessToken;
+            family.RefreshToken = refreshToken;
+            family.ExpiresAt = expiresAt;
+
             Write(current);
             return current;
         }
 
-        /// <summary>Delete the stored credentials (sign-out). No-op when none exist.</summary>
+        /// <summary>
+        /// Delete the stored credentials — explicit sign-out only, never an error-recovery path
+        /// (an unreadable store must be preserved for the user). No-op when none exist.
+        /// </summary>
         public void Delete()
         {
             if (File.Exists(CredentialsPath))
@@ -162,6 +280,147 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
 
             EnsureBaseDirectory();
             File.WriteAllText(JwksCachePath, jwksJson);
+        }
+
+        // ── Test / diagnostic seams (InternalsVisibleTo: McpPlugin.Tests) ────────────────────────
+
+        /// <summary>
+        /// The decrypted credential document text, or <c>null</c> when missing. Test/diagnostic seam —
+        /// lets raw-document assertions (mirror emission, unknown-field preservation, golden vectors)
+        /// run on Windows, where the on-disk bytes are DPAPI-encrypted. Throws on an unreadable store.
+        /// </summary>
+        internal string? ReadPlaintextJson()
+        {
+            if (!File.Exists(CredentialsPath))
+                return null;
+
+            var raw = File.ReadAllBytes(CredentialsPath);
+            var plaintext = IsWindows ? Unprotect(raw) : raw;
+            return Encoding.UTF8.GetString(plaintext);
+        }
+
+        /// <summary>
+        /// Write a raw credential document (protect + atomic write), bypassing the
+        /// <see cref="MachineCredentials"/> model. Test seam for planting v1 / corrupted / newer-schema
+        /// fixtures on every OS.
+        /// </summary>
+        internal void WritePlaintextJson(string json)
+        {
+            EnsureBaseDirectory();
+            WriteProtected(json);
+        }
+
+        /// <summary>Unprotect raw on-disk bytes (no-op on POSIX). Test seam for concurrency probes.</summary>
+        internal static byte[] UnprotectBytes(byte[] data) => IsWindows ? Unprotect(data) : data;
+
+        // ── Atomic write (design 04 §1) ──────────────────────────────────────────────────────────
+
+        private void WriteProtected(string json)
+        {
+            var plaintext = Encoding.UTF8.GetBytes(json);
+            var bytes = IsWindows ? Protect(plaintext) : plaintext;
+            WriteFileAtomic(CredentialsPath, bytes);
+            SetPosixPermissions(CredentialsPath, PosixFilePermissions);
+        }
+
+        /// <summary>
+        /// Whole-file atomic write: a temp sibling <b>in the same directory</b> (same volume — a
+        /// cross-volume temp would turn the rename into a copy) is created with owner-only
+        /// permissions, written, fsynced, then renamed over the destination with retry. A reader can
+        /// observe the old document or the new document, never a truncated one; a writer killed
+        /// before the rename leaves the destination untouched (plus a stray <c>*.tmp</c> sibling the
+        /// reader ignores).
+        /// </summary>
+        private void WriteFileAtomic(string destinationPath, byte[] bytes)
+        {
+            var directory = Path.GetDirectoryName(destinationPath);
+            if (string.IsNullOrEmpty(directory))
+                throw new ArgumentException("Destination path has no directory: " + destinationPath, nameof(destinationPath));
+
+            var tempPath = Path.Combine(directory, Path.GetFileName(destinationPath) + "." + Guid.NewGuid().ToString("N") + ".tmp");
+            try
+            {
+                using (var stream = new FileStream(tempPath, FileMode.CreateNew, FileAccess.Write, FileShare.None))
+                {
+                    // Restrict before any secret byte lands (the file is still empty here).
+                    SetPosixPermissions(tempPath, PosixFilePermissions);
+                    stream.Write(bytes, 0, bytes.Length);
+                    stream.Flush(flushToDisk: true); // fsync: the temp is durable before it replaces the destination
+                }
+
+                ReplaceWithRetry(tempPath, destinationPath);
+            }
+            catch
+            {
+                TryDeleteFile(tempPath);
+                throw;
+            }
+
+            TryFsyncDirectory(directory); // advisory (POSIX): make the rename itself power-loss durable
+        }
+
+        /// <summary>
+        /// Rename the fsynced temp sibling over the destination. Prefers
+        /// <see cref="File.Replace(string, string, string)"/> (atomic; preserves the destination's
+        /// DACL on Windows), falling back to a move for the create case. Retries
+        /// <see cref="RenameRetryAttempts"/> times with <see cref="RenameRetryDelayMs"/> ms backoff on
+        /// EBUSY / EPERM / EACCES-alike failures (AV scanners, indexers, concurrent readers holding
+        /// the destination) — the retry policy is part of the store contract (design 04 §1).
+        /// </summary>
+        private static void ReplaceWithRetry(string tempPath, string destinationPath)
+        {
+            for (var attempt = 1; attempt <= RenameRetryAttempts; attempt++)
+            {
+                try
+                {
+                    if (File.Exists(destinationPath))
+                        File.Replace(tempPath, destinationPath, destinationBackupFileName: null);
+                    else
+                        File.Move(tempPath, destinationPath);
+                    return;
+                }
+                catch (Exception ex) when (attempt < RenameRetryAttempts && (ex is IOException || ex is UnauthorizedAccessException))
+                {
+                    // Transient holder (or the destination appeared/vanished between the existence
+                    // check and the rename — FileNotFoundException is an IOException, and the next
+                    // attempt re-evaluates which path to take). Back off and retry.
+                    Thread.Sleep(RenameRetryDelayMs);
+                }
+            }
+
+            // Unreachable: the final attempt either returned or threw (its exception filter is false).
+            throw new IOException("Atomic rename retry loop exited unexpectedly for: " + destinationPath);
+        }
+
+        private static byte[] ReadAllBytesWithRetry(string path)
+        {
+            const int readAttempts = 3;
+            for (var attempt = 1; ; attempt++)
+            {
+                try
+                {
+                    return File.ReadAllBytes(path);
+                }
+                catch (Exception ex) when (attempt < readAttempts && ex is IOException
+                    && !(ex is FileNotFoundException) && !(ex is DirectoryNotFoundException))
+                {
+                    // Transient sharing violation with a concurrent atomic rename — brief backoff.
+                    Thread.Sleep(50);
+                }
+            }
+        }
+
+        private static void TryDeleteFile(string path)
+        {
+            try
+            {
+                if (File.Exists(path))
+                    File.Delete(path);
+            }
+            catch
+            {
+                // Best-effort cleanup of the temp sibling; never mask the original failure.
+            }
         }
 
         private void EnsureBaseDirectory()
@@ -192,9 +451,48 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
         private static extern int chmod(string path, uint mode);
 #endif
 
+        // ── POSIX directory fsync (advisory durability for the rename; design 04 §1) ─────────────
+
+        private const int O_RDONLY = 0;
+
+        private static void TryFsyncDirectory(string directory)
+        {
+            if (IsWindows)
+                return;
+
+            try
+            {
+                var fd = open(directory, O_RDONLY);
+                if (fd < 0)
+                    return;
+                try
+                {
+                    _ = fsync(fd);
+                }
+                finally
+                {
+                    _ = close(fd);
+                }
+            }
+            catch
+            {
+                // Advisory only (design 04 §1): power-loss durability parity, never a failure path.
+            }
+        }
+
+        [DllImport("libc", EntryPoint = "open", SetLastError = true)]
+        private static extern int open(string path, int flags);
+
+        [DllImport("libc", EntryPoint = "fsync", SetLastError = true)]
+        private static extern int fsync(int fd);
+
+        [DllImport("libc", EntryPoint = "close", SetLastError = true)]
+        private static extern int close(int fd);
+
         // ── Windows DPAPI (CryptProtectData / CryptUnprotectData) via P/Invoke ───────────────────
         // Self-contained (no NuGet dependency added to this Unity-consumed library). Only invoked on
-        // Windows; the DllImports compile on every TFM but are never called on POSIX.
+        // Windows; the DllImports compile on every TFM but are never called on POSIX. DPAPI use is
+        // pinned by design D2: CurrentUser scope, null entropy, CRYPTPROTECT_UI_FORBIDDEN.
 
         private static byte[] Protect(byte[] data)
         {

--- a/McpPlugin/src/AgentConfig/MachineCredentials.cs
+++ b/McpPlugin/src/AgentConfig/MachineCredentials.cs
@@ -10,6 +10,8 @@
 
 #nullable enable
 using System;
+using System.Collections.Generic;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace com.IvanMurzak.McpPlugin.AgentConfig
@@ -20,28 +22,53 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
     ///
     /// <para>
     /// A single ai-game.dev account credential shared by every engine plugin, CLI, and the local
-    /// server on the machine — sign-in happens once per machine, not per engine/project. Unknown
-    /// JSON fields are ignored on read so the schema can grow forwards-compatibly.
+    /// server on the machine — sign-in happens once per machine, not per engine/project.
     /// </para>
+    ///
+    /// <para><b>Schema v2 (store contract, design 04 §1).</b> Token material lives in
+    /// <see cref="Families"/> (<c>agent</c> / <c>plugin</c> / <c>legacy</c>), each family carrying
+    /// its own <c>clientId</c> and <c>scope</c>. The top-level
+    /// <see cref="AccessToken"/> / <see cref="RefreshToken"/> / <see cref="ExpiresAt"/> fields are a
+    /// <b>v1 compat mirror of the plugin family</b> (transition releases only): every v2 write
+    /// re-stamps them from <c>families.plugin</c> (falling back to <c>families.legacy</c> when no
+    /// plugin family exists) so pre-v2 readers, which key on the top-level fields, keep working.
+    /// A <c>{version: 1}</c> document is interpreted as <c>families.legacy</c> on read and upgraded
+    /// to v2 (+mirror) on its first write.</para>
+    ///
+    /// <para><b>Unknown JSON fields are preserved</b> across a read→write round-trip
+    /// (<see cref="ExtensionData"/>, <c>[JsonExtensionData]</c>) so a newer schema is never
+    /// destroyed by an older writer. Documents with <see cref="Version"/> above
+    /// <see cref="CurrentVersion"/> keep their version stamp on write (version passthrough).</para>
     ///
     /// <para><b>Never write this to a project file or VCS</b> — it lives only in the protected
     /// machine store (0600 on POSIX / DPAPI on Windows).</para>
     /// </summary>
     public sealed class MachineCredentials
     {
-        /// <summary>Schema version of the persisted document (currently 1).</summary>
-        [JsonPropertyName("version")]
-        public int Version { get; set; } = 1;
+        /// <summary>The schema version written by this codec (v2 families schema).</summary>
+        public const int CurrentVersion = 2;
 
-        /// <summary>The current short-lived ES256 JWT access token (MCP audience).</summary>
+        /// <summary>
+        /// Schema version of the persisted document. Defaults to <see cref="CurrentVersion"/> for
+        /// freshly constructed credentials; reflects the on-disk value after a read.
+        /// </summary>
+        [JsonPropertyName("version")]
+        public int Version { get; set; } = CurrentVersion;
+
+        /// <summary>
+        /// v1 compat mirror: the plugin-plane access token (short-lived ES256 JWT, MCP audience).
+        /// Re-stamped from <see cref="MachineCredentialFamilies.Plugin"/> (or
+        /// <see cref="MachineCredentialFamilies.Legacy"/>) on every write — mutate the family, not
+        /// this mirror.
+        /// </summary>
         [JsonPropertyName("accessToken")]
         public string? AccessToken { get; set; }
 
-        /// <summary>The rotating refresh token used to mint a new access token before <see cref="ExpiresAt"/>.</summary>
+        /// <summary>v1 compat mirror: the plugin-plane rotating refresh token (see <see cref="AccessToken"/>).</summary>
         [JsonPropertyName("refreshToken")]
         public string? RefreshToken { get; set; }
 
-        /// <summary>Absolute expiry of <see cref="AccessToken"/>; used to schedule proactive refresh.</summary>
+        /// <summary>v1 compat mirror: absolute expiry of the plugin-plane access token (see <see cref="AccessToken"/>).</summary>
         [JsonPropertyName("expiresAt")]
         public DateTimeOffset? ExpiresAt { get; set; }
 
@@ -52,5 +79,72 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
         /// <summary>The account id (<c>sub</c>) the credential resolves to. Optional; audit/diagnostic only.</summary>
         [JsonPropertyName("subject")]
         public string? Subject { get; set; }
+
+        /// <summary>
+        /// The v2 per-family token material (<c>agent</c> / <c>plugin</c> / <c>legacy</c>).
+        /// <c>null</c> on a pure v1 document until it is adopted (read) / upgraded (write).
+        /// </summary>
+        [JsonPropertyName("families")]
+        public MachineCredentialFamilies? Families { get; set; }
+
+        /// <summary>
+        /// Unknown JSON fields captured on read and re-emitted on write, so a document written by a
+        /// newer schema survives a round-trip through this codec unharmed.
+        /// </summary>
+        [JsonExtensionData]
+        public Dictionary<string, JsonElement>? ExtensionData { get; set; }
+
+        /// <summary>
+        /// v1 read-compat (design 04 §1): when the document carries top-level token material but no
+        /// <see cref="Families"/>, interpret the top-level fields as <c>families.legacy</c> — a
+        /// credential whose <c>clientId</c> / <c>scope</c> are unknown by definition. Idempotent;
+        /// no-op on documents that already carry families.
+        /// </summary>
+        internal void AdoptLegacyTokens()
+        {
+            if (Families != null)
+                return;
+            if (AccessToken == null && RefreshToken == null && ExpiresAt == null)
+                return;
+
+            Families = new MachineCredentialFamilies
+            {
+                Legacy = new MachineCredentialFamily
+                {
+                    AccessToken = AccessToken,
+                    RefreshToken = RefreshToken,
+                    ExpiresAt = ExpiresAt,
+                },
+            };
+        }
+
+        /// <summary>
+        /// The family whose token material pre-v2 readers must see at the top level: the plugin
+        /// family, falling back to the legacy family when no plugin family exists (a v1-adopted
+        /// document's only plugin-plane credential). <c>null</c> for an agent-only document.
+        /// </summary>
+        internal MachineCredentialFamily? MirrorSource => Families?.Plugin ?? Families?.Legacy;
+
+        /// <summary>
+        /// Normalize the document to the v2 write contract (design 04 §1), in order:
+        /// v1 adoption (<see cref="AdoptLegacyTokens"/>), version upgrade
+        /// (<see cref="Version"/> becomes at least <see cref="CurrentVersion"/>; a newer version is
+        /// passed through), then the v1 compat mirror — the top-level token fields are re-stamped
+        /// from <see cref="MirrorSource"/> (cleared when the document has families but no
+        /// plugin-plane family, so a stale mirror never outlives its source).
+        /// Called by <see cref="MachineCredentialStore.Write"/> on every persist.
+        /// </summary>
+        internal void NormalizeForWrite()
+        {
+            AdoptLegacyTokens();
+
+            if (Version < CurrentVersion)
+                Version = CurrentVersion;
+
+            var mirror = MirrorSource;
+            AccessToken = mirror?.AccessToken;
+            RefreshToken = mirror?.RefreshToken;
+            ExpiresAt = mirror?.ExpiresAt;
+        }
     }
 }


### PR DESCRIPTION
Taskflow **unified-machine-auth**, task **b1-cs-store-v2** (security-critical). Implements the v2 store contract from design `04-credential-store-and-refresh.md` §1.

## What changed

- **v2 schema**: `families.{agent,plugin,legacy}` with per-family `clientId` + `scope` (`MachineCredentialFamilies` / `MachineCredentialFamily`).
- **v1 compat mirror**: every v2 write re-stamps the top-level `accessToken`/`refreshToken`/`expiresAt` from `families.plugin` (falling back to `families.legacy`; cleared for agent-only documents) so pre-v2 readers keep working during the transition window.
- **v1 read-compat**: a `{version:1}` document is interpreted as `families.legacy` on read; the first write upgrades it to v2 (+mirror). Versions newer than 2 pass through unchanged (no downgrade stamping).
- **Unknown-field preservation**: `[JsonExtensionData]` at the top level, the families container, and inside each family — fixes the shipped drop-on-read. Serializer options untouched (camelCase, null-omitting, indented); tests compare parsed values, never bytes.
- **Atomic writes** (replacing `File.WriteAllBytes`): temp sibling **in the same directory** → fsync → `File.Replace` (preserves the destination DACL) with a move fallback for the create case; **retry policy is part of the contract** — `RenameRetryAttempts = 5` (≥4), `RenameRetryDelayMs = 250` (≥250) on EBUSY/EPERM/EACCES-alike holders. Advisory parent-directory fsync on POSIX. The temp file is created `0600` before any secret byte lands.
- **Structured "store unreadable" state**: new `TryRead()` → `Missing` / `Ok` / `Unreadable`. DPAPI unprotect failure or a corrupted document never crashes, never deletes, never overwrites: `Rotate()` refuses on an unreadable store; an explicit re-auth `Write()` replaces it; `Read()` remains the lossy compat surface (null, never a throw). `Exists` documented as never being a signed-in signal.
- **`Rotate()` is family-aware**: rotates `families.plugin` (falling back to `legacy`, creating it on an empty store); the mirror follows on write.
- **DPAPI/POSIX unchanged**: CurrentUser, null entropy, `CRYPTPROTECT_UI_FORBIDDEN`; 0600/0700 re-asserted on the replace path.
- **CI**: the `test` job now runs on `ubuntu-latest` / `windows-latest` / `macos-latest` (the store's behaviour is OS-specific: DPAPI + rename/handle timing on Windows, permission asserts on POSIX). The docker-based result-publish step stays Linux-only; each leg uploads its own `.trx` artifact.

## Out of scope (per task boundaries)

- `ITokenRefresher`/refresh flow (task b3), lock protocol (task b2), NuGet release (task b4).

## Mandated plants (design 04 §5) — all RED-verified by mutation, then restored

| Plant | Mutation applied | Result |
|---|---|---|
| Atomicity | atomic write → direct `File.WriteAllBytes` | RED: concurrent readers observed truncation (5× "empty credential file") |
| Rename retry | retry filter disabled (single attempt) | RED: immediate sharing-violation `IOException` under a held destination handle |
| DPAPI corrupt fixture | `CryptographicException` catch removed | RED: 3 unreadable-state tests crash with `CryptographicException` |
| Unknown fields | `[JsonExtensionData]` removed at each of the 3 levels (3 runs) | RED each time: `KeyNotFoundException` on the preserved field |

Full suite after restore: **3032 passed, 0 failed** locally on Windows (net8.0 + net9.0; DPAPI and handle-holder legs exercised for real).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017azy3BykDQDSpxc5F51GAF
