### PR TITLE
feat(auth): C# cross-process lock protocol for the machine credential store (b2-cs-lock)

### DIFF
--- a/McpPlugin.Tests.LockHarness/McpPlugin.Tests.LockHarness.csproj
+++ b/McpPlugin.Tests.LockHarness/McpPlugin.Tests.LockHarness.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!-- Real-subprocess harness for the machine credential lock takeover plants (design 04 §5:
+       "Concurrency - real processes, not threads"). Referenced by McpPlugin.Tests, which spawns
+       it as an actual OS process to exercise kill -9 recovery, holder liveness, and the
+       two-waiter compare-and-delete race. Test infrastructure only - never packed. -->
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>11.0</LangVersion>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>com.IvanMurzak.McpPlugin.Tests.LockHarness</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../McpPlugin/McpPlugin.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/McpPlugin.Tests.LockHarness/Program.cs
+++ b/McpPlugin.Tests.LockHarness/Program.cs
@@ -1,0 +1,169 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using com.IvanMurzak.McpPlugin.AgentConfig;
+
+namespace com.IvanMurzak.McpPlugin.Tests.LockHarness
+{
+    /// <summary>
+    /// Subprocess harness for the machine-credential-lock takeover plants (design 04 §5 — real OS
+    /// processes, not threads). Spawned by <c>MachineCredentialLockTakeoverPlantTests</c>. Every
+    /// protocol-relevant event is reported as a machine-parseable stdout line stamped with a
+    /// wall-clock unix-ms timestamp, flushed immediately so the parent can react (e.g. kill -9 a
+    /// holder the moment it reports <c>ACQUIRED</c>).
+    ///
+    /// <para>Commands (all use the PUBLIC lock constructor — real contract constants):</para>
+    /// <list type="bullet">
+    ///   <item><c>hold &lt;baseDir&gt; &lt;holdMs&gt;</c> — acquire, report, sleep
+    ///         <c>holdMs</c> inside the critical section, verify the lock is still our own
+    ///         (<c>OWNED=…</c>), release. Exit 0 = held throughout; 2 = busy; 3 = stolen.</item>
+    ///   <item><c>acquire &lt;baseDir&gt; &lt;csHoldMs&gt; [--wait-go]</c> — acquire within the
+    ///         budget, prove exclusive entry via an exclusive-create sentinel
+    ///         (<c>cs.sentinel</c>), hold the critical section <c>csHoldMs</c>, release. Exit
+    ///         0 = clean exclusive run; 2 = busy; 4 = OVERLAP (a second holder was inside the
+    ///         critical section — mutual-exclusion violation). With <c>--wait-go</c> the process
+    ///         reports <c>READY</c> and spins until <c>go</c> appears in <c>baseDir</c> before
+    ///         acquiring — a start barrier so two waiters observe the SAME stale lock instead of
+    ///         being serialised by process-spawn jitter.</item>
+    /// </list>
+    /// </summary>
+    internal static class Program
+    {
+        private const int ExitOk = 0;
+        private const int ExitUsage = 1;
+        private const int ExitBusy = 2;
+        private const int ExitStolen = 3;
+        private const int ExitOverlap = 4;
+
+        /// <summary>Sentinel proving exclusive critical-section entry in the two-waiter plant.</summary>
+        private const string SentinelFileName = "cs.sentinel";
+
+        private static long NowUnixMs => DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+
+        private static void Report(string line)
+        {
+            Console.Out.WriteLine(line);
+            Console.Out.Flush(); // the parent test reacts to lines in real time — never buffer
+        }
+
+        private static int Main(string[] args)
+        {
+            if (args.Length < 3 || args.Length > 4)
+            {
+                Console.Error.WriteLine("usage: (hold|acquire) <baseDir> <milliseconds> [--wait-go]");
+                return ExitUsage;
+            }
+
+            var command = args[0];
+            var baseDir = args[1];
+            var milliseconds = int.Parse(args[2]);
+            var waitGo = args.Length == 4 && args[3] == "--wait-go";
+
+            switch (command)
+            {
+                case "hold":
+                    return Hold(baseDir, milliseconds);
+                case "acquire":
+                    return Acquire(baseDir, milliseconds, waitGo);
+                default:
+                    Console.Error.WriteLine("unknown command: " + command);
+                    return ExitUsage;
+            }
+        }
+
+        /// <summary>
+        /// Start barrier: report <c>READY</c>, then spin until the parent creates
+        /// <c>&lt;baseDir&gt;/go</c>. Lets the parent line up N waiters and release them within a
+        /// few milliseconds of each other.
+        /// </summary>
+        private static void AwaitGoSignal(string baseDir)
+        {
+            Report("READY t=" + NowUnixMs);
+            var goPath = Path.Combine(baseDir, "go");
+            var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(30);
+            while (!File.Exists(goPath))
+            {
+                if (DateTime.UtcNow > deadline)
+                    throw new TimeoutException("go signal never arrived at " + goPath);
+                Thread.Sleep(5);
+            }
+        }
+
+        private static int Hold(string baseDir, int holdMs)
+        {
+            var mutex = new MachineCredentialLock(baseDir);
+            var stopwatch = Stopwatch.StartNew();
+            var handle = mutex.TryAcquire();
+            if (handle == null)
+            {
+                Report("BUSY elapsed=" + stopwatch.ElapsedMilliseconds);
+                return ExitBusy;
+            }
+
+            Report("ACQUIRED t=" + NowUnixMs + " elapsed=" + stopwatch.ElapsedMilliseconds + " pid=" + Environment.ProcessId);
+
+            Thread.Sleep(holdMs); // the "refresh in flight" window — a kill -9 lands here
+
+            var owned = handle.IsStillOwned();
+            Report("OWNED=" + (owned ? "true" : "false") + " t=" + NowUnixMs);
+
+            handle.Dispose();
+            Report("RELEASED t=" + NowUnixMs);
+            return owned ? ExitOk : ExitStolen;
+        }
+
+        private static int Acquire(string baseDir, int csHoldMs, bool waitGo)
+        {
+            if (waitGo)
+                AwaitGoSignal(baseDir);
+
+            var mutex = new MachineCredentialLock(baseDir);
+            var stopwatch = Stopwatch.StartNew();
+            var handle = mutex.TryAcquire();
+            if (handle == null)
+            {
+                Report("BUSY elapsed=" + stopwatch.ElapsedMilliseconds);
+                return ExitBusy;
+            }
+
+            var acquiredAt = NowUnixMs;
+            Report("ACQUIRED t=" + acquiredAt + " elapsed=" + stopwatch.ElapsedMilliseconds + " pid=" + Environment.ProcessId);
+
+            // Exclusive-create sentinel: if a second process is inside the critical section at the
+            // same time, its CreateNew fails and it reports OVERLAP — the direct, cross-process
+            // proof of the mutual-exclusion property the two-waiter plant asserts.
+            var sentinelPath = Path.Combine(baseDir, SentinelFileName);
+            try
+            {
+                using (new FileStream(sentinelPath, FileMode.CreateNew, FileAccess.Write, FileShare.Read))
+                {
+                }
+            }
+            catch (IOException)
+            {
+                Report("OVERLAP t=" + NowUnixMs);
+                handle.Dispose();
+                return ExitOverlap;
+            }
+
+            Thread.Sleep(csHoldMs); // widen the critical-section window so an overlap is observable
+
+            File.Delete(sentinelPath);
+            handle.Dispose();
+            Report("DONE t=" + NowUnixMs);
+            return ExitOk;
+        }
+    }
+}

--- a/McpPlugin.Tests/AgentConfig/MachineCredentialLockTakeoverPlantTests.cs
+++ b/McpPlugin.Tests/AgentConfig/MachineCredentialLockTakeoverPlantTests.cs
@@ -1,0 +1,351 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using System.Threading;
+using com.IvanMurzak.McpPlugin.AgentConfig;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
+{
+    /// <summary>
+    /// The three mandated stale-takeover plants (design 04 §5), run with REAL OS subprocesses —
+    /// not threads — and the REAL contract constants (public constructor; no timing overrides):
+    /// <list type="number">
+    ///   <item>kill -9 the holder mid-refresh → survivors recover after
+    ///         <see cref="MachineCredentialLock.LOCK_STALE_MS"/> within
+    ///         <see cref="MachineCredentialLock.ACQUIRE_BUDGET"/>;</item>
+    ///   <item>a holder sleeping <see cref="MachineCredentialLock.REFRESH_HTTP_TIMEOUT"/> inside
+    ///         the lock is NOT taken over;</item>
+    ///   <item>two waiters observing the same stale lock never both acquire
+    ///         (compare-and-delete).</item>
+    /// </list>
+    /// The subprocess is <c>McpPlugin.Tests.LockHarness</c>, spawned via <c>dotnet</c>. These
+    /// tests are wall-clock slow BY DESIGN (the first waits through the real 60 s staleness
+    /// threshold): scaling the constants down would test a different protocol than the one that
+    /// ships.
+    /// </summary>
+    public sealed class MachineCredentialLockTakeoverPlantTests : IDisposable
+    {
+        private readonly string _baseDir;
+
+        public MachineCredentialLockTakeoverPlantTests()
+        {
+            _baseDir = Path.Combine(Path.GetTempPath(), "agd-lock-plant-" + Guid.NewGuid().ToString("N"), ".ai-game-dev");
+            Directory.CreateDirectory(_baseDir);
+        }
+
+        public void Dispose()
+        {
+            var parent = Path.GetDirectoryName(_baseDir);
+            try
+            {
+                if (parent != null && Directory.Exists(parent))
+                    Directory.Delete(parent, recursive: true);
+            }
+            catch (IOException)
+            {
+                // A straggler subprocess may still hold a file for a moment; temp dirs are
+                // OS-cleaned eventually. Never fail a plant on teardown.
+            }
+        }
+
+        private string LockPath => Path.Combine(_baseDir, MachineCredentialLock.LockFileName);
+
+        // ── Plant 1: kill -9 recovery ───────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Mandated plant (04 §5): kill -9 the holder mid-refresh; a survivor recovers after
+        /// <c>LOCK_STALE_MS</c> within <c>ACQUIRE_BUDGET</c>. RED when the stale-takeover path is
+        /// removed (the survivor stays busy for the full budget and exits 2). The lower time
+        /// bound proves the takeover was not premature; the budget bound proves it is reachable —
+        /// the ordering invariant, live.
+        /// </summary>
+        [Fact]
+        public void KillNineHolder_SurvivorRecoversAfterStaleThreshold_WithinBudget()
+        {
+            using var holder = HarnessProcess.Start("hold", _baseDir, 600_000);
+            holder.WaitForLine("ACQUIRED", TimeSpan.FromSeconds(60));
+
+            var lockMtimeUtc = File.GetLastWriteTimeUtc(LockPath);
+            holder.Kill(); // TerminateProcess / SIGKILL: no finally blocks, no release — a crash
+            File.Exists(LockPath).ShouldBeTrue("the killed holder must leave its lock file behind");
+
+            using var survivor = HarnessProcess.Start("acquire", _baseDir, 100);
+            survivor.WaitForExit(TimeSpan.FromMilliseconds(MachineCredentialLock.ACQUIRE_BUDGET + 45_000));
+
+            survivor.ExitCode.ShouldBe(0, "survivor output: " + survivor.Describe());
+            var acquiredLine = survivor.Lines.First(l => l.StartsWith("ACQUIRED", StringComparison.Ordinal));
+
+            // Not premature: the survivor entered only once the dead holder's lock had aged past
+            // LOCK_STALE_MS (2 s tolerance for filesystem timestamp granularity).
+            var acquiredAtUtc = DateTimeOffset.FromUnixTimeMilliseconds(ParseT(acquiredLine)).UtcDateTime;
+            (acquiredAtUtc - lockMtimeUtc).TotalMilliseconds
+                .ShouldBeGreaterThanOrEqualTo(MachineCredentialLock.LOCK_STALE_MS - 2_000);
+
+            // Within budget: recovery is reachable (LOCK_STALE_MS < ACQUIRE_BUDGET).
+            ParseElapsed(acquiredLine).ShouldBeLessThanOrEqualTo(MachineCredentialLock.ACQUIRE_BUDGET);
+
+            File.Exists(LockPath).ShouldBeFalse("the survivor completed its critical section and released");
+        }
+
+        // ── Plant 2: a live holder inside one HTTP call is never declared stale ─────────────────
+
+        /// <summary>
+        /// Mandated plant (04 §5): a holder sleeping <c>REFRESH_HTTP_TIMEOUT</c> (the longest a
+        /// refresh HTTP call may take) inside the lock is NOT taken over. The holder itself
+        /// proves it — after the sleep it re-reads the lock and reports <c>OWNED=true</c> only if
+        /// the document is still byte-identical to its own. RED when the ordering invariant
+        /// <c>REFRESH_HTTP_TIMEOUT &lt; LOCK_STALE_MS</c> is broken (a waiter steals the lock
+        /// mid-hold and the holder exits 3 with <c>OWNED=false</c>).
+        /// </summary>
+        [Fact]
+        public void HolderSleepingRefreshHttpTimeout_IsNotTakenOver()
+        {
+            using var holder = HarnessProcess.Start("hold", _baseDir, MachineCredentialLock.REFRESH_HTTP_TIMEOUT);
+            var holderAcquired = holder.WaitForLine("ACQUIRED", TimeSpan.FromSeconds(60));
+
+            // The waiter runs CONCURRENTLY with the ~15 s hold and must simply wait it out.
+            using var waiter = HarnessProcess.Start("acquire", _baseDir, 100);
+
+            holder.WaitForExit(TimeSpan.FromSeconds(90));
+            waiter.WaitForExit(TimeSpan.FromSeconds(120));
+
+            holder.ExitCode.ShouldBe(0, "holder output: " + holder.Describe());
+            holder.Lines.Any(l => l.StartsWith("OWNED=true", StringComparison.Ordinal))
+                .ShouldBeTrue("the holder must hold its own lock through the whole simulated refresh: " + holder.Describe());
+
+            waiter.ExitCode.ShouldBe(0, "waiter output: " + waiter.Describe());
+            var waiterAcquired = waiter.Lines.First(l => l.StartsWith("ACQUIRED", StringComparison.Ordinal));
+            var holderReleasedAt = ParseT(holder.Lines.First(l => l.StartsWith("RELEASED", StringComparison.Ordinal)));
+
+            // The waiter entered only AFTER the holder released — never by takeover (100 ms
+            // tolerance for cross-process wall-clock reads).
+            ParseT(waiterAcquired).ShouldBeGreaterThanOrEqualTo(holderReleasedAt - 100);
+
+            // Anti-vacuity: the waiter genuinely overlapped the hold (it spent most of the 15 s
+            // window waiting) — a waiter that started after the release would prove nothing.
+            ParseElapsed(waiterAcquired).ShouldBeGreaterThanOrEqualTo(8_000);
+            ParseT(waiterAcquired).ShouldBeGreaterThanOrEqualTo(ParseT(holderAcquired));
+        }
+
+        // ── Plant 3: two waiters on the SAME stale lock — compare-and-delete ────────────────────
+
+        /// <summary>
+        /// Mandated plant (04 §5): two waiters observing the same stale lock must not both
+        /// acquire. Both are held at a start barrier and released together so they race the SAME
+        /// candidate (spawn jitter would otherwise serialise them trivially). Exclusive entry is
+        /// proven by an exclusive-create sentinel inside the critical section (<c>OVERLAP</c>
+        /// when violated) plus the sequential-timing assertion. Three rounds, because the
+        /// interleaving that compare-and-delete + verify-own-content exists to stop (waiter B
+        /// deleting waiter A's FRESH lock straight after A's create) is scheduling-dependent —
+        /// removing the guards turns this RED via OVERLAP within a few rounds.
+        /// </summary>
+        [Fact]
+        public void TwoWaitersOnTheSameStaleLock_NeverBothAcquire()
+        {
+            const int rounds = 3;
+            const int csHoldMs = 1_500;
+            var localHostId = new MachineCredentialLock(_baseDir).HostId;
+
+            for (var round = 1; round <= rounds; round++)
+            {
+                var roundDir = Path.Combine(_baseDir, "round-" + round);
+                Directory.CreateDirectory(roundDir);
+                var lockPath = Path.Combine(roundDir, MachineCredentialLock.LockFileName);
+
+                // The shared stale candidate: local hostId (so the 60 s bar applies), aged well
+                // past LOCK_STALE_MS, from a pid that no longer exists.
+                File.WriteAllText(lockPath,
+                    "{\"pid\":424242,\"startedAt\":\"2026-01-01T00:00:00.0000000+00:00\",\"hostId\":" +
+                    JsonSerializer.Serialize(localHostId) + "}");
+                File.SetLastWriteTimeUtc(lockPath,
+                    DateTime.UtcNow - TimeSpan.FromMilliseconds(MachineCredentialLock.LOCK_STALE_MS + 30_000));
+
+                using var waiterA = HarnessProcess.Start("acquire", roundDir, csHoldMs, waitGo: true);
+                using var waiterB = HarnessProcess.Start("acquire", roundDir, csHoldMs, waitGo: true);
+                waiterA.WaitForLine("READY", TimeSpan.FromSeconds(60));
+                waiterB.WaitForLine("READY", TimeSpan.FromSeconds(60));
+                File.WriteAllText(Path.Combine(roundDir, "go"), "go"); // release the barrier
+
+                waiterA.WaitForExit(TimeSpan.FromSeconds(150));
+                waiterB.WaitForExit(TimeSpan.FromSeconds(150));
+
+                var context = "round " + round + "; A: " + waiterA.Describe() + "; B: " + waiterB.Describe();
+
+                // Mutual exclusion, directly: nobody ever found the critical-section sentinel taken.
+                waiterA.Lines.Any(l => l.StartsWith("OVERLAP", StringComparison.Ordinal)).ShouldBeFalse(context);
+                waiterB.Lines.Any(l => l.StartsWith("OVERLAP", StringComparison.Ordinal)).ShouldBeFalse(context);
+                waiterA.ExitCode.ShouldBe(0, context);
+                waiterB.ExitCode.ShouldBe(0, context);
+
+                // Sequential, not simultaneous: the second entry began only after the first
+                // waiter's full 1.5 s critical section (100 ms cross-process clock tolerance).
+                var tA = ParseT(waiterA.Lines.First(l => l.StartsWith("ACQUIRED", StringComparison.Ordinal)));
+                var tB = ParseT(waiterB.Lines.First(l => l.StartsWith("ACQUIRED", StringComparison.Ordinal)));
+                Math.Abs(tA - tB).ShouldBeGreaterThanOrEqualTo(csHoldMs - 100, context);
+
+                // Anti-vacuity: the FIRST entrant got in fast, via the stale-takeover path — not
+                // by both waiters timing into some slower route.
+                var firstElapsed = Math.Min(
+                    ParseElapsed(waiterA.Lines.First(l => l.StartsWith("ACQUIRED", StringComparison.Ordinal))),
+                    ParseElapsed(waiterB.Lines.First(l => l.StartsWith("ACQUIRED", StringComparison.Ordinal))));
+                firstElapsed.ShouldBeLessThan(15_000, context);
+            }
+        }
+
+        // ── Harness plumbing ────────────────────────────────────────────────────────────────────
+
+        private static long ParseT(string line)
+        {
+            var match = Regex.Match(line, @"\bt=(\d+)");
+            match.Success.ShouldBeTrue("no t= in line: " + line);
+            return long.Parse(match.Groups[1].Value);
+        }
+
+        private static long ParseElapsed(string line)
+        {
+            var match = Regex.Match(line, @"\belapsed=(\d+)");
+            match.Success.ShouldBeTrue("no elapsed= in line: " + line);
+            return long.Parse(match.Groups[1].Value);
+        }
+
+        /// <summary>
+        /// A running lock-harness subprocess (<c>dotnet McpPlugin.Tests.LockHarness.dll …</c>)
+        /// with line-buffered stdout capture the test can wait on in real time.
+        /// </summary>
+        private sealed class HarnessProcess : IDisposable
+        {
+            private readonly Process _process;
+            private readonly List<string> _lines = new();
+            private readonly StringBuilder _stderr = new();
+            private readonly object _gate = new();
+
+            public static HarnessProcess Start(string command, string baseDir, int milliseconds, bool waitGo = false)
+            {
+                var harnessDll = Path.Combine(AppContext.BaseDirectory, "McpPlugin.Tests.LockHarness.dll");
+                File.Exists(harnessDll).ShouldBeTrue(
+                    "lock harness not found at " + harnessDll + " — is the McpPlugin.Tests.LockHarness ProjectReference intact?");
+
+                var startInfo = new ProcessStartInfo
+                {
+                    FileName = "dotnet",
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    WorkingDirectory = AppContext.BaseDirectory,
+                };
+                startInfo.ArgumentList.Add(harnessDll);
+                startInfo.ArgumentList.Add(command);
+                startInfo.ArgumentList.Add(baseDir);
+                startInfo.ArgumentList.Add(milliseconds.ToString());
+                if (waitGo)
+                    startInfo.ArgumentList.Add("--wait-go");
+
+                return new HarnessProcess(startInfo);
+            }
+
+            private HarnessProcess(ProcessStartInfo startInfo)
+            {
+                _process = new Process { StartInfo = startInfo };
+                _process.OutputDataReceived += (_, e) =>
+                {
+                    if (e.Data == null)
+                        return;
+                    lock (_gate)
+                    {
+                        _lines.Add(e.Data);
+                        Monitor.PulseAll(_gate);
+                    }
+                };
+                _process.ErrorDataReceived += (_, e) =>
+                {
+                    if (e.Data != null)
+                        _stderr.AppendLine(e.Data);
+                };
+                _process.Start();
+                _process.BeginOutputReadLine();
+                _process.BeginErrorReadLine();
+            }
+
+            public IReadOnlyList<string> Lines
+            {
+                get
+                {
+                    lock (_gate)
+                        return _lines.ToArray();
+                }
+            }
+
+            public int ExitCode => _process.ExitCode;
+
+            public string Describe()
+            {
+                lock (_gate)
+                    return "stdout=[" + string.Join(" | ", _lines) + "] stderr=[" + _stderr.ToString().Trim() + "]";
+            }
+
+            public string WaitForLine(string prefix, TimeSpan timeout)
+            {
+                var deadlineUtc = DateTime.UtcNow + timeout;
+                lock (_gate)
+                {
+                    while (true)
+                    {
+                        var match = _lines.FirstOrDefault(l => l.StartsWith(prefix, StringComparison.Ordinal));
+                        if (match != null)
+                            return match;
+                        var remaining = deadlineUtc - DateTime.UtcNow;
+                        if (remaining <= TimeSpan.Zero)
+                            throw new TimeoutException(
+                                "no '" + prefix + "' line within " + timeout + "; " + DescribeUnlocked());
+                        Monitor.Wait(_gate, remaining);
+                    }
+                }
+            }
+
+            private string DescribeUnlocked() =>
+                "stdout=[" + string.Join(" | ", _lines) + "] stderr=[" + _stderr.ToString().Trim() + "]";
+
+            public void Kill()
+            {
+                _process.Kill();
+                _process.WaitForExit();
+            }
+
+            public void WaitForExit(TimeSpan timeout)
+            {
+                _process.WaitForExit((int)timeout.TotalMilliseconds)
+                    .ShouldBeTrue("harness did not exit within " + timeout + "; " + Describe());
+                _process.WaitForExit(); // flush the async output readers (documented overload quirk)
+            }
+
+            public void Dispose()
+            {
+                try
+                {
+                    if (!_process.HasExited)
+                        _process.Kill();
+                }
+                catch (InvalidOperationException)
+                {
+                }
+                _process.Dispose();
+            }
+        }
+    }
+}

--- a/McpPlugin.Tests/AgentConfig/MachineCredentialLockTakeoverPlantTests.cs
+++ b/McpPlugin.Tests/AgentConfig/MachineCredentialLockTakeoverPlantTests.cs
@@ -23,6 +23,17 @@ using Xunit;
 namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
 {
     /// <summary>
+    /// Serialises the lock takeover plants against the WHOLE test suite
+    /// (<c>DisableParallelization</c>): their real-subprocess spawns must not share the runner's
+    /// cores with timing-sensitive tests in other collections.
+    /// </summary>
+    [CollectionDefinition(Name, DisableParallelization = true)]
+    public sealed class MachineCredentialLockTakeoverPlantCollection
+    {
+        public const string Name = "MachineCredentialLock takeover plants (real subprocesses)";
+    }
+
+    /// <summary>
     /// The three mandated stale-takeover plants (design 04 §5), run with REAL OS subprocesses —
     /// not threads — and the REAL contract constants (public constructor; no timing overrides):
     /// <list type="number">
@@ -38,7 +49,14 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
     /// tests are wall-clock slow BY DESIGN (the first waits through the real 60 s staleness
     /// threshold): scaling the constants down would test a different protocol than the one that
     /// ships.
+    ///
+    /// <para>The class runs in its own <b>non-parallel</b> collection: each subprocess spawn is a
+    /// CPU burst (dotnet host + JIT) that, interleaved with the rest of the suite on a 2-core CI
+    /// runner, starves other timing-sensitive tests — observed as
+    /// <c>MachineCredentialStoreAtomicityTests.Write_RetriesUntilDestinationHandleReleased_Windows</c>
+    /// exhausting its rename-retry window because the 600 ms holder-release task woke late.</para>
     /// </summary>
+    [Collection(MachineCredentialLockTakeoverPlantCollection.Name)]
     public sealed class MachineCredentialLockTakeoverPlantTests : IDisposable
     {
         private readonly string _baseDir;

--- a/McpPlugin.Tests/AgentConfig/MachineCredentialLockTests.cs
+++ b/McpPlugin.Tests/AgentConfig/MachineCredentialLockTests.cs
@@ -109,6 +109,18 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
             root.GetProperty("lockStaleMs").GetInt32().ShouldBe(MachineCredentialLock.LOCK_STALE_MS);
             root.GetProperty("acquireBudgetMs").GetInt32().ShouldBe(MachineCredentialLock.ACQUIRE_BUDGET);
             root.GetProperty("foreignLockStaleMs").GetInt64().ShouldBe(MachineCredentialLock.FOREIGN_HOST_STALE_MS);
+            root.GetProperty("hostIdCompare").GetString().ShouldBe("case-insensitive");
+
+            // The vector's field list must match what an acquisition ACTUALLY writes, in order.
+            var vectorFields = root.GetProperty("lockDocumentFields").EnumerateArray()
+                .Select(e => e.GetString()).ToArray();
+            var mutex = NewLock();
+            using (var handle = mutex.TryAcquire())
+            {
+                handle.ShouldNotBeNull();
+                using var lockDoc = JsonDocument.Parse(File.ReadAllText(LockPath));
+                lockDoc.RootElement.EnumerateObject().Select(p => p.Name).ToArray().ShouldBe(vectorFields);
+            }
         }
 
         [Fact]
@@ -344,6 +356,59 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
             File.ReadAllText(LockPath).ShouldBe("not json at all");
         }
 
+        [Fact]
+        public void Classifier_MirrorsTheTsTwin()
+        {
+            // One shared classifier for lock AND intent documents, byte-for-byte semantics with
+            // the TS twin's classifyLockDocument: JSON-object-ness is the parseability criterion
+            // and hostId ALONE drives local-vs-foreign.
+            var mutex = NewLock();
+            var cls = new Func<string, MachineCredentialLock.LockDocumentClass>(
+                json => mutex.ClassifyLockDocument(Encoding.UTF8.GetBytes(json)));
+
+            cls("").ShouldBe(MachineCredentialLock.LockDocumentClass.Unparseable);              // zero-byte
+            cls("not json").ShouldBe(MachineCredentialLock.LockDocumentClass.Unparseable);      // corrupted
+            cls("42").ShouldBe(MachineCredentialLock.LockDocumentClass.Unparseable);            // valid JSON, non-object
+            cls("[1,2]").ShouldBe(MachineCredentialLock.LockDocumentClass.Unparseable);         // valid JSON, array
+            cls("{\"pid\":1}").ShouldBe(MachineCredentialLock.LockDocumentClass.Foreign);       // object, no hostId
+            cls("{\"hostId\":\"\"}").ShouldBe(MachineCredentialLock.LockDocumentClass.Foreign); // empty hostId
+            cls("{\"hostId\":42}").ShouldBe(MachineCredentialLock.LockDocumentClass.Foreign);   // non-string hostId
+            cls("{\"hostId\":\"another-host\"}").ShouldBe(MachineCredentialLock.LockDocumentClass.Foreign);
+            // hostId alone decides — no pid/startedAt shape requirement (mirror), ordinal
+            // case-insensitive comparison (the pinned cross-language semantic).
+            cls("{\"hostId\":" + JsonSerializer.Serialize(mutex.HostId.ToUpperInvariant()) + "}")
+                .ShouldBe(MachineCredentialLock.LockDocumentClass.Local);
+        }
+
+        [Fact]
+        public void ValidJsonNonObjectLock_ClassifiesUnparseable_AndIsStaleEligibleAtTheLocalBar()
+        {
+            // End-to-end for the classifier mirror: an alien-but-valid-JSON artifact (an array)
+            // is Unparseable → 60 s bar, not 24 h.
+            PlantFile(LockPath, "[1,2,3]", TimeSpan.FromMinutes(5));
+
+            using var handle = NewLock(budgetMs: 10_000).TryAcquire();
+            handle.ShouldNotBeNull();
+        }
+
+        [Fact]
+        public void ZeroByteIntent_DoesNotWedgeTakeoverFor24Hours()
+        {
+            // The intent-side half of the B2 amendment: a zero-byte intent from a killed creator
+            // is recovered at the 60 s bar (silently — the diagnostic asymmetry is deliberate:
+            // only unparseable LOCK takeover warns), so takeover proceeds.
+            var warnings = new List<string>();
+            var mutex = NewLock(budgetMs: 10_000, diagnostics: warnings.Add);
+            PlantLock(mutex.HostId, StalePastLocalBar);
+            PlantFile(IntentPath, "", StalePastLocalBar); // killed intent creator
+
+            using var handle = mutex.TryAcquire();
+
+            handle.ShouldNotBeNull();          // recovered + taken over within the budget
+            File.Exists(IntentPath).ShouldBeFalse();
+            warnings.ShouldBeEmpty();          // intent recovery is silent; the LOCK was parseable
+        }
+
         // ── The takeover-intent arbiter ─────────────────────────────────────────────────────────
 
         [Fact]
@@ -363,6 +428,57 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
 
             File.ReadAllBytes(LockPath).ShouldBe(lockBytes);     // stale lock untouched
             File.ReadAllBytes(IntentPath).ShouldBe(intentBytes); // live intent untouched
+        }
+
+        [Fact]
+        public void IntentReadBack_DetectsADisplacedIntent_BeforeRelyingOnIt()
+        {
+            // Deterministic pin for the intent READ-BACK control (its deletion is otherwise
+            // invisible: the pre-removal re-verify downstream masks it). Choreography: displace
+            // the intent between create and read-back, and RESTORE our bytes at the later seam —
+            // so ONLY the read-back can catch the displacement. With the control present the
+            // claimant walks away busy; with it deleted, the restored intent sails through the
+            // pre-removal re-verify and the takeover completes — RED.
+            var mutex = NewLock(budgetMs: 1_500);
+            PlantLock(mutex.HostId, StalePastLocalBar);
+            var peerBytes = Encoding.UTF8.GetBytes(WellFormedDocument(mutex.HostId, pid: "999999"));
+            byte[]? ourIntentBytes = null;
+            mutex.AfterIntentCreateInjection = () =>
+            {
+                ourIntentBytes = File.ReadAllBytes(IntentPath); // capture OUR intent…
+                File.WriteAllBytes(IntentPath, peerBytes);      // …then a racing recovery displaces it
+            };
+            mutex.AfterIntentAcquiredInjection = () => File.WriteAllBytes(IntentPath, ourIntentBytes!);
+
+            mutex.TryAcquire().ShouldBeNull(); // the displaced arbiter is not ours — back off, busy
+
+            ourIntentBytes.ShouldNotBeNull();       // anti-vacuity: the create path actually ran
+            File.Exists(LockPath).ShouldBeTrue();   // the stale lock was never removed
+        }
+
+        [Fact]
+        public void PreRemovalIntentReVerify_AbortsWhenTheArbiterIsDisplaced_AfterAcquisition()
+        {
+            // Deterministic pin for the PRE-REMOVAL ownership re-verify: a crashed-intent
+            // recovery displaces our intent after acquisition but before the removal — the
+            // removal authority is no longer ours, so the claimant must abort without touching
+            // the stale lock or the displaced intent. With the control deleted, the takeover
+            // proceeds under a stolen arbiter and acquires — RED.
+            var mutex = NewLock(budgetMs: 1_500);
+            PlantLock(mutex.HostId, StalePastLocalBar);
+            var peerBytes = Encoding.UTF8.GetBytes(WellFormedDocument(mutex.HostId, pid: "999999"));
+            var fired = 0;
+            mutex.AfterIntentAcquiredInjection = () =>
+            {
+                fired++;
+                File.WriteAllBytes(IntentPath, peerBytes);
+            };
+
+            mutex.TryAcquire().ShouldBeNull(); // busy — never act under a stolen arbiter
+
+            fired.ShouldBeGreaterThanOrEqualTo(1);        // anti-vacuity: acquisition happened
+            File.Exists(LockPath).ShouldBeTrue();         // stale lock untouched
+            File.ReadAllBytes(IntentPath).ShouldBe(peerBytes); // the displaced intent was respected
         }
 
         [Fact]

--- a/McpPlugin.Tests/AgentConfig/MachineCredentialLockTests.cs
+++ b/McpPlugin.Tests/AgentConfig/MachineCredentialLockTests.cs
@@ -8,10 +8,13 @@
 └────────────────────────────────────────────────────────────────────────┘
 */
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using com.IvanMurzak.McpPlugin.AgentConfig;
 using Shouldly;
 using Xunit;
@@ -19,10 +22,14 @@ using Xunit;
 namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
 {
     /// <summary>
-    /// The cross-process lock protocol (design 04 §2) — in-process halves: the shared
-    /// cross-language constant contract, acquire/release document semantics, the busy path
-    /// (never lock-free, D9 REVISED), the local-vs-foreign staleness bar, guarded release, and
-    /// the F6 logout delete path. The three mandated takeover plants run as REAL subprocesses in
+    /// The cross-process lock protocol (design 04 §2 + the owner-adopted b2/c2 review amendments)
+    /// — in-process halves: the shared cross-language constant contract (pinned against
+    /// <c>LockProtocol.GoldenVectors.json</c>), acquire/release document semantics (incl. the
+    /// per-acquisition nonce), the busy path (never lock-free, D9 REVISED), the staleness bars
+    /// (local 60 s / foreign 24 h / unparseable 60 s per the B2 amendment), the takeover-intent
+    /// arbiter (deterministic live-intent backoff + crashed-intent recovery), the B1
+    /// own-artifact cleanup, guarded release, and the F6 logout delete path. The three mandated
+    /// takeover plants run as REAL subprocesses in
     /// <see cref="MachineCredentialLockTakeoverPlantTests"/>.
     /// Tests that exercise waiting paths use the internal timing-override constructor so they do
     /// not consume the real 75 s budget; the contract constants themselves are pinned below.
@@ -44,24 +51,33 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
         }
 
         private string LockPath => Path.Combine(_baseDir, MachineCredentialLock.LockFileName);
+        private string IntentPath => Path.Combine(_baseDir, MachineCredentialLock.TakeoverIntentFileName);
 
-        private MachineCredentialLock NewLock() => new(_baseDir);
+        private MachineCredentialLock NewLock(Action<string>? diagnostics = null) => new(_baseDir, null, diagnostics);
 
-        private MachineCredentialLock NewLock(int budgetMs, string? hostId = null) =>
+        private MachineCredentialLock NewLock(int budgetMs, string? hostId = null, Action<string>? diagnostics = null) =>
             new(_baseDir, hostId,
                 acquireBudgetMs: budgetMs,
                 staleMs: MachineCredentialLock.LOCK_STALE_MS,
-                foreignStaleMs: MachineCredentialLock.FOREIGN_HOST_STALE_MS);
+                foreignStaleMs: MachineCredentialLock.FOREIGN_HOST_STALE_MS,
+                diagnostics: diagnostics);
 
-        /// <summary>Plant a lock file with the given hostId, aged by <paramref name="age"/>.</summary>
-        private void PlantLock(string hostId, TimeSpan age, string pid = "424242")
+        /// <summary>Well-formed lock document JSON with the given hostId (no nonce — shape only needs pid/startedAt/hostId).</summary>
+        private static string WellFormedDocument(string hostId, string pid = "424242") =>
+            "{\"pid\":" + pid + ",\"startedAt\":\"2026-01-01T00:00:00.0000000+00:00\",\"hostId\":" +
+            JsonSerializer.Serialize(hostId) + "}";
+
+        /// <summary>Plant a protocol file with the given content, aged by <paramref name="age"/>.</summary>
+        private void PlantFile(string path, string content, TimeSpan age)
         {
             Directory.CreateDirectory(_baseDir);
-            File.WriteAllText(LockPath,
-                "{\"pid\":" + pid + ",\"startedAt\":\"2026-01-01T00:00:00.0000000+00:00\",\"hostId\":" +
-                JsonSerializer.Serialize(hostId) + "}");
-            File.SetLastWriteTimeUtc(LockPath, DateTime.UtcNow - age);
+            File.WriteAllText(path, content);
+            File.SetLastWriteTimeUtc(path, DateTime.UtcNow - age);
         }
+
+        private void PlantLock(string hostId, TimeSpan age) => PlantFile(LockPath, WellFormedDocument(hostId), age);
+
+        private static readonly TimeSpan StalePastLocalBar = TimeSpan.FromMilliseconds(MachineCredentialLock.LOCK_STALE_MS * 2);
 
         // ── Shared cross-language constant contract (04 §2; asserted against TS by x1) ──────────
 
@@ -74,6 +90,25 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
             MachineCredentialLock.ACQUIRE_BUDGET.ShouldBe(75_000);
             MachineCredentialLock.FOREIGN_HOST_STALE_MS.ShouldBe(86_400_000L);
             MachineCredentialLock.LockFileName.ShouldBe("credentials.lock");
+            MachineCredentialLock.TakeoverIntentFileName.ShouldBe("credentials.lock.takeover");
+        }
+
+        [Fact]
+        public void Constants_MatchTheCommittedGoldenVector()
+        {
+            // The same document the TS twin pins (test/golden-vectors/LockProtocol.GoldenVectors.json
+            // in cli-core) — x1 asserts both sides against it, parsed-value comparison (04 §5).
+            var path = Path.Combine(AppContext.BaseDirectory, "LockProtocol.GoldenVectors.json");
+            File.Exists(path).ShouldBeTrue("golden vector missing from test output: " + path);
+
+            using var document = JsonDocument.Parse(File.ReadAllText(path));
+            var root = document.RootElement;
+            root.GetProperty("lockFileName").GetString().ShouldBe(MachineCredentialLock.LockFileName);
+            root.GetProperty("takeoverIntentFileName").GetString().ShouldBe(MachineCredentialLock.TakeoverIntentFileName);
+            root.GetProperty("refreshHttpTimeoutMs").GetInt32().ShouldBe(MachineCredentialLock.REFRESH_HTTP_TIMEOUT);
+            root.GetProperty("lockStaleMs").GetInt32().ShouldBe(MachineCredentialLock.LOCK_STALE_MS);
+            root.GetProperty("acquireBudgetMs").GetInt32().ShouldBe(MachineCredentialLock.ACQUIRE_BUDGET);
+            root.GetProperty("foreignLockStaleMs").GetInt64().ShouldBe(MachineCredentialLock.FOREIGN_HOST_STALE_MS);
         }
 
         [Fact]
@@ -88,19 +123,22 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
         }
 
         [Fact]
-        public void LockFile_IsASiblingOfTheCredentialFile_NeverTheDataFileItself()
+        public void LockAndIntent_AreSiblingsOfTheCredentialFile_NeverTheDataFileItself()
         {
             var mutex = NewLock();
             var store = new MachineCredentialStore(_baseDir);
 
             Path.GetDirectoryName(mutex.LockPath).ShouldBe(Path.GetDirectoryName(store.CredentialsPath));
+            Path.GetDirectoryName(mutex.TakeoverIntentPath).ShouldBe(Path.GetDirectoryName(store.CredentialsPath));
             mutex.LockPath.ShouldNotBe(store.CredentialsPath);
+            mutex.TakeoverIntentPath.ShouldNotBe(store.CredentialsPath);
+            mutex.TakeoverIntentPath.ShouldNotBe(mutex.LockPath);
         }
 
         // ── Acquire / release document semantics ────────────────────────────────────────────────
 
         [Fact]
-        public void Acquire_WritesPidStartedAtHostId_AndReleaseDeletesTheLock()
+        public void Acquire_WritesExactlyPidStartedAtHostIdNonce_AndReleaseDeletesTheLock()
         {
             var mutex = NewLock();
 
@@ -110,14 +148,45 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
                 File.Exists(LockPath).ShouldBeTrue();
 
                 using var document = JsonDocument.Parse(File.ReadAllText(LockPath));
-                document.RootElement.GetProperty("pid").GetInt64()
-                    .ShouldBe(Environment.ProcessId);
+                var names = document.RootElement.EnumerateObject().Select(p => p.Name).OrderBy(n => n).ToArray();
+                names.ShouldBe(new[] { "hostId", "nonce", "pid", "startedAt" }); // the shared doc shape (x1)
+
+                document.RootElement.GetProperty("pid").GetInt64().ShouldBe(Environment.ProcessId);
                 document.RootElement.GetProperty("hostId").GetString().ShouldBe(mutex.HostId);
                 DateTimeOffset.Parse(document.RootElement.GetProperty("startedAt").GetString()!)
                     .ShouldBeGreaterThan(DateTimeOffset.UtcNow.AddMinutes(-1));
+                // Nonce: fresh random 128-bit hex per acquisition attempt.
+                Regex.IsMatch(document.RootElement.GetProperty("nonce").GetString()!, "^[0-9a-f]{32}$").ShouldBeTrue();
             }
 
             File.Exists(LockPath).ShouldBeFalse(); // release = delete the lock file (04 §2)
+        }
+
+        [Fact]
+        public void Acquire_UsesAFreshNoncePerAcquisition()
+        {
+            var mutex = NewLock();
+
+            string NonceOfCurrentLock()
+            {
+                using var document = JsonDocument.Parse(File.ReadAllText(LockPath));
+                return document.RootElement.GetProperty("nonce").GetString()!;
+            }
+
+            string first;
+            using (var handle = mutex.TryAcquire())
+            {
+                handle.ShouldNotBeNull();
+                first = NonceOfCurrentLock();
+            }
+            using (var handle = mutex.TryAcquire())
+            {
+                handle.ShouldNotBeNull();
+                // Same process, same instance, possibly the same clock tick — the nonce is what
+                // keeps the two documents distinct (review A2: byte-identical verify-own must
+                // never confuse two attempts).
+                NonceOfCurrentLock().ShouldNotBe(first);
+            }
         }
 
         [Fact]
@@ -132,6 +201,20 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
             // handle at all.
             var bytes = File.ReadAllBytes(LockPath);
             bytes.Length.ShouldBeGreaterThan(0);
+        }
+
+        [Fact]
+        public void Parser_ToleratesUnknownFields_InTheLockDocument()
+        {
+            // A future twin may extend the document; extra fields must not demote a local doc to
+            // the foreign bar. Planted: well-formed + local hostId + unknown fields, stale.
+            PlantFile(LockPath,
+                "{\"pid\":1,\"startedAt\":\"2026-01-01T00:00:00Z\",\"hostId\":" +
+                JsonSerializer.Serialize(NewLock().HostId) + ",\"nonce\":\"aa\",\"futureField\":123}",
+                StalePastLocalBar);
+
+            using var handle = NewLock(budgetMs: 10_000).TryAcquire();
+            handle.ShouldNotBeNull(); // local bar applied despite unknown fields
         }
 
         // ── Busy: budget exhaustion is a failure, never lock-free (04 §2, D9 REVISED) ───────────
@@ -157,27 +240,39 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
             File.GetLastWriteTimeUtc(LockPath).ShouldBe(originalMtime); // …and untouched
         }
 
-        // ── Staleness: local 60 s bar, foreign/unparseable 24 h bar (04 §2) ─────────────────────
+        // ── Staleness bars: local 60 s / foreign 24 h / unparseable 60 s (B2 amendment) ─────────
 
         [Fact]
-        public void StaleLocalLock_IsTakenOver_AndTheNewLockIsOurOwn()
+        public void StaleLocalLock_IsTakenOver_AndTheIntentIsCleanedUp()
         {
             var mutex = NewLock(budgetMs: 10_000);
-            PlantLock(mutex.HostId, age: TimeSpan.FromMilliseconds(MachineCredentialLock.LOCK_STALE_MS * 2));
+            PlantLock(mutex.HostId, StalePastLocalBar);
 
             using var handle = mutex.TryAcquire();
 
-            handle.ShouldNotBeNull(); // stale local candidate → compare-and-delete takeover
+            handle.ShouldNotBeNull(); // stale local candidate → intent-serialized takeover
             handle.IsStillOwned().ShouldBeTrue(); // the on-disk lock is OUR document now
             using var document = JsonDocument.Parse(File.ReadAllText(LockPath));
             document.RootElement.GetProperty("pid").GetInt64().ShouldBe(Environment.ProcessId);
+            File.Exists(IntentPath).ShouldBeFalse(); // the arbiter releases its intent on every path
+        }
+
+        [Fact]
+        public void HostIdComparison_IsCaseInsensitive()
+        {
+            var mutex = NewLock(budgetMs: 10_000);
+            // A TS peer's os.hostname() may differ from ours only by case — still LOCAL.
+            PlantLock(mutex.HostId.ToUpperInvariant(), StalePastLocalBar);
+
+            using var handle = mutex.TryAcquire();
+            handle.ShouldNotBeNull();
         }
 
         [Fact]
         public void ForeignHostLock_PastTheLocalStaleBar_IsNotTakenOver()
         {
             var mutex = NewLock(budgetMs: 1_200);
-            PlantLock("some-other-host.example", age: TimeSpan.FromMilliseconds(MachineCredentialLock.LOCK_STALE_MS * 2));
+            PlantLock("some-other-host.example", StalePastLocalBar);
             var originalBytes = File.ReadAllBytes(LockPath);
 
             mutex.TryAcquire().ShouldBeNull(); // foreign hostId (network home) → 24 h bar → busy
@@ -188,7 +283,7 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
         public void ForeignHostLock_OlderThan24Hours_IsTakenOver()
         {
             var mutex = NewLock(budgetMs: 10_000);
-            PlantLock("some-other-host.example", age: TimeSpan.FromHours(25));
+            PlantLock("some-other-host.example", TimeSpan.FromHours(25));
 
             using var handle = mutex.TryAcquire();
 
@@ -197,17 +292,143 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
         }
 
         [Fact]
-        public void UnparseableLock_IsTreatedAsForeign_NotTakenOverAtTheLocalBar()
+        public void EmptyOrMissingHostId_InAWellFormedDocument_ComparesAsForeign()
         {
-            // A writer killed between create and write leaves an empty/garbage document with no
-            // provable local owner — conservative 24 h bar, never the 60 s local bar.
-            Directory.CreateDirectory(_baseDir);
-            File.WriteAllText(LockPath, "not json at all");
-            File.SetLastWriteTimeUtc(LockPath, DateTime.UtcNow - TimeSpan.FromMinutes(5));
+            // Its writer COMPLETED a write (valid JSON), so the torn-write argument does not
+            // apply — apply the conservative 24 h bar (contract item 7).
+            PlantFile(LockPath, WellFormedDocument(hostId: ""), StalePastLocalBar);
+            NewLock(budgetMs: 1_200).TryAcquire().ShouldBeNull();
 
-            var mutex = NewLock(budgetMs: 1_200);
-            mutex.TryAcquire().ShouldBeNull();
+            // Valid JSON of the wrong shape (missing hostId entirely): same class.
+            PlantFile(LockPath, "{\"pid\":1}", StalePastLocalBar);
+            NewLock(budgetMs: 1_200).TryAcquire().ShouldBeNull();
+            File.ReadAllText(LockPath).ShouldBe("{\"pid\":1}");
+        }
+
+        [Fact]
+        public void UnparseableLock_IsStaleEligibleAtTheLocalBar_AndEmitsOneDiagnostic()
+        {
+            // OWNER-ADOPTED AMENDMENT (review B2, flipping the original 24 h pin): a torn
+            // document's writer provably never completed its acquire write, which precedes
+            // entering the critical section — so taking it over can never collide with an
+            // in-flight refresh, and the 24 h bar would only turn every crash-in-the-create-window
+            // artifact into a day-long machine-wide auth freeze.
+            var warnings = new List<string>();
+            PlantFile(LockPath, "not json at all", TimeSpan.FromMinutes(5));
+
+            using var handle = NewLock(budgetMs: 10_000, diagnostics: warnings.Add).TryAcquire();
+
+            handle.ShouldNotBeNull(); // 60 s bar, not 24 h
+            handle.IsStillOwned().ShouldBeTrue();
+            warnings.Count(w => w.Contains("unparseable")).ShouldBe(1); // exactly one diagnostic
+        }
+
+        [Fact]
+        public void ZeroByteLock_IsStaleEligibleAtTheLocalBar()
+        {
+            // The B1 crash shape itself: a writer killed between create and write.
+            PlantFile(LockPath, "", TimeSpan.FromMinutes(5));
+
+            using var handle = NewLock(budgetMs: 10_000).TryAcquire();
+            handle.ShouldNotBeNull();
+        }
+
+        [Fact]
+        public void FreshUnparseableLock_IsNotTakenOverBeforeTheLocalBar()
+        {
+            // The amendment moves the bar to 60 s — NOT to zero: a fresh torn artifact still
+            // waits out LOCK_STALE_MS (its writer may be frozen mid-create, the accepted residual).
+            PlantFile(LockPath, "not json at all", TimeSpan.FromSeconds(1));
+
+            NewLock(budgetMs: 1_200).TryAcquire().ShouldBeNull();
             File.ReadAllText(LockPath).ShouldBe("not json at all");
+        }
+
+        // ── The takeover-intent arbiter ─────────────────────────────────────────────────────────
+
+        [Fact]
+        public void StaleTakeover_BacksOff_WhileALiveTakeoverIntentExists()
+        {
+            // DETERMINISTIC arbiter test (mandated): a stale lock is takeover-eligible, but a
+            // LIVE intent file proves another claimant is mid-takeover — this waiter must back
+            // off and fail busy, touching neither artifact. REDs when the arbiter is bypassed
+            // (a waiter that ignores the intent takes the stale lock and acquires).
+            var mutex = NewLock(budgetMs: 1_500);
+            PlantLock(mutex.HostId, StalePastLocalBar);
+            PlantFile(IntentPath, WellFormedDocument(mutex.HostId, pid: "999999"), TimeSpan.Zero); // live claimant
+            var lockBytes = File.ReadAllBytes(LockPath);
+            var intentBytes = File.ReadAllBytes(IntentPath);
+
+            mutex.TryAcquire().ShouldBeNull(); // backed off — busy, never a bypass
+
+            File.ReadAllBytes(LockPath).ShouldBe(lockBytes);     // stale lock untouched
+            File.ReadAllBytes(IntentPath).ShouldBe(intentBytes); // live intent untouched
+        }
+
+        [Fact]
+        public void CrashedIntent_IsRecovered_ByTheSameStalenessRules()
+        {
+            // A claimant that died between intent-create and intent-release leaves its intent
+            // behind; it is recovered by the same staleness + compare-and-delete rules, after
+            // which the stale lock itself is taken over.
+            var mutex = NewLock(budgetMs: 10_000);
+            PlantLock(mutex.HostId, StalePastLocalBar);
+            PlantFile(IntentPath, WellFormedDocument(mutex.HostId, pid: "999999"), StalePastLocalBar); // crashed claimant
+
+            using var handle = mutex.TryAcquire();
+
+            handle.ShouldNotBeNull();
+            handle.IsStillOwned().ShouldBeTrue();
+            File.Exists(IntentPath).ShouldBeFalse(); // recovered, used, and released
+        }
+
+        // ── B1: own-artifact cleanup on write failure after a successful exclusive-create ───────
+
+        [Fact]
+        public void CreateWriteFailure_NeverLeavesAPoisonedLockArtifact()
+        {
+            // Review B1: CreateNew succeeded ⇒ this process provably owns the file; a write
+            // failure (disk full, AV) must best-effort delete it. Without the cleanup, the empty
+            // file survives as a poisoned artifact every peer must wait out.
+            var mutex = NewLock(budgetMs: 800);
+            mutex.WriteFaultInjection = () => throw new IOException("disk full (injected)");
+
+            mutex.TryAcquire().ShouldBeNull(); // every attempt faults → busy
+            File.Exists(LockPath).ShouldBeFalse(); // no zero-byte lock survives (RED without B1)
+        }
+
+        [Fact]
+        public void CreateWriteFailure_IsTransient_TheNextAttemptAcquires()
+        {
+            // One-shot fault: the first create's write fails and is cleaned up; the retry inside
+            // the same budget succeeds with a complete document.
+            var mutex = NewLock(budgetMs: 10_000);
+            var faults = 0;
+            mutex.WriteFaultInjection = () =>
+            {
+                if (faults++ == 0)
+                    throw new IOException("transient (injected)");
+            };
+
+            using var handle = mutex.TryAcquire();
+
+            handle.ShouldNotBeNull();
+            faults.ShouldBeGreaterThanOrEqualTo(2); // the fault DID fire on attempt 1 (anti-vacuity)
+            handle.IsStillOwned().ShouldBeTrue();   // final document is complete and ours
+        }
+
+        [Fact]
+        public void IntentWriteFailure_NeverLeavesAPoisonedIntentArtifact()
+        {
+            // Same B1 control at the second create site: a poisoned empty intent would block all
+            // stale takeovers until it ages out.
+            var mutex = NewLock(budgetMs: 1_000);
+            PlantLock(mutex.HostId, StalePastLocalBar); // forces the takeover path (lock create fails first)
+            mutex.WriteFaultInjection = () => throw new IOException("disk full (injected)");
+
+            mutex.TryAcquire().ShouldBeNull(); // intent creation faults every time → busy
+            File.Exists(IntentPath).ShouldBeFalse(); // no zero-byte intent survives (RED without B1)
+            File.Exists(LockPath).ShouldBeTrue();    // and the stale lock was never deleted without an intent
         }
 
         // ── Guarded release ─────────────────────────────────────────────────────────────────────
@@ -303,7 +524,7 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
                     Plugin = new MachineCredentialFamily { AccessToken = "AT", RefreshToken = "RT" },
                 },
             });
-            PlantLock("some-other-host.example", age: TimeSpan.Zero); // live foreign holder
+            PlantLock("some-other-host.example", TimeSpan.Zero); // live foreign holder
 
             NewLock(budgetMs: 800).TryDeleteStore(store).ShouldBeFalse();
 

--- a/McpPlugin.Tests/AgentConfig/MachineCredentialLockTests.cs
+++ b/McpPlugin.Tests/AgentConfig/MachineCredentialLockTests.cs
@@ -1,0 +1,314 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using com.IvanMurzak.McpPlugin.AgentConfig;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
+{
+    /// <summary>
+    /// The cross-process lock protocol (design 04 §2) — in-process halves: the shared
+    /// cross-language constant contract, acquire/release document semantics, the busy path
+    /// (never lock-free, D9 REVISED), the local-vs-foreign staleness bar, guarded release, and
+    /// the F6 logout delete path. The three mandated takeover plants run as REAL subprocesses in
+    /// <see cref="MachineCredentialLockTakeoverPlantTests"/>.
+    /// Tests that exercise waiting paths use the internal timing-override constructor so they do
+    /// not consume the real 75 s budget; the contract constants themselves are pinned below.
+    /// </summary>
+    public sealed class MachineCredentialLockTests : IDisposable
+    {
+        private readonly string _baseDir;
+
+        public MachineCredentialLockTests()
+        {
+            _baseDir = Path.Combine(Path.GetTempPath(), "agd-lock-" + Guid.NewGuid().ToString("N"), ".ai-game-dev");
+        }
+
+        public void Dispose()
+        {
+            var parent = Path.GetDirectoryName(_baseDir);
+            if (parent != null && Directory.Exists(parent))
+                Directory.Delete(parent, recursive: true);
+        }
+
+        private string LockPath => Path.Combine(_baseDir, MachineCredentialLock.LockFileName);
+
+        private MachineCredentialLock NewLock() => new(_baseDir);
+
+        private MachineCredentialLock NewLock(int budgetMs, string? hostId = null) =>
+            new(_baseDir, hostId,
+                acquireBudgetMs: budgetMs,
+                staleMs: MachineCredentialLock.LOCK_STALE_MS,
+                foreignStaleMs: MachineCredentialLock.FOREIGN_HOST_STALE_MS);
+
+        /// <summary>Plant a lock file with the given hostId, aged by <paramref name="age"/>.</summary>
+        private void PlantLock(string hostId, TimeSpan age, string pid = "424242")
+        {
+            Directory.CreateDirectory(_baseDir);
+            File.WriteAllText(LockPath,
+                "{\"pid\":" + pid + ",\"startedAt\":\"2026-01-01T00:00:00.0000000+00:00\",\"hostId\":" +
+                JsonSerializer.Serialize(hostId) + "}");
+            File.SetLastWriteTimeUtc(LockPath, DateTime.UtcNow - age);
+        }
+
+        // ── Shared cross-language constant contract (04 §2; asserted against TS by x1) ──────────
+
+        [Fact]
+        public void Constants_MatchTheSharedCrossLanguageContract()
+        {
+            // Values are the contract (same names/values in the TS twin) — not tunables.
+            MachineCredentialLock.REFRESH_HTTP_TIMEOUT.ShouldBe(15_000);
+            MachineCredentialLock.LOCK_STALE_MS.ShouldBe(60_000);
+            MachineCredentialLock.ACQUIRE_BUDGET.ShouldBe(75_000);
+            MachineCredentialLock.FOREIGN_HOST_STALE_MS.ShouldBe(86_400_000L);
+            MachineCredentialLock.LockFileName.ShouldBe("credentials.lock");
+        }
+
+        [Fact]
+        public void Constants_Ordering_IsTheProtocolInvariant()
+        {
+            // REFRESH_HTTP_TIMEOUT < LOCK_STALE_MS: a live holder inside one HTTP call can never
+            // be declared stale. LOCK_STALE_MS < ACQUIRE_BUDGET: a waiter outlives the stale
+            // threshold, so takeover is reachable.
+            MachineCredentialLock.REFRESH_HTTP_TIMEOUT.ShouldBeLessThan(MachineCredentialLock.LOCK_STALE_MS);
+            MachineCredentialLock.LOCK_STALE_MS.ShouldBeLessThan(MachineCredentialLock.ACQUIRE_BUDGET);
+            ((long)MachineCredentialLock.LOCK_STALE_MS).ShouldBeLessThan(MachineCredentialLock.FOREIGN_HOST_STALE_MS);
+        }
+
+        [Fact]
+        public void LockFile_IsASiblingOfTheCredentialFile_NeverTheDataFileItself()
+        {
+            var mutex = NewLock();
+            var store = new MachineCredentialStore(_baseDir);
+
+            Path.GetDirectoryName(mutex.LockPath).ShouldBe(Path.GetDirectoryName(store.CredentialsPath));
+            mutex.LockPath.ShouldNotBe(store.CredentialsPath);
+        }
+
+        // ── Acquire / release document semantics ────────────────────────────────────────────────
+
+        [Fact]
+        public void Acquire_WritesPidStartedAtHostId_AndReleaseDeletesTheLock()
+        {
+            var mutex = NewLock();
+
+            using (var handle = mutex.TryAcquire())
+            {
+                handle.ShouldNotBeNull();
+                File.Exists(LockPath).ShouldBeTrue();
+
+                using var document = JsonDocument.Parse(File.ReadAllText(LockPath));
+                document.RootElement.GetProperty("pid").GetInt64()
+                    .ShouldBe(Environment.ProcessId);
+                document.RootElement.GetProperty("hostId").GetString().ShouldBe(mutex.HostId);
+                DateTimeOffset.Parse(document.RootElement.GetProperty("startedAt").GetString()!)
+                    .ShouldBeGreaterThan(DateTimeOffset.UtcNow.AddMinutes(-1));
+            }
+
+            File.Exists(LockPath).ShouldBeFalse(); // release = delete the lock file (04 §2)
+        }
+
+        [Fact]
+        public void Acquire_ClosesTheHandleImmediately_TheLockFileIsPeerReadableWhileHeld()
+        {
+            var mutex = NewLock();
+            using var handle = mutex.TryAcquire();
+            handle.ShouldNotBeNull();
+
+            // No FileShare.None / flock reliance anywhere (O6): while the lock is HELD, a peer
+            // must be able to read the document (staleness checks) — the holder keeps no open
+            // handle at all.
+            var bytes = File.ReadAllBytes(LockPath);
+            bytes.Length.ShouldBeGreaterThan(0);
+        }
+
+        // ── Busy: budget exhaustion is a failure, never lock-free (04 §2, D9 REVISED) ───────────
+
+        [Fact]
+        public void Acquire_AgainstALiveLocalHolder_FailsBusy_AndNeverTouchesTheLock()
+        {
+            var mutex = NewLock();
+            using var held = mutex.TryAcquire();
+            held.ShouldNotBeNull();
+
+            var originalBytes = File.ReadAllBytes(LockPath);
+            var originalMtime = File.GetLastWriteTimeUtc(LockPath);
+
+            var waiter = NewLock(budgetMs: 1_200);
+            var stopwatch = Stopwatch.StartNew();
+            var result = waiter.TryAcquire();
+            stopwatch.Stop();
+
+            result.ShouldBeNull(); // busy — never lock-free
+            stopwatch.ElapsedMilliseconds.ShouldBeGreaterThanOrEqualTo(1_200); // kept trying the whole budget
+            File.ReadAllBytes(LockPath).ShouldBe(originalBytes); // holder's lock byte-identical
+            File.GetLastWriteTimeUtc(LockPath).ShouldBe(originalMtime); // …and untouched
+        }
+
+        // ── Staleness: local 60 s bar, foreign/unparseable 24 h bar (04 §2) ─────────────────────
+
+        [Fact]
+        public void StaleLocalLock_IsTakenOver_AndTheNewLockIsOurOwn()
+        {
+            var mutex = NewLock(budgetMs: 10_000);
+            PlantLock(mutex.HostId, age: TimeSpan.FromMilliseconds(MachineCredentialLock.LOCK_STALE_MS * 2));
+
+            using var handle = mutex.TryAcquire();
+
+            handle.ShouldNotBeNull(); // stale local candidate → compare-and-delete takeover
+            handle.IsStillOwned().ShouldBeTrue(); // the on-disk lock is OUR document now
+            using var document = JsonDocument.Parse(File.ReadAllText(LockPath));
+            document.RootElement.GetProperty("pid").GetInt64().ShouldBe(Environment.ProcessId);
+        }
+
+        [Fact]
+        public void ForeignHostLock_PastTheLocalStaleBar_IsNotTakenOver()
+        {
+            var mutex = NewLock(budgetMs: 1_200);
+            PlantLock("some-other-host.example", age: TimeSpan.FromMilliseconds(MachineCredentialLock.LOCK_STALE_MS * 2));
+            var originalBytes = File.ReadAllBytes(LockPath);
+
+            mutex.TryAcquire().ShouldBeNull(); // foreign hostId (network home) → 24 h bar → busy
+            File.ReadAllBytes(LockPath).ShouldBe(originalBytes);
+        }
+
+        [Fact]
+        public void ForeignHostLock_OlderThan24Hours_IsTakenOver()
+        {
+            var mutex = NewLock(budgetMs: 10_000);
+            PlantLock("some-other-host.example", age: TimeSpan.FromHours(25));
+
+            using var handle = mutex.TryAcquire();
+
+            handle.ShouldNotBeNull();
+            handle.IsStillOwned().ShouldBeTrue();
+        }
+
+        [Fact]
+        public void UnparseableLock_IsTreatedAsForeign_NotTakenOverAtTheLocalBar()
+        {
+            // A writer killed between create and write leaves an empty/garbage document with no
+            // provable local owner — conservative 24 h bar, never the 60 s local bar.
+            Directory.CreateDirectory(_baseDir);
+            File.WriteAllText(LockPath, "not json at all");
+            File.SetLastWriteTimeUtc(LockPath, DateTime.UtcNow - TimeSpan.FromMinutes(5));
+
+            var mutex = NewLock(budgetMs: 1_200);
+            mutex.TryAcquire().ShouldBeNull();
+            File.ReadAllText(LockPath).ShouldBe("not json at all");
+        }
+
+        // ── Guarded release ─────────────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void Release_NeverDeletesAPeersLock()
+        {
+            var mutex = NewLock();
+            var handle = mutex.TryAcquire();
+            handle.ShouldNotBeNull();
+
+            // Simulate a (protocol-violating) usurper replacing our lock while we hold it.
+            File.WriteAllText(LockPath, "{\"pid\":1,\"startedAt\":\"x\",\"hostId\":\"usurper\"}");
+
+            handle.IsStillOwned().ShouldBeFalse();
+            handle.Dispose();
+
+            File.Exists(LockPath).ShouldBeTrue(); // the usurper's lock survives our release
+            File.ReadAllText(LockPath).ShouldContain("usurper");
+        }
+
+        [Fact]
+        public void Release_IsIdempotent()
+        {
+            var mutex = NewLock();
+            var handle = mutex.TryAcquire();
+            handle.ShouldNotBeNull();
+
+            handle.Dispose();
+            handle.Dispose(); // second dispose is a no-op, not an error
+
+            File.Exists(LockPath).ShouldBeFalse();
+        }
+
+        // ── TryRunExclusive + the F6 logout delete path (04 §2) ─────────────────────────────────
+
+        [Fact]
+        public void TryRunExclusive_RunsTheActionUnderTheLock_ThenReleases()
+        {
+            var mutex = NewLock();
+            var ranUnderLock = false;
+
+            var entered = mutex.TryRunExclusive(() =>
+            {
+                File.Exists(LockPath).ShouldBeTrue(); // the lock is held while the action runs
+                ranUnderLock = true;
+            });
+
+            entered.ShouldBeTrue();
+            ranUnderLock.ShouldBeTrue();
+            File.Exists(LockPath).ShouldBeFalse();
+        }
+
+        [Fact]
+        public void TryRunExclusive_WhenBusy_DoesNotRunTheAction()
+        {
+            var mutex = NewLock();
+            using var held = mutex.TryAcquire();
+            held.ShouldNotBeNull();
+
+            var ran = false;
+            NewLock(budgetMs: 800).TryRunExclusive(() => ran = true).ShouldBeFalse();
+            ran.ShouldBeFalse(); // busy means FAIL — never proceed lock-free (D9 REVISED)
+        }
+
+        [Fact]
+        public void TryDeleteStore_AcquiresUnlinksStoreReleasesUnlinksLock()
+        {
+            var store = new MachineCredentialStore(_baseDir);
+            store.Write(new MachineCredentials
+            {
+                Families = new MachineCredentialFamilies
+                {
+                    Plugin = new MachineCredentialFamily { AccessToken = "AT", RefreshToken = "RT" },
+                },
+            });
+
+            var mutex = NewLock();
+            mutex.TryDeleteStore(store).ShouldBeTrue();
+
+            File.Exists(store.CredentialsPath).ShouldBeFalse(); // store unlinked under the lock
+            File.Exists(LockPath).ShouldBeFalse();              // …and the lock unlinked after release
+        }
+
+        [Fact]
+        public void TryDeleteStore_WhenBusy_LeavesTheStoreIntact()
+        {
+            var store = new MachineCredentialStore(_baseDir);
+            store.Write(new MachineCredentials
+            {
+                Families = new MachineCredentialFamilies
+                {
+                    Plugin = new MachineCredentialFamily { AccessToken = "AT", RefreshToken = "RT" },
+                },
+            });
+            PlantLock("some-other-host.example", age: TimeSpan.Zero); // live foreign holder
+
+            NewLock(budgetMs: 800).TryDeleteStore(store).ShouldBeFalse();
+
+            File.Exists(store.CredentialsPath).ShouldBeTrue(); // busy logout deletes NOTHING
+            File.Exists(LockPath).ShouldBeTrue();
+        }
+    }
+}

--- a/McpPlugin.Tests/AgentConfig/MachineCredentialStoreAtomicityTests.cs
+++ b/McpPlugin.Tests/AgentConfig/MachineCredentialStoreAtomicityTests.cs
@@ -91,7 +91,7 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
         /// The elapsed floor proves a retry actually happened (the first attempt fails at ~0 ms).
         /// </summary>
         [Fact]
-        public async Task Write_RetriesUntilDestinationHandleReleased_Windows()
+        public void Write_RetriesUntilDestinationHandleReleased_Windows()
         {
             if (!OperatingSystem.IsWindows())
                 return; // FileShare semantics are only enforced by Windows; POSIX rename ignores holders.
@@ -101,17 +101,22 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
 
             // Hold the destination WITHOUT FileShare.Delete: File.Replace needs delete access on the
             // destination, so every rename attempt fails with a sharing violation until release.
+            // The release runs on a DEDICATED thread, not Task.Run: on a saturated 2-core CI
+            // runner the thread pool can delay a queued work item far past the 600 ms sleep
+            // (observed >1 s: the write exhausted its full retry window AND teardown still found
+            // the handle open), which fails the test for a reason the store does not have.
             var holder = new FileStream(store.CredentialsPath, FileMode.Open, FileAccess.Read, FileShare.Read);
-            var release = Task.Run(() =>
+            var release = new Thread(() =>
             {
                 Thread.Sleep(600);
                 holder.Dispose();
             });
+            release.Start();
 
             var stopwatch = Stopwatch.StartNew();
             store.Write(Credentials("NEW-AT", "NEW-RT")); // must survive the holder via retries
             stopwatch.Stop();
-            await release;
+            release.Join();
 
             stopwatch.ElapsedMilliseconds.ShouldBeGreaterThanOrEqualTo(400); // ≥1 backoff happened
             store.Read()!.Families!.Plugin!.AccessToken.ShouldBe("NEW-AT");

--- a/McpPlugin.Tests/McpPlugin.Tests.csproj
+++ b/McpPlugin.Tests/McpPlugin.Tests.csproj
@@ -20,6 +20,10 @@
 
   <ItemGroup>
     <ProjectReference Include="../McpPlugin/McpPlugin.csproj" />
+    <!-- Real-subprocess harness for the lock takeover plants (design 04 §5): the reference copies
+         the harness executable next to the test assembly, where
+         MachineCredentialLockTakeoverPlantTests spawns it via `dotnet`. -->
+    <ProjectReference Include="../McpPlugin.Tests.LockHarness/McpPlugin.Tests.LockHarness.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/McpPlugin.Tests/McpPlugin.Tests.csproj
+++ b/McpPlugin.Tests/McpPlugin.Tests.csproj
@@ -31,6 +31,7 @@
          assembly so ProjectIdentityGoldenVectorTests can load them at runtime. -->
     <None Include="../McpPlugin/src/AgentConfig/ProjectIdentity.GoldenVectors.json" Link="ProjectIdentity.GoldenVectors.json" CopyToOutputDirectory="PreserveNewest" />
     <None Include="../McpPlugin/src/AgentConfig/ProjectIdentity.GoldenVectors.v2.json" Link="ProjectIdentity.GoldenVectors.v2.json" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="../McpPlugin/src/AgentConfig/LockProtocol.GoldenVectors.json" Link="LockProtocol.GoldenVectors.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>

--- a/McpPlugin.sln
+++ b/McpPlugin.sln
@@ -17,6 +17,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DemoConsoleApp", "DemoConso
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DemoWebApp", "DemoWebApp\DemoWebApp.csproj", "{A1B2C3D4-E5F6-4A5B-9C8D-7E6F5A4B3C2D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "McpPlugin.Tests.LockHarness", "McpPlugin.Tests.LockHarness\McpPlugin.Tests.LockHarness.csproj", "{ED1FA9D0-232B-4947-B182-E3ED3EA04A11}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -111,6 +113,18 @@ Global
 		{A1B2C3D4-E5F6-4A5B-9C8D-7E6F5A4B3C2D}.Release|x64.Build.0 = Release|Any CPU
 		{A1B2C3D4-E5F6-4A5B-9C8D-7E6F5A4B3C2D}.Release|x86.ActiveCfg = Release|Any CPU
 		{A1B2C3D4-E5F6-4A5B-9C8D-7E6F5A4B3C2D}.Release|x86.Build.0 = Release|Any CPU
+		{ED1FA9D0-232B-4947-B182-E3ED3EA04A11}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ED1FA9D0-232B-4947-B182-E3ED3EA04A11}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ED1FA9D0-232B-4947-B182-E3ED3EA04A11}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{ED1FA9D0-232B-4947-B182-E3ED3EA04A11}.Debug|x64.Build.0 = Debug|Any CPU
+		{ED1FA9D0-232B-4947-B182-E3ED3EA04A11}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{ED1FA9D0-232B-4947-B182-E3ED3EA04A11}.Debug|x86.Build.0 = Debug|Any CPU
+		{ED1FA9D0-232B-4947-B182-E3ED3EA04A11}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ED1FA9D0-232B-4947-B182-E3ED3EA04A11}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ED1FA9D0-232B-4947-B182-E3ED3EA04A11}.Release|x64.ActiveCfg = Release|Any CPU
+		{ED1FA9D0-232B-4947-B182-E3ED3EA04A11}.Release|x64.Build.0 = Release|Any CPU
+		{ED1FA9D0-232B-4947-B182-E3ED3EA04A11}.Release|x86.ActiveCfg = Release|Any CPU
+		{ED1FA9D0-232B-4947-B182-E3ED3EA04A11}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/McpPlugin/src/AgentConfig/LockProtocol.GoldenVectors.json
+++ b/McpPlugin/src/AgentConfig/LockProtocol.GoldenVectors.json
@@ -2,6 +2,8 @@
   "comment": "Cross-language lock-protocol constants (unified-machine-auth 04 §2). The C# (MCP-Plugin-dotnet, b2) and TS (cli-core, c2) implementations MUST agree on every value here; the x1 parity suite asserts both sides against this document. Values are integer milliseconds. Ordering invariant: refreshHttpTimeoutMs < lockStaleMs < acquireBudgetMs.",
   "lockFileName": "credentials.lock",
   "takeoverIntentFileName": "credentials.lock.takeover",
+  "lockDocumentFields": ["pid", "startedAt", "hostId", "nonce"],
+  "hostIdCompare": "case-insensitive",
   "refreshHttpTimeoutMs": 15000,
   "lockStaleMs": 60000,
   "acquireBudgetMs": 75000,

--- a/McpPlugin/src/AgentConfig/LockProtocol.GoldenVectors.json
+++ b/McpPlugin/src/AgentConfig/LockProtocol.GoldenVectors.json
@@ -1,0 +1,9 @@
+{
+  "comment": "Cross-language lock-protocol constants (unified-machine-auth 04 §2). The C# (MCP-Plugin-dotnet, b2) and TS (cli-core, c2) implementations MUST agree on every value here; the x1 parity suite asserts both sides against this document. Values are integer milliseconds. Ordering invariant: refreshHttpTimeoutMs < lockStaleMs < acquireBudgetMs.",
+  "lockFileName": "credentials.lock",
+  "takeoverIntentFileName": "credentials.lock.takeover",
+  "refreshHttpTimeoutMs": 15000,
+  "lockStaleMs": 60000,
+  "acquireBudgetMs": 75000,
+  "foreignLockStaleMs": 86400000
+}

--- a/McpPlugin/src/AgentConfig/MachineCredentialLock.cs
+++ b/McpPlugin/src/AgentConfig/MachineCredentialLock.cs
@@ -13,6 +13,7 @@ using System;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
+using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -22,35 +23,74 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
 {
     /// <summary>
     /// The cross-process lock protecting the machine credential store — design 04 §2, identical
-    /// semantics in C# (this class) and TS (cli-core twin). Lock file:
-    /// <c>~/.ai-game-dev/credentials.lock</c>, a sibling of the data file, never the data file
-    /// itself.
+    /// semantics in C# (this class) and TS (cli-core <c>credential-lock.ts</c>, task c2). Lock
+    /// file: <c>~/.ai-game-dev/credentials.lock</c>, a sibling of the data file, never the data
+    /// file itself. The shared contract is pinned by
+    /// <c>LockProtocol.GoldenVectors.json</c> (asserted by both languages via x1).
     ///
-    /// <para><b>Protocol (04 §2):</b></para>
+    /// <para><b>Protocol (04 §2, with the owner-adopted amendments from the b2/c2 review
+    /// round):</b></para>
     /// <list type="bullet">
     ///   <item><b>Acquire</b> — exclusive-create <b>only</b> (<see cref="FileMode.CreateNew"/> /
-    ///         TS <c>open(…,'wx')</c>), writing <c>{pid, startedAt, hostId}</c>; the handle is
-    ///         closed immediately after the write so the mtime is visible to peers. No
-    ///         <c>FileShare.None</c>/flock reliance anywhere: .NET skips advisory locks on NFS/SMB
-    ///         and <c>File.Delete</c> ignores them on Linux (O6). Failure retries with jittered
-    ///         backoff.</item>
-    ///   <item><b>Stale takeover (compare-and-delete)</b> — a candidate whose <b>last-write</b>
-    ///         time (never last-access) is older than <see cref="LOCK_STALE_MS"/> and whose
-    ///         <c>hostId</c> matches the local host: read its content, re-stat, delete only if the
-    ///         content is byte-identical to what was read, race for exclusive-create, and verify
-    ///         the new lock's content is our own before entering. A lock with a foreign (or
-    ///         unparseable) <c>hostId</c> — a network home — is only taken over after
-    ///         <see cref="FOREIGN_HOST_STALE_MS"/> (24 h).</item>
-    ///   <item><b>Release</b> — delete the lock file (guarded: never deletes a peer's lock — see
-    ///         <see cref="MachineCredentialLockHandle.Dispose"/>).</item>
+    ///         TS <c>open(…,'wx')</c>), writing <c>{pid, startedAt, hostId, nonce}</c>; the handle
+    ///         is closed immediately after the write so the mtime is visible to peers, then the
+    ///         file is read back to verify it still carries OUR bytes before we consider
+    ///         ourselves the holder. No <c>FileShare.None</c>/flock reliance anywhere: .NET skips
+    ///         advisory locks on NFS/SMB and <c>File.Delete</c> ignores them on Linux (O6).
+    ///         Failure retries with jittered backoff. The <c>nonce</c> (fresh random 128-bit hex
+    ///         per acquisition attempt) makes every document unique, so byte-identical
+    ///         verify-own can never confuse two attempts — even two in the same process within
+    ///         one clock tick (review A2).</item>
+    ///   <item><b>Own-artifact cleanup (review B1)</b> — if the exclusive-create succeeded but
+    ///         the content write failed (disk full, AV), the empty file this process provably
+    ///         created is best-effort deleted before backing off, for the lock AND the intent
+    ///         file. A poisoned zero-byte artifact must never outlive its creator's attempt.</item>
+    ///   <item><b>Stale takeover, SERIALIZED through a takeover-intent file</b> — a candidate
+    ///         whose <b>last-write</b> time (never last-access) is older than its staleness bar
+    ///         may be removed, but only by the claimant that first wins an exclusive-create of
+    ///         the sibling intent file (<see cref="TakeoverIntentFileName"/>), reads it back to
+    ///         verify ownership, re-validates the candidate is the SAME artifact it judged stale
+    ///         (mtime + size + byte-identical content), re-verifies intent ownership immediately
+    ///         before the delete, and only then unlinks it — then releases the intent and races
+    ///         exclusive-create for the lock itself. The intent arbiter is LOAD-BEARING: without
+    ///         it, two lockstep waiters both validate the same unchanged stale file and the
+    ///         slower one's delete lands on a freshly re-created LIVE lock (measured
+    ///         double-acquiring in the TS twin's 4-process hammer, 3/25 lockstep rounds). A live
+    ///         intent (younger than its staleness bar) makes claimants back off; a crashed
+    ///         claimant's intent is itself recovered by the same staleness +
+    ///         compare-and-delete rules (deliberately unserialized — the residual needs the rare
+    ///         crashed-intent precondition ON TOP of the tight race window; accepted by design in
+    ///         both languages).</item>
+    ///   <item><b>Staleness bars</b> — well-formed document with a case-insensitively local
+    ///         <c>hostId</c>: <see cref="LOCK_STALE_MS"/> (60 s). Well-formed but foreign,
+    ///         empty, or missing <c>hostId</c> (network home / unknown writer):
+    ///         <see cref="FOREIGN_HOST_STALE_MS"/> (24 h). <b>Unparseable or zero-byte document
+    ///         (owner-adopted amendment, review B2): <see cref="LOCK_STALE_MS"/> (60 s)</b> — a
+    ///         torn document's writer provably never completed its acquire write, which precedes
+    ///         handle-return, which precedes the critical section, so taking it over can never
+    ///         collide with an in-flight refresh; the 24 h bar would only convert every
+    ///         crash-in-the-create-window artifact into a day-long machine-wide auth freeze. One
+    ///         diagnostic warning is emitted when an unparseable lock is taken over. The same
+    ///         classification applies to the intent file (same writer-never-proceeded
+    ///         argument).</item>
+    ///   <item><b>Release</b> — delete the lock file, guarded: the on-disk bytes are compared to
+    ///         our own first, so a peer's lock is never deleted
+    ///         (<see cref="MachineCredentialLockHandle.Dispose"/>).</item>
     ///   <item><b>Budget exhausted</b> — the attempt fails as <b>busy</b>
     ///         (<see cref="TryAcquire"/> returns <c>null</c>); it never proceeds lock-free
     ///         (D9 REVISED — the removed "kill-switch" would have reintroduced the reuse
     ///         race).</item>
+    ///   <item><b>Windows delete-pending is contention</b> — an exclusive-create racing a
+    ///         concurrent unlink can land in the file's DELETE-PENDING window, surfacing as
+    ///         <see cref="UnauthorizedAccessException"/> / EPERM-alike <see cref="IOException"/>
+    ///         rather than "already exists". Both create sites (lock and intent) treat every such
+    ///         failure as transient contention and back off — never a hard failure. (POSIX never
+    ///         takes this branch for contention.)</item>
     /// </list>
     ///
     /// <para><b>Constants are a shared cross-language contract</b>: the names and values match the
-    /// TS twin verbatim so the golden-parity suite (task x1) can assert equality. The ordering
+    /// TS twin verbatim and both sides assert them against
+    /// <c>LockProtocol.GoldenVectors.json</c> (x1). The ordering
     /// <see cref="REFRESH_HTTP_TIMEOUT"/> &lt; <see cref="LOCK_STALE_MS"/> &lt;
     /// <see cref="ACQUIRE_BUDGET"/> is the invariant: a live holder inside one HTTP call can never
     /// be declared stale, and a waiter always outlives the stale threshold so takeover is
@@ -58,25 +98,43 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
     ///
     /// <para><b>Windows <c>FileOptions.DeleteOnClose</c> (04 §2 "optional hardening") is
     /// deliberately not used:</b> holding the handle open would conflict with the base protocol's
-    /// "close immediately so the mtime is peer-visible" requirement, diverge the observable
-    /// semantics from the TS twin (which cannot hold-with-delete-on-close), and change what peers
-    /// can read while the lock is held. Crash release is instead provided by the stale-takeover
-    /// path, proven by the kill -9 recovery plant (04 §5).</para>
+    /// "close immediately so the mtime is peer-visible" requirement and diverge the observable
+    /// semantics from the TS twin. Crash release is the stale-takeover path, proven by the
+    /// kill -9 recovery plant (04 §5).</para>
     ///
     /// <para><b>hostId</b> defaults to <see cref="System.Net.Dns.GetHostName"/> — the same
-    /// <c>gethostname</c> source Node's <c>os.hostname()</c> uses, so C# and TS processes on one
-    /// machine recognise each other as local. Comparison is case-insensitive.</para>
+    /// <c>gethostname</c> source as Node's <c>os.hostname()</c>, so C# and TS processes on one
+    /// machine recognise each other as local. Comparison is case-insensitive
+    /// (invariant-culture); an empty or missing <c>hostId</c> always compares as foreign.</para>
+    ///
+    /// <para><b>Clock caveats (spec-inherent, shared with the TS twin):</b> a backward clock jump
+    /// only delays takeover (safe direction); a forward step &gt; ~45 s can declare a live holder
+    /// prematurely stale (double refresh — absorbed by the server's D10 grace window); on an
+    /// NFS-hosted home the mtime is server-clock while ages are judged against local UtcNow, so a
+    /// &gt;60 s skew mis-ages fresh locks. Also note <see cref="File.GetLastWriteTimeUtc(string)"/>
+    /// returns the 1601 FILETIME-zero sentinel for a vanished file instead of throwing — every
+    /// consumer below pairs the stat with a content read whose null result aborts the path.</para>
     /// </summary>
     public sealed class MachineCredentialLock
     {
         /// <summary>File name of the lock file, a sibling of the credential data file (04 §2).</summary>
         public const string LockFileName = "credentials.lock";
 
+        /// <summary>
+        /// File name of the takeover-intent file (sibling of the lock). Removing a stale
+        /// <see cref="LockFileName"/> requires FIRST winning an exclusive-create of this file —
+        /// the atomic arbiter that serializes concurrent stale-takeover claimants. Part of the
+        /// shared cross-language protocol surface (TS: <c>CREDENTIALS_LOCK_TAKEOVER_FILE_NAME</c>);
+        /// a C#/TS fleet disagreeing here degrades to the measured double-acquire race.
+        /// </summary>
+        public const string TakeoverIntentFileName = "credentials.lock.takeover";
+
         // ── Shared cross-language contract constants (04 §2) ─────────────────────────────────────
-        // Names and values match the TS twin verbatim (x1 asserts cross-language equality), which
-        // is why they are SCREAMING_SNAKE_CASE rather than C# convention. All values are in
-        // milliseconds. The ordering REFRESH_HTTP_TIMEOUT < LOCK_STALE_MS < ACQUIRE_BUDGET is the
-        // protocol invariant — never edit one without re-checking the other two.
+        // Names and values match the TS twin verbatim and are pinned by
+        // LockProtocol.GoldenVectors.json (x1 asserts cross-language equality), which is why they
+        // are SCREAMING_SNAKE_CASE rather than C# convention. All values are in milliseconds. The
+        // ordering REFRESH_HTTP_TIMEOUT < LOCK_STALE_MS < ACQUIRE_BUDGET is the protocol
+        // invariant — never edit one without re-checking the other two.
 
         /// <summary>
         /// Timeout for the refresh HTTP call made inside the critical section, in ms. Must be
@@ -87,7 +145,8 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
         public const int REFRESH_HTTP_TIMEOUT = 15_000;
 
         /// <summary>
-        /// Age (by last-write time) past which a local-host lock is a stale-takeover candidate, in ms.
+        /// Age (by last-write time) past which a local-host — or unparseable/zero-byte (B2
+        /// amendment) — lock is a stale-takeover candidate, in ms.
         /// </summary>
         public const int LOCK_STALE_MS = 60_000;
 
@@ -99,17 +158,18 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
         public const int ACQUIRE_BUDGET = 75_000;
 
         /// <summary>
-        /// Age past which a lock with a foreign or unparseable <c>hostId</c> may be taken over, in
-        /// ms (24 h; 04 §2). Foreign PIDs cannot be probed and cross-host mtimes are clock-skewed,
-        /// so the bar is deliberately high. An unparseable lock document has no provable local
-        /// owner either, so it gets the same conservative bar.
+        /// Age past which a lock whose well-formed document carries a foreign, empty, or missing
+        /// <c>hostId</c> may be taken over, in ms (24 h; 04 §2). Foreign PIDs cannot be probed and
+        /// cross-host mtimes are clock-skewed, so the bar is deliberately high. (An unparseable
+        /// document is NOT in this class — see <see cref="LOCK_STALE_MS"/> and the B2 amendment.)
         /// </summary>
         public const long FOREIGN_HOST_STALE_MS = 24L * 60 * 60 * 1000;
 
-        // Jittered backoff between acquire attempts (04 §2): doubling from Initial to Max, each
-        // delay drawn uniformly from [d/2, d]. Internal tuning, not part of the shared contract.
-        private const int InitialBackoffMs = 50;
-        private const int MaxBackoffMs = 1_000;
+        // Jittered backoff between acquire attempts (04 §2), mirroring the TS twin: base 25 ms
+        // doubled per attempt, capped at 500 ms, then jittered ×[0.5, 1.5). Internal tuning, not
+        // part of the shared contract.
+        private const int BackoffBaseMs = 25;
+        private const int BackoffCapMs = 500;
 
         // 0700 (owner rwx) as a binary bit-pattern — C# has no octal literals. Mirrors
         // MachineCredentialStore's directory policy so a lock-first code path (login acquires the
@@ -126,25 +186,38 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
 
         private readonly string _baseDirectory;
         private readonly string _lockPath;
+        private readonly string _intentPath;
         private readonly string _hostId;
         private readonly int _acquireBudgetMs;
         private readonly long _staleMs;
         private readonly long _foreignStaleMs;
+        private readonly Action<string>? _diagnostics;
+
+        /// <summary>
+        /// Test seam (InternalsVisibleTo: McpPlugin.Tests): when set, invoked inside the create
+        /// window of BOTH create sites (lock and intent) right after a successful exclusive-create
+        /// and before the content write — throwing from it simulates a write failure (disk full,
+        /// AV) so the B1 own-artifact cleanup path can be exercised deterministically. Never set
+        /// in production.
+        /// </summary>
+        internal Action? WriteFaultInjection;
 
         /// <summary>
         /// Create a lock rooted at <paramref name="baseDirectory"/>, or at <c>~/.ai-game-dev</c>
         /// when null (the same root as <see cref="MachineCredentialStore"/>).
         /// <paramref name="hostId"/> overrides the local host identifier — tests only; production
-        /// callers use the default.
+        /// callers use the default. <paramref name="diagnostics"/> receives rare protocol
+        /// warnings (e.g. taking over an unparseable lock); when null they go to
+        /// <see cref="Trace.TraceWarning(string)"/>.
         /// </summary>
-        public MachineCredentialLock(string? baseDirectory = null, string? hostId = null)
-            : this(baseDirectory, hostId, ACQUIRE_BUDGET, LOCK_STALE_MS, FOREIGN_HOST_STALE_MS)
+        public MachineCredentialLock(string? baseDirectory = null, string? hostId = null, Action<string>? diagnostics = null)
+            : this(baseDirectory, hostId, ACQUIRE_BUDGET, LOCK_STALE_MS, FOREIGN_HOST_STALE_MS, diagnostics)
         {
         }
 
         /// <summary>
         /// Test seam (InternalsVisibleTo: McpPlugin.Tests): override the protocol timings so unit
-        /// tests of the busy / foreign-bar paths do not consume the real 75 s budget. Production
+        /// tests of the busy / staleness paths do not consume the real 75 s budget. Production
         /// code paths always go through the public constructor, which pins the contract constants.
         /// </summary>
         internal MachineCredentialLock(
@@ -152,16 +225,19 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
             string? hostId,
             int acquireBudgetMs,
             long staleMs,
-            long foreignStaleMs)
+            long foreignStaleMs,
+            Action<string>? diagnostics = null)
         {
             _baseDirectory = baseDirectory ?? Path.Combine(
                 Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
                 MachineCredentialStore.DirectoryName);
             _lockPath = Path.Combine(_baseDirectory, LockFileName);
+            _intentPath = Path.Combine(_baseDirectory, TakeoverIntentFileName);
             _hostId = hostId ?? ResolveLocalHostId();
             _acquireBudgetMs = acquireBudgetMs;
             _staleMs = staleMs;
             _foreignStaleMs = foreignStaleMs;
+            _diagnostics = diagnostics;
         }
 
         /// <summary>Absolute path of the directory holding the lock (and the store).</summary>
@@ -169,6 +245,9 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
 
         /// <summary>Absolute path of the lock file.</summary>
         public string LockPath => _lockPath;
+
+        /// <summary>Absolute path of the takeover-intent file (<c>credentials.lock.takeover</c>).</summary>
+        public string TakeoverIntentPath => _intentPath;
 
         /// <summary>The host identifier written into (and compared against) lock documents.</summary>
         public string HostId => _hostId;
@@ -184,7 +263,7 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
 
             var stopwatch = Stopwatch.StartNew();
             var random = new Random();
-            var backoffMs = InitialBackoffMs;
+            var attempt = 0;
 
             while (true)
             {
@@ -192,21 +271,18 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
                 if (handle != null)
                     return handle;
 
-                handle = TryTakeOverStaleLock();
-                if (handle != null)
-                    return handle;
+                if (TryRemoveStaleLock())
+                    continue; // stale lock removed — race exclusive-create immediately, no backoff
 
                 var remainingMs = _acquireBudgetMs - stopwatch.ElapsedMilliseconds;
                 if (remainingMs <= 0)
                     return null; // busy — never lock-free (04 §2, D9 REVISED)
 
-                // Jittered backoff (04 §2): uniform in [backoff/2, backoff], clamped so the final
-                // sleep wakes exactly at the deadline for one last attempt.
-                var delayMs = backoffMs / 2 + random.Next(backoffMs / 2 + 1);
+                var delayMs = NextBackoffMs(random, attempt);
                 if (delayMs > remainingMs)
-                    delayMs = (int)remainingMs;
+                    delayMs = (int)remainingMs; // wake exactly at the deadline for one last attempt
                 Thread.Sleep(delayMs);
-                backoffMs = Math.Min(backoffMs * 2, MaxBackoffMs);
+                attempt++;
             }
         }
 
@@ -246,116 +322,259 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
 
         private MachineCredentialLockHandle? TryCreateOwnLock()
         {
-            var content = BuildOwnContent();
-            try
-            {
-                // FileMode.CreateNew is the entire mutual-exclusion primitive — atomic on every
-                // OS and every filesystem we support, including NFS/SMB (O6). FileShare.Read lets
-                // a peer's staleness read proceed during the microseconds the handle is open.
-                using (var stream = new FileStream(_lockPath, FileMode.CreateNew, FileAccess.Write, FileShare.Read))
-                {
-                    stream.Write(content, 0, content.Length);
-                } // closed immediately: the close publishes the mtime to peers (04 §2)
-            }
-            catch (IOException)
-            {
-                return null; // the lock exists — somebody else holds it (or a transient failure; retry)
-            }
-            catch (UnauthorizedAccessException)
-            {
+            var content = BuildOwnDocument();
+            if (!TryExclusiveCreateWithContent(_lockPath, content))
                 return null;
-            }
+
+            // Verify the new lock's content is our own before considering ourselves the holder
+            // (04 §2): a (protocol-violating or crashed-intent-residual) racer may have replaced
+            // our fresh lock in the window after the close. Never touch a mismatching file.
+            var readBack = TryReadAllBytes(_lockPath);
+            if (readBack == null || !BytesEqual(readBack, content))
+                return null;
 
             return new MachineCredentialLockHandle(_lockPath, content);
         }
 
-        // ── Stale takeover: compare-and-delete (04 §2) ───────────────────────────────────────────
-
-        private MachineCredentialLockHandle? TryTakeOverStaleLock()
+        /// <summary>
+        /// One exclusive-create attempt writing <paramref name="content"/> and closing the handle
+        /// immediately (the close publishes the mtime to peers, 04 §2). Returns false on ANY
+        /// create failure: "already exists" AND the Windows delete-pending window
+        /// (EPERM/EACCES/EBUSY-alikes) are both transient contention — back off, never fail hard.
+        /// B1: when the create itself succeeded but the write failed, the empty artifact this
+        /// process provably created is best-effort deleted before returning — race-safe, because
+        /// a milliseconds-old artifact is never a takeover candidate and exclusive-create excludes
+        /// peers, so the path can only hold our own file at cleanup time.
+        /// </summary>
+        private bool TryExclusiveCreateWithContent(string path, byte[] content)
         {
-            if (!File.Exists(_lockPath))
-                return null; // vanished — the next loop iteration races exclusive-create
-
-            DateTime firstLastWriteUtc;
+            var created = false;
             try
             {
-                // Last-WRITE time, never last-access (04 §2): atime is unreliable (relatime,
-                // noatime mounts) and is touched by the peers' own staleness reads.
-                firstLastWriteUtc = File.GetLastWriteTimeUtc(_lockPath);
+                // FileMode.CreateNew is the mutual-exclusion primitive — atomic on every OS and
+                // every filesystem we support, including NFS/SMB (O6). FileShare.Read lets a
+                // peer's staleness read proceed during the microseconds the handle is open.
+                using (var stream = new FileStream(path, FileMode.CreateNew, FileAccess.Write, FileShare.Read))
+                {
+                    created = true;
+                    WriteFaultInjection?.Invoke(); // test seam (B1); no-op in production
+                    stream.Write(content, 0, content.Length);
+                }
             }
             catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
             {
-                return null;
+                if (created)
+                    TryDeleteFileBestEffort(path); // B1: no poisoned zero-byte artifact survives
+                return false;
             }
-
-            var observed = TryReadAllBytes(_lockPath);
-            if (observed == null)
-                return null; // vanished or unreadable right now — retry later
-
-            var ageMs = (DateTime.UtcNow - firstLastWriteUtc).TotalMilliseconds;
-            var isLocal = HostIdMatchesLocal(ParseHostId(observed));
-            var thresholdMs = isLocal ? _staleMs : _foreignStaleMs;
-            if (ageMs < thresholdMs)
-                return null; // a live (or not-provably-dead) holder — keep waiting
-
-            // Compare-and-delete: re-stat, then delete only if the content is still byte-identical
-            // to what was read — a candidate that changed under us was re-acquired and is not stale.
-            try
-            {
-                if (File.GetLastWriteTimeUtc(_lockPath) != firstLastWriteUtc)
-                    return null;
-            }
-            catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
-            {
-                return null;
-            }
-
-            var reRead = TryReadAllBytes(_lockPath);
-            if (reRead == null || !BytesEqual(observed, reRead))
-                return null;
-
-            try
-            {
-                File.Delete(_lockPath);
-            }
-            catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
-            {
-                return null; // somebody else's delete/create won — retry
-            }
-
-            // Race for exclusive-create…
-            var handle = TryCreateOwnLock();
-            if (handle == null)
-                return null; // another waiter won the create race
-
-            // …and verify the new lock's content is our own before entering the critical section
-            // (04 §2): a racing waiter's compare-and-delete may have destroyed our fresh lock and
-            // replaced it with its own in the window between our create and now.
-            if (!handle.IsStillOwned())
-            {
-                handle.Dispose(); // guarded release: never deletes the usurper's lock
-                return null;
-            }
-
-            return handle;
+            return true;
         }
 
-        // ── Lock document {pid, startedAt, hostId} (04 §2) ───────────────────────────────────────
+        // ── Stale takeover: compare-and-delete, serialized through the intent file (04 §2) ──────
+
+        /// <summary>
+        /// Stale-takeover attempt: returns true when the stale lock was REMOVED (the caller then
+        /// races exclusive-create immediately); false when there is nothing stale, we lost a race,
+        /// or a live claimant's intent told us to back off. Mirrors the TS twin's
+        /// <c>tryStaleTakeover</c> with the owner-adopted narrowings: intent read-back
+        /// verification after create, and intent ownership re-verification immediately before the
+        /// lock delete.
+        /// </summary>
+        private bool TryRemoveStaleLock()
+        {
+            if (!File.Exists(_lockPath))
+                return false; // gone — the caller's next exclusive-create attempt races for it
+
+            // stat №1: last-WRITE time (never last-access: atime is unreliable and touched by the
+            // peers' own staleness reads) + size, from one fresh FileInfo refresh.
+            DateTime mtime1;
+            long size1;
+            try
+            {
+                var info = new FileInfo(_lockPath);
+                mtime1 = info.LastWriteTimeUtc;
+                size1 = info.Length;
+            }
+            catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+            {
+                return false;
+            }
+
+            var content1 = TryReadAllBytes(_lockPath);
+            if (content1 == null)
+                return false; // vanished or unreadable right now — retry later
+
+            var thresholdMs = StalenessThresholdMs(content1, out var unparseable);
+            if ((DateTime.UtcNow - mtime1).TotalMilliseconds < thresholdMs)
+                return false; // a live (or not-provably-dead) holder — keep waiting
+
+            // Serialize claimants: only the winner of the intent file's exclusive-create may
+            // remove the stale artifact. Without this arbiter, two lockstep claimants both
+            // validate the SAME unchanged stale file and the slower delete lands on a freshly
+            // re-created LIVE lock (measured in the TS twin: 3/25 lockstep rounds double-acquired).
+            var intentContent = TryAcquireTakeoverIntent();
+            if (intentContent == null)
+                return false; // a live claimant is mid-takeover (or we lost the intent race) — back off
+
+            try
+            {
+                // Re-validate under the intent: remove only the exact artifact we judged stale
+                // (mtime + size + byte-identical content — a live replacement always differs, its
+                // startedAt/nonce are newer than the dead holder's).
+                DateTime mtime2;
+                long size2;
+                try
+                {
+                    var info2 = new FileInfo(_lockPath);
+                    mtime2 = info2.LastWriteTimeUtc;
+                    size2 = info2.Length;
+                }
+                catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+                {
+                    return false; // released or removed while we acquired the intent
+                }
+
+                var content2 = TryReadAllBytes(_lockPath);
+                if (content2 == null)
+                    return false;
+                if (mtime2 != mtime1 || size2 != size1 || !BytesEqual(content1, content2))
+                    return false; // replaced by a live lock while we acquired the intent — leave it
+
+                // Re-verify intent ownership immediately before the delete: if a crashed-intent
+                // recovery replaced our intent in the meantime, the arbiter is no longer ours and
+                // we must not act under it.
+                var intentNow = TryReadAllBytes(_intentPath);
+                if (intentNow == null || !BytesEqual(intentNow, intentContent))
+                    return false;
+
+                if (unparseable)
+                {
+                    Warn("machine credential lock: taking over an unparseable/zero-byte lock document at "
+                        + _lockPath + " (age past LOCK_STALE_MS; its writer never completed an acquire — "
+                        + "likely a process killed in the create window or a cleaned-up write failure)");
+                }
+
+                try
+                {
+                    File.Delete(_lockPath);
+                }
+                catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+                {
+                    return false; // somebody else's delete won — retry
+                }
+                return true;
+            }
+            finally
+            {
+                ReleaseTakeoverIntent(intentContent);
+            }
+        }
+
+        /// <summary>
+        /// Win the takeover-intent file by exclusive-create (read back to verify ownership),
+        /// recovering a CRASHED claimant's intent by the same staleness + compare-and-delete
+        /// rules. Returns the intent content bytes on success, or null when a live claimant holds
+        /// it (back off). The crashed-intent recovery is deliberately unserialized (there is no
+        /// third lock): it is reachable only when a claimant died between intent-create and
+        /// intent-release, and its residual is another claimant pair racing the MAIN takeover —
+        /// two small probabilities multiplied, accepted by design in both languages.
+        /// </summary>
+        private byte[]? TryAcquireTakeoverIntent()
+        {
+            var content = BuildOwnDocument();
+
+            for (var createAttempt = 0; createAttempt < 2; createAttempt++)
+            {
+                if (TryExclusiveCreateWithContent(_intentPath, content))
+                {
+                    // Read back and verify the intent is OURS (owner-adopted narrowing): a racing
+                    // crashed-intent recovery could have deleted and replaced it already.
+                    var readBack = TryReadAllBytes(_intentPath);
+                    if (readBack == null || !BytesEqual(readBack, content))
+                        return null;
+                    return content;
+                }
+
+                // Create failed. If no intent exists (delete-pending window / vanished), retry the
+                // exclusive-create once; if one exists, recover it only when its claimant crashed.
+                if (!File.Exists(_intentPath))
+                    continue;
+
+                DateTime imtime1;
+                try
+                {
+                    imtime1 = File.GetLastWriteTimeUtc(_intentPath);
+                }
+                catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+                {
+                    return null;
+                }
+
+                var icontent1 = TryReadAllBytes(_intentPath);
+                if (icontent1 == null)
+                    continue; // vanished — retry the exclusive-create once
+
+                var ithresholdMs = StalenessThresholdMs(icontent1, out _);
+                if ((DateTime.UtcNow - imtime1).TotalMilliseconds < ithresholdMs)
+                    return null; // a live claimant is mid-takeover — back off
+
+                // Compare-and-delete the crashed intent, then retry the exclusive-create once.
+                DateTime imtime2;
+                try
+                {
+                    imtime2 = File.GetLastWriteTimeUtc(_intentPath);
+                }
+                catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+                {
+                    return null;
+                }
+                var icontent2 = TryReadAllBytes(_intentPath);
+                if (icontent2 == null)
+                    continue;
+                if (imtime2 != imtime1 || !BytesEqual(icontent1, icontent2))
+                    return null;
+                try
+                {
+                    File.Delete(_intentPath);
+                }
+                catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+                {
+                    return null;
+                }
+            }
+            return null;
+        }
+
+        /// <summary>Release the takeover-intent file — only when it still carries OUR content.</summary>
+        private void ReleaseTakeoverIntent(byte[] ownContent)
+        {
+            var current = TryReadAllBytes(_intentPath);
+            if (current == null)
+                return; // already gone
+            if (!BytesEqual(current, ownContent))
+                return; // a crashed-intent recovery replaced it — it is someone else's now
+
+            TryDeleteFileBestEffort(_intentPath);
+        }
+
+        // ── Lock document {pid, startedAt, hostId, nonce} (04 §2 + A2 nonce amendment) ───────────
 
         private sealed class LockDocument
         {
             public long Pid { get; set; }
             public string? StartedAt { get; set; }
             public string? HostId { get; set; }
+            public string? Nonce { get; set; }
         }
 
-        private byte[] BuildOwnContent()
+        private byte[] BuildOwnDocument()
         {
             var document = new LockDocument
             {
                 Pid = CurrentPid,
                 StartedAt = DateTimeOffset.UtcNow.ToString("O", CultureInfo.InvariantCulture),
                 HostId = _hostId,
+                Nonce = NewNonce(), // fresh 128-bit hex per acquisition attempt: makes every document unique
             };
             return Encoding.UTF8.GetBytes(JsonSerializer.Serialize(document, SerializerOptions));
         }
@@ -369,28 +588,77 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
             }
         }
 
-        private static string? ParseHostId(byte[] content)
+        private static string NewNonce()
         {
+            var bytes = new byte[16];
+            using (var rng = RandomNumberGenerator.Create())
+                rng.GetBytes(bytes);
+            var builder = new StringBuilder(32);
+            foreach (var b in bytes)
+                builder.Append(b.ToString("x2", CultureInfo.InvariantCulture));
+            return builder.ToString();
+        }
+
+        /// <summary>
+        /// Classify a lock/intent document into its staleness bar (04 §2 + B2 amendment):
+        /// unparseable/zero-byte → <see cref="LOCK_STALE_MS"/> (writer provably never completed an
+        /// acquire; <paramref name="unparseable"/> true); well-formed with a local hostId →
+        /// <see cref="LOCK_STALE_MS"/>; well-formed but foreign/empty/missing hostId (or valid
+        /// JSON of the wrong shape — its writer DID complete a write, so the torn-write argument
+        /// does not apply) → <see cref="FOREIGN_HOST_STALE_MS"/>. Unknown extra fields are
+        /// tolerated.
+        /// </summary>
+        private long StalenessThresholdMs(byte[] content, out bool unparseable)
+        {
+            unparseable = false;
+
+            if (content.Length == 0)
+            {
+                unparseable = true;
+                return _staleMs;
+            }
+
+            string? hostId = null;
+            var wellFormed = false;
             try
             {
                 using (var document = JsonDocument.Parse(content))
                 {
-                    if (document.RootElement.ValueKind == JsonValueKind.Object
-                        && document.RootElement.TryGetProperty("hostId", out var hostId)
-                        && hostId.ValueKind == JsonValueKind.String)
-                        return hostId.GetString();
+                    var root = document.RootElement;
+                    // Same shape requirements as the TS twin's parseLockContent: pid number,
+                    // startedAt string, hostId string; unknown fields tolerated.
+                    if (root.ValueKind == JsonValueKind.Object
+                        && root.TryGetProperty("pid", out var pid) && pid.ValueKind == JsonValueKind.Number
+                        && root.TryGetProperty("startedAt", out var startedAt) && startedAt.ValueKind == JsonValueKind.String
+                        && root.TryGetProperty("hostId", out var host) && host.ValueKind == JsonValueKind.String)
+                    {
+                        wellFormed = true;
+                        hostId = host.GetString();
+                    }
                 }
             }
             catch (JsonException)
             {
-                // Unparseable (empty file from a writer killed between create and write, foreign
-                // format, corruption) — no provable local owner, treated as foreign (24 h bar).
+                // Torn/partial write: the writer was killed between create and write (or the
+                // artifact is a cleaned-up write failure). It provably never entered the critical
+                // section — short bar (B2, owner-adopted).
+                unparseable = true;
+                return _staleMs;
             }
-            return null;
+
+            if (!wellFormed)
+                return _foreignStaleMs; // valid JSON, wrong shape: a completed write by an unknown writer
+
+            return IsLocalHostId(hostId) ? _staleMs : _foreignStaleMs;
         }
 
-        private bool HostIdMatchesLocal(string? hostId)
-            => hostId != null && string.Equals(hostId, _hostId, StringComparison.OrdinalIgnoreCase);
+        /// <summary>
+        /// Case-insensitive (invariant-culture) hostId comparison; empty or missing hostId always
+        /// compares as foreign.
+        /// </summary>
+        private bool IsLocalHostId(string? hostId)
+            => !string.IsNullOrEmpty(hostId)
+               && string.Equals(hostId, _hostId, StringComparison.InvariantCultureIgnoreCase);
 
         private static string ResolveLocalHostId()
         {
@@ -398,7 +666,9 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
             {
                 // Same gethostname source as Node's os.hostname(), so the TS twin's locks are
                 // recognised as local. Environment.MachineName (NetBIOS, upper-cased, 15-char
-                // truncated on Windows) would NOT match it.
+                // truncated on Windows) would NOT match it and is only the exception fallback —
+                // over-conservative direction only (a mismatch means the foreign bar, never a
+                // wrongful takeover).
                 return System.Net.Dns.GetHostName();
             }
             catch (Exception)
@@ -407,10 +677,37 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
             }
         }
 
+        private void Warn(string message)
+        {
+            var sink = _diagnostics;
+            if (sink != null)
+            {
+                try
+                {
+                    sink(message);
+                }
+                catch
+                {
+                    // A diagnostics sink must never break the protocol.
+                }
+                return;
+            }
+            Trace.TraceWarning(message);
+        }
+
+        private static int NextBackoffMs(Random random, int attempt)
+        {
+            // Mirror the TS twin: base 25 ms doubled per attempt (exponent capped), capped at
+            // 500 ms, then jittered ×[0.5, 1.5).
+            var uncapped = (long)BackoffBaseMs << Math.Min(attempt, 10);
+            var capped = (int)Math.Min(uncapped, BackoffCapMs);
+            return Math.Max(1, (int)Math.Round(capped * (0.5 + random.NextDouble())));
+        }
+
         // ── Shared low-level helpers (also used by the handle) ───────────────────────────────────
 
         /// <summary>
-        /// Read the lock file without ever blocking a peer's rename/delete
+        /// Read a protocol file without ever blocking a peer's rename/delete
         /// (<c>FileShare.ReadWrite | FileShare.Delete</c>), with a short retry for transient
         /// sharing violations. Returns <c>null</c> when the file is gone or unreadable.
         /// </summary>
@@ -457,6 +754,18 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
                     return false;
             }
             return true;
+        }
+
+        internal static void TryDeleteFileBestEffort(string path)
+        {
+            try
+            {
+                File.Delete(path);
+            }
+            catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+            {
+                // Best-effort: an undeletable artifact ages into stale takeover (04 §2).
+            }
         }
 
         private void EnsureBaseDirectory()
@@ -510,9 +819,11 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
 
         /// <summary>
         /// True when the on-disk lock document is still byte-identical to what this process
-        /// wrote — i.e. the lock has not been (wrongly) taken over. Used by the takeover path's
-        /// verify-own-content step (04 §2) and by holders that want to assert their own integrity
-        /// after a long critical section.
+        /// wrote — i.e. the lock has not been (wrongly) taken over. The per-acquisition nonce
+        /// makes the comparison unambiguous even across attempts of the same process. Used by the
+        /// acquire path's verify-own-content step (04 §2) and by holders that want to assert their
+        /// own integrity after a long critical section (recommended for b3: check immediately
+        /// before the store write).
         /// </summary>
         public bool IsStillOwned()
         {
@@ -530,14 +841,7 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
             if (onDisk != null && !MachineCredentialLock.BytesEqual(onDisk, _content))
                 return; // not ours any more — never delete a peer's lock
 
-            try
-            {
-                File.Delete(_lockPath);
-            }
-            catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
-            {
-                // Best-effort: an undeletable lock file ages into stale takeover (04 §2).
-            }
+            MachineCredentialLock.TryDeleteFileBestEffort(_lockPath);
         }
     }
 }

--- a/McpPlugin/src/AgentConfig/MachineCredentialLock.cs
+++ b/McpPlugin/src/AgentConfig/MachineCredentialLock.cs
@@ -61,18 +61,22 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
     ///         compare-and-delete rules (deliberately unserialized — the residual needs the rare
     ///         crashed-intent precondition ON TOP of the tight race window; accepted by design in
     ///         both languages).</item>
-    ///   <item><b>Staleness bars</b> — well-formed document with a case-insensitively local
-    ///         <c>hostId</c>: <see cref="LOCK_STALE_MS"/> (60 s). Well-formed but foreign,
-    ///         empty, or missing <c>hostId</c> (network home / unknown writer):
-    ///         <see cref="FOREIGN_HOST_STALE_MS"/> (24 h). <b>Unparseable or zero-byte document
-    ///         (owner-adopted amendment, review B2): <see cref="LOCK_STALE_MS"/> (60 s)</b> — a
-    ///         torn document's writer provably never completed its acquire write, which precedes
-    ///         handle-return, which precedes the critical section, so taking it over can never
-    ///         collide with an in-flight refresh; the 24 h bar would only convert every
-    ///         crash-in-the-create-window artifact into a day-long machine-wide auth freeze. One
-    ///         diagnostic warning is emitted when an unparseable lock is taken over. The same
-    ///         classification applies to the intent file (same writer-never-proceeded
-    ///         argument).</item>
+    ///   <item><b>Staleness classes</b> — one shared classifier (mirror of the TS twin's
+    ///         <c>classifyLockDocument</c>), applied to the lock AND the intent file:
+    ///         <c>local</c> (JSON object whose <c>hostId</c> equals ours,
+    ///         <see cref="StringComparison.OrdinalIgnoreCase"/> — the pinned cross-language
+    ///         semantic; TS folds via <c>toLowerCase()</c>, diverging only on non-ASCII
+    ///         hostnames in the conservative direction) → <see cref="LOCK_STALE_MS"/> (60 s);
+    ///         <c>foreign</c> (JSON object with a missing, empty, or different <c>hostId</c> —
+    ///         network home / unknown writer) → <see cref="FOREIGN_HOST_STALE_MS"/> (24 h);
+    ///         <c>unparseable</c> (zero-byte, corrupted, or any non-object JSON — owner-adopted
+    ///         amendment, review B2) → <see cref="LOCK_STALE_MS"/> (60 s), because such an
+    ///         artifact's writer provably never completed its acquire write, which precedes
+    ///         handle-return, which precedes the critical section — taking it over can never
+    ///         collide with an in-flight refresh, and the 24 h bar would only convert every
+    ///         crash-in-the-create-window artifact into a day-long machine-wide auth freeze.
+    ///         One diagnostic warning is emitted after an unparseable LOCK artifact is removed;
+    ///         intent recovery is intentionally silent (mirrored asymmetry).</item>
     ///   <item><b>Release</b> — delete the lock file, guarded: the on-disk bytes are compared to
     ///         our own first, so a peer's lock is never deleted
     ///         (<see cref="MachineCredentialLockHandle.Dispose"/>).</item>
@@ -104,8 +108,8 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
     ///
     /// <para><b>hostId</b> defaults to <see cref="System.Net.Dns.GetHostName"/> — the same
     /// <c>gethostname</c> source as Node's <c>os.hostname()</c>, so C# and TS processes on one
-    /// machine recognise each other as local. Comparison is case-insensitive
-    /// (invariant-culture); an empty or missing <c>hostId</c> always compares as foreign.</para>
+    /// machine recognise each other as local. Comparison is ordinal case-insensitive; an empty
+    /// or missing <c>hostId</c> always compares as foreign.</para>
     ///
     /// <para><b>Clock caveats (spec-inherent, shared with the TS twin):</b> a backward clock jump
     /// only delays takeover (safe direction); a forward step &gt; ~45 s can declare a live holder
@@ -201,6 +205,22 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
         /// in production.
         /// </summary>
         internal Action? WriteFaultInjection;
+
+        /// <summary>
+        /// Test seam: invoked between the intent file's successful exclusive-create and its
+        /// read-back verification — lets a test displace the intent there, deterministically
+        /// pinning the read-back control (whose deletion is otherwise invisible: the pre-removal
+        /// re-verify downstream masks it). Never set in production.
+        /// </summary>
+        internal Action? AfterIntentCreateInjection;
+
+        /// <summary>
+        /// Test seam: invoked right after intent acquisition succeeds, before the candidate
+        /// re-validation and the pre-removal intent re-verify — lets a test displace (or restore)
+        /// the intent there, deterministically pinning the pre-removal re-verify control. Never
+        /// set in production.
+        /// </summary>
+        internal Action? AfterIntentAcquiredInjection;
 
         /// <summary>
         /// Create a lock rooted at <paramref name="baseDirectory"/>, or at <c>~/.ai-game-dev</c>
@@ -404,8 +424,8 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
             if (content1 == null)
                 return false; // vanished or unreadable right now — retry later
 
-            var thresholdMs = StalenessThresholdMs(content1, out var unparseable);
-            if ((DateTime.UtcNow - mtime1).TotalMilliseconds < thresholdMs)
+            var documentClass = ClassifyLockDocument(content1);
+            if ((DateTime.UtcNow - mtime1).TotalMilliseconds < StalenessThresholdMs(documentClass))
                 return false; // a live (or not-provably-dead) holder — keep waiting
 
             // Serialize claimants: only the winner of the intent file's exclusive-create may
@@ -418,6 +438,8 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
 
             try
             {
+                AfterIntentAcquiredInjection?.Invoke(); // test seam; no-op in production
+
                 // Re-validate under the intent: remove only the exact artifact we judged stale
                 // (mtime + size + byte-identical content — a live replacement always differs, its
                 // startedAt/nonce are newer than the dead holder's).
@@ -447,13 +469,6 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
                 if (intentNow == null || !BytesEqual(intentNow, intentContent))
                     return false;
 
-                if (unparseable)
-                {
-                    Warn("machine credential lock: taking over an unparseable/zero-byte lock document at "
-                        + _lockPath + " (age past LOCK_STALE_MS; its writer never completed an acquire — "
-                        + "likely a process killed in the create window or a cleaned-up write failure)");
-                }
-
                 try
                 {
                     File.Delete(_lockPath);
@@ -461,6 +476,18 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
                 catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
                 {
                     return false; // somebody else's delete won — retry
+                }
+
+                if (documentClass == LockDocumentClass.Unparseable)
+                {
+                    // One diagnostic per takeover of a corrupt artifact (fix-round amendment,
+                    // AFTER the successful removal — mirroring the TS twin): its writer never
+                    // entered the critical section, but its existence usually means a crashed or
+                    // interrupted acquisition worth surfacing. Lock documents carry no token
+                    // material. Intent recovery is intentionally silent (mirrored asymmetry).
+                    Warn("credential lock takeover: removed an unparseable (zero-byte or corrupted) lock artifact at "
+                        + _lockPath + "; treated as stale at LOCK_STALE_MS because its writer can never have "
+                        + "entered the critical section");
                 }
                 return true;
             }
@@ -487,11 +514,13 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
             {
                 if (TryExclusiveCreateWithContent(_intentPath, content))
                 {
+                    AfterIntentCreateInjection?.Invoke(); // test seam; no-op in production
+
                     // Read back and verify the intent is OURS (owner-adopted narrowing): a racing
                     // crashed-intent recovery could have deleted and replaced it already.
                     var readBack = TryReadAllBytes(_intentPath);
                     if (readBack == null || !BytesEqual(readBack, content))
-                        return null;
+                        return null; // displaced — the removal authority is not ours; never delete theirs
                     return content;
                 }
 
@@ -514,7 +543,10 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
                 if (icontent1 == null)
                     continue; // vanished — retry the exclusive-create once
 
-                var ithresholdMs = StalenessThresholdMs(icontent1, out _);
+                // Same classification rules as the lock itself: an unparseable/zero-byte intent's
+                // writer never completed intent acquisition, so it gets the short threshold too
+                // (a killed creator must not wedge takeover for 24 h). Recovery is silent.
+                var ithresholdMs = StalenessThresholdMs(ClassifyLockDocument(icontent1));
                 if ((DateTime.UtcNow - imtime1).TotalMilliseconds < ithresholdMs)
                     return null; // a live claimant is mid-takeover — back off
 
@@ -600,41 +632,48 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
         }
 
         /// <summary>
-        /// Classify a lock/intent document into its staleness bar (04 §2 + B2 amendment):
-        /// unparseable/zero-byte → <see cref="LOCK_STALE_MS"/> (writer provably never completed an
-        /// acquire; <paramref name="unparseable"/> true); well-formed with a local hostId →
-        /// <see cref="LOCK_STALE_MS"/>; well-formed but foreign/empty/missing hostId (or valid
-        /// JSON of the wrong shape — its writer DID complete a write, so the torn-write argument
-        /// does not apply) → <see cref="FOREIGN_HOST_STALE_MS"/>. Unknown extra fields are
-        /// tolerated.
+        /// Staleness class of a lock/intent document (mirror of the TS twin's
+        /// <c>classifyLockDocument</c>): <c>Local</c>/<c>Unparseable</c> take the short bar,
+        /// <c>Foreign</c> the 24 h bar — see <see cref="StalenessThresholdMs"/>.
         /// </summary>
-        private long StalenessThresholdMs(byte[] content, out bool unparseable)
+        internal enum LockDocumentClass
         {
-            unparseable = false;
+            Local,
+            Foreign,
+            Unparseable,
+        }
 
+        /// <summary>
+        /// Classify a lock/intent document (one shared classifier for BOTH files, mirroring the
+        /// TS twin's <c>classifyLockDocument</c>): invalid JSON, zero bytes, or any non-object
+        /// JSON → <see cref="LockDocumentClass.Unparseable"/> (a torn or alien artifact — its
+        /// writer never completed a protocol acquire); JSON object with a missing, empty, or
+        /// non-string <c>hostId</c> → <see cref="LockDocumentClass.Foreign"/> (a completed write
+        /// proving nothing about which machine wrote it); otherwise the ordinal case-insensitive
+        /// <c>hostId</c> comparison decides Local vs Foreign (the pinned cross-language semantic —
+        /// TS folds via <c>toLowerCase()</c>, diverging only on non-ASCII hostnames, in the
+        /// conservative direction). Unknown extra fields are tolerated.
+        /// </summary>
+        internal LockDocumentClass ClassifyLockDocument(byte[] content)
+        {
             if (content.Length == 0)
-            {
-                unparseable = true;
-                return _staleMs;
-            }
+                return LockDocumentClass.Unparseable;
 
-            string? hostId = null;
-            var wellFormed = false;
             try
             {
                 using (var document = JsonDocument.Parse(content))
                 {
                     var root = document.RootElement;
-                    // Same shape requirements as the TS twin's parseLockContent: pid number,
-                    // startedAt string, hostId string; unknown fields tolerated.
-                    if (root.ValueKind == JsonValueKind.Object
-                        && root.TryGetProperty("pid", out var pid) && pid.ValueKind == JsonValueKind.Number
-                        && root.TryGetProperty("startedAt", out var startedAt) && startedAt.ValueKind == JsonValueKind.String
-                        && root.TryGetProperty("hostId", out var host) && host.ValueKind == JsonValueKind.String)
-                    {
-                        wellFormed = true;
-                        hostId = host.GetString();
-                    }
+                    if (root.ValueKind != JsonValueKind.Object)
+                        return LockDocumentClass.Unparseable;
+                    if (!root.TryGetProperty("hostId", out var host) || host.ValueKind != JsonValueKind.String)
+                        return LockDocumentClass.Foreign;
+                    var hostId = host.GetString();
+                    if (string.IsNullOrEmpty(hostId))
+                        return LockDocumentClass.Foreign;
+                    return string.Equals(hostId, _hostId, StringComparison.OrdinalIgnoreCase)
+                        ? LockDocumentClass.Local
+                        : LockDocumentClass.Foreign;
                 }
             }
             catch (JsonException)
@@ -642,23 +681,13 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
                 // Torn/partial write: the writer was killed between create and write (or the
                 // artifact is a cleaned-up write failure). It provably never entered the critical
                 // section — short bar (B2, owner-adopted).
-                unparseable = true;
-                return _staleMs;
+                return LockDocumentClass.Unparseable;
             }
-
-            if (!wellFormed)
-                return _foreignStaleMs; // valid JSON, wrong shape: a completed write by an unknown writer
-
-            return IsLocalHostId(hostId) ? _staleMs : _foreignStaleMs;
         }
 
-        /// <summary>
-        /// Case-insensitive (invariant-culture) hostId comparison; empty or missing hostId always
-        /// compares as foreign.
-        /// </summary>
-        private bool IsLocalHostId(string? hostId)
-            => !string.IsNullOrEmpty(hostId)
-               && string.Equals(hostId, _hostId, StringComparison.InvariantCultureIgnoreCase);
+        /// <summary>The staleness bar for a document class (B2 amendment: unparseable = short bar).</summary>
+        private long StalenessThresholdMs(LockDocumentClass documentClass)
+            => documentClass == LockDocumentClass.Foreign ? _foreignStaleMs : _staleMs;
 
         private static string ResolveLocalHostId()
         {

--- a/McpPlugin/src/AgentConfig/MachineCredentialLock.cs
+++ b/McpPlugin/src/AgentConfig/MachineCredentialLock.cs
@@ -1,0 +1,543 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+
+namespace com.IvanMurzak.McpPlugin.AgentConfig
+{
+    /// <summary>
+    /// The cross-process lock protecting the machine credential store — design 04 §2, identical
+    /// semantics in C# (this class) and TS (cli-core twin). Lock file:
+    /// <c>~/.ai-game-dev/credentials.lock</c>, a sibling of the data file, never the data file
+    /// itself.
+    ///
+    /// <para><b>Protocol (04 §2):</b></para>
+    /// <list type="bullet">
+    ///   <item><b>Acquire</b> — exclusive-create <b>only</b> (<see cref="FileMode.CreateNew"/> /
+    ///         TS <c>open(…,'wx')</c>), writing <c>{pid, startedAt, hostId}</c>; the handle is
+    ///         closed immediately after the write so the mtime is visible to peers. No
+    ///         <c>FileShare.None</c>/flock reliance anywhere: .NET skips advisory locks on NFS/SMB
+    ///         and <c>File.Delete</c> ignores them on Linux (O6). Failure retries with jittered
+    ///         backoff.</item>
+    ///   <item><b>Stale takeover (compare-and-delete)</b> — a candidate whose <b>last-write</b>
+    ///         time (never last-access) is older than <see cref="LOCK_STALE_MS"/> and whose
+    ///         <c>hostId</c> matches the local host: read its content, re-stat, delete only if the
+    ///         content is byte-identical to what was read, race for exclusive-create, and verify
+    ///         the new lock's content is our own before entering. A lock with a foreign (or
+    ///         unparseable) <c>hostId</c> — a network home — is only taken over after
+    ///         <see cref="FOREIGN_HOST_STALE_MS"/> (24 h).</item>
+    ///   <item><b>Release</b> — delete the lock file (guarded: never deletes a peer's lock — see
+    ///         <see cref="MachineCredentialLockHandle.Dispose"/>).</item>
+    ///   <item><b>Budget exhausted</b> — the attempt fails as <b>busy</b>
+    ///         (<see cref="TryAcquire"/> returns <c>null</c>); it never proceeds lock-free
+    ///         (D9 REVISED — the removed "kill-switch" would have reintroduced the reuse
+    ///         race).</item>
+    /// </list>
+    ///
+    /// <para><b>Constants are a shared cross-language contract</b>: the names and values match the
+    /// TS twin verbatim so the golden-parity suite (task x1) can assert equality. The ordering
+    /// <see cref="REFRESH_HTTP_TIMEOUT"/> &lt; <see cref="LOCK_STALE_MS"/> &lt;
+    /// <see cref="ACQUIRE_BUDGET"/> is the invariant: a live holder inside one HTTP call can never
+    /// be declared stale, and a waiter always outlives the stale threshold so takeover is
+    /// reachable.</para>
+    ///
+    /// <para><b>Windows <c>FileOptions.DeleteOnClose</c> (04 §2 "optional hardening") is
+    /// deliberately not used:</b> holding the handle open would conflict with the base protocol's
+    /// "close immediately so the mtime is peer-visible" requirement, diverge the observable
+    /// semantics from the TS twin (which cannot hold-with-delete-on-close), and change what peers
+    /// can read while the lock is held. Crash release is instead provided by the stale-takeover
+    /// path, proven by the kill -9 recovery plant (04 §5).</para>
+    ///
+    /// <para><b>hostId</b> defaults to <see cref="System.Net.Dns.GetHostName"/> — the same
+    /// <c>gethostname</c> source Node's <c>os.hostname()</c> uses, so C# and TS processes on one
+    /// machine recognise each other as local. Comparison is case-insensitive.</para>
+    /// </summary>
+    public sealed class MachineCredentialLock
+    {
+        /// <summary>File name of the lock file, a sibling of the credential data file (04 §2).</summary>
+        public const string LockFileName = "credentials.lock";
+
+        // ── Shared cross-language contract constants (04 §2) ─────────────────────────────────────
+        // Names and values match the TS twin verbatim (x1 asserts cross-language equality), which
+        // is why they are SCREAMING_SNAKE_CASE rather than C# convention. All values are in
+        // milliseconds. The ordering REFRESH_HTTP_TIMEOUT < LOCK_STALE_MS < ACQUIRE_BUDGET is the
+        // protocol invariant — never edit one without re-checking the other two.
+
+        /// <summary>
+        /// Timeout for the refresh HTTP call made inside the critical section, in ms. Must be
+        /// explicitly applied to the HttpClient by the refresher (task b3) — .NET's default is
+        /// 100 s, which would outlive <see cref="LOCK_STALE_MS"/> and let a live holder be
+        /// declared stale.
+        /// </summary>
+        public const int REFRESH_HTTP_TIMEOUT = 15_000;
+
+        /// <summary>
+        /// Age (by last-write time) past which a local-host lock is a stale-takeover candidate, in ms.
+        /// </summary>
+        public const int LOCK_STALE_MS = 60_000;
+
+        /// <summary>
+        /// Total time an acquire attempt keeps trying before failing as "busy", in ms. Strictly
+        /// greater than <see cref="LOCK_STALE_MS"/> so a waiter outlives the stale threshold and
+        /// takeover is reachable.
+        /// </summary>
+        public const int ACQUIRE_BUDGET = 75_000;
+
+        /// <summary>
+        /// Age past which a lock with a foreign or unparseable <c>hostId</c> may be taken over, in
+        /// ms (24 h; 04 §2). Foreign PIDs cannot be probed and cross-host mtimes are clock-skewed,
+        /// so the bar is deliberately high. An unparseable lock document has no provable local
+        /// owner either, so it gets the same conservative bar.
+        /// </summary>
+        public const long FOREIGN_HOST_STALE_MS = 24L * 60 * 60 * 1000;
+
+        // Jittered backoff between acquire attempts (04 §2): doubling from Initial to Max, each
+        // delay drawn uniformly from [d/2, d]. Internal tuning, not part of the shared contract.
+        private const int InitialBackoffMs = 50;
+        private const int MaxBackoffMs = 1_000;
+
+        // 0700 (owner rwx) as a binary bit-pattern — C# has no octal literals. Mirrors
+        // MachineCredentialStore's directory policy so a lock-first code path (login acquires the
+        // lock before the first store write) never leaves ~/.ai-game-dev world-readable.
+        private const uint PosixDirectoryPermissions = 0b111_000_000; // rwx --- ---
+
+        private static readonly JsonSerializerOptions SerializerOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            PropertyNameCaseInsensitive = true,
+            WriteIndented = false, // compact, like the TS twin's JSON.stringify default
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        };
+
+        private readonly string _baseDirectory;
+        private readonly string _lockPath;
+        private readonly string _hostId;
+        private readonly int _acquireBudgetMs;
+        private readonly long _staleMs;
+        private readonly long _foreignStaleMs;
+
+        /// <summary>
+        /// Create a lock rooted at <paramref name="baseDirectory"/>, or at <c>~/.ai-game-dev</c>
+        /// when null (the same root as <see cref="MachineCredentialStore"/>).
+        /// <paramref name="hostId"/> overrides the local host identifier — tests only; production
+        /// callers use the default.
+        /// </summary>
+        public MachineCredentialLock(string? baseDirectory = null, string? hostId = null)
+            : this(baseDirectory, hostId, ACQUIRE_BUDGET, LOCK_STALE_MS, FOREIGN_HOST_STALE_MS)
+        {
+        }
+
+        /// <summary>
+        /// Test seam (InternalsVisibleTo: McpPlugin.Tests): override the protocol timings so unit
+        /// tests of the busy / foreign-bar paths do not consume the real 75 s budget. Production
+        /// code paths always go through the public constructor, which pins the contract constants.
+        /// </summary>
+        internal MachineCredentialLock(
+            string? baseDirectory,
+            string? hostId,
+            int acquireBudgetMs,
+            long staleMs,
+            long foreignStaleMs)
+        {
+            _baseDirectory = baseDirectory ?? Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                MachineCredentialStore.DirectoryName);
+            _lockPath = Path.Combine(_baseDirectory, LockFileName);
+            _hostId = hostId ?? ResolveLocalHostId();
+            _acquireBudgetMs = acquireBudgetMs;
+            _staleMs = staleMs;
+            _foreignStaleMs = foreignStaleMs;
+        }
+
+        /// <summary>Absolute path of the directory holding the lock (and the store).</summary>
+        public string BaseDirectory => _baseDirectory;
+
+        /// <summary>Absolute path of the lock file.</summary>
+        public string LockPath => _lockPath;
+
+        /// <summary>The host identifier written into (and compared against) lock documents.</summary>
+        public string HostId => _hostId;
+
+        /// <summary>
+        /// Try to acquire the lock within <see cref="ACQUIRE_BUDGET"/>. Returns the held lock, or
+        /// <c>null</c> when the budget is exhausted — the attempt then fails as <b>busy</b> and the
+        /// caller must NOT proceed lock-free (04 §2, D9 REVISED). Dispose the handle to release.
+        /// </summary>
+        public MachineCredentialLockHandle? TryAcquire()
+        {
+            EnsureBaseDirectory();
+
+            var stopwatch = Stopwatch.StartNew();
+            var random = new Random();
+            var backoffMs = InitialBackoffMs;
+
+            while (true)
+            {
+                var handle = TryCreateOwnLock();
+                if (handle != null)
+                    return handle;
+
+                handle = TryTakeOverStaleLock();
+                if (handle != null)
+                    return handle;
+
+                var remainingMs = _acquireBudgetMs - stopwatch.ElapsedMilliseconds;
+                if (remainingMs <= 0)
+                    return null; // busy — never lock-free (04 §2, D9 REVISED)
+
+                // Jittered backoff (04 §2): uniform in [backoff/2, backoff], clamped so the final
+                // sleep wakes exactly at the deadline for one last attempt.
+                var delayMs = backoffMs / 2 + random.Next(backoffMs / 2 + 1);
+                if (delayMs > remainingMs)
+                    delayMs = (int)remainingMs;
+                Thread.Sleep(delayMs);
+                backoffMs = Math.Min(backoffMs * 2, MaxBackoffMs);
+            }
+        }
+
+        /// <summary>
+        /// Run <paramref name="criticalSection"/> while holding the lock, then release. Returns
+        /// <c>false</c> (without running the action) when the acquire budget is exhausted — busy,
+        /// never lock-free.
+        /// </summary>
+        public bool TryRunExclusive(Action criticalSection)
+        {
+            if (criticalSection == null)
+                throw new ArgumentNullException(nameof(criticalSection));
+
+            using (var handle = TryAcquire())
+            {
+                if (handle == null)
+                    return false;
+                criticalSection();
+                return true;
+            }
+        }
+
+        /// <summary>
+        /// The logout delete path (04 §2, exposed for F6): acquire → unlink store → release →
+        /// unlink lock. Server-side revocation is the caller's job and happens before this call.
+        /// Returns <c>false</c> (store untouched) when the lock is busy.
+        /// </summary>
+        public bool TryDeleteStore(MachineCredentialStore store)
+        {
+            if (store == null)
+                throw new ArgumentNullException(nameof(store));
+
+            return TryRunExclusive(store.Delete);
+        }
+
+        // ── Acquire: exclusive-create only (04 §2) ───────────────────────────────────────────────
+
+        private MachineCredentialLockHandle? TryCreateOwnLock()
+        {
+            var content = BuildOwnContent();
+            try
+            {
+                // FileMode.CreateNew is the entire mutual-exclusion primitive — atomic on every
+                // OS and every filesystem we support, including NFS/SMB (O6). FileShare.Read lets
+                // a peer's staleness read proceed during the microseconds the handle is open.
+                using (var stream = new FileStream(_lockPath, FileMode.CreateNew, FileAccess.Write, FileShare.Read))
+                {
+                    stream.Write(content, 0, content.Length);
+                } // closed immediately: the close publishes the mtime to peers (04 §2)
+            }
+            catch (IOException)
+            {
+                return null; // the lock exists — somebody else holds it (or a transient failure; retry)
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return null;
+            }
+
+            return new MachineCredentialLockHandle(_lockPath, content);
+        }
+
+        // ── Stale takeover: compare-and-delete (04 §2) ───────────────────────────────────────────
+
+        private MachineCredentialLockHandle? TryTakeOverStaleLock()
+        {
+            if (!File.Exists(_lockPath))
+                return null; // vanished — the next loop iteration races exclusive-create
+
+            DateTime firstLastWriteUtc;
+            try
+            {
+                // Last-WRITE time, never last-access (04 §2): atime is unreliable (relatime,
+                // noatime mounts) and is touched by the peers' own staleness reads.
+                firstLastWriteUtc = File.GetLastWriteTimeUtc(_lockPath);
+            }
+            catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+            {
+                return null;
+            }
+
+            var observed = TryReadAllBytes(_lockPath);
+            if (observed == null)
+                return null; // vanished or unreadable right now — retry later
+
+            var ageMs = (DateTime.UtcNow - firstLastWriteUtc).TotalMilliseconds;
+            var isLocal = HostIdMatchesLocal(ParseHostId(observed));
+            var thresholdMs = isLocal ? _staleMs : _foreignStaleMs;
+            if (ageMs < thresholdMs)
+                return null; // a live (or not-provably-dead) holder — keep waiting
+
+            // Compare-and-delete: re-stat, then delete only if the content is still byte-identical
+            // to what was read — a candidate that changed under us was re-acquired and is not stale.
+            try
+            {
+                if (File.GetLastWriteTimeUtc(_lockPath) != firstLastWriteUtc)
+                    return null;
+            }
+            catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+            {
+                return null;
+            }
+
+            var reRead = TryReadAllBytes(_lockPath);
+            if (reRead == null || !BytesEqual(observed, reRead))
+                return null;
+
+            try
+            {
+                File.Delete(_lockPath);
+            }
+            catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+            {
+                return null; // somebody else's delete/create won — retry
+            }
+
+            // Race for exclusive-create…
+            var handle = TryCreateOwnLock();
+            if (handle == null)
+                return null; // another waiter won the create race
+
+            // …and verify the new lock's content is our own before entering the critical section
+            // (04 §2): a racing waiter's compare-and-delete may have destroyed our fresh lock and
+            // replaced it with its own in the window between our create and now.
+            if (!handle.IsStillOwned())
+            {
+                handle.Dispose(); // guarded release: never deletes the usurper's lock
+                return null;
+            }
+
+            return handle;
+        }
+
+        // ── Lock document {pid, startedAt, hostId} (04 §2) ───────────────────────────────────────
+
+        private sealed class LockDocument
+        {
+            public long Pid { get; set; }
+            public string? StartedAt { get; set; }
+            public string? HostId { get; set; }
+        }
+
+        private byte[] BuildOwnContent()
+        {
+            var document = new LockDocument
+            {
+                Pid = CurrentPid,
+                StartedAt = DateTimeOffset.UtcNow.ToString("O", CultureInfo.InvariantCulture),
+                HostId = _hostId,
+            };
+            return Encoding.UTF8.GetBytes(JsonSerializer.Serialize(document, SerializerOptions));
+        }
+
+        private static long CurrentPid
+        {
+            get
+            {
+                using (var process = Process.GetCurrentProcess())
+                    return process.Id; // netstandard2.1-safe (Environment.ProcessId is net5+)
+            }
+        }
+
+        private static string? ParseHostId(byte[] content)
+        {
+            try
+            {
+                using (var document = JsonDocument.Parse(content))
+                {
+                    if (document.RootElement.ValueKind == JsonValueKind.Object
+                        && document.RootElement.TryGetProperty("hostId", out var hostId)
+                        && hostId.ValueKind == JsonValueKind.String)
+                        return hostId.GetString();
+                }
+            }
+            catch (JsonException)
+            {
+                // Unparseable (empty file from a writer killed between create and write, foreign
+                // format, corruption) — no provable local owner, treated as foreign (24 h bar).
+            }
+            return null;
+        }
+
+        private bool HostIdMatchesLocal(string? hostId)
+            => hostId != null && string.Equals(hostId, _hostId, StringComparison.OrdinalIgnoreCase);
+
+        private static string ResolveLocalHostId()
+        {
+            try
+            {
+                // Same gethostname source as Node's os.hostname(), so the TS twin's locks are
+                // recognised as local. Environment.MachineName (NetBIOS, upper-cased, 15-char
+                // truncated on Windows) would NOT match it.
+                return System.Net.Dns.GetHostName();
+            }
+            catch (Exception)
+            {
+                return Environment.MachineName;
+            }
+        }
+
+        // ── Shared low-level helpers (also used by the handle) ───────────────────────────────────
+
+        /// <summary>
+        /// Read the lock file without ever blocking a peer's rename/delete
+        /// (<c>FileShare.ReadWrite | FileShare.Delete</c>), with a short retry for transient
+        /// sharing violations. Returns <c>null</c> when the file is gone or unreadable.
+        /// </summary>
+        internal static byte[]? TryReadAllBytes(string path)
+        {
+            const int readAttempts = 3;
+            for (var attempt = 1; attempt <= readAttempts; attempt++)
+            {
+                try
+                {
+                    using (var stream = new FileStream(path, FileMode.Open, FileAccess.Read,
+                        FileShare.ReadWrite | FileShare.Delete))
+                    using (var buffer = new MemoryStream())
+                    {
+                        stream.CopyTo(buffer);
+                        return buffer.ToArray();
+                    }
+                }
+                catch (FileNotFoundException)
+                {
+                    return null;
+                }
+                catch (DirectoryNotFoundException)
+                {
+                    return null;
+                }
+                catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+                {
+                    if (attempt == readAttempts)
+                        return null;
+                    Thread.Sleep(25);
+                }
+            }
+            return null;
+        }
+
+        internal static bool BytesEqual(byte[] left, byte[] right)
+        {
+            if (left.Length != right.Length)
+                return false;
+            for (var i = 0; i < left.Length; i++)
+            {
+                if (left[i] != right[i])
+                    return false;
+            }
+            return true;
+        }
+
+        private void EnsureBaseDirectory()
+        {
+            Directory.CreateDirectory(_baseDirectory);
+            SetPosixDirectoryPermissions(_baseDirectory);
+        }
+
+        // Owner-only directory permissions, mirroring MachineCredentialStore's policy (that class
+        // is deliberately not modified here — see the b2 task boundary). Same CA1416 pattern.
+        private static void SetPosixDirectoryPermissions(string path)
+        {
+#if NET8_0_OR_GREATER
+            if (OperatingSystem.IsWindows())
+                return;
+            File.SetUnixFileMode(path, (UnixFileMode)PosixDirectoryPermissions);
+#else
+            if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
+                    System.Runtime.InteropServices.OSPlatform.Windows))
+                return;
+            _ = chmod(path, PosixDirectoryPermissions);
+#endif
+        }
+
+#if !NET8_0_OR_GREATER
+        [System.Runtime.InteropServices.DllImport("libc", EntryPoint = "chmod", SetLastError = true)]
+        private static extern int chmod(string path, uint mode);
+#endif
+    }
+
+    /// <summary>
+    /// A held <see cref="MachineCredentialLock"/>. Dispose to release (04 §2: delete the lock
+    /// file). The release is guarded — it compares the on-disk document against the bytes this
+    /// process wrote and skips the delete when they differ, so a peer's lock is never destroyed
+    /// even if ours was (protocol-violatingly) taken over.
+    /// </summary>
+    public sealed class MachineCredentialLockHandle : IDisposable
+    {
+        private readonly string _lockPath;
+        private readonly byte[] _content;
+        private int _disposed;
+
+        internal MachineCredentialLockHandle(string lockPath, byte[] content)
+        {
+            _lockPath = lockPath;
+            _content = content;
+        }
+
+        /// <summary>Absolute path of the lock file this handle owns.</summary>
+        public string LockPath => _lockPath;
+
+        /// <summary>
+        /// True when the on-disk lock document is still byte-identical to what this process
+        /// wrote — i.e. the lock has not been (wrongly) taken over. Used by the takeover path's
+        /// verify-own-content step (04 §2) and by holders that want to assert their own integrity
+        /// after a long critical section.
+        /// </summary>
+        public bool IsStillOwned()
+        {
+            var onDisk = MachineCredentialLock.TryReadAllBytes(_lockPath);
+            return onDisk != null && MachineCredentialLock.BytesEqual(onDisk, _content);
+        }
+
+        /// <summary>Release the lock (04 §2): guarded delete of the lock file. Idempotent.</summary>
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
+                return;
+
+            var onDisk = MachineCredentialLock.TryReadAllBytes(_lockPath);
+            if (onDisk != null && !MachineCredentialLock.BytesEqual(onDisk, _content))
+                return; // not ours any more — never delete a peer's lock
+
+            try
+            {
+                File.Delete(_lockPath);
+            }
+            catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+            {
+                // Best-effort: an undeletable lock file ages into stale takeover (04 §2).
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements taskflow `unified-machine-auth` task **b2-cs-lock** — design `04-credential-store-and-refresh.md` §2, byte-semantics twin of the upcoming TS lock (c2).

## What

`MachineCredentialLock` (`McpPlugin/src/AgentConfig/MachineCredentialLock.cs`):

- **Acquire**: `~/.ai-game-dev/credentials.lock`, `FileMode.CreateNew` **only** — no `FileShare.None`/flock reliance anywhere (O6). Writes `{pid, startedAt, hostId}`, closes the handle immediately so the mtime is peer-visible, jittered backoff on failure.
- **Constants** (shared cross-language contract, exported for x1 to assert against the TS values): `REFRESH_HTTP_TIMEOUT = 15_000` < `LOCK_STALE_MS = 60_000` < `ACQUIRE_BUDGET = 75_000` (ms; the ordering is the invariant), plus `FOREIGN_HOST_STALE_MS = 24 h`.
- **Stale takeover (compare-and-delete)**: last-**write**-time older than `LOCK_STALE_MS` AND local `hostId` → read → re-stat → delete only if byte-identical → race exclusive-create → **verify own content** before entering. Foreign or unparseable `hostId` → 24 h bar.
- **Busy**: budget exhaustion fails as "busy" (`TryAcquire()` → `null`) — never lock-free (D9 REVISED).
- **Guarded release**: never deletes a peer's lock (byte-compare before delete).
- **F6 logout delete path**: `TryDeleteStore(store)` = acquire → unlink store → release → unlink lock. `TryRunExclusive(Action)` is the seam b3 will wire `Rotate()` through (this PR does **not** touch `MachineCredentialStore` flows, per the task boundary).
- `hostId` = `Dns.GetHostName()` — same `gethostname` source as Node `os.hostname()`, so C# and TS processes on one machine see each other as local (c2 must mirror this).

## Deliberate decisions

- **`FileOptions.DeleteOnClose` (04 §2 "optional Windows hardening") omitted**: holding the handle conflicts with close-immediately mtime visibility and diverges observable semantics from the TS twin; crash release is provided by the stale-takeover path (proven by plant 1). Documented in the class docs.
- **Unparseable lock document** (e.g. empty file from a writer killed between create and write) has no provable local owner → conservative 24 h foreign bar, never the 60 s local bar. c2 should mirror.

## Tests (real subprocesses for the takeover plants — 04 §5)

New `McpPlugin.Tests.LockHarness` console project (test-only, `IsPackable=false`), spawned as real OS processes with the **real contract constants**:

1. **kill -9 recovery**: holder killed mid-hold → survivor recovers after `LOCK_STALE_MS` (lower time bound asserted against the dead lock mtime) within `ACQUIRE_BUDGET`.
2. **live holder**: holder sleeping `REFRESH_HTTP_TIMEOUT` inside the lock is never taken over (holder itself re-verifies byte-identity → `OWNED=true`); the concurrent waiter enters only after the release.
3. **two waiters, one stale lock**: barrier-synchronized start; exclusive critical-section entry proven by an exclusive-create sentinel + sequential-timing assertion; 3 rounds.

Plus 16 in-process tests: constant values + ordering invariant, document semantics, busy-never-lock-free, foreign/unparseable 24 h bar, guarded release, idempotent release, `TryRunExclusive`, logout delete path (incl. busy → store intact).

## RED verification (G-SEC-1) — each plant fails when its control is removed

| Mutation | Plant | Observed RED |
|---|---|---|
| M1: stale takeover call removed | 1 | survivor `BUSY elapsed=75006`, exit 2 |
| M2: local stale bar → 5 s (breaks `REFRESH_HTTP_TIMEOUT < LOCK_STALE_MS`) | 2 | holder `OWNED=false`, exit 3 |
| M3: compare-and-delete + verify-own removed | 3 | both waiters ACQUIRED 4 ms apart, `OVERLAP` on the sentinel |

All mutations reverted; full solution suite green locally on net8.0 + net9.0 (851/851 McpPlugin.Tests, 684/684 McpPlugin.Server.Tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017azy3BykDQDSpxc5F51GAF