### PR TITLE
test(auth): x1 cross-language golden-vector parity — store v2, cohort, DPAPI cross-impl

### DIFF
--- a/McpPlugin.Tests/AgentConfig/MachineCredentialDpapiCrossImplementationTests.cs
+++ b/McpPlugin.Tests/AgentConfig/MachineCredentialDpapiCrossImplementationTests.cs
@@ -1,0 +1,140 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text;
+using com.IvanMurzak.McpPlugin.AgentConfig;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
+{
+    /// <summary>
+    /// Cross-implementation DPAPI parity (unified-machine-auth 04 §1, task x1, Windows CI leg only):
+    /// proves the C# store's <c>CryptProtectData</c>/<c>CryptUnprotectData</c> P/Invoke codec
+    /// (<see cref="MachineCredentialStore"/>) and cli-core's TS codec — which shells out to
+    /// <c>powershell.exe</c> running <c>[System.Security.Cryptography.ProtectedData]</c> (see
+    /// <c>machine-credentials.ts</c> <c>dpapiTransform</c>) — are byte-interoperable: a blob written
+    /// by one is readable by the other, on the SAME machine/user (DPAPI's CurrentUser scope makes a
+    /// cross-machine committed ciphertext vector meaningless — this is why the proof is a live
+    /// round-trip, not a static golden file).
+    ///
+    /// <para>This test file reproduces the TS side's exact mechanism verbatim (the same PowerShell
+    /// script <c>machine-credentials.ts</c> spawns) rather than shelling out to Node, so each repo's
+    /// CI can prove interop hermetically without installing the sibling language's toolchain.</para>
+    ///
+    /// <para><b>Entropy plant (mandated, DoD):</b> DPAPI's optional entropy parameter must be
+    /// <c>null</c> on BOTH sides — <see cref="MachineCredentialStore"/>'s <c>Protect</c>/<c>Unprotect</c>
+    /// pass <c>IntPtr.Zero</c>, and the TS <c>dpapiTransform</c> script passes <c>$null</c>.
+    /// <see cref="EntropyMismatch_TurnsTheCrossDecryptRed_BothDirections"/> proves a non-null entropy
+    /// on EITHER side breaks the round trip — verified RED locally before this suite shipped (see the
+    /// x1 task report for the exact mutation and failure output).</para>
+    /// </summary>
+    public sealed class MachineCredentialDpapiCrossImplementationTests
+    {
+        private static bool IsWindows => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+        private static readonly byte[] SamplePlaintext =
+            Encoding.UTF8.GetBytes("{\"accessToken\":\"dpapi-cross-impl-AT\",\"refreshToken\":\"dpapi-cross-impl-RT\"}");
+
+        /// <summary>
+        /// Verbatim transcription of cli-core's <c>dpapiTransform</c> (machine-credentials.ts) — the
+        /// REAL script the TS store spawns on Windows. Not a re-implementation of DPAPI: it is the
+        /// TS codec's actual mechanism, run here so the C# repo can prove interop without a Node
+        /// toolchain in CI.
+        /// </summary>
+        private static byte[] RunTsShapePowerShellDpapi(string action, byte[] input, byte[]? entropy)
+        {
+            var entropyExpr = entropy == null ? "$null" : "[Convert]::FromBase64String($env:AIGD_ENTROPY)";
+            var script =
+                "$ErrorActionPreference='Stop';" +
+                "Add-Type -AssemblyName System.Security;" +
+                "$in=[Convert]::FromBase64String($env:AIGD_IN);" +
+                $"$out=[System.Security.Cryptography.ProtectedData]::{action}($in,{entropyExpr},[System.Security.Cryptography.DataProtectionScope]::CurrentUser);" +
+                "[Convert]::ToBase64String($out)";
+
+            var psi = new ProcessStartInfo("powershell.exe")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+            psi.ArgumentList.Add("-NoProfile");
+            psi.ArgumentList.Add("-NonInteractive");
+            psi.ArgumentList.Add("-Command");
+            psi.ArgumentList.Add(script);
+            psi.Environment["AIGD_IN"] = Convert.ToBase64String(input);
+            if (entropy != null)
+                psi.Environment["AIGD_ENTROPY"] = Convert.ToBase64String(entropy);
+
+            using var process = Process.Start(psi) ?? throw new InvalidOperationException("failed to start powershell.exe");
+            var stdout = process.StandardOutput.ReadToEnd();
+            var stderr = process.StandardError.ReadToEnd();
+            process.WaitForExit(20_000).ShouldBeTrue("powershell.exe DPAPI helper timed out");
+
+            if (process.ExitCode != 0)
+                throw new CryptographicException($"powershell.exe DPAPI helper ({action}) failed (exit {process.ExitCode}): {stderr}");
+
+            return Convert.FromBase64String(stdout.Trim());
+        }
+
+        [Fact]
+        public void RoundTrip_CSharpProtect_ThenTsShapePowerShellUnprotect_RecoversPlaintext()
+        {
+            if (!IsWindows)
+                return; // Windows-only assertion; exercised on the windows-latest CI leg.
+
+            // Encrypt via the REAL C# codec path (CryptProtectData P/Invoke).
+            var ciphertext = MachineCredentialStore.ProtectBytes(SamplePlaintext);
+
+            // Decrypt via the TS codec's real mechanism (ProtectedData via powershell.exe).
+            var recovered = RunTsShapePowerShellDpapi("Unprotect", ciphertext, entropy: null);
+
+            recovered.ShouldBe(SamplePlaintext);
+        }
+
+        [Fact]
+        public void RoundTrip_TsShapePowerShellProtect_ThenCSharpUnprotect_RecoversPlaintext()
+        {
+            if (!IsWindows)
+                return; // Windows-only assertion; exercised on the windows-latest CI leg.
+
+            // Encrypt via the TS codec's real mechanism (ProtectedData via powershell.exe).
+            var ciphertext = RunTsShapePowerShellDpapi("Protect", SamplePlaintext, entropy: null);
+
+            // Decrypt via the REAL C# codec path (CryptUnprotectData P/Invoke).
+            var recovered = MachineCredentialStore.UnprotectBytes(ciphertext);
+
+            recovered.ShouldBe(SamplePlaintext);
+        }
+
+        [Fact]
+        public void EntropyMismatch_TurnsTheCrossDecryptRed_BothDirections()
+        {
+            if (!IsWindows)
+                return; // Windows-only assertion; exercised on the windows-latest CI leg.
+
+            var entropy = Encoding.UTF8.GetBytes("non-null-entropy-must-break-interop");
+
+            // Direction 1: TS-shape encrypts WITH entropy; C#'s real Unprotect always passes null
+            // entropy (matches production) — must fail, not silently recover different bytes.
+            var tsCipherWithEntropy = RunTsShapePowerShellDpapi("Protect", SamplePlaintext, entropy);
+            Should.Throw<CryptographicException>(() => MachineCredentialStore.UnprotectBytes(tsCipherWithEntropy));
+
+            // Direction 2: C# encrypts with real (null-entropy) Protect; TS-shape decrypt WITH
+            // entropy — must fail.
+            var csharpCipher = MachineCredentialStore.ProtectBytes(SamplePlaintext);
+            Should.Throw<CryptographicException>(() => RunTsShapePowerShellDpapi("Unprotect", csharpCipher, entropy));
+        }
+    }
+}

--- a/McpPlugin.Tests/AgentConfig/MachineCredentialsCohortTests.cs
+++ b/McpPlugin.Tests/AgentConfig/MachineCredentialsCohortTests.cs
@@ -1,0 +1,120 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+using System;
+using System.IO;
+using System.Text.Json;
+using com.IvanMurzak.McpPlugin.AgentConfig;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
+{
+    /// <summary>
+    /// One case per <c>06-migration-rollout.md</c> cohort row that has a store FILE-SHAPE (v1-only
+    /// reader, mixed writer, legacy family) — O4 REVISED: "no cohort regresses below status quo at
+    /// any intermediate step", each verified here against the committed
+    /// <c>MachineCredentials.GoldenVectors.json</c> shared with the TS twin (task x1). The C# twin of
+    /// cli-core's <c>test/machine-credentials-cohort.test.ts</c>.
+    /// </summary>
+    public sealed class MachineCredentialsCohortTests : IDisposable
+    {
+        private const string GoldenFileName = "MachineCredentials.GoldenVectors.json";
+        private static string GoldenFilePath => Path.Combine(AppContext.BaseDirectory, GoldenFileName);
+        private static JsonDocument LoadVectors() => JsonDocument.Parse(File.ReadAllText(GoldenFilePath));
+
+        private readonly string _baseDir;
+
+        public MachineCredentialsCohortTests()
+        {
+            _baseDir = Path.Combine(Path.GetTempPath(), "agd-cred-cohort-" + Guid.NewGuid().ToString("N"), ".ai-game-dev");
+        }
+
+        public void Dispose()
+        {
+            var parent = Path.GetDirectoryName(_baseDir);
+            if (parent != null && Directory.Exists(parent))
+                Directory.Delete(parent, recursive: true);
+        }
+
+        private MachineCredentialStore NewStore() => new MachineCredentialStore(_baseDir);
+
+        /// <summary>
+        /// Cohort row "Credential minted by own plugin (v1 file)": an OLD (v1-only) reader keys only
+        /// on the top-level fields; an UPDATED reader sees the identical values via
+        /// <c>families.legacy</c>. Neither reader is worse off than before the rollout — status quo,
+        /// not regressed (06 row 1 / O4 REVISED).
+        /// </summary>
+        [Fact]
+        public void Cohort_V1OnlyReader_AndUpdatedReader_SeeIdenticalTokenValues()
+        {
+            using var vectors = LoadVectors();
+            var v1 = vectors.RootElement.GetProperty("v1Document");
+            var store = NewStore();
+            store.WritePlaintextJson(v1.GetRawText());
+
+            // The OLD reader simulation: read the raw top-level fields only (no families concept).
+            using var rawDoc = JsonDocument.Parse(store.ReadPlaintextJson()!);
+            var oldReaderAccessToken = rawDoc.RootElement.GetProperty("accessToken").GetString();
+            var oldReaderRefreshToken = rawDoc.RootElement.GetProperty("refreshToken").GetString();
+
+            // The UPDATED reader: families.legacy view.
+            var updatedRead = store.Read()!;
+            var legacy = updatedRead.Families!.Legacy!;
+
+            legacy.AccessToken.ShouldBe(oldReaderAccessToken);
+            legacy.RefreshToken.ShouldBe(oldReaderRefreshToken);
+            legacy.AccessToken.ShouldBe(v1.GetProperty("accessToken").GetString());
+        }
+
+        /// <summary>
+        /// Cohort row "Mixed versions (updated writer + old reader)": an old C# <c>Rotate()</c> that
+        /// predates the families schema rewrites the v2 file as pure v1 (its codec drops
+        /// <c>families.*</c>) — the machine "degrades to v1 state until the next updated-component
+        /// touch re-adopts" (06 row 4, F11.1). This proves the heal: after the degraded document is
+        /// planted, the next updated read+write reproduces the golden
+        /// <c>reAdoptedOnNextUpdatedWrite</c> shape exactly — no token lost across the degrade cycle.
+        /// </summary>
+        [Fact]
+        public void Cohort_MixedVersions_OldWriterCollapseToV1_HealsOnNextUpdatedWrite()
+        {
+            using var vectors = LoadVectors();
+            var cohort = vectors.RootElement.GetProperty("cohortMixedVersionsOldWriterCollapse");
+            var collapsed = cohort.GetProperty("document");
+            var expectedHealed = cohort.GetProperty("reAdoptedOnNextUpdatedWrite");
+
+            var store = NewStore();
+            // Plant the collapsed pure-v1 on-disk shape, exactly as an old writer would have left it.
+            store.WritePlaintextJson(collapsed.GetRawText());
+            collapsed.GetProperty("version").GetInt32().ShouldBe(1); // sanity: the vector really is v1-shaped
+
+            // The next updated-component touch: read (adopts to families.legacy in-memory), write
+            // (persists v2 + mirror) — 04 §1 "first write by updated code upgrades".
+            var credentials = store.Read()!;
+            store.Write(credentials);
+
+            using var raw = JsonDocument.Parse(store.ReadPlaintextJson()!);
+            raw.RootElement.GetProperty("version").GetInt32().ShouldBe(expectedHealed.GetProperty("version").GetInt32());
+            raw.RootElement.GetProperty("accessToken").GetString().ShouldBe(expectedHealed.GetProperty("accessToken").GetString());
+            raw.RootElement.GetProperty("refreshToken").GetString().ShouldBe(expectedHealed.GetProperty("refreshToken").GetString());
+            raw.RootElement.GetProperty("serverTarget").GetString().ShouldBe(expectedHealed.GetProperty("serverTarget").GetString());
+            raw.RootElement.GetProperty("subject").GetString().ShouldBe(expectedHealed.GetProperty("subject").GetString());
+
+            var legacy = raw.RootElement.GetProperty("families").GetProperty("legacy");
+            var expectedLegacy = expectedHealed.GetProperty("families").GetProperty("legacy");
+            legacy.GetProperty("accessToken").GetString().ShouldBe(expectedLegacy.GetProperty("accessToken").GetString());
+            legacy.GetProperty("refreshToken").GetString().ShouldBe(expectedLegacy.GetProperty("refreshToken").GetString());
+
+            // Provenance was genuinely lost by the collapse (clientId/scope), same as any legacy family.
+            var readBack = store.Read()!;
+            readBack.Families!.Legacy!.ClientId.ShouldBeNull();
+            readBack.Families.Legacy.Scope.ShouldBeNull();
+        }
+    }
+}

--- a/McpPlugin.Tests/AgentConfig/MachineCredentialsGoldenVectorTests.cs
+++ b/McpPlugin.Tests/AgentConfig/MachineCredentialsGoldenVectorTests.cs
@@ -130,6 +130,61 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
             raw.RootElement.GetProperty("accessToken").GetString().ShouldNotBe(agentExpected.GetProperty("accessToken").GetString());
         }
 
+        // ── Per-family clientId fidelity (review B1, x1 fix round 1) ────────────────────────────────
+        //
+        // families.agent.clientId and families.plugin.clientId used to be identical
+        // ("unity-mcp-plugin" on both), so ANY assertion that only checks "does the family have A
+        // clientId" — or that round-trips vectors.v2Document through Write()/Read() and compares the
+        // result back to the SAME parsed vector (as V2Document_WrittenThenRead... above does) —
+        // passes under a cross-family clientId swap, because both the written input and the expected
+        // value move together (verified locally: swapping the vector's two clientId strings left
+        // every existing vector-driven test green, TS and C# alike — the swap is invisible to a
+        // write-then-read echo by construction, since clientId has no independent derivation to check
+        // against, unlike ProjectIdentity.DerivePin).
+        //
+        // The two literals below are therefore deliberately HARDCODED, redundantly with the vector,
+        // so a future accidental re-symmetrization (or an authoring mistake that swaps which family
+        // gets which id) reddens THIS file even though it would not redden the round-trip test above.
+
+        private const string ExpectedAgentClientId = "agd-app-8f3a1c2e";
+        private const string ExpectedPluginClientId = "unity-mcp-plugin";
+
+        [Fact]
+        public void Vector_PinsTheExpectedLiteralClientId_UnderEachFamily_SanityFailsLoudlyIfTheVectorDrifts()
+        {
+            using var vectors = LoadVectors();
+            var families = vectors.RootElement.GetProperty("v2Document").GetProperty("families");
+            families.GetProperty("agent").GetProperty("clientId").GetString().ShouldBe(ExpectedAgentClientId);
+            families.GetProperty("plugin").GetProperty("clientId").GetString().ShouldBe(ExpectedPluginClientId);
+            ExpectedAgentClientId.ShouldNotBe(ExpectedPluginClientId);
+        }
+
+        [Fact]
+        public void PerFamilyWrite_KeepsEachFamilysClientId_UnderItsOwnFamilyKey_NeverTheOthers()
+        {
+            // Exercises the real object-model write path (not a bulk write(vectors.v2Document)) so a
+            // hypothetical per-family assignment bug (family A's data landing under family B's key)
+            // is also caught, not just a vector-authoring mistake.
+            var credentials = new MachineCredentials
+            {
+                Families = new MachineCredentialFamilies
+                {
+                    Agent = new MachineCredentialFamily { AccessToken = "a", RefreshToken = "r", ClientId = ExpectedAgentClientId, Scope = "mcp:agent" },
+                    Plugin = new MachineCredentialFamily { AccessToken = "a2", RefreshToken = "r2", ClientId = ExpectedPluginClientId, Scope = "mcp:plugin" },
+                },
+            };
+            NewStore().Write(credentials);
+
+            var read = NewStore().Read();
+            read.ShouldNotBeNull();
+            read!.Families!.Agent!.ClientId.ShouldBe(ExpectedAgentClientId);
+            read.Families.Plugin!.ClientId.ShouldBe(ExpectedPluginClientId);
+            // The discriminating check: NOT merely "the two differ" (a swap keeps them differing from
+            // each other too) — each is pinned to ITS OWN hardcoded literal, so a swap mismatches here.
+            read.Families.Agent.ClientId.ShouldNotBe(ExpectedPluginClientId);
+            read.Families.Plugin.ClientId.ShouldNotBe(ExpectedAgentClientId);
+        }
+
         // ── v1 read-compat and adoption (04 §1 / F11.1, golden vector) ──────────────────────────────
 
         [Fact]

--- a/McpPlugin.Tests/AgentConfig/MachineCredentialsGoldenVectorTests.cs
+++ b/McpPlugin.Tests/AgentConfig/MachineCredentialsGoldenVectorTests.cs
@@ -1,0 +1,186 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+using System;
+using System.IO;
+using System.Text.Json;
+using com.IvanMurzak.McpPlugin.AgentConfig;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.AgentConfig.Tests
+{
+    /// <summary>
+    /// The C# twin of cli-core's <c>test/machine-credentials-v2.test.ts</c> "golden vector" describe
+    /// blocks (unified-machine-auth 04 §1, task x1): both implementations are asserted against the
+    /// SAME committed <c>MachineCredentials.GoldenVectors.json</c> (byte-identical copy — see
+    /// <c>McpPlugin.Tests.csproj</c>), so the store contract can never drift silently between the two
+    /// languages. Comparisons are PARSED VALUES, never raw bytes (the C# codec writes indented JSON,
+    /// the TS codec 2-space — indent asymmetry is deliberate, 04 §5).
+    ///
+    /// <para>Covers: v2 serialization both directions, v1→v2 adoption, the v2→v1-mirror
+    /// old-reader-simulation (a mandated plant — drop the mirror step and this file's
+    /// <see cref="V2Document_OldReaderSimulation_SeesExactlyThePluginFamilyAtTopLevel"/> goes RED),
+    /// per-family <c>clientId</c>/<c>scope</c> fidelity, and <c>subject</c> handling.</para>
+    /// </summary>
+    public sealed class MachineCredentialsGoldenVectorTests : IDisposable
+    {
+        private const string GoldenFileName = "MachineCredentials.GoldenVectors.json";
+        private static string GoldenFilePath => Path.Combine(AppContext.BaseDirectory, GoldenFileName);
+        private static JsonDocument LoadVectors() => JsonDocument.Parse(File.ReadAllText(GoldenFilePath));
+
+        private readonly string _baseDir;
+
+        public MachineCredentialsGoldenVectorTests()
+        {
+            _baseDir = Path.Combine(Path.GetTempPath(), "agd-cred-golden-" + Guid.NewGuid().ToString("N"), ".ai-game-dev");
+        }
+
+        public void Dispose()
+        {
+            var parent = Path.GetDirectoryName(_baseDir);
+            if (parent != null && Directory.Exists(parent))
+                Directory.Delete(parent, recursive: true);
+        }
+
+        private MachineCredentialStore NewStore() => new MachineCredentialStore(_baseDir);
+
+        private static void AssertFamily(JsonElement expectedFamily, MachineCredentialFamily? actual, string label)
+        {
+            actual.ShouldNotBeNull(label + " family must be present");
+            actual!.AccessToken.ShouldBe(expectedFamily.GetProperty("accessToken").GetString());
+            actual.RefreshToken.ShouldBe(expectedFamily.GetProperty("refreshToken").GetString());
+            if (expectedFamily.TryGetProperty("expiresAt", out var expiresAt))
+                actual.ExpiresAt.ShouldBe(DateTimeOffset.Parse(expiresAt.GetString()!));
+            if (expectedFamily.TryGetProperty("clientId", out var clientId))
+                actual.ClientId.ShouldBe(clientId.GetString());
+            if (expectedFamily.TryGetProperty("scope", out var scope))
+                actual.Scope.ShouldBe(scope.GetString());
+        }
+
+        // ── v2 round-trip (golden vector) ────────────────────────────────────────────────────────
+
+        [Fact]
+        public void V2Document_WrittenThenRead_MatchesGoldenVectorValueForValue()
+        {
+            using var vectors = LoadVectors();
+            var expected = vectors.RootElement.GetProperty("v2Document");
+
+            // Plant the TS-authored document verbatim on disk (as if TS had written it) — proves the
+            // C# codec READS what the TS codec's shape actually is, not just what C# itself wrote.
+            NewStore().WritePlaintextJson(expected.GetRawText());
+
+            var read = NewStore().Read();
+            read.ShouldNotBeNull();
+            read!.Version.ShouldBe(expected.GetProperty("version").GetInt32());
+            read.ServerTarget.ShouldBe(expected.GetProperty("serverTarget").GetString());
+            read.Subject.ShouldBe(expected.GetProperty("subject").GetString());
+            read.AccessToken.ShouldBe(expected.GetProperty("accessToken").GetString());
+            read.RefreshToken.ShouldBe(expected.GetProperty("refreshToken").GetString());
+
+            var families = expected.GetProperty("families");
+            AssertFamily(families.GetProperty("agent"), read.Families?.Agent, "agent");
+            AssertFamily(families.GetProperty("plugin"), read.Families?.Plugin, "plugin");
+
+            // Family-distinct vector values: the agent and plugin tokens must never be confused.
+            read.Families!.Agent!.AccessToken.ShouldNotBe(read.Families.Plugin!.AccessToken);
+        }
+
+        [Fact]
+        public void V2Document_OldReaderSimulation_SeesExactlyThePluginFamilyAtTopLevel()
+        {
+            // Write via the REAL object API (built from the vector) so the mirror-emission code path
+            // actually runs — this is the assertion a mandated "drop the mirror" plant must redden.
+            using var vectors = LoadVectors();
+            var expected = vectors.RootElement.GetProperty("v2Document");
+            var credentials = JsonSerializer.Deserialize<MachineCredentials>(expected.GetRawText());
+            credentials.ShouldNotBeNull();
+
+            // Strip the pre-baked top-level triple: the vector's top level already matches
+            // families.plugin (it doubles as the round-trip fixture above), so leaving it in place
+            // would make this assertion pass even if NormalizeForWrite() stopped re-stamping the
+            // mirror (verified locally with a mandated mirror-drop plant). Clearing it first means
+            // the ONLY source of the on-disk top-level values is the real mirror step.
+            credentials!.AccessToken = null;
+            credentials.RefreshToken = null;
+            credentials.ExpiresAt = null;
+
+            NewStore().Write(credentials);
+
+            var rawJson = NewStore().ReadPlaintextJson();
+            rawJson.ShouldNotBeNull();
+            using var raw = JsonDocument.Parse(rawJson!);
+
+            var pluginExpected = expected.GetProperty("families").GetProperty("plugin");
+            var agentExpected = expected.GetProperty("families").GetProperty("agent");
+
+            // An old v1-only reader keys ONLY on these top-level fields — never on `families`.
+            raw.RootElement.GetProperty("accessToken").GetString().ShouldBe(pluginExpected.GetProperty("accessToken").GetString());
+            raw.RootElement.GetProperty("refreshToken").GetString().ShouldBe(pluginExpected.GetProperty("refreshToken").GetString());
+            DateTimeOffset.Parse(raw.RootElement.GetProperty("expiresAt").GetString()!)
+                .ShouldBe(DateTimeOffset.Parse(pluginExpected.GetProperty("expiresAt").GetString()!));
+
+            // The mirror must be the PLUGIN family, never the agent family.
+            raw.RootElement.GetProperty("accessToken").GetString().ShouldNotBe(agentExpected.GetProperty("accessToken").GetString());
+        }
+
+        // ── v1 read-compat and adoption (04 §1 / F11.1, golden vector) ──────────────────────────────
+
+        [Fact]
+        public void V1Document_ReadAsLegacyFamily_IsAViewOnly_FileStaysUntouched()
+        {
+            using var vectors = LoadVectors();
+            var v1 = vectors.RootElement.GetProperty("v1Document");
+            var store = NewStore();
+            store.WritePlaintextJson(v1.GetRawText());
+            var before = File.ReadAllBytes(store.CredentialsPath);
+
+            var read = store.Read();
+            read.ShouldNotBeNull();
+            AssertFamily(v1, read!.Families?.Legacy, "legacy");
+            read.Families!.Legacy!.ClientId.ShouldBeNull(); // unknown by definition (04 §1)
+            read.Families.Legacy.Scope.ShouldBeNull();
+            read.Families.Agent.ShouldBeNull();
+            read.Families.Plugin.ShouldBeNull();
+
+            // Reading is a VIEW — the v1 file itself is untouched.
+            File.ReadAllBytes(store.CredentialsPath).ShouldBe(before);
+        }
+
+        [Fact]
+        public void V1Document_UpgradedOnFirstWrite_MatchesGoldenAdoptionResultExactly()
+        {
+            using var vectors = LoadVectors();
+            var v1 = vectors.RootElement.GetProperty("v1Document");
+            var expectedAdopted = vectors.RootElement.GetProperty("v1DocumentAdoptedToV2");
+
+            var store = NewStore();
+            store.WritePlaintextJson(v1.GetRawText());
+
+            var credentials = store.Read(); // v1 read-compat -> families.legacy (in-memory only)
+            store.Write(credentials!); // first write by updated code -> v2 + mirror (04 §1 / F11.1)
+
+            var rawJson = store.ReadPlaintextJson();
+            using var raw = JsonDocument.Parse(rawJson!);
+
+            raw.RootElement.GetProperty("version").GetInt32().ShouldBe(expectedAdopted.GetProperty("version").GetInt32());
+            raw.RootElement.GetProperty("accessToken").GetString().ShouldBe(expectedAdopted.GetProperty("accessToken").GetString());
+            raw.RootElement.GetProperty("refreshToken").GetString().ShouldBe(expectedAdopted.GetProperty("refreshToken").GetString());
+            raw.RootElement.GetProperty("serverTarget").GetString().ShouldBe(expectedAdopted.GetProperty("serverTarget").GetString());
+            raw.RootElement.GetProperty("subject").GetString().ShouldBe(expectedAdopted.GetProperty("subject").GetString());
+            raw.RootElement.GetProperty("futureUnknownField").GetString()
+                .ShouldBe(expectedAdopted.GetProperty("futureUnknownField").GetString());
+
+            var legacy = raw.RootElement.GetProperty("families").GetProperty("legacy");
+            var expectedLegacy = expectedAdopted.GetProperty("families").GetProperty("legacy");
+            legacy.GetProperty("accessToken").GetString().ShouldBe(expectedLegacy.GetProperty("accessToken").GetString());
+            legacy.GetProperty("refreshToken").GetString().ShouldBe(expectedLegacy.GetProperty("refreshToken").GetString());
+        }
+    }
+}

--- a/McpPlugin.Tests/McpPlugin.Tests.csproj
+++ b/McpPlugin.Tests/McpPlugin.Tests.csproj
@@ -32,6 +32,10 @@
     <None Include="../McpPlugin/src/AgentConfig/ProjectIdentity.GoldenVectors.json" Link="ProjectIdentity.GoldenVectors.json" CopyToOutputDirectory="PreserveNewest" />
     <None Include="../McpPlugin/src/AgentConfig/ProjectIdentity.GoldenVectors.v2.json" Link="ProjectIdentity.GoldenVectors.v2.json" CopyToOutputDirectory="PreserveNewest" />
     <None Include="../McpPlugin/src/AgentConfig/LockProtocol.GoldenVectors.json" Link="LockProtocol.GoldenVectors.json" CopyToOutputDirectory="PreserveNewest" />
+    <!-- Committed cross-language golden vectors for the machine credential store schema v2
+         (unified-machine-auth 04 §1, task x1) — byte-identical copy of
+         cli-core/test/golden-vectors/MachineCredentials.GoldenVectors.json. -->
+    <None Include="../McpPlugin/src/AgentConfig/MachineCredentials.GoldenVectors.json" Link="MachineCredentials.GoldenVectors.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>

--- a/McpPlugin/src/AgentConfig/MachineCredentialStore.cs
+++ b/McpPlugin/src/AgentConfig/MachineCredentialStore.cs
@@ -313,6 +313,15 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
         /// <summary>Unprotect raw on-disk bytes (no-op on POSIX). Test seam for concurrency probes.</summary>
         internal static byte[] UnprotectBytes(byte[] data) => IsWindows ? Unprotect(data) : data;
 
+        /// <summary>
+        /// Protect raw bytes with the store's real DPAPI codec (no-op on POSIX). Test seam
+        /// (InternalsVisibleTo: McpPlugin.Tests) for the cross-implementation DPAPI parity suite
+        /// (unified-machine-auth 04 §1, task x1): exercises the EXACT <c>CryptProtectData</c>
+        /// P/Invoke call the store uses on Windows, so a TS-side decrypt of the result is a genuine
+        /// interop proof, not a re-implementation of DPAPI.
+        /// </summary>
+        internal static byte[] ProtectBytes(byte[] data) => IsWindows ? Protect(data) : data;
+
         // ── Atomic write (design 04 §1) ──────────────────────────────────────────────────────────
 
         private void WriteProtected(string json)

--- a/McpPlugin/src/AgentConfig/MachineCredentials.GoldenVectors.json
+++ b/McpPlugin/src/AgentConfig/MachineCredentials.GoldenVectors.json
@@ -1,5 +1,5 @@
 {
-  "description": "Cross-language golden vectors for the machine credential store schema v2 (unified-machine-auth 04 §1). Compare PARSED VALUES, never raw bytes: the C# codec emits 4-space and the TS codec 2-space indentation. Every token value is family-distinct on purpose, so a v1-compat mirror that copies from the wrong family cannot pass. The C# store (MCP-Plugin-dotnet MachineCredentialStore, task b1) consumes this same file for parity.",
+  "description": "Cross-language golden vectors for the machine credential store schema v2 (unified-machine-auth 04 §1). Compare PARSED VALUES, never raw bytes: the C# codec emits 4-space and the TS codec 2-space indentation. Every token value AND every clientId is family-distinct on purpose (review B1, x1 fix round 1) — a v1-compat mirror or a per-family clientId assertion that reads from the wrong family, or from a cross-family swap, cannot pass. families.agent.clientId is a DCR-derived id (06 'App browser-PKCE (DCR) users' cohort row: the agent-plane login happened via the App, clientId = the resolved DCR id, 04 §1); families.plugin.clientId is the exchanging engine's own static id (04 §1 'the exchanging client's own id, RFC 8693, O2') — a real divergent-clientId production shape, not merely a distinct string. The C# store (MCP-Plugin-dotnet MachineCredentialStore, task b1) consumes this same file for parity.",
   "v2Document": {
     "version": 2,
     "serverTarget": "https://ai-game.dev",
@@ -12,7 +12,7 @@
         "accessToken": "agent-access-token-A1",
         "refreshToken": "agent-refresh-token-B1",
         "expiresAt": "2026-09-01T11:22:33.000Z",
-        "clientId": "unity-mcp-plugin",
+        "clientId": "agd-app-8f3a1c2e",
         "scope": "mcp:agent"
       },
       "plugin": {

--- a/McpPlugin/src/AgentConfig/MachineCredentials.GoldenVectors.json
+++ b/McpPlugin/src/AgentConfig/MachineCredentials.GoldenVectors.json
@@ -1,0 +1,78 @@
+{
+  "description": "Cross-language golden vectors for the machine credential store schema v2 (unified-machine-auth 04 §1). Compare PARSED VALUES, never raw bytes: the C# codec emits 4-space and the TS codec 2-space indentation. Every token value is family-distinct on purpose, so a v1-compat mirror that copies from the wrong family cannot pass. The C# store (MCP-Plugin-dotnet MachineCredentialStore, task b1) consumes this same file for parity.",
+  "v2Document": {
+    "version": 2,
+    "serverTarget": "https://ai-game.dev",
+    "subject": "usr_9f8e7d6c",
+    "accessToken": "plugin-access-token-A2",
+    "refreshToken": "plugin-refresh-token-B2",
+    "expiresAt": "2026-09-01T12:34:56.000Z",
+    "families": {
+      "agent": {
+        "accessToken": "agent-access-token-A1",
+        "refreshToken": "agent-refresh-token-B1",
+        "expiresAt": "2026-09-01T11:22:33.000Z",
+        "clientId": "unity-mcp-plugin",
+        "scope": "mcp:agent"
+      },
+      "plugin": {
+        "accessToken": "plugin-access-token-A2",
+        "refreshToken": "plugin-refresh-token-B2",
+        "expiresAt": "2026-09-01T12:34:56.000Z",
+        "clientId": "unity-mcp-plugin",
+        "scope": "mcp:plugin"
+      }
+    }
+  },
+  "v1Document": {
+    "version": 1,
+    "accessToken": "legacy-access-token-A0",
+    "refreshToken": "legacy-refresh-token-B0",
+    "expiresAt": "2026-08-20T00:00:00.000Z",
+    "serverTarget": "https://ai-game.dev",
+    "subject": "usr_9f8e7d6c",
+    "futureUnknownField": "must-survive-adoption"
+  },
+  "v1DocumentAdoptedToV2": {
+    "version": 2,
+    "accessToken": "legacy-access-token-A0",
+    "refreshToken": "legacy-refresh-token-B0",
+    "expiresAt": "2026-08-20T00:00:00.000Z",
+    "serverTarget": "https://ai-game.dev",
+    "subject": "usr_9f8e7d6c",
+    "futureUnknownField": "must-survive-adoption",
+    "families": {
+      "legacy": {
+        "accessToken": "legacy-access-token-A0",
+        "refreshToken": "legacy-refresh-token-B0",
+        "expiresAt": "2026-08-20T00:00:00.000Z"
+      }
+    }
+  },
+  "cohortMixedVersionsOldWriterCollapse": {
+    "comment": "06-migration-rollout.md cohort row 'Mixed versions (updated writer + old reader)': an old C# Rotate() that does not know about families rewrites the v2 file as pure v1 (its codec drops families.*) — 'document' is that collapsed on-disk shape (same token values as v2Document.families.plugin, so this vector composes with v2Document rather than inventing new tokens). 'reAdoptedOnNextUpdatedWrite' is what the NEXT updated-component write must produce: the collapsed credential lands in families.legacy (mint client/scope unknown — the collapse lost that provenance) and the v1 compat mirror keeps the exact same top-level values, so no cohort regresses below status quo (O4 REVISED) across the degrade-then-heal cycle.",
+    "document": {
+      "version": 1,
+      "accessToken": "plugin-access-token-A2",
+      "refreshToken": "plugin-refresh-token-B2",
+      "expiresAt": "2026-09-01T12:34:56.000Z",
+      "serverTarget": "https://ai-game.dev",
+      "subject": "usr_9f8e7d6c"
+    },
+    "reAdoptedOnNextUpdatedWrite": {
+      "version": 2,
+      "accessToken": "plugin-access-token-A2",
+      "refreshToken": "plugin-refresh-token-B2",
+      "expiresAt": "2026-09-01T12:34:56.000Z",
+      "serverTarget": "https://ai-game.dev",
+      "subject": "usr_9f8e7d6c",
+      "families": {
+        "legacy": {
+          "accessToken": "plugin-access-token-A2",
+          "refreshToken": "plugin-refresh-token-B2",
+          "expiresAt": "2026-09-01T12:34:56.000Z"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

C# twin of the cli-core PR (unified-machine-auth 04 §1, task **x1-golden-parity**). Companion PR:
IvanMurzak/AI-Game-Dev-CLI-Core#9. Adds the store v2 cross-language golden-vector consumption this
repo was missing (only `LockProtocol`/`ProjectIdentity` vectors existed here before).

- `McpPlugin/src/AgentConfig/MachineCredentials.GoldenVectors.json`: byte-identical copy of
  `cli-core/test/golden-vectors/MachineCredentials.GoldenVectors.json` (verified with `diff` +
  SHA256), wired into `McpPlugin.Tests.csproj` the same way `LockProtocol`/`ProjectIdentity`
  vectors already are.
- `MachineCredentialsGoldenVectorTests.cs`: v2 round-trip, v2→v1-mirror old-reader simulation
  (non-vacuous — strips the vector's pre-baked top-level triple before `Write()` so the mirror step
  is the only source of truth; verified RED locally against a mandated mirror-drop plant in
  `MachineCredentials.NormalizeForWrite`, then reverted), v1→v2 adoption matching the golden
  adoption result exactly.
- `MachineCredentialsCohortTests.cs`: the two 06-migration-rollout cohort rows with a store
  file-shape — v1-only reader/legacy family (row 1) and mixed writer/old reader (row 4, using the
  new `cohortMixedVersionsOldWriterCollapse` vector) — "no cohort regresses below status quo" (O4).
- `MachineCredentialDpapiCrossImplementationTests.cs` (Windows CI leg): round-trips a blob
  encrypted via the store's real `CryptProtectData` P/Invoke (new `ProtectBytes` test seam,
  mirroring the existing `UnprotectBytes`) through a literal transcription of cli-core's
  `dpapiTransform` PowerShell script, and vice versa. Includes the mandated entropy plant.
- `MachineCredentialStore.cs`: adds the `ProtectBytes` internal test seam (`InternalsVisibleTo:
  McpPlugin.Tests`) used by the DPAPI cross-implementation tests above.

## Test plan

- [x] `dotnet build McpPlugin.Tests/McpPlugin.Tests.csproj` (net8.0 + net9.0) — clean
- [x] `dotnet test` (net9.0) — 877 passed, 0 failed
- [x] `dotnet test` (net8.0, new test files) — 9 passed, 0 failed
- [x] Mandated plants, verified locally then reverted (see PR description / task report for exact
      mutations and RED output):
  - Mirror-drop plant (`NormalizeForWrite` skips the mirror re-stamp): the new
    `V2Document_OldReaderSimulation_SeesExactlyThePluginFamilyAtTopLevel` test went RED, along with
    5 other pre-existing store tests (confirms a real, widely-felt mutation).
  - Entropy plant (`Protect()` P/Invoke passes non-null entropy): the
    `RoundTrip_CSharpProtect_ThenTsShapePowerShellUnprotect_RecoversPlaintext` test went RED.
- [x] Golden vector file verified byte-identical (SHA256) to the copy committed in the companion
      cli-core PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017azy3BykDQDSpxc5F51GAF