### PR TITLE
fix(network): close ConnectionManager single-flight race + de-flake rejection tests

### DIFF
--- a/McpPlugin.Tests/Network/Connection/ConnectionManagerRejectionTests.cs
+++ b/McpPlugin.Tests/Network/Connection/ConnectionManagerRejectionTests.cs
@@ -55,11 +55,18 @@ namespace com.IvanMurzak.McpPlugin.Tests.Network.Connection
                 _logger, _testVersion, _testEndpoint, _mockProvider.Object
             );
 
-            // Act
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            // Act: the loop terminates ON ITS OWN via the rejection cap; the CTS is a pure hang
+            // guard that must NEVER fire. It needs generous headroom: the happy path already
+            // spends real time (ConnectionManager's 1s post-create stabilization delay plus one
+            // RejectionThreshold window per rejection), and on a loaded CI runner every timer
+            // resumption can stretch by seconds — a tight budget turns runner load into a
+            // truncated loop and a bogus AttemptCount failure (the documented CI flake).
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
             var result = await cm.Connect(cts.Token);
 
             // Assert
+            cts.Token.IsCancellationRequested.ShouldBeFalse(
+                "The loop must stop via the rejection cap, not the hang-guard CTS");
             result.ShouldBeFalse("Connection should fail after repeated rejections");
             cm.KeepConnected.CurrentValue.ShouldBeFalse("KeepConnected should be disabled after rejection threshold");
             cm.AttemptCount.ShouldBe(3, "Should have attempted exactly MaxConsecutiveRejections times");
@@ -80,12 +87,20 @@ namespace com.IvanMurzak.McpPlugin.Tests.Network.Connection
                 attemptResults: sequence
             );
 
-            // Act
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            // Act: the loop terminates ON ITS OWN when the sequence is exhausted (the manager
+            // flips _continueToReconnect off); the CTS is a pure hang guard that must NEVER
+            // fire. It needs generous headroom: the happy path already spends real time
+            // (ConnectionManager's 1s post-create stabilization delay plus one
+            // RejectionThreshold window per rejection), and on a loaded CI runner every timer
+            // resumption can stretch by seconds — the old 5s budget let runner load truncate
+            // the loop mid-sequence, producing the documented "AttemptCount not > 3" CI flake.
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
             var result = await cm.Connect(cts.Token);
 
             // Assert: more than 3 attempts must have been consumed.
             // If rejection counter weren't being reset by failures, it would stop at 3.
+            cts.Token.IsCancellationRequested.ShouldBeFalse(
+                "The loop must stop via sequence exhaustion, not the hang-guard CTS");
             result.ShouldBeFalse("Connection should eventually fail");
             cm.AttemptCount.ShouldBeGreaterThan(3,
                 "More than MaxConsecutiveRejections attempts should run — counter was reset by interleaved failures");

--- a/McpPlugin.Tests/Network/Connection/ConnectionManagerTests.cs
+++ b/McpPlugin.Tests/Network/Connection/ConnectionManagerTests.cs
@@ -16,6 +16,7 @@ using Microsoft.AspNetCore.Http.Connections;
 using Microsoft.AspNetCore.SignalR.Client;
 using Microsoft.Extensions.Logging;
 using Moq;
+using R3;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -384,6 +385,85 @@ namespace com.IvanMurzak.McpPlugin.Tests.Network.Connection
             tasks.Length.ShouldBe(20);
             // Due to concurrency control, only one connection should be created
             callCount.ShouldBe(1, "concurrent calls should reuse the same connection attempt");
+        }
+
+        [Fact]
+        public async Task Connect_CallerInPrePublicationWindow_JoinsInFlightAttempt()
+        {
+            // Deterministically pins the interleaving behind the CI flake "callCount 1 vs 2":
+            // a caller whose single-flight check runs BEFORE the leader publishes its attempt
+            // parks on the connection gate; when the leader's (failed) attempt completes it
+            // must ADOPT that outcome — never begin a second, duplicate attempt of its own.
+            //
+            // The KeepConnected subscription below fires SYNCHRONOUSLY on the leader's thread
+            // when Connect enables reconnection — i.e. exactly inside the window between the
+            // leader's single-flight check and the publication of its attempt task — so the
+            // second Connect is issued deterministically inside the window: no sleeps, no
+            // timing assumptions.
+            var providerCallCount = 0;
+            var firstProviderCallEntered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var allowProviderToReturn = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var secondProviderCallSeen = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            _mockHubConnectionProvider
+                .Setup(x => x.CreateConnectionAsync(_testEndpoint))
+                .Returns(async () =>
+                {
+                    var count = Interlocked.Increment(ref providerCallCount);
+                    if (count == 1)
+                        firstProviderCallEntered.TrySetResult(true);
+                    else
+                        secondProviderCallSeen.TrySetResult(true);
+                    await allowProviderToReturn.Task;
+                    return CreateMockHubConnection();
+                });
+
+            await using var connectionManager = new ConnectionManager(
+                _logger, _testVersion, _testEndpoint, _mockHubConnectionProvider.Object);
+
+            // Hang guards only — the test is driven purely by explicit signals; these must never fire.
+            using var firstCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            using var secondCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+            Task<bool>? secondConnect = null;
+            var windowHooked = 0;
+            using var subscription = connectionManager.KeepConnected
+                .Subscribe(keep =>
+                {
+                    if (keep && Interlocked.Exchange(ref windowHooked, 1) == 0)
+                        secondConnect = connectionManager.Connect(secondCts.Token);
+                });
+
+            // Leader: its synchronous prefix (on this thread) runs through the subscriber above
+            // and then suspends inside the provider callback.
+            var firstConnect = connectionManager.Connect(firstCts.Token);
+
+            await EnsureConnectionStartedAsync(firstProviderCallEntered.Task);
+            secondConnect.ShouldNotBeNull("the in-window second Connect must have been issued");
+            providerCallCount.ShouldBe(1, "while the first attempt is in flight only one connection may be created");
+
+            // Complete the first attempt as a FAILURE: cancel first, then let the provider return —
+            // the canceled token makes the leader discard the connection and return false quickly,
+            // with no real-time waits.
+            firstCts.Cancel();
+            allowProviderToReturn.TrySetResult(true);
+
+            var firstResult = await firstConnect;
+            firstResult.ShouldBeFalse("the leader's attempt was canceled");
+
+            // On the buggy interleaving the second caller now acquires the gate and calls the
+            // provider AGAIN; detect that and cancel so the test fails fast instead of sitting
+            // out the doomed duplicate attempt.
+            var completed = await Task.WhenAny(secondConnect!, secondProviderCallSeen.Task);
+            if (completed == secondProviderCallSeen.Task)
+                secondCts.Cancel();
+
+            var secondResult = await secondConnect!;
+            secondResult.ShouldBeFalse("the adopted attempt failed");
+
+            providerCallCount.ShouldBe(1,
+                "a Connect call issued while another attempt is in flight must join that attempt — " +
+                "a second CreateConnectionAsync call is the single-flight race");
         }
 
         #endregion

--- a/McpPlugin/src/McpPlugin/Network/Connection/ConnectionManager.Connect.cs
+++ b/McpPlugin/src/McpPlugin/Network/Connection/ConnectionManager.Connect.cs
@@ -39,14 +39,77 @@ namespace com.IvanMurzak.McpPlugin
                 return false;
             }
 
-            // Check if there's already an ongoing connection attempt
+            // SINGLE-FLIGHT: atomically either JOIN the in-flight attempt or INSTALL ourselves
+            // as its leader. The check and the publication happen under ONE
+            // _ongoingConnectionGate hold. Previously the check and the publication were
+            // separated by the _gate acquisition (check-then-act race): a caller that read
+            // null here before the leader published would queue on _gate — which the leader
+            // holds for the WHOLE attempt — wake only after that attempt completed and the
+            // field was cleared, and then start a second, duplicate connection attempt.
+            // A TaskCompletionSource proxy (instead of the real attempt task) is published
+            // because the real task can only be created while holding _gate, and _gate must
+            // NOT be acquired under _ongoingConnectionGate (Disconnect acquires them in the
+            // opposite order: _gate → _ongoingConnectionGate).
+            Task<bool>? ongoingTask;
+            TaskCompletionSource<bool>? connectionAttempt = null;
             await _ongoingConnectionGate.WaitAsync(cancellationToken);
-            var ongoingTask = _ongoingConnectionTask;
-            _ongoingConnectionGate.Release();
+            try
+            {
+                ongoingTask = _ongoingConnectionTask;
+                if (ongoingTask == null)
+                {
+                    connectionAttempt = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                    _ongoingConnectionTask = connectionAttempt.Task;
+                }
+            }
+            finally
+            {
+                _ongoingConnectionGate.Release();
+            }
 
             if (ongoingTask != null)
                 return await WaitForConnectionCompletion(ongoingTask, cancellationToken);
 
+            var result = false;
+            try
+            {
+                result = await ConnectCore(cancellationToken);
+                return result;
+            }
+            finally
+            {
+                try
+                {
+                    // Use CancellationToken.None: cleanup must run even when cancellationToken
+                    // has already been cancelled by DisconnectImmediate.
+                    await _ongoingConnectionGate.WaitAsync(CancellationToken.None);
+                    // DisconnectImmediate may have detached this attempt (nulled the field) and a
+                    // successor Connect may already have installed itself — never clobber it.
+                    if (ReferenceEquals(_ongoingConnectionTask, connectionAttempt!.Task))
+                        _ongoingConnectionTask = null;
+                    _ongoingConnectionGate.Release();
+                }
+                catch (ObjectDisposedException)
+                {
+                    // Disposed mid-attempt: the field no longer matters, but the proxy below MUST
+                    // still complete so joined callers are never orphaned.
+                }
+                finally
+                {
+                    // Complete the proxy only AFTER the field is cleared, so a caller arriving
+                    // after completion starts a fresh attempt instead of adopting a stale result.
+                    connectionAttempt!.TrySetResult(result);
+                }
+            }
+        }
+
+        /// <summary>
+        /// The single-flight leader's connection flow: serializes on <see cref="_gate"/> and runs
+        /// the actual connection attempt. Only ever entered by the caller that installed itself in
+        /// <see cref="_ongoingConnectionTask"/>; everyone else joins that task instead.
+        /// </summary>
+        private async Task<bool> ConnectCore(CancellationToken cancellationToken)
+        {
             try
             {
                 _logger.LogDebug("{class}[{guid}] {method} acquiring gate.",
@@ -80,19 +143,6 @@ namespace com.IvanMurzak.McpPlugin
                     return false; // already disposed
                 }
 
-                // Double-check for ongoing task after acquiring gate
-                await _ongoingConnectionGate.WaitAsync(cancellationToken);
-                ongoingTask = _ongoingConnectionTask;
-                _ongoingConnectionGate.Release();
-
-                if (ongoingTask != null)
-                {
-                    _logger.LogDebug("{class}[{guid}] {method} Connection already in progress after acquiring gate, releasing gate and waiting.",
-                        nameof(ConnectionManager), _guid, nameof(Connect));
-                    _gate.Release();
-                    return await WaitForConnectionCompletion(ongoingTask, cancellationToken);
-                }
-
                 if (_hubConnection.CurrentValue?.State is HubConnectionState.Connected or HubConnectionState.Connecting)
                 {
                     _logger.LogDebug("{class}[{guid}] {method} Already connected. Ignoring.",
@@ -108,23 +158,7 @@ namespace com.IvanMurzak.McpPlugin
 
                 _continueToReconnect.Value = true;
 
-                Task<bool> connectionTask;
-                await _ongoingConnectionGate.WaitAsync(cancellationToken);
-                connectionTask = InternalConnect(cancellationToken); // local ref first — never null
-                _ongoingConnectionTask = connectionTask;             // publish to shared field under gate
-                _ongoingConnectionGate.Release();
-                try
-                {
-                    return await connectionTask; // safe: local ref was captured before the gate was released
-                }
-                finally
-                {
-                    // Use CancellationToken.None: cleanup must run even when cancellationToken
-                    // (the internal CTS token) has already been cancelled by DisconnectImmediate.
-                    await _ongoingConnectionGate.WaitAsync(CancellationToken.None);
-                    _ongoingConnectionTask = null;
-                    _ongoingConnectionGate.Release();
-                }
+                return await InternalConnect(cancellationToken);
             }
             finally
             {


### PR DESCRIPTION
## Root cause of the ConnectionManager flaky-test family

~9 documented red CI events over one day across ubuntu/macOS/windows, on PRs whose diffs never touch Network code (PR #203 runs + 4 consecutive rerun attempts of PR #204's run 31876647434). Two distinct mechanisms, both diagnosed by **forcing them deterministically**:

### 1. Product race — `Connect_ThreadSafety_NoRaceConditionsUnderLoad` (`callCount` 1 vs 2)

`ConnectionManager.Connect`'s single-flight was a **non-atomic check-then-act**: the `_ongoingConnectionTask` null-check and the publication of the attempt task were separated by the `_gate` acquisition. A caller that read `null` in that window queued on `_gate` — which the leader holds for the **whole** attempt — woke only after the attempt completed and the field was cleared, and then started a second, duplicate connection attempt (a second `CreateConnectionAsync` call). The window is microseconds wide, which is why it only fired on loaded CI runners.

**Deterministic proof:** the new pin test `Connect_CallerInPrePublicationWindow_JoinsInFlightAttempt` issues a second `Connect` synchronously from a `KeepConnected` subscription — R3 fires it on the leader's thread exactly inside the race window (Connect enables reconnection before publishing). On the old code it fails with the exact CI shape, no sleeps involved:

```
Shouldly.ShouldAssertException : providerCallCount  should be 1  but was 2
```

**Fix:** `Connect` now atomically either JOINS the in-flight attempt or INSTALLS itself as leader under one `_ongoingConnectionGate` hold, publishing a `TaskCompletionSource` proxy (the real task can only be created under `_gate`, and `_gate` must not be taken while holding `_ongoingConnectionGate` — `Disconnect` acquires them in the opposite order, so doing that would deadlock). The leader's cleanup clears the field only if it still owns it (`DisconnectImmediate` may have detached the attempt and a successor may have installed itself) and always completes the proxy so joined callers are never orphaned. The now-dead in-gate double-check is removed.

This also hardens the sibling assertions (`Connect_WhenMultipleThreadsCallSimultaneously_ProviderCalledOnlyOnce`, `Connect_WhenCalledConcurrently_ReusesFirstConnectionAttempt`, `Disconnect_WhenCalledAfterConcurrentConnects_PreventsQueuedConnectFromProceeding`) which assert the same guaranteed-coalescing contract and carried the same latent race.

### 2. Test time-budget — `Connect_FailedAttemptsResetRejectionCounter` (windows, preceded by parallel-fixture log spam)

The loop self-terminates via sequence exhaustion; the 5s CTS was meant as a hang guard but silently doubled as a **timing assumption**: the happy path already spends ~1.2s of real time (the product's hard 1s post-create stabilization delay + 3×50ms rejection windows), so runner load stretching timer resumptions past the remaining budget truncated the loop mid-sequence.

**Deterministic proof:** shrinking the budget to 1.1s reproduces the exact CI shape:

```
Shouldly.ShouldAssertException : cm.AttemptCount  should be greater than 3  but was 3
```

**Fix:** in both self-terminating rejection tests the CTS is now a pure 30s hang guard with an explicit `cts.Token.IsCancellationRequested.ShouldBeFalse(...)` assertion that it never fires — the pattern this file already uses in `Connect_StopsAfterConsecutiveConnectionFailures_WhenOptedIn`. No assertion was weakened; each test gained one.

## Evidence

| Check | Result |
|---|---|
| Pin test on old code | RED — `providerCallCount should be 1 but was 2` (CI shape) |
| Rejection test with squeezed budget on old code | RED — `AttemptCount should be greater than 3 but was 3` (CI shape) |
| Pin test on fixed code | GREEN, 25/25 repeat runs |
| 100-iteration repeat runs (2 flaky tests + pin test), net8.0 + net9.0, under concurrent full-suite load | **0 failures** on both TFMs |
| Baseline 100-iteration runs on unfixed code (idle dev box) | 0 failures — consistent with the race being load-dependent, hence the deterministic forcing above |
| Full `McpPlugin.Tests` suite on the merged tree | **880/880 green on net8.0 and net9.0** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017azy3BykDQDSpxc5F51GAF
