### PR TITLE
fix(ci): eliminate all warnings surfaced by GitHub Actions runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,11 @@ jobs:
 
       - name: Test
         working-directory: ./
-        run: dotnet test --no-build --verbosity normal --configuration Release --logger "trx;LogFileName=test-results.trx" --results-directory ./TestResults
+        # LogFilePrefix (not LogFileName): 2 test projects x 2 TFMs = 4 test runs; a fixed
+        # LogFileName makes each run overwrite the previous .trx ("WARNING: Overwriting results
+        # file") so only the last leg's results survived. One uniquely-named .trx per run instead;
+        # all still match the TestResults/**/*.trx globs below.
+        run: dotnet test --no-build --verbosity normal --configuration Release --logger "trx;LogFilePrefix=test-results" --results-directory ./TestResults
 
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -40,7 +40,11 @@ jobs:
 
       - name: Test
         working-directory: ./
-        run: dotnet test --no-build --verbosity normal --configuration Release --logger "trx;LogFileName=test-results.trx" --results-directory ./TestResults
+        # LogFilePrefix (not LogFileName): the solution has 2 test projects x 2 TFMs = 4 test runs;
+        # a fixed LogFileName makes each run overwrite the previous .trx ("WARNING: Overwriting
+        # results file") so only the last leg's results survived to upload/publish. The prefix form
+        # yields one uniquely-named .trx per run, all still matching TestResults/**/*.trx below.
+        run: dotnet test --no-build --verbosity normal --configuration Release --logger "trx;LogFilePrefix=test-results" --results-directory ./TestResults
 
       - name: Publish Test Results
         # The docker-based action only runs on Linux; the Windows/macOS legs upload their .trx

--- a/McpPlugin.Common/src/Data/Response/Tool/Call/ResponseCallValueTool.Static.cs
+++ b/McpPlugin.Common/src/Data/Response/Tool/Call/ResponseCallValueTool.Static.cs
@@ -16,12 +16,12 @@ namespace com.IvanMurzak.McpPlugin.Common.Model
 {
     public partial class ResponseCallValueTool<T> : ResponseCallTool
     {
-        public static new ResponseCallValueTool<T> Error(Exception exception)
+        public static ResponseCallValueTool<T> Error(Exception exception)
         {
             return Error($"[Error] {exception?.Message}\n{exception?.StackTrace}");
         }
 
-        public static new ResponseCallValueTool<T> Error(string? message = null)
+        public static ResponseCallValueTool<T> Error(string? message = null)
         {
             return new ResponseCallValueTool<T>(
                 status: ResponseStatus.Error,
@@ -58,7 +58,7 @@ namespace com.IvanMurzak.McpPlugin.Common.Model
                 status: ResponseStatus.Success);
         }
 
-        public static new ResponseCallValueTool<T> ErrorStructured(JsonNode? structuredContent)
+        public static ResponseCallValueTool<T> ErrorStructured(JsonNode? structuredContent)
         {
             return new ResponseCallValueTool<T>(
                 structuredContent: structuredContent,

--- a/McpPlugin.Tests/Network/Connection/ConnectionManagerTests.cs
+++ b/McpPlugin.Tests/Network/Connection/ConnectionManagerTests.cs
@@ -439,7 +439,9 @@ namespace com.IvanMurzak.McpPlugin.Tests.Network.Connection
             var firstConnect = connectionManager.Connect(firstCts.Token);
 
             await EnsureConnectionStartedAsync(firstProviderCallEntered.Task);
-            secondConnect.ShouldNotBeNull("the in-window second Connect must have been issued");
+            // ShouldNotBeNull RETURNS the task it validated; discard it explicitly — the task is
+            // deliberately not awaited here (it is awaited below, after the leader completes).
+            _ = secondConnect.ShouldNotBeNull("the in-window second Connect must have been issued");
             providerCallCount.ShouldBe(1, "while the first attempt is in flight only one connection may be created");
 
             // Complete the first attempt as a FAILURE: cancel first, then let the provider return —


### PR DESCRIPTION
Every job of the reference run (https://github.com/IvanMurzak/MCP-Plugin-dotnet/actions/runs/31879231425) was green but carried warning annotations. This PR eliminates every warning the workflows surface, behavior-neutrally. Full inventory (enumerated from a clean local mirror of the CI steps AND from the run's complete logs — all 40 `##[warning]` markers across the run reduce to these root causes):

### 1. CS0109 ×3 — `McpPlugin.Common/src/Data/Response/Tool/Call/ResponseCallValueTool.Static.cs:19,24,61`
`Error(Exception)`, `Error(string?)`, `ErrorStructured(JsonNode?)` declared `new`, but the base `ResponseCallTool` overloads take extra optional parameters (`ResponseErrorKind`, `int?`) — different signatures, nothing hidden, so the compiler flags the modifier as spurious. **Fix:** removed `new` on those three. `new` is source-level only (no effect on member lookup, overload resolution, or IL), so public API and behavior are unchanged. `Success`/`SuccessStructured`/`Processing` hide identical base signatures and correctly keep `new`.

### 2. CS4014 ×2 TFMs — `McpPlugin.Tests/Network/Connection/ConnectionManagerTests.cs:442`
Shouldly's `ShouldNotBeNull` **returns** the `Task<bool>` it validated; the bare statement discarded an awaitable inside an async method. The task is *deliberately* un-awaited there — the single-flight race-pin test awaits it later, after the leader completes. **Fix:** explicit discard (`_ = …`) + comment. Execution order and test semantics untouched.

### 3. `WARNING: Overwriting results file` ×3 per test job (workflow logs)
`--logger "trx;LogFileName=test-results.trx"` makes all 4 test runs (2 projects × 2 TFMs) write the same file — 3 of 4 .trx result files were destroyed before upload/publish. **Fix:** `LogFilePrefix=test-results` in `test-pull-request.yml` and `release.yml` — one uniquely-named .trx per run, all still matching the existing `TestResults/**/*.trx` globs. No job/check names changed. (`deploy.yml`'s test step uses no trx logger; its three `dotnet pack` steps were verified warning-free locally.)

### Not actionable (reported for completeness)
- git's `init.defaultBranch` hint during `actions/checkout` — runner-side git chatter, not repo-fixable.
- `warn:`-level application log lines during tests — intentional product logging that tests (e.g. `RouterLogCaptureTests`) assert on; not CI warnings.

### Proof (local, mirroring CI exactly: clean tree → restore → build Release → test; plus the golden-vector job's commands)
- `dotnet build --no-restore --configuration Release`: **0 Warning(s), 0 Error(s)**
- `dotnet build McpPlugin.Tests/... --no-restore --configuration Release`: **0 Warning(s), 0 Error(s)**
- Full suite green both TFMs: McpPlugin.Tests **880/880** (net8.0 + net9.0), McpPlugin.Server.Tests **684/684** (net8.0 + net9.0), golden vectors **71/71** both TFMs
- Test run with the new logger form: **0** overwrite warnings; 4 uniquely-named .trx files produced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017azy3BykDQDSpxc5F51GAF