### PR TITLE
b3: shared HttpTokenRefresher, family-aware ITokenRefresher API, RFC 8693 exchange + RFC 7009 revocation clients, lock-integrated provider refresh

### DIFF
--- a/McpPlugin.Tests/Infrastructure/RecordingHttpMessageHandler.cs
+++ b/McpPlugin.Tests/Infrastructure/RecordingHttpMessageHandler.cs
@@ -1,0 +1,160 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace com.IvanMurzak.McpPlugin.Tests.Infrastructure
+{
+    /// <summary>
+    /// An <see cref="HttpMessageHandler"/> that records every request (URL + decoded form fields)
+    /// and replays scripted responses — the wire-assertion seam for the unified-machine-auth b3
+    /// HTTP clients (<c>HttpTokenRefresher</c>, <c>TokenExchangeClient</c>,
+    /// <c>TokenRevocationClient</c>). No sockets, no ports (workspace rule: workers bind only
+    /// assigned ports — this binds none).
+    /// </summary>
+    public sealed class RecordingHttpMessageHandler : HttpMessageHandler
+    {
+        readonly Queue<Func<RecordedRequest, HttpResponseMessage>> _scripted = new Queue<Func<RecordedRequest, HttpResponseMessage>>();
+        readonly List<RecordedRequest> _requests = new List<RecordedRequest>();
+        Func<RecordedRequest, HttpResponseMessage>? _fallback;
+        TimeSpan _delay = TimeSpan.Zero;
+        Action<RecordedRequest>? _onRequest;
+
+        /// <summary>One recorded request: absolute URL and the decoded form body.</summary>
+        public sealed class RecordedRequest
+        {
+            public RecordedRequest(string url, IReadOnlyDictionary<string, string> form)
+            {
+                Url = url;
+                Form = form;
+            }
+
+            public string Url { get; }
+            public IReadOnlyDictionary<string, string> Form { get; }
+        }
+
+        /// <summary>Every request this handler served, in order.</summary>
+        public IReadOnlyList<RecordedRequest> Requests => _requests;
+
+        /// <summary>Enqueue one scripted response (consumed in FIFO order before <see cref="RespondWith"/>).</summary>
+        public RecordingHttpMessageHandler Enqueue(HttpStatusCode status, string json)
+        {
+            _scripted.Enqueue(_ => JsonResponse(status, json));
+            return this;
+        }
+
+        /// <summary>The response used when the scripted queue is empty.</summary>
+        public RecordingHttpMessageHandler RespondWith(HttpStatusCode status, string json)
+        {
+            _fallback = _ => JsonResponse(status, json);
+            return this;
+        }
+
+        /// <summary>Delay every response (for timeout tests).</summary>
+        public RecordingHttpMessageHandler DelayEachResponse(TimeSpan delay)
+        {
+            _delay = delay;
+            return this;
+        }
+
+        /// <summary>Invoked synchronously as each request is recorded (e.g. to displace a lock file mid-call).</summary>
+        public RecordingHttpMessageHandler OnRequest(Action<RecordedRequest> callback)
+        {
+            _onRequest = callback;
+            return this;
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var body = request.Content == null ? "" : await request.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var recorded = new RecordedRequest(request.RequestUri?.ToString() ?? "", DecodeForm(body));
+            lock (_requests)
+                _requests.Add(recorded);
+            _onRequest?.Invoke(recorded);
+
+            if (_delay > TimeSpan.Zero)
+                await Task.Delay(_delay, cancellationToken).ConfigureAwait(false);
+
+            Func<RecordedRequest, HttpResponseMessage>? producer;
+            lock (_requests)
+                producer = _scripted.Count > 0 ? _scripted.Dequeue() : _fallback;
+            if (producer == null)
+                throw new InvalidOperationException("RecordingHttpMessageHandler: no scripted response left and no fallback configured.");
+            return producer(recorded);
+        }
+
+        static HttpResponseMessage JsonResponse(HttpStatusCode status, string json)
+            => new HttpResponseMessage(status)
+            {
+                Content = new StringContent(json, Encoding.UTF8, "application/json"),
+            };
+
+        static IReadOnlyDictionary<string, string> DecodeForm(string body)
+        {
+            var result = new Dictionary<string, string>(StringComparer.Ordinal);
+            foreach (var pair in body.Split(new[] { '&' }, StringSplitOptions.RemoveEmptyEntries))
+            {
+                var eq = pair.IndexOf('=');
+                var key = eq < 0 ? pair : pair.Substring(0, eq);
+                var value = eq < 0 ? "" : pair.Substring(eq + 1);
+                result[Uri.UnescapeDataString(key.Replace('+', ' '))] = Uri.UnescapeDataString(value.Replace('+', ' '));
+            }
+            return result;
+        }
+    }
+
+    /// <summary>
+    /// A deterministic scripted <see cref="ITokenRefresher"/> for provider tests. Hand-rolled (not
+    /// Moq) on purpose: the interface now carries a default implementation for the request-based
+    /// overload, and a hand-written fake pins EXACTLY which overload the provider invokes —
+    /// proxy-generated mocks leave that dispatch ambiguous.
+    /// </summary>
+    public sealed class FakeTokenRefresher : ITokenRefresher
+    {
+        readonly Func<TokenRefreshRequest, TokenRefreshResult> _onRefresh;
+        readonly List<TokenRefreshRequest> _requests = new List<TokenRefreshRequest>();
+
+        public FakeTokenRefresher(Func<TokenRefreshRequest, TokenRefreshResult> onRefresh)
+        {
+            _onRefresh = onRefresh;
+        }
+
+        public FakeTokenRefresher(TokenRefreshResult fixedResult)
+            : this(_ => fixedResult)
+        {
+        }
+
+        /// <summary>Every request-based refresh call the provider made, in order.</summary>
+        public IReadOnlyList<TokenRefreshRequest> Requests => _requests;
+
+        /// <summary>How many times the LEGACY two-string API was called (must stay 0 — the provider uses the family-aware API).</summary>
+        public int LegacyCalls { get; private set; }
+
+        public Task<TokenRefreshResult> RefreshAsync(string refreshToken, string? serverTarget, CancellationToken cancellationToken = default)
+        {
+            LegacyCalls++;
+            return Task.FromResult(_onRefresh(new TokenRefreshRequest(refreshToken, serverTarget, clientId: null)));
+        }
+
+        public Task<TokenRefreshResult> RefreshAsync(TokenRefreshRequest request, CancellationToken cancellationToken = default)
+        {
+            _requests.Add(request);
+            return Task.FromResult(_onRefresh(request));
+        }
+    }
+}

--- a/McpPlugin.Tests/Network/Connection/Credentials/ConnectionCredentialCoordinatorTests.cs
+++ b/McpPlugin.Tests/Network/Connection/Credentials/ConnectionCredentialCoordinatorTests.cs
@@ -94,7 +94,9 @@ namespace com.IvanMurzak.McpPlugin.Tests.Network.Connection.Credentials
         [Fact]
         public async Task HandleRejection_RefreshFails_DoesNotReconnect_SurfacesSignInRequired()
         {
-            var refresher = RefresherReturning(TokenRefreshResult.Failure("refresh token expired"));
+            // "refresh token expired" IS an invalid_grant — the dead-family kind, the ONLY kind
+            // that reaches SignInRequired (review B2; a transient failure stays signed in).
+            var refresher = RefresherReturning(TokenRefreshResult.Failure("refresh token expired", TokenRefreshFailureKind.InvalidGrant));
             using var provider = SeededProvider(refresher.Object);
             using var connection = new FakeConnection();
             using var coordinator = new ConnectionCredentialCoordinator(connection, provider);

--- a/McpPlugin.Tests/Network/Connection/Credentials/ConnectionCredentialCoordinatorTests.cs
+++ b/McpPlugin.Tests/Network/Connection/Credentials/ConnectionCredentialCoordinatorTests.cs
@@ -65,6 +65,11 @@ namespace com.IvanMurzak.McpPlugin.Tests.Network.Connection.Credentials
             refresher
                 .Setup(r => r.RefreshAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(result);
+            // The provider invokes the family-aware overload (unified-machine-auth b3); the proxy
+            // intercepts the interface's default implementation, so it needs its own setup.
+            refresher
+                .Setup(r => r.RefreshAsync(It.IsAny<TokenRefreshRequest>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(result);
             return refresher;
         }
 

--- a/McpPlugin.Tests/Network/Connection/Credentials/HttpTokenRefresherTests.cs
+++ b/McpPlugin.Tests/Network/Connection/Credentials/HttpTokenRefresherTests.cs
@@ -1,0 +1,285 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.AgentConfig;
+using com.IvanMurzak.McpPlugin.Tests.Infrastructure;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.Tests.Network.Connection.Credentials
+{
+    /// <summary>
+    /// Wire-contract coverage for the shared <see cref="HttpTokenRefresher"/> (unified-machine-auth
+    /// 04 §3, task b3). The two security-critical rules each have a mandated plant (G-SEC-1):
+    /// <list type="bullet">
+    ///   <item><b>Stored-clientId rule (04 §3.2, probe Q1):</b> a refresher that ignores the
+    ///   family's stored <c>clientId</c> and presents its component default cross-mints the family
+    ///   → <see cref="Refresh_PresentsTheFamilysStoredClientId_NeverTheComponentDefault"/> must go
+    ///   RED under that mutation.</item>
+    ///   <item><b>Omit-scope rule (04 §3.3, P0-3):</b> a refresher that sends a default
+    ///   <c>scope</c> permanently narrows an agent family →
+    ///   <see cref="Refresh_OmitsScopeAndResourceEntirely"/> must go RED under that mutation.</item>
+    /// </list>
+    /// </summary>
+    public sealed class HttpTokenRefresherTests
+    {
+        const string ComponentClientId = "unity-mcp-plugin";
+        const string StoredClientId = "app-dcr-4f2a9c31"; // ≠ the component default, by construction
+        const string RefreshToken = "RT-family-aaa";
+        const string ServerTarget = "https://ai-game.dev";
+
+        static readonly string SuccessJson =
+            "{\"access_token\":\"eyJ.NEW.xyz\",\"refresh_token\":\"RT-family-bbb\",\"expires_in\":3600,\"token_type\":\"Bearer\"}";
+
+        static HttpTokenRefresher NewRefresher(RecordingHttpMessageHandler handler,
+            Func<DateTimeOffset>? clock = null, TimeSpan? window = null, int? timeoutMs = null)
+            => new HttpTokenRefresher(ServerTarget, ComponentClientId, new HttpClient(handler), clock, window, timeoutMs);
+
+        // ── The stored-clientId rule (04 §3.2) — plant target 1, mirrors probe Q1. ──
+
+        [Fact]
+        public async Task Refresh_PresentsTheFamilysStoredClientId_NeverTheComponentDefault()
+        {
+            var handler = new RecordingHttpMessageHandler().RespondWith(HttpStatusCode.OK, SuccessJson);
+            var refresher = NewRefresher(handler);
+
+            var result = await refresher.RefreshAsync(new TokenRefreshRequest(RefreshToken, ServerTarget, StoredClientId));
+
+            result.Succeeded.ShouldBeTrue();
+            var form = handler.Requests.ShouldHaveSingleItem().Form;
+            // The cross-mint discriminator: the wire request carries the STORED id, and provably
+            // not the component default (which is a different string by construction).
+            form["client_id"].ShouldBe(StoredClientId);
+            form["client_id"].ShouldNotBe(ComponentClientId);
+        }
+
+        [Fact]
+        public async Task Refresh_LegacyFamilyOfUnknownId_PresentsTheComponentDefault()
+        {
+            var handler = new RecordingHttpMessageHandler().RespondWith(HttpStatusCode.OK, SuccessJson);
+            var refresher = NewRefresher(handler);
+
+            // 04 §3.7: ClientId null = a v1-adopted legacy family — status-quo component default.
+            await refresher.RefreshAsync(new TokenRefreshRequest(RefreshToken, ServerTarget, clientId: null));
+
+            handler.Requests.ShouldHaveSingleItem().Form["client_id"].ShouldBe(ComponentClientId);
+        }
+
+        [Fact]
+        public async Task Refresh_LegacyTwoStringApi_PresentsTheComponentDefault_AndStillOmitsScope()
+        {
+            var handler = new RecordingHttpMessageHandler().RespondWith(HttpStatusCode.OK, SuccessJson);
+            ITokenRefresher refresher = NewRefresher(handler);
+
+            await refresher.RefreshAsync(RefreshToken, ServerTarget);
+
+            var form = handler.Requests.ShouldHaveSingleItem().Form;
+            form["client_id"].ShouldBe(ComponentClientId);
+            form.ContainsKey("scope").ShouldBeFalse(); // unlike the pre-b3 engine refreshers
+        }
+
+        // ── The omit-scope/omit-resource rule (04 §3.3, P0-3) — plant target 2. ──
+
+        [Fact]
+        public async Task Refresh_OmitsScopeAndResourceEntirely()
+        {
+            var handler = new RecordingHttpMessageHandler().RespondWith(HttpStatusCode.OK, SuccessJson);
+            var refresher = NewRefresher(handler);
+
+            // An AGENT-plane family (a stored id minted for mcp:agent): sending any component
+            // default scope here would permanently narrow it (P0-3).
+            await refresher.RefreshAsync(new TokenRefreshRequest(RefreshToken, ServerTarget, StoredClientId));
+
+            var form = handler.Requests.ShouldHaveSingleItem().Form;
+            form.ContainsKey("scope").ShouldBeFalse();
+            form.ContainsKey("resource").ShouldBeFalse();
+            form.ContainsKey("audience").ShouldBeFalse();
+            // Belt-and-braces: the request is EXACTLY the three contract parameters — a mutation
+            // that adds any fourth parameter (scope included) turns this red.
+            form.Keys.ShouldBe(new[] { "grant_type", "refresh_token", "client_id" }, ignoreOrder: true);
+            form["grant_type"].ShouldBe("refresh_token");
+            form["refresh_token"].ShouldBe(RefreshToken);
+        }
+
+        [Fact]
+        public async Task Refresh_PostsToTheOAuthTokenEndpoint_OnTheNormalizedAsRoot()
+        {
+            var handler = new RecordingHttpMessageHandler().RespondWith(HttpStatusCode.OK, SuccessJson);
+            var refresher = NewRefresher(handler);
+
+            // A stored hub target ("…/mcp", trailing slash) must normalize to the AS root.
+            await refresher.RefreshAsync(new TokenRefreshRequest(RefreshToken, "https://ai-game.dev/mcp/", StoredClientId));
+
+            handler.Requests.ShouldHaveSingleItem().Url.ShouldBe("https://ai-game.dev/oauth/token");
+        }
+
+        // ── Rotation response without refresh_token keeps the previous one (04 §3.4). ──
+
+        [Fact]
+        public async Task Refresh_ResponseWithoutRefreshToken_YieldsNullRefreshToken_SoCallerKeepsPrevious()
+        {
+            var handler = new RecordingHttpMessageHandler()
+                .RespondWith(HttpStatusCode.OK, "{\"access_token\":\"eyJ.NEW.xyz\",\"expires_in\":3600}");
+            var refresher = NewRefresher(handler);
+
+            var result = await refresher.RefreshAsync(new TokenRefreshRequest(RefreshToken, ServerTarget, StoredClientId));
+
+            result.Succeeded.ShouldBeTrue();
+            result.AccessToken.ShouldBe("eyJ.NEW.xyz");
+            result.RefreshToken.ShouldBeNull(); // the caller's keep-previous contract
+        }
+
+        [Fact]
+        public async Task Refresh_Success_ComputesExpiryFromExpiresIn()
+        {
+            var now = new DateTimeOffset(2026, 8, 15, 12, 0, 0, TimeSpan.Zero);
+            var handler = new RecordingHttpMessageHandler().RespondWith(HttpStatusCode.OK, SuccessJson);
+            var refresher = NewRefresher(handler, clock: () => now);
+
+            var result = await refresher.RefreshAsync(new TokenRefreshRequest(RefreshToken, ServerTarget, StoredClientId));
+
+            result.ExpiresAt.ShouldBe(now.AddSeconds(3600));
+        }
+
+        // ── Failure classification (04 §3.5). ──
+
+        [Fact]
+        public async Task Refresh_InvalidGrant_IsClassifiedInvalidGrant()
+        {
+            var handler = new RecordingHttpMessageHandler()
+                .RespondWith(HttpStatusCode.BadRequest, "{\"error\":\"invalid_grant\",\"error_description\":\"revoked\"}");
+            var refresher = NewRefresher(handler);
+
+            var result = await refresher.RefreshAsync(new TokenRefreshRequest(RefreshToken, ServerTarget, StoredClientId));
+
+            result.Succeeded.ShouldBeFalse();
+            result.FailureKind.ShouldBe(TokenRefreshFailureKind.InvalidGrant);
+            result.FailureReason.ShouldContain("invalid_grant");
+        }
+
+        [Theory]
+        [InlineData(HttpStatusCode.BadRequest, "{\"error\":\"invalid_client\"}")]         // a DIFFERENT OAuth error
+        [InlineData(HttpStatusCode.InternalServerError, "{\"detail\":\"boom\"}")]          // 5xx
+        [InlineData(HttpStatusCode.OK, "this is not json")]                                // malformed body
+        public async Task Refresh_NonInvalidGrantFailures_AreClassifiedTransient(HttpStatusCode status, string body)
+        {
+            var handler = new RecordingHttpMessageHandler().RespondWith(status, body);
+            var refresher = NewRefresher(handler);
+
+            var result = await refresher.RefreshAsync(new TokenRefreshRequest(RefreshToken, ServerTarget, StoredClientId));
+
+            result.Succeeded.ShouldBeFalse();
+            result.FailureKind.ShouldBe(TokenRefreshFailureKind.Transient);
+        }
+
+        // ── The 15 s HTTP timeout (04 §2) — tested at a shrunk test-seam timeout. ──
+
+        [Fact]
+        public void HttpTimeout_IsTheSharedContractConstant()
+        {
+            // The refresher pins the cross-language 04 §2 value — .NET's 100 s default would
+            // outlive LOCK_STALE_MS and let a live lock holder be declared stale.
+            HttpTokenRefresher.HttpTimeoutMs.ShouldBe(MachineCredentialLock.REFRESH_HTTP_TIMEOUT);
+            HttpTokenRefresher.HttpTimeoutMs.ShouldBe(15_000);
+        }
+
+        [Fact]
+        public async Task Refresh_SlowServer_TimesOutAsTransientFailure()
+        {
+            var handler = new RecordingHttpMessageHandler()
+                .DelayEachResponse(TimeSpan.FromSeconds(30))
+                .RespondWith(HttpStatusCode.OK, SuccessJson);
+            var refresher = NewRefresher(handler, timeoutMs: 150); // shrunk seam; production pins 15 s
+
+            var result = await refresher.RefreshAsync(new TokenRefreshRequest(RefreshToken, ServerTarget, StoredClientId));
+
+            result.Succeeded.ShouldBeFalse();
+            result.FailureKind.ShouldBe(TokenRefreshFailureKind.Transient);
+            result.FailureReason.ShouldContain("timed out");
+        }
+
+        [Fact]
+        public async Task Refresh_CallerCancellation_Rethrows_NotAFailureResult()
+        {
+            var handler = new RecordingHttpMessageHandler().RespondWith(HttpStatusCode.OK, SuccessJson);
+            var refresher = NewRefresher(handler);
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            await Should.ThrowAsync<OperationCanceledException>(
+                () => refresher.RefreshAsync(new TokenRefreshRequest(RefreshToken, ServerTarget, StoredClientId), cts.Token));
+        }
+
+        // ── Rate discipline (04 §3.6): one network attempt per family per window. ──
+
+        [Fact]
+        public async Task Refresh_SameFamilyTwiceInsideTheWindow_MakesOneNetworkAttempt_AndSharesTheResult()
+        {
+            var handler = new RecordingHttpMessageHandler().RespondWith(HttpStatusCode.OK, SuccessJson);
+            var refresher = NewRefresher(handler);
+
+            var first = await refresher.RefreshAsync(new TokenRefreshRequest(RefreshToken, ServerTarget, StoredClientId));
+            var second = await refresher.RefreshAsync(new TokenRefreshRequest(RefreshToken, ServerTarget, StoredClientId));
+
+            handler.Requests.Count.ShouldBe(1); // the second call replayed the window's attempt
+            second.ShouldBeSameAs(first);
+        }
+
+        [Fact]
+        public async Task Refresh_DifferentFamilies_AreRateLimitedIndependently()
+        {
+            var handler = new RecordingHttpMessageHandler().RespondWith(HttpStatusCode.OK, SuccessJson);
+            var refresher = NewRefresher(handler);
+
+            await refresher.RefreshAsync(new TokenRefreshRequest("RT-family-agent", ServerTarget, StoredClientId));
+            await refresher.RefreshAsync(new TokenRefreshRequest("RT-family-plugin", ServerTarget, StoredClientId));
+
+            handler.Requests.Count.ShouldBe(2); // distinct refresh tokens = distinct families
+        }
+
+        [Fact]
+        public async Task Refresh_SameFamilyAfterTheWindow_AttemptsAgain()
+        {
+            var now = new DateTimeOffset(2026, 8, 15, 12, 0, 0, TimeSpan.Zero);
+            var handler = new RecordingHttpMessageHandler().RespondWith(HttpStatusCode.OK, SuccessJson);
+            var refresher = NewRefresher(handler, clock: () => now, window: TimeSpan.FromSeconds(60));
+
+            await refresher.RefreshAsync(new TokenRefreshRequest(RefreshToken, ServerTarget, StoredClientId));
+            now = now.AddSeconds(61); // the window elapsed
+            await refresher.RefreshAsync(new TokenRefreshRequest(RefreshToken, ServerTarget, StoredClientId));
+
+            handler.Requests.Count.ShouldBe(2);
+        }
+
+        // ── Fail-closed basics. ──
+
+        [Fact]
+        public async Task Refresh_NoServerTargetAnywhere_FailsClosed()
+        {
+            var handler = new RecordingHttpMessageHandler().RespondWith(HttpStatusCode.OK, SuccessJson);
+            var refresher = new HttpTokenRefresher("", ComponentClientId, new HttpClient(handler));
+
+            var result = await refresher.RefreshAsync(new TokenRefreshRequest(RefreshToken, serverTarget: null, StoredClientId));
+
+            result.Succeeded.ShouldBeFalse();
+            handler.Requests.ShouldBeEmpty();
+        }
+
+        [Fact]
+        public void Construction_RequiresAComponentClientId()
+        {
+            Should.Throw<ArgumentException>(() => new HttpTokenRefresher(ServerTarget, componentClientId: " "));
+        }
+    }
+}

--- a/McpPlugin.Tests/Network/Connection/Credentials/MachineCredentialLoginCommitTests.cs
+++ b/McpPlugin.Tests/Network/Connection/Credentials/MachineCredentialLoginCommitTests.cs
@@ -1,0 +1,234 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.AgentConfig;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.Tests.Network.Connection.Credentials
+{
+    /// <summary>
+    /// The two-lock-hold login commit sequence (unified-machine-auth 04 §4, design 03 F1 steps
+    /// 3–4): agent family under the first hold, RFC 8693 exchange between the holds, plugin family
+    /// + v1 mirror under the second — and the failure paths that motivate the two separate holds.
+    /// </summary>
+    public sealed class MachineCredentialLoginCommitTests : IDisposable
+    {
+        const string OwnClientId = "unreal-mcp-plugin";
+        const string ServerTarget = "https://ai-game.dev";
+
+        readonly string _baseDir;
+
+        public MachineCredentialLoginCommitTests()
+        {
+            _baseDir = Path.Combine(Path.GetTempPath(), "agd-logincommit-" + Guid.NewGuid().ToString("N"), ".ai-game-dev");
+        }
+
+        public void Dispose()
+        {
+            var parent = Path.GetDirectoryName(_baseDir);
+            if (parent != null && Directory.Exists(parent))
+                Directory.Delete(parent, recursive: true);
+        }
+
+        MachineCredentialStore NewStore() => new MachineCredentialStore(_baseDir);
+        MachineCredentialLock NewLock() => new MachineCredentialLock(_baseDir);
+
+        static MachineCredentialFamily NewAgentFamily() => new MachineCredentialFamily
+        {
+            AccessToken = "eyJ.AGENT.sig",
+            RefreshToken = "RT-agent-aaa",
+            ExpiresAt = DateTimeOffset.UtcNow.AddHours(1),
+            ClientId = OwnClientId,
+            Scope = "mcp:agent",
+        };
+
+        sealed class FakeExchangeClient : ITokenExchangeClient
+        {
+            readonly Func<string, TokenExchangeResult> _onExchange;
+            public readonly List<string> SubjectTokens = new List<string>();
+
+            public FakeExchangeClient(Func<string, TokenExchangeResult> onExchange) { _onExchange = onExchange; }
+            public FakeExchangeClient(TokenExchangeResult fixedResult) : this(_ => fixedResult) { }
+
+            public string ClientId => OwnClientId;
+
+            public Task<TokenExchangeResult> ExchangeAsync(string subjectAccessToken, string? serverTarget, CancellationToken cancellationToken = default)
+            {
+                SubjectTokens.Add(subjectAccessToken);
+                return Task.FromResult(_onExchange(subjectAccessToken));
+            }
+        }
+
+        static TokenExchangeResult SuccessfulExchange() => TokenExchangeResult.Success(
+            "eyJ.PLUGIN.sig", "RT-plugin-aaa", DateTimeOffset.UtcNow.AddHours(1), "mcp:plugin", "usr_123",
+            "urn:ietf:params:oauth:token-type:access_token");
+
+        // ── The happy path: F1 steps 3–5. ──
+
+        [Fact]
+        public async Task Commit_FullSequence_PersistsAgentThenPluginFamilies_WithMirror()
+        {
+            var exchange = new FakeExchangeClient(SuccessfulExchange());
+
+            var result = await MachineCredentialLoginCommit.CommitAsync(
+                NewStore(), NewLock(), NewAgentFamily(), ServerTarget, "usr_123", exchange);
+
+            result.Status.ShouldBe(LoginCommitStatus.FullyCommitted);
+
+            // The exchange subject was the agent access token (04 §4: a fresh ES256 agent token).
+            exchange.SubjectTokens.ShouldHaveSingleItem().ShouldBe("eyJ.AGENT.sig");
+
+            var stored = NewStore().Read()!;
+            stored.Subject.ShouldBe("usr_123");
+            stored.ServerTarget.ShouldBe(ServerTarget);
+            // Agent family, with the clientId it was minted under (D8).
+            stored.Families!.Agent!.AccessToken.ShouldBe("eyJ.AGENT.sig");
+            stored.Families.Agent.ClientId.ShouldBe(OwnClientId);
+            // Plugin family, stamped with the id the exchange PRESENTED and the response scope.
+            stored.Families.Plugin!.AccessToken.ShouldBe("eyJ.PLUGIN.sig");
+            stored.Families.Plugin.RefreshToken.ShouldBe("RT-plugin-aaa");
+            stored.Families.Plugin.ClientId.ShouldBe(OwnClientId);
+            stored.Families.Plugin.Scope.ShouldBe("mcp:plugin");
+            // The v1 compat mirror follows the plugin family (write contract).
+            stored.AccessToken.ShouldBe("eyJ.PLUGIN.sig");
+            stored.RefreshToken.ShouldBe("RT-plugin-aaa");
+
+            // Both holds were released (no residual lock artifact).
+            File.Exists(NewLock().LockPath).ShouldBeFalse();
+        }
+
+        // ── The F1 failure path: a failed exchange leaves a committed agent family. ──
+
+        [Fact]
+        public async Task Commit_ExchangeFails_AgentFamilyStaysCommitted_StatusAgentOnly()
+        {
+            var exchange = new FakeExchangeClient(TokenExchangeResult.Failure("as unreachable"));
+
+            var result = await MachineCredentialLoginCommit.CommitAsync(
+                NewStore(), NewLock(), NewAgentFamily(), ServerTarget, "usr_123", exchange);
+
+            result.Status.ShouldBe(LoginCommitStatus.AgentOnly); // caller retries with backoff (F1)
+            var stored = NewStore().Read()!;
+            stored.Families!.Agent!.AccessToken.ShouldBe("eyJ.AGENT.sig"); // first hold committed
+            stored.Families.Plugin.ShouldBeNull();
+            stored.AccessToken.ShouldBeNull(); // no plugin-plane credential ⇒ no v1 mirror
+        }
+
+        [Fact]
+        public async Task Commit_ExchangeThrows_AgentFamilyStaysCommitted_StatusAgentOnly()
+        {
+            var exchange = new FakeExchangeClient(_ => throw new InvalidOperationException("boom"));
+
+            var result = await MachineCredentialLoginCommit.CommitAsync(
+                NewStore(), NewLock(), NewAgentFamily(), ServerTarget, "usr_123", exchange);
+
+            result.Status.ShouldBe(LoginCommitStatus.AgentOnly);
+            NewStore().Read()!.Families!.Agent.ShouldNotBeNull();
+        }
+
+        // ── The subject guard (F7/D6): never silently overwrite another account's store. ──
+
+        [Fact]
+        public async Task Commit_DifferentSubjectInStore_RefusesWithoutWriting()
+        {
+            NewStore().Write(new MachineCredentials
+            {
+                Subject = "usr_OTHER",
+                Families = new MachineCredentialFamilies
+                {
+                    Plugin = new MachineCredentialFamily { AccessToken = "eyJ.OTHER.sig", RefreshToken = "RT-other" },
+                },
+            });
+            var exchange = new FakeExchangeClient(SuccessfulExchange());
+
+            var result = await MachineCredentialLoginCommit.CommitAsync(
+                NewStore(), NewLock(), NewAgentFamily(), ServerTarget, "usr_123", exchange);
+
+            result.Status.ShouldBe(LoginCommitStatus.SubjectMismatch);
+            exchange.SubjectTokens.ShouldBeEmpty(); // refused before any network call
+            var stored = NewStore().Read()!;
+            stored.Subject.ShouldBe("usr_OTHER"); // untouched
+            stored.Families!.Agent.ShouldBeNull();
+        }
+
+        [Fact]
+        public async Task Commit_DifferentSubject_WithExplicitOverwrite_Proceeds()
+        {
+            NewStore().Write(new MachineCredentials { Subject = "usr_OTHER" });
+            var exchange = new FakeExchangeClient(SuccessfulExchange());
+
+            var result = await MachineCredentialLoginCommit.CommitAsync(
+                NewStore(), NewLock(), NewAgentFamily(), ServerTarget, "usr_123", exchange,
+                overwriteDifferentSubject: true);
+
+            result.Status.ShouldBe(LoginCommitStatus.FullyCommitted);
+            NewStore().Read()!.Subject.ShouldBe("usr_123");
+        }
+
+        // ── Busy paths: nothing written outside the lock. ──
+
+        [Fact]
+        public async Task Commit_FirstHoldBusy_WritesNothing()
+        {
+            var exchange = new FakeExchangeClient(SuccessfulExchange());
+            var shortBudgetLock = new MachineCredentialLock(_baseDir, hostId: null,
+                acquireBudgetMs: 200, staleMs: MachineCredentialLock.LOCK_STALE_MS,
+                foreignStaleMs: MachineCredentialLock.FOREIGN_HOST_STALE_MS);
+
+            using var peerHold = NewLock().TryAcquire();
+            peerHold.ShouldNotBeNull();
+
+            var result = await MachineCredentialLoginCommit.CommitAsync(
+                NewStore(), shortBudgetLock, NewAgentFamily(), ServerTarget, "usr_123", exchange);
+
+            result.Status.ShouldBe(LoginCommitStatus.Busy);
+            exchange.SubjectTokens.ShouldBeEmpty();
+            NewStore().Exists.ShouldBeFalse(); // nothing was written lock-free
+        }
+
+        [Fact]
+        public async Task CommitPluginFamily_RetriesTheSecondPhaseAlone_WithoutReExchanging()
+        {
+            // Simulate a PluginCommitBusy recovery: the agent family is already committed and the
+            // exchange result is in hand — only the second phase runs.
+            NewStore().Write(new MachineCredentials
+            {
+                Subject = "usr_123",
+                ServerTarget = ServerTarget,
+                Families = new MachineCredentialFamilies { Agent = NewAgentFamily() },
+            });
+
+            var result = await MachineCredentialLoginCommit.CommitPluginFamilyAsync(
+                NewStore(), NewLock(), SuccessfulExchange(), OwnClientId, ServerTarget);
+
+            result.Status.ShouldBe(LoginCommitStatus.FullyCommitted);
+            var stored = NewStore().Read()!;
+            stored.Families!.Agent.ShouldNotBeNull(); // preserved
+            stored.Families.Plugin!.AccessToken.ShouldBe("eyJ.PLUGIN.sig");
+            stored.AccessToken.ShouldBe("eyJ.PLUGIN.sig"); // mirror
+        }
+
+        [Fact]
+        public async Task Commit_RequiresTheAgentFamilysMintClientId()
+        {
+            var family = NewAgentFamily();
+            family.ClientId = null; // D8 violation: an agent family must know its mint id
+
+            await Should.ThrowAsync<ArgumentException>(() => MachineCredentialLoginCommit.CommitAsync(
+                NewStore(), NewLock(), family, ServerTarget, "usr_123",
+                new FakeExchangeClient(SuccessfulExchange())));
+        }
+    }
+}

--- a/McpPlugin.Tests/Network/Connection/Credentials/MachineCredentialLoginCommitTests.cs
+++ b/McpPlugin.Tests/Network/Connection/Credentials/MachineCredentialLoginCommitTests.cs
@@ -75,6 +75,17 @@ namespace com.IvanMurzak.McpPlugin.Tests.Network.Connection.Credentials
             "eyJ.PLUGIN.sig", "RT-plugin-aaa", DateTimeOffset.UtcNow.AddHours(1), "mcp:plugin", "usr_123",
             "urn:ietf:params:oauth:token-type:access_token");
 
+        sealed class FakeRevocationClient : ITokenRevocationClient
+        {
+            public readonly List<(string Token, string? ClientId)> Calls = new List<(string, string?)>();
+
+            public Task<bool> RevokeAsync(string token, string? clientId, string? serverTarget, CancellationToken cancellationToken = default)
+            {
+                Calls.Add((token, clientId));
+                return Task.FromResult(true);
+            }
+        }
+
         // ── The happy path: F1 steps 3–5. ──
 
         [Fact]
@@ -164,17 +175,41 @@ namespace com.IvanMurzak.McpPlugin.Tests.Network.Connection.Credentials
         }
 
         [Fact]
-        public async Task Commit_DifferentSubject_WithExplicitOverwrite_Proceeds()
+        public async Task Commit_DifferentSubject_WithConfirmedSwitch_Proceeds()
         {
             NewStore().Write(new MachineCredentials { Subject = "usr_OTHER" });
             var exchange = new FakeExchangeClient(SuccessfulExchange());
 
+            // The user confirmed replacing usr_OTHER in the F7 dialog — the confirmation names
+            // exactly the account being displaced (twin: exact-premise confirmed switch).
             var result = await MachineCredentialLoginCommit.CommitAsync(
                 NewStore(), NewLock(), NewAgentFamily(), ServerTarget, "usr_123", exchange,
-                overwriteDifferentSubject: true);
+                confirmedReplaceOfSubject: "usr_OTHER");
 
             result.Status.ShouldBe(LoginCommitStatus.FullyCommitted);
             NewStore().Read()!.Subject.ShouldBe("usr_123");
+        }
+
+        [Fact]
+        public async Task Commit_ConfirmedSwitch_ButStoreOwnerChangedAgain_AbortsGuardPremiseChanged()
+        {
+            // The user confirmed replacing usr_OTHER — but by the time the hold is taken, a THIRD
+            // account owns the store. The confirmation's premise is void (twin:
+            // guard-premise-changed): nothing written, nothing exchanged, nothing revoked.
+            NewStore().Write(new MachineCredentials { Subject = "usr_THIRD" });
+            var exchange = new FakeExchangeClient(SuccessfulExchange());
+            var revocation = new FakeRevocationClient();
+
+            var result = await MachineCredentialLoginCommit.CommitAsync(
+                NewStore(), NewLock(), NewAgentFamily(), ServerTarget, "usr_123", exchange,
+                confirmedReplaceOfSubject: "usr_OTHER", revocationClient: revocation);
+
+            result.Status.ShouldBe(LoginCommitStatus.GuardPremiseChanged);
+            exchange.SubjectTokens.ShouldBeEmpty();          // refused before any network call
+            revocation.Calls.ShouldBeEmpty();                // hold-1 premise aborts revoke NOTHING (twin rule 4)
+            var stored = NewStore().Read()!;
+            stored.Subject.ShouldBe("usr_THIRD");            // untouched
+            stored.Families?.Agent.ShouldBeNull();
         }
 
         // ── Busy paths: nothing written outside the lock. ──
@@ -211,13 +246,186 @@ namespace com.IvanMurzak.McpPlugin.Tests.Network.Connection.Credentials
             });
 
             var result = await MachineCredentialLoginCommit.CommitPluginFamilyAsync(
-                NewStore(), NewLock(), SuccessfulExchange(), OwnClientId, ServerTarget);
+                NewStore(), NewLock(), SuccessfulExchange(), OwnClientId, expectedSubject: "usr_123", ServerTarget);
 
             result.Status.ShouldBe(LoginCommitStatus.FullyCommitted);
             var stored = NewStore().Read()!;
             stored.Families!.Agent.ShouldNotBeNull(); // preserved
             stored.Families.Plugin!.AccessToken.ShouldBe("eyJ.PLUGIN.sig");
             stored.AccessToken.ShouldBe("eyJ.PLUGIN.sig"); // mirror
+        }
+
+        // ── The F7 guard at the SECOND hold (review B1): the commit's premise is re-verified
+        //    before the plugin-family write — an interleaved login/sign-out between the holds
+        //    must abort, never mix accounts, never recreate a signed-out store. ──
+
+        [Fact]
+        public async Task Commit_SubjectChangedBetweenHolds_AbortsSecondPhase_NeverMixesAccounts_RevokesTheOrphan()
+        {
+            var exchange = new FakeExchangeClient(_ =>
+            {
+                // Interleaved login-as-B lands BETWEEN the holds (the exchange runs lock-free):
+                // the store now belongs to account B while our exchange derived from account A.
+                NewStore().Write(new MachineCredentials
+                {
+                    Subject = "usr_B",
+                    ServerTarget = ServerTarget,
+                    Families = new MachineCredentialFamilies
+                    {
+                        Agent = new MachineCredentialFamily
+                        {
+                            AccessToken = "eyJ.B-AGENT.sig",
+                            RefreshToken = "RT-b-agent",
+                            ClientId = "app-dcr-b",
+                            Scope = "mcp:agent",
+                        },
+                    },
+                });
+                return SuccessfulExchange();
+            });
+            var revocation = new FakeRevocationClient();
+
+            var result = await MachineCredentialLoginCommit.CommitAsync(
+                NewStore(), NewLock(), NewAgentFamily(), ServerTarget, "usr_123", exchange,
+                revocationClient: revocation);
+
+            // 03 F7.2: a store with subject B plus a plugin family derived from account A is the
+            // forbidden silent cross-account mix — the second phase must abort without writing.
+            result.Status.ShouldBe(LoginCommitStatus.SubjectMismatch);
+            var stored = NewStore().Read()!;
+            stored.Subject.ShouldBe("usr_B");                    // B's store is untouched
+            stored.Families!.Plugin.ShouldBeNull();              // A's plugin family was NOT written
+            stored.Families.Agent!.AccessToken.ShouldBe("eyJ.B-AGENT.sig");
+
+            // Twin rule 4: the just-derived, invisible-to-others plugin family is best-effort
+            // revoked — refresh-token preferred, presented under the deriving client's id.
+            var revoked = revocation.Calls.ShouldHaveSingleItem();
+            revoked.Token.ShouldBe("RT-plugin-aaa");
+            revoked.ClientId.ShouldBe(OwnClientId);
+        }
+
+        [Fact]
+        public async Task Commit_StoreDeletedBetweenHolds_Aborts_NeverRecreates_RevokesTheOrphan()
+        {
+            var exchange = new FakeExchangeClient(_ =>
+            {
+                NewStore().Delete(); // a machine-wide sign-out (F6) lands between the holds
+                return SuccessfulExchange();
+            });
+            var revocation = new FakeRevocationClient();
+
+            var result = await MachineCredentialLoginCommit.CommitAsync(
+                NewStore(), NewLock(), NewAgentFamily(), ServerTarget, "usr_123", exchange,
+                revocationClient: revocation);
+
+            result.Status.ShouldBe(LoginCommitStatus.StoreSignedOut);
+            NewStore().Exists.ShouldBeFalse(); // the sign-out wins — never recreated signed-in
+            revocation.Calls.ShouldHaveSingleItem().Token.ShouldBe("RT-plugin-aaa"); // orphan revoked
+        }
+
+        [Fact]
+        public async Task Commit_HoldOneSubjectMismatch_RevokesNothing()
+        {
+            // Hold-1 premise aborts revoke NOTHING (twin rule 4): no plugin family was derived
+            // yet, and the agent mint is reused by the retry after the F7 dialog.
+            NewStore().Write(new MachineCredentials { Subject = "usr_OTHER" });
+            var exchange = new FakeExchangeClient(SuccessfulExchange());
+            var revocation = new FakeRevocationClient();
+
+            var result = await MachineCredentialLoginCommit.CommitAsync(
+                NewStore(), NewLock(), NewAgentFamily(), ServerTarget, "usr_123", exchange,
+                revocationClient: revocation);
+
+            result.Status.ShouldBe(LoginCommitStatus.SubjectMismatch);
+            revocation.Calls.ShouldBeEmpty();
+            exchange.SubjectTokens.ShouldBeEmpty();
+        }
+
+        [Fact]
+        public async Task CommitPluginFamily_SubjectMismatchAtTheSecondHold_AbortsWithoutWriting()
+        {
+            NewStore().Write(new MachineCredentials { Subject = "usr_B" });
+
+            var result = await MachineCredentialLoginCommit.CommitPluginFamilyAsync(
+                NewStore(), NewLock(), SuccessfulExchange(), OwnClientId, expectedSubject: "usr_123", ServerTarget);
+
+            result.Status.ShouldBe(LoginCommitStatus.SubjectMismatch);
+            var stored = NewStore().Read()!;
+            stored.Subject.ShouldBe("usr_B");
+            stored.Families?.Plugin.ShouldBeNull();
+        }
+
+        [Fact]
+        public async Task CommitPluginFamily_StoreMissing_Aborts_NeverRecreates()
+        {
+            var result = await MachineCredentialLoginCommit.CommitPluginFamilyAsync(
+                NewStore(), NewLock(), SuccessfulExchange(), OwnClientId, expectedSubject: "usr_123", ServerTarget);
+
+            result.Status.ShouldBe(LoginCommitStatus.StoreSignedOut);
+            NewStore().Exists.ShouldBeFalse();
+        }
+
+        [Fact]
+        public async Task CommitPluginFamily_UnreadableStore_ReturnsARetryShapedOutcome_NeverWrites_NeverRevokes()
+        {
+            Directory.CreateDirectory(_baseDir);
+            var credentialsPath = Path.Combine(_baseDir, MachineCredentialStore.CredentialsFileName);
+            File.WriteAllBytes(credentialsPath, new byte[] { 0x01, 0x02, 0x03 });
+            var corrupted = File.ReadAllBytes(credentialsPath);
+            var revocation = new FakeRevocationClient();
+
+            var result = await MachineCredentialLoginCommit.CommitPluginFamilyAsync(
+                NewStore(), NewLock(), SuccessfulExchange(), OwnClientId, expectedSubject: "usr_123", ServerTarget,
+                revocationClient: revocation);
+
+            // Result-shaped (no exception), retryable, the unreadable file untouched — and the
+            // mint NOT revoked, because the retry commits this same mint (twin: store-unreadable).
+            result.Status.ShouldBe(LoginCommitStatus.StoreUnreadable);
+            result.ExchangeResult.ShouldNotBeNull(); // the minted family is carried for the retry
+            File.ReadAllBytes(credentialsPath).ShouldBe(corrupted);
+            revocation.Calls.ShouldBeEmpty();
+        }
+
+        [Fact]
+        public async Task Commit_SubjectlessPremise_InterleavedSubjectfulLogin_ProceedsPerF73()
+        {
+            // Twin-converged (F7.3): subject compares fire only when BOTH subjects are known. A
+            // subject-less premise (pre-a6/no-sub mint) cannot discriminate ownership, so the
+            // commit proceeds — and the sub backfill is only-when-absent, so the interloper's
+            // stamped subject is NOT overwritten.
+            var exchange = new FakeExchangeClient(_ =>
+            {
+                var doc = NewStore().Read()!;
+                doc.Subject = "usr_B";
+                NewStore().Write(doc);
+                return SuccessfulExchange();
+            });
+
+            var result = await MachineCredentialLoginCommit.CommitAsync(
+                NewStore(), NewLock(), NewAgentFamily(), ServerTarget, subject: null, exchange);
+
+            result.Status.ShouldBe(LoginCommitStatus.FullyCommitted);
+            var stored = NewStore().Read()!;
+            stored.Subject.ShouldBe("usr_B");                       // backfill only-when-absent (twin rule 5)
+            stored.Families!.Plugin!.AccessToken.ShouldBe("eyJ.PLUGIN.sig");
+        }
+
+        [Fact]
+        public async Task CommitPluginFamily_SubBackfill_OnlyWhenAbsent()
+        {
+            // A subject-less store + a successful exchange carrying sub ⇒ the sub is backfilled
+            // (O5); a store that already carries a subject keeps it (previous test's negative).
+            NewStore().Write(new MachineCredentials
+            {
+                ServerTarget = ServerTarget,
+                Families = new MachineCredentialFamilies { Agent = NewAgentFamily() },
+            });
+
+            var result = await MachineCredentialLoginCommit.CommitPluginFamilyAsync(
+                NewStore(), NewLock(), SuccessfulExchange(), OwnClientId, expectedSubject: null, ServerTarget);
+
+            result.Status.ShouldBe(LoginCommitStatus.FullyCommitted);
+            NewStore().Read()!.Subject.ShouldBe("usr_123"); // from the exchange response's sub
         }
 
         [Fact]

--- a/McpPlugin.Tests/Network/Connection/Credentials/MachineWideSignOutTests.cs
+++ b/McpPlugin.Tests/Network/Connection/Credentials/MachineWideSignOutTests.cs
@@ -1,0 +1,224 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.AgentConfig;
+using com.IvanMurzak.McpPlugin.Tests.Infrastructure;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.Tests.Network.Connection.Credentials
+{
+    /// <summary>
+    /// Machine-wide sign-out (unified-machine-auth design 03 F6, task b3): RFC 7009 revocation of
+    /// every family — stored <c>clientId</c>s, component default for legacy (F6.2) — with bounded
+    /// retries, then the 04 §2 lock-protocol delete path; offline sign-out still deletes locally
+    /// (F6.4). Plus the wire contract of the production <see cref="TokenRevocationClient"/>.
+    /// </summary>
+    public sealed class MachineWideSignOutTests : IDisposable
+    {
+        const string ComponentClientId = "unity-mcp-plugin";
+        const string ServerTarget = "https://ai-game.dev";
+
+        readonly string _baseDir;
+
+        public MachineWideSignOutTests()
+        {
+            _baseDir = Path.Combine(Path.GetTempPath(), "agd-signout-" + Guid.NewGuid().ToString("N"), ".ai-game-dev");
+        }
+
+        public void Dispose()
+        {
+            var parent = Path.GetDirectoryName(_baseDir);
+            if (parent != null && Directory.Exists(parent))
+                Directory.Delete(parent, recursive: true);
+        }
+
+        MachineCredentialStore NewStore() => new MachineCredentialStore(_baseDir);
+        MachineCredentialLock NewLock() => new MachineCredentialLock(_baseDir);
+
+        void SeedAllThreeFamilies()
+        {
+            NewStore().Write(new MachineCredentials
+            {
+                ServerTarget = ServerTarget,
+                Subject = "usr_123",
+                Families = new MachineCredentialFamilies
+                {
+                    Agent = new MachineCredentialFamily { AccessToken = "eyJ.A.s", RefreshToken = "RT-agent", ClientId = "app-dcr-1234" },
+                    Plugin = new MachineCredentialFamily { AccessToken = "eyJ.P.s", RefreshToken = "RT-plugin", ClientId = "godot-mcp-plugin" },
+                    Legacy = new MachineCredentialFamily { AccessToken = "eyJ.L.s", RefreshToken = "RT-legacy" }, // no clientId, by definition
+                },
+            });
+        }
+
+        sealed class FakeRevocationClient : ITokenRevocationClient
+        {
+            readonly Func<string, bool> _onRevoke;
+            public readonly List<(string Token, string? ClientId, string? ServerTarget)> Calls
+                = new List<(string, string?, string?)>();
+
+            public FakeRevocationClient(Func<string, bool>? onRevoke = null) { _onRevoke = onRevoke ?? (_ => true); }
+
+            public Task<bool> RevokeAsync(string token, string? clientId, string? serverTarget, CancellationToken cancellationToken = default)
+            {
+                Calls.Add((token, clientId, serverTarget));
+                return Task.FromResult(_onRevoke(token));
+            }
+        }
+
+        // ── The full F6 sequence. ──
+
+        [Fact]
+        public async Task SignOut_RevokesEveryFamilyWithItsOwnClientId_ThenDeletesTheStore()
+        {
+            SeedAllThreeFamilies();
+            var revocation = new FakeRevocationClient();
+
+            var result = await MachineWideSignOut.SignOutAsync(
+                NewStore(), NewLock(), revocation, ComponentClientId);
+
+            result.StoreDeleted.ShouldBeTrue();
+            result.Busy.ShouldBeFalse();
+            result.FamiliesRevoked.ShouldBe(3);
+            result.RevocationsFailed.ShouldBe(0);
+
+            // Each family presented ITS stored clientId; the legacy family (unknown id) presented
+            // the component default (F6.2).
+            revocation.Calls.Count.ShouldBe(3);
+            revocation.Calls.ShouldContain(c => c.Token == "RT-agent" && c.ClientId == "app-dcr-1234");
+            revocation.Calls.ShouldContain(c => c.Token == "RT-plugin" && c.ClientId == "godot-mcp-plugin");
+            revocation.Calls.ShouldContain(c => c.Token == "RT-legacy" && c.ClientId == ComponentClientId);
+            revocation.Calls.ForEach(c => c.ServerTarget.ShouldBe(ServerTarget));
+
+            NewStore().Exists.ShouldBeFalse();                    // unlinked via the lock delete path
+            File.Exists(NewLock().LockPath).ShouldBeFalse();      // and the lock was released
+        }
+
+        // ── Offline sign-out (F6.4): bounded retries, then delete anyway. ──
+
+        [Fact]
+        public async Task SignOut_RevocationKeepsFailing_RetriesBounded_ThenStillDeletesLocally()
+        {
+            SeedAllThreeFamilies();
+            var revocation = new FakeRevocationClient(_ => false); // AS unreachable
+
+            var result = await MachineWideSignOut.SignOutAsync(
+                NewStore(), NewLock(), revocation, ComponentClientId);
+
+            result.StoreDeleted.ShouldBeTrue(); // offline sign-out still signs the machine out
+            result.FamiliesRevoked.ShouldBe(0);
+            result.RevocationsFailed.ShouldBe(3);
+            // Bounded: exactly RevokeAttemptsPerFamily attempts per family, never unbounded.
+            revocation.Calls.Count.ShouldBe(3 * MachineWideSignOut.RevokeAttemptsPerFamily);
+            NewStore().Exists.ShouldBeFalse();
+        }
+
+        [Fact]
+        public async Task SignOut_TransientRevocationFailure_SucceedsWithinTheRetryBudget()
+        {
+            SeedAllThreeFamilies();
+            var attemptsByToken = new Dictionary<string, int>();
+            var revocation = new FakeRevocationClient(token =>
+            {
+                attemptsByToken[token] = attemptsByToken.TryGetValue(token, out var n) ? n + 1 : 1;
+                return attemptsByToken[token] >= 2; // first attempt fails, second succeeds
+            });
+
+            var result = await MachineWideSignOut.SignOutAsync(
+                NewStore(), NewLock(), revocation, ComponentClientId);
+
+            result.FamiliesRevoked.ShouldBe(3);
+            result.RevocationsFailed.ShouldBe(0);
+        }
+
+        // ── The delete path is lock-protocol only: busy ⇒ store untouched. ──
+
+        [Fact]
+        public async Task SignOut_LockBusy_RevokesButDoesNotDeleteTheStore()
+        {
+            SeedAllThreeFamilies();
+            var revocation = new FakeRevocationClient();
+            var shortBudgetLock = new MachineCredentialLock(_baseDir, hostId: null,
+                acquireBudgetMs: 200, staleMs: MachineCredentialLock.LOCK_STALE_MS,
+                foreignStaleMs: MachineCredentialLock.FOREIGN_HOST_STALE_MS);
+
+            using var peerHold = NewLock().TryAcquire();
+            peerHold.ShouldNotBeNull();
+
+            var result = await MachineWideSignOut.SignOutAsync(
+                NewStore(), shortBudgetLock, revocation, ComponentClientId);
+
+            result.StoreDeleted.ShouldBeFalse();
+            result.Busy.ShouldBeTrue();
+            NewStore().Exists.ShouldBeTrue(); // never unlinked outside the lock protocol
+        }
+
+        [Fact]
+        public async Task SignOut_EmptyStore_IsAQuietNoOp()
+        {
+            var revocation = new FakeRevocationClient();
+
+            var result = await MachineWideSignOut.SignOutAsync(
+                NewStore(), NewLock(), revocation, ComponentClientId);
+
+            result.StoreDeleted.ShouldBeTrue(); // idempotent — the machine ends signed out
+            revocation.Calls.ShouldBeEmpty();
+        }
+
+        [Fact]
+        public async Task SignOut_UnreadableStore_SkipsRevocation_ButStillDeletes()
+        {
+            Directory.CreateDirectory(_baseDir);
+            File.WriteAllBytes(Path.Combine(_baseDir, MachineCredentialStore.CredentialsFileName), new byte[] { 0x01 });
+            var revocation = new FakeRevocationClient();
+
+            // Sign-out IS the explicit user action that authorizes removing an unreadable store (04 §1).
+            var result = await MachineWideSignOut.SignOutAsync(
+                NewStore(), NewLock(), revocation, ComponentClientId);
+
+            result.StoreDeleted.ShouldBeTrue();
+            revocation.Calls.ShouldBeEmpty(); // its tokens could not be read
+            NewStore().Exists.ShouldBeFalse();
+        }
+
+        // ── The production RFC 7009 client's wire contract. ──
+
+        [Fact]
+        public async Task RevocationClient_PostsTokenHintAndClientId_ToTheRevokeEndpoint()
+        {
+            var handler = new RecordingHttpMessageHandler().RespondWith(HttpStatusCode.OK, "{}");
+            var client = new TokenRevocationClient(ServerTarget, new HttpClient(handler));
+
+            var acknowledged = await client.RevokeAsync("RT-x", "godot-mcp-plugin", ServerTarget);
+
+            acknowledged.ShouldBeTrue();
+            var request = handler.Requests.ShouldHaveSingleItem();
+            request.Url.ShouldBe("https://ai-game.dev/oauth/revoke");
+            request.Form["token"].ShouldBe("RT-x");
+            request.Form["token_type_hint"].ShouldBe("refresh_token");
+            request.Form["client_id"].ShouldBe("godot-mcp-plugin");
+        }
+
+        [Fact]
+        public async Task RevocationClient_ServerError_FailsSoft()
+        {
+            var handler = new RecordingHttpMessageHandler().RespondWith(HttpStatusCode.ServiceUnavailable, "{}");
+            var client = new TokenRevocationClient(ServerTarget, new HttpClient(handler));
+
+            (await client.RevokeAsync("RT-x", null, ServerTarget)).ShouldBeFalse();
+        }
+    }
+}

--- a/McpPlugin.Tests/Network/Connection/Credentials/PluginCredentialProviderFamilyRefreshTests.cs
+++ b/McpPlugin.Tests/Network/Connection/Credentials/PluginCredentialProviderFamilyRefreshTests.cs
@@ -153,9 +153,13 @@ namespace com.IvanMurzak.McpPlugin.Tests.Network.Connection.Credentials
                 TokenRefreshResult.Failure("invalid_grant: revoked", TokenRefreshFailureKind.InvalidGrant));
             using var provider = new PluginCredentialProvider(NewStore(), refresher);
 
+            var signInRequiredFired = false;
+            using var _ = provider.OnSignInRequired.Subscribe(__ => { signInRequiredFired = true; });
+
             (await provider.RefreshAsync()).ShouldBeFalse();
 
             provider.State.CurrentValue.ShouldBe(AuthState.SignInRequired);
+            signInRequiredFired.ShouldBeTrue(); // the dead-family verdict IS the sign-in prompt (B2: the only path to it)
             refresher.Requests.Count.ShouldBe(1); // never loops
 
             // Never delete other families, never delete the store (03 F3.5).

--- a/McpPlugin.Tests/Network/Connection/Credentials/PluginCredentialProviderFamilyRefreshTests.cs
+++ b/McpPlugin.Tests/Network/Connection/Credentials/PluginCredentialProviderFamilyRefreshTests.cs
@@ -1,0 +1,335 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.AgentConfig;
+using com.IvanMurzak.McpPlugin.Tests.Infrastructure;
+using R3;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.Tests.Network.Connection.Credentials
+{
+    /// <summary>
+    /// The unified-machine-auth b3 provider behaviours (design 04 §3, 03 F3): the lock-integrated
+    /// double-checked refresh path, family context handed to the refresher, the dead-family
+    /// (<c>invalid_grant</c>) verdict with its post-failure re-read, unreadable-store-as-busy
+    /// (b1 review A3), the §3.7 legacy rewrite, and lock-busy-as-transient.
+    /// </summary>
+    public sealed class PluginCredentialProviderFamilyRefreshTests : IDisposable
+    {
+        const string StoredClientId = "app-dcr-4f2a9c31";
+        const string AgentClientId = "godot-mcp-plugin";
+        const string ServerTarget = "https://ai-game.dev";
+
+        readonly string _baseDir;
+
+        public PluginCredentialProviderFamilyRefreshTests()
+        {
+            _baseDir = Path.Combine(Path.GetTempPath(), "agd-credfam-" + Guid.NewGuid().ToString("N"), ".ai-game-dev");
+        }
+
+        public void Dispose()
+        {
+            var parent = Path.GetDirectoryName(_baseDir);
+            if (parent != null && Directory.Exists(parent))
+                Directory.Delete(parent, recursive: true);
+        }
+
+        MachineCredentialStore NewStore() => new MachineCredentialStore(_baseDir);
+
+        MachineCredentials SeedV2(DateTimeOffset? pluginExpiresAt = null)
+        {
+            var credentials = new MachineCredentials
+            {
+                ServerTarget = ServerTarget,
+                Subject = "usr_123",
+                Families = new MachineCredentialFamilies
+                {
+                    Agent = new MachineCredentialFamily
+                    {
+                        AccessToken = "eyJ.AGENT.sig",
+                        RefreshToken = "RT-agent-aaa",
+                        ExpiresAt = DateTimeOffset.UtcNow.AddHours(1),
+                        ClientId = AgentClientId,
+                        Scope = "mcp:agent",
+                    },
+                    Plugin = new MachineCredentialFamily
+                    {
+                        AccessToken = "eyJ.PLUGIN.sig",
+                        RefreshToken = "RT-plugin-aaa",
+                        ExpiresAt = pluginExpiresAt ?? DateTimeOffset.UtcNow.AddHours(1),
+                        ClientId = StoredClientId,
+                        Scope = "mcp:plugin",
+                    },
+                },
+            };
+            NewStore().Write(credentials);
+            return credentials;
+        }
+
+        // ── Family context: the refresher gets the STORED clientId (04 §3.2). ──
+
+        [Fact]
+        public async Task Refresh_HandsTheRefresherThePluginFamilysStoredClientId()
+        {
+            SeedV2();
+            var refresher = new FakeTokenRefresher(
+                TokenRefreshResult.Success("eyJ.PLUGIN2.sig", "RT-plugin-bbb", DateTimeOffset.UtcNow.AddHours(1)));
+
+            using var provider = new PluginCredentialProvider(NewStore(), refresher);
+
+            (await provider.RefreshAsync()).ShouldBeTrue();
+
+            var request = refresher.Requests.ShouldHaveSingleItem();
+            request.ClientId.ShouldBe(StoredClientId); // never the component default, never the agent family's
+            request.RefreshToken.ShouldBe("RT-plugin-aaa");
+            request.ServerTarget.ShouldBe(ServerTarget);
+            refresher.LegacyCalls.ShouldBe(0);
+        }
+
+        [Fact]
+        public async Task Refresh_PluginFamilySuccess_NeverTouchesTheAgentFamily()
+        {
+            SeedV2();
+            var refresher = new FakeTokenRefresher(
+                TokenRefreshResult.Success("eyJ.PLUGIN2.sig", "RT-plugin-bbb", DateTimeOffset.UtcNow.AddHours(1)));
+            using var provider = new PluginCredentialProvider(NewStore(), refresher);
+
+            (await provider.RefreshAsync()).ShouldBeTrue();
+
+            var reread = NewStore().Read()!;
+            reread.Families!.Plugin!.AccessToken.ShouldBe("eyJ.PLUGIN2.sig");
+            reread.Families.Plugin.RefreshToken.ShouldBe("RT-plugin-bbb");
+            reread.Families.Plugin.ClientId.ShouldBe(StoredClientId); // identity preserved through rotation
+            reread.Families.Plugin.Scope.ShouldBe("mcp:plugin");
+            // The agent family is untouched by a plugin-plane rotation.
+            reread.Families.Agent!.AccessToken.ShouldBe("eyJ.AGENT.sig");
+            reread.Families.Agent.RefreshToken.ShouldBe("RT-agent-aaa");
+            reread.Families.Agent.ClientId.ShouldBe(AgentClientId);
+            // And the v1 mirror follows the plugin family (write contract).
+            reread.AccessToken.ShouldBe("eyJ.PLUGIN2.sig");
+        }
+
+        // ── Double-checked refresh (03 F3.2): a peer's rotation is adopted without a network call. ──
+
+        [Fact]
+        public async Task Refresh_PeerAlreadyRotatedTheStore_AdoptsWithoutANetworkCall()
+        {
+            SeedV2();
+            var refresher = new FakeTokenRefresher(TokenRefreshResult.Failure("must not be called"));
+            using var provider = new PluginCredentialProvider(NewStore(), refresher);
+
+            // A peer process rotates the plugin family AFTER our provider booted (its in-memory
+            // token is now the predecessor the server just rejected).
+            var peer = NewStore().Read()!;
+            peer.Families!.Plugin!.AccessToken = "eyJ.PEER-FRESH.sig";
+            peer.Families.Plugin.RefreshToken = "RT-plugin-peer";
+            peer.Families.Plugin.ExpiresAt = DateTimeOffset.UtcNow.AddHours(1);
+            NewStore().Write(peer);
+
+            (await provider.RefreshAsync()).ShouldBeTrue();
+
+            refresher.Requests.ShouldBeEmpty(); // the re-read under the lock satisfied the refresh
+            (await provider.GetAccessTokenAsync()).ShouldBe("eyJ.PEER-FRESH.sig");
+            provider.State.CurrentValue.ShouldBe(AuthState.SignedIn);
+        }
+
+        // ── invalid_grant (04 §3.5 / 03 F3.5): post-failure re-read, then the dead-family verdict. ──
+
+        [Fact]
+        public async Task Refresh_InvalidGrant_WithNoPeerRotation_IsDeadFamily_SignInRequired_OneAttempt()
+        {
+            SeedV2();
+            var refresher = new FakeTokenRefresher(
+                TokenRefreshResult.Failure("invalid_grant: revoked", TokenRefreshFailureKind.InvalidGrant));
+            using var provider = new PluginCredentialProvider(NewStore(), refresher);
+
+            (await provider.RefreshAsync()).ShouldBeFalse();
+
+            provider.State.CurrentValue.ShouldBe(AuthState.SignInRequired);
+            refresher.Requests.Count.ShouldBe(1); // never loops
+
+            // Never delete other families, never delete the store (03 F3.5).
+            var reread = NewStore().Read()!;
+            reread.Families!.Agent.ShouldNotBeNull();
+            reread.Families.Agent!.RefreshToken.ShouldBe("RT-agent-aaa");
+            reread.Families.Plugin.ShouldNotBeNull(); // even the dead family's material is preserved on disk
+        }
+
+        [Fact]
+        public async Task Refresh_InvalidGrant_ButAPeerRotatedMeanwhile_AdoptsThePeersTokens()
+        {
+            SeedV2();
+            var store = NewStore();
+            var refresher = new FakeTokenRefresher(_ =>
+            {
+                // Simulate the race 03 F3.5 describes: OUR refresh token was reuse-revoked because
+                // a peer legitimately rotated it. The peer's write lands while our HTTP call is in
+                // flight (we hold the file lock, but this peer had rotated between our re-read and
+                // the AS answering — the re-read window the post-failure re-read exists for).
+                var peer = store.Read()!;
+                peer.Families!.Plugin!.AccessToken = "eyJ.RACER.sig";
+                peer.Families.Plugin.RefreshToken = "RT-plugin-racer";
+                store.Write(peer);
+                return TokenRefreshResult.Failure("invalid_grant", TokenRefreshFailureKind.InvalidGrant);
+            });
+            using var provider = new PluginCredentialProvider(NewStore(), refresher);
+
+            (await provider.RefreshAsync()).ShouldBeTrue(); // the racer's rotation IS a successful refresh
+
+            provider.State.CurrentValue.ShouldBe(AuthState.SignedIn);
+            (await provider.GetAccessTokenAsync()).ShouldBe("eyJ.RACER.sig");
+        }
+
+        // ── Unreadable store mid-refresh = busy/retry (b1 review A3) — never signed-out, never overwrite. ──
+
+        [Fact]
+        public async Task Refresh_StoreUnreadableAtReread_IsBusy_NotSignInRequired_AndStoreIsPreserved()
+        {
+            SeedV2();
+            using var provider = new PluginCredentialProvider(
+                NewStore(),
+                new FakeTokenRefresher(TokenRefreshResult.Failure("must not be called")));
+
+            // Corrupt the store AFTER boot: the refresh-time re-read now yields Unreadable.
+            File.WriteAllBytes(NewStore().CredentialsPath, new byte[] { 0x01, 0x02, 0x03 });
+            var corrupted = File.ReadAllBytes(NewStore().CredentialsPath);
+
+            var signInRequiredFired = false;
+            using var _ = provider.OnSignInRequired.Subscribe(__ => { signInRequiredFired = true; });
+
+            (await provider.RefreshAsync()).ShouldBeFalse();
+
+            // Busy semantics: no sign-in-required, the provider stays signed in on its in-memory
+            // token, and the unreadable file was neither deleted nor overwritten.
+            signInRequiredFired.ShouldBeFalse();
+            provider.State.CurrentValue.ShouldBe(AuthState.SignedIn);
+            File.ReadAllBytes(NewStore().CredentialsPath).ShouldBe(corrupted);
+        }
+
+        [Fact]
+        public void Boot_UnreadableStore_IsSignInRequired_NotSignedOut_AndFileIsPreserved()
+        {
+            Directory.CreateDirectory(_baseDir);
+            File.WriteAllBytes(Path.Combine(_baseDir, MachineCredentialStore.CredentialsFileName), new byte[] { 0x01 });
+
+            using var provider = new PluginCredentialProvider(NewStore());
+
+            provider.State.CurrentValue.ShouldBe(AuthState.SignInRequired); // 03 F11.4: distinct from a clean machine
+            NewStore().Exists.ShouldBeTrue(); // never deleted
+        }
+
+        // ── Lock integration (04 §2): busy is transient; the peer's lock survives. ──
+
+        [Fact]
+        public async Task Refresh_LockHeldByAPeer_FailsAsBusy_NoNetworkCall_NoStateChange()
+        {
+            SeedV2();
+            var refresher = new FakeTokenRefresher(TokenRefreshResult.Failure("must not be called"));
+
+            // A short-budget lock (test seam) so "busy" resolves in milliseconds, not 75 s.
+            var shortBudgetLock = new MachineCredentialLock(_baseDir, hostId: null,
+                acquireBudgetMs: 200, staleMs: MachineCredentialLock.LOCK_STALE_MS,
+                foreignStaleMs: MachineCredentialLock.FOREIGN_HOST_STALE_MS);
+            using var provider = new PluginCredentialProvider(
+                NewStore(), refresher, credentialLock: shortBudgetLock);
+
+            // A live peer holds the lock.
+            var peerLock = new MachineCredentialLock(_baseDir);
+            using var peerHold = peerLock.TryAcquire();
+            peerHold.ShouldNotBeNull();
+
+            var signInRequiredFired = false;
+            using var _ = provider.OnSignInRequired.Subscribe(__ => { signInRequiredFired = true; });
+
+            (await provider.RefreshAsync()).ShouldBeFalse();
+
+            refresher.Requests.ShouldBeEmpty(); // never refreshes lock-free (D9 REVISED)
+            signInRequiredFired.ShouldBeFalse(); // busy ≠ auth failure
+            provider.State.CurrentValue.ShouldBe(AuthState.SignedIn);
+            File.Exists(peerLock.LockPath).ShouldBeTrue(); // the peer's lock was not stolen
+        }
+
+        [Fact]
+        public async Task Refresh_LockTakenOverMidCall_SkipsTheDiskWrite_ButKeepsTheTokenInMemory()
+        {
+            SeedV2(pluginExpiresAt: DateTimeOffset.UtcNow.AddHours(1));
+            var lockPath = Path.Combine(_baseDir, MachineCredentialLock.LockFileName);
+            var refresher = new FakeTokenRefresher(_ =>
+            {
+                // Simulate a (protocol-violating / clock-skewed) takeover during the HTTP call:
+                // our lock file is replaced by a foreign one. IsStillOwned() must catch this
+                // immediately before the write (b2 review A1).
+                File.WriteAllText(lockPath, "{\"pid\":999,\"hostId\":\"intruder\",\"nonce\":\"ff\"}");
+                return TokenRefreshResult.Success("eyJ.FRESH.sig", "RT-plugin-fresh", DateTimeOffset.UtcNow.AddHours(1));
+            });
+            using var provider = new PluginCredentialProvider(NewStore(), refresher);
+
+            (await provider.RefreshAsync()).ShouldBeTrue(); // in-memory refresh still succeeds
+
+            (await provider.GetAccessTokenAsync()).ShouldBe("eyJ.FRESH.sig");
+            // But the store was NOT written by a writer that no longer holds the lock.
+            NewStore().Read()!.Families!.Plugin!.AccessToken.ShouldBe("eyJ.PLUGIN.sig");
+        }
+
+        // ── A peer's machine-wide sign-out is adopted quietly (03 F6.3). ──
+
+        [Fact]
+        public async Task Refresh_StoreDeletedByAPeer_AdoptsSignedOut_WithoutSignInRequired()
+        {
+            SeedV2();
+            using var provider = new PluginCredentialProvider(
+                NewStore(),
+                new FakeTokenRefresher(TokenRefreshResult.Failure("must not be called")));
+
+            NewStore().Delete(); // the peer's F6 sign-out
+
+            var signInRequiredFired = false;
+            using var _ = provider.OnSignInRequired.Subscribe(__ => { signInRequiredFired = true; });
+
+            (await provider.RefreshAsync()).ShouldBeFalse();
+
+            provider.State.CurrentValue.ShouldBe(AuthState.SignedOut);
+            signInRequiredFired.ShouldBeFalse();
+        }
+
+        // ── Legacy family (04 §3.7): component-default id at the refresher, v2 rewrite on success. ──
+
+        [Fact]
+        public async Task Refresh_LegacyV1Document_HandsNullClientIdToTheRefresher_AndRewritesAsV2OnSuccess()
+        {
+            // Plant a REAL v1 document (top-level fields only), as an old writer left it.
+            NewStore().WritePlaintextJson(
+                "{\"version\":1,\"accessToken\":\"eyJ.V1.sig\",\"refreshToken\":\"RT-v1-aaa\"," +
+                "\"expiresAt\":\"2026-01-01T00:00:00+00:00\",\"serverTarget\":\"https://ai-game.dev\"}");
+
+            var refresher = new FakeTokenRefresher(
+                TokenRefreshResult.Success("eyJ.V2.sig", "RT-v2-bbb", DateTimeOffset.UtcNow.AddHours(1)));
+            using var provider = new PluginCredentialProvider(NewStore(), refresher);
+
+            (await provider.RefreshAsync()).ShouldBeTrue();
+
+            // The refresher saw a legacy family: unknown clientId (⇒ it presents its component default).
+            refresher.Requests.ShouldHaveSingleItem().ClientId.ShouldBeNull();
+
+            // §3.7: the document was rewritten as v2 families.legacy (+ mirror, it being the sole
+            // plugin-plane credential).
+            var raw = NewStore().ReadPlaintextJson()!;
+            raw.ShouldContain("\"version\": 2");
+            var reread = NewStore().Read()!;
+            reread.Families!.Legacy!.AccessToken.ShouldBe("eyJ.V2.sig");
+            reread.Families.Legacy.RefreshToken.ShouldBe("RT-v2-bbb");
+            reread.Families.Legacy.ClientId.ShouldBeNull(); // still unknown by definition
+            reread.AccessToken.ShouldBe("eyJ.V2.sig"); // the v1 mirror
+        }
+    }
+}

--- a/McpPlugin.Tests/Network/Connection/Credentials/PluginCredentialProviderTests.cs
+++ b/McpPlugin.Tests/Network/Connection/Credentials/PluginCredentialProviderTests.cs
@@ -9,10 +9,9 @@
 */
 using System;
 using System.IO;
-using System.Threading;
 using System.Threading.Tasks;
 using com.IvanMurzak.McpPlugin.AgentConfig;
-using Moq;
+using com.IvanMurzak.McpPlugin.Tests.Infrastructure;
 using R3;
 using Shouldly;
 using Xunit;
@@ -22,7 +21,8 @@ namespace com.IvanMurzak.McpPlugin.Tests.Network.Connection.Credentials
     /// <summary>
     /// Coverage for the mcp-authorize b7 account credential provider: machine-store auto-adopt (the
     /// zero-button rule), proactive refresh before expiry, reactive refresh, and the sign-in-again state
-    /// surfaced on refresh failure.
+    /// surfaced on refresh failure. The unified-machine-auth b3 behaviours (family/lock/double-checked
+    /// refresh) are covered in <see cref="PluginCredentialProviderFamilyRefreshTests"/>.
     /// </summary>
     public sealed class PluginCredentialProviderTests : IDisposable
     {
@@ -62,9 +62,9 @@ namespace com.IvanMurzak.McpPlugin.Tests.Network.Connection.Credentials
         public async Task AutoAdopt_SeededStore_IsSignedInWithoutRefresherInteraction()
         {
             NewStore().Write(Seed(expiresAt: DateTimeOffset.UtcNow.AddHours(1)));
-            var refresher = new Mock<ITokenRefresher>(MockBehavior.Strict);
+            var refresher = new FakeTokenRefresher(TokenRefreshResult.Failure("must never be called"));
 
-            using var provider = new PluginCredentialProvider(NewStore(), refresher.Object);
+            using var provider = new PluginCredentialProvider(NewStore(), refresher);
 
             // Signed in purely from the store read — no device flow, no network, no refresh.
             provider.State.CurrentValue.ShouldBe(AuthState.SignedIn);
@@ -75,9 +75,9 @@ namespace com.IvanMurzak.McpPlugin.Tests.Network.Connection.Credentials
             var token = await provider.GetAccessTokenAsync();
             token.ShouldBe(SeededAccessToken);
 
-            // The zero-button rule: nothing but the store was touched (a strict mock proves the refresher
-            // was never invoked during boot + token fetch of a still-valid credential).
-            refresher.VerifyNoOtherCalls();
+            // The zero-button rule: nothing but the store was touched.
+            refresher.Requests.ShouldBeEmpty();
+            refresher.LegacyCalls.ShouldBe(0);
         }
 
         [Fact]
@@ -102,17 +102,18 @@ namespace com.IvanMurzak.McpPlugin.Tests.Network.Connection.Credentials
         public async Task GetAccessToken_TokenNearExpiry_ProactivelyRefreshes()
         {
             NewStore().Write(Seed(expiresAt: DateTimeOffset.UtcNow.AddSeconds(10))); // within the 60s skew
-            var refresher = new Mock<ITokenRefresher>();
-            refresher
-                .Setup(r => r.RefreshAsync(SeededRefreshToken, "https://ai-game.dev", It.IsAny<CancellationToken>()))
-                .ReturnsAsync(TokenRefreshResult.Success(RefreshedAccessToken, RefreshedRefreshToken, DateTimeOffset.UtcNow.AddHours(1)));
+            var refresher = new FakeTokenRefresher(
+                TokenRefreshResult.Success(RefreshedAccessToken, RefreshedRefreshToken, DateTimeOffset.UtcNow.AddHours(1)));
 
-            using var provider = new PluginCredentialProvider(NewStore(), refresher.Object);
+            using var provider = new PluginCredentialProvider(NewStore(), refresher);
 
             var token = await provider.GetAccessTokenAsync();
 
             token.ShouldBe(RefreshedAccessToken);
-            refresher.Verify(r => r.RefreshAsync(SeededRefreshToken, "https://ai-game.dev", It.IsAny<CancellationToken>()), Times.Once);
+            var request = refresher.Requests.ShouldHaveSingleItem();
+            request.RefreshToken.ShouldBe(SeededRefreshToken);
+            request.ServerTarget.ShouldBe("https://ai-game.dev");
+            refresher.LegacyCalls.ShouldBe(0); // the provider uses the family-aware API
 
             // The rotated token was persisted (a fresh store instance re-reads it) with identity preserved.
             var reread = NewStore().Read();
@@ -125,12 +126,12 @@ namespace com.IvanMurzak.McpPlugin.Tests.Network.Connection.Credentials
         public async Task GetAccessToken_TokenFarFromExpiry_DoesNotRefresh()
         {
             NewStore().Write(Seed(expiresAt: DateTimeOffset.UtcNow.AddHours(2)));
-            var refresher = new Mock<ITokenRefresher>();
+            var refresher = new FakeTokenRefresher(TokenRefreshResult.Failure("must never be called"));
 
-            using var provider = new PluginCredentialProvider(NewStore(), refresher.Object);
+            using var provider = new PluginCredentialProvider(NewStore(), refresher);
 
             (await provider.GetAccessTokenAsync()).ShouldBe(SeededAccessToken);
-            refresher.Verify(r => r.RefreshAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+            refresher.Requests.ShouldBeEmpty();
         }
 
         // ── DoD: refresh-on-reject — RefreshAsync mints + persists a new token. ──
@@ -139,12 +140,10 @@ namespace com.IvanMurzak.McpPlugin.Tests.Network.Connection.Credentials
         public async Task RefreshAsync_Success_RotatesTokenAndStaysSignedIn()
         {
             NewStore().Write(Seed(expiresAt: DateTimeOffset.UtcNow.AddHours(1)));
-            var refresher = new Mock<ITokenRefresher>();
-            refresher
-                .Setup(r => r.RefreshAsync(SeededRefreshToken, It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(TokenRefreshResult.Success(RefreshedAccessToken, RefreshedRefreshToken, DateTimeOffset.UtcNow.AddHours(1)));
+            var refresher = new FakeTokenRefresher(
+                TokenRefreshResult.Success(RefreshedAccessToken, RefreshedRefreshToken, DateTimeOffset.UtcNow.AddHours(1)));
 
-            using var provider = new PluginCredentialProvider(NewStore(), refresher.Object);
+            using var provider = new PluginCredentialProvider(NewStore(), refresher);
 
             (await provider.RefreshAsync()).ShouldBeTrue();
             provider.State.CurrentValue.ShouldBe(AuthState.SignedIn);
@@ -155,12 +154,10 @@ namespace com.IvanMurzak.McpPlugin.Tests.Network.Connection.Credentials
         public async Task RefreshAsync_Success_WithoutRotatedRefreshToken_KeepsExistingRefreshToken()
         {
             NewStore().Write(Seed(expiresAt: DateTimeOffset.UtcNow.AddHours(1)));
-            var refresher = new Mock<ITokenRefresher>();
-            refresher
-                .Setup(r => r.RefreshAsync(SeededRefreshToken, It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(TokenRefreshResult.Success(RefreshedAccessToken)); // AS did not rotate the refresh token
+            var refresher = new FakeTokenRefresher(
+                TokenRefreshResult.Success(RefreshedAccessToken)); // AS did not rotate the refresh token
 
-            using var provider = new PluginCredentialProvider(NewStore(), refresher.Object);
+            using var provider = new PluginCredentialProvider(NewStore(), refresher);
 
             (await provider.RefreshAsync()).ShouldBeTrue();
             NewStore().Read()!.RefreshToken.ShouldBe(SeededRefreshToken);
@@ -172,12 +169,9 @@ namespace com.IvanMurzak.McpPlugin.Tests.Network.Connection.Credentials
         public async Task RefreshAsync_Failure_SurfacesSignInRequired()
         {
             NewStore().Write(Seed(expiresAt: DateTimeOffset.UtcNow.AddHours(1)));
-            var refresher = new Mock<ITokenRefresher>();
-            refresher
-                .Setup(r => r.RefreshAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(TokenRefreshResult.Failure("refresh token expired"));
+            var refresher = new FakeTokenRefresher(TokenRefreshResult.Failure("refresh token expired"));
 
-            using var provider = new PluginCredentialProvider(NewStore(), refresher.Object);
+            using var provider = new PluginCredentialProvider(NewStore(), refresher);
 
             var signInRequiredFired = false;
             using var _ = provider.OnSignInRequired.Subscribe(__ => { signInRequiredFired = true; });
@@ -191,12 +185,9 @@ namespace com.IvanMurzak.McpPlugin.Tests.Network.Connection.Credentials
         public async Task RefreshAsync_ThrowingRefresher_SurfacesSignInRequired_WithoutLeaking()
         {
             NewStore().Write(Seed(expiresAt: DateTimeOffset.UtcNow.AddHours(1)));
-            var refresher = new Mock<ITokenRefresher>();
-            refresher
-                .Setup(r => r.RefreshAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .ThrowsAsync(new InvalidOperationException("network down"));
+            var refresher = new FakeTokenRefresher(_ => throw new InvalidOperationException("network down"));
 
-            using var provider = new PluginCredentialProvider(NewStore(), refresher.Object);
+            using var provider = new PluginCredentialProvider(NewStore(), refresher);
 
             (await provider.RefreshAsync()).ShouldBeFalse();
             provider.State.CurrentValue.ShouldBe(AuthState.SignInRequired);
@@ -243,6 +234,34 @@ namespace com.IvanMurzak.McpPlugin.Tests.Network.Connection.Credentials
 
             provider.State.CurrentValue.ShouldBe(AuthState.SignedIn);
             NewStore().Read()!.AccessToken.ShouldBe(RefreshedAccessToken);
+        }
+
+        // ── The Adopt/Write in-place-mutation seam (unified-machine-auth b1 review A1, pinned). ──
+
+        [Fact]
+        public void Adopt_ReliesOnWriteMutatingItsArgumentIntoFamilyShape()
+        {
+            // MachineCredentialStore.Write() normalizes its ARGUMENT in place (v1 adoption →
+            // families.legacy, version upgrade, mirror stamp) and Adopt() keeps that same mutated
+            // instance as the provider's current credential. The provider's family-aware refresh
+            // path depends on this — so the seam is pinned here instead of being refactored away
+            // silently (b1 review A1). If Write() ever stops mutating its argument, this test goes
+            // red and the provider must clone-and-adopt explicitly.
+            var adopted = new MachineCredentials
+            {
+                AccessToken = RefreshedAccessToken,
+                RefreshToken = RefreshedRefreshToken,
+                ExpiresAt = DateTimeOffset.UtcNow.AddHours(1),
+            };
+
+            using var provider = new PluginCredentialProvider(NewStore());
+            provider.Adopt(adopted);
+
+            // The caller's own instance became family-shaped (v2) during the write.
+            adopted.Families.ShouldNotBeNull();
+            adopted.Families!.Legacy.ShouldNotBeNull();
+            adopted.Families.Legacy!.AccessToken.ShouldBe(RefreshedAccessToken);
+            adopted.Version.ShouldBe(MachineCredentials.CurrentVersion);
         }
     }
 }

--- a/McpPlugin.Tests/Network/Connection/Credentials/PluginCredentialProviderTests.cs
+++ b/McpPlugin.Tests/Network/Connection/Credentials/PluginCredentialProviderTests.cs
@@ -163,13 +163,35 @@ namespace com.IvanMurzak.McpPlugin.Tests.Network.Connection.Credentials
             NewStore().Read()!.RefreshToken.ShouldBe(SeededRefreshToken);
         }
 
-        // ── DoD: refresh failure surfaces "sign in again". ──
+        // ── Failure-state split (review B2, 03 F3.5/F9): SignInRequired is DEAD-FAMILY-only.
+        //    A transient failure (AS unreachable, 5xx, timeout) keeps the machine signed in and
+        //    retries later — offline self-heals silently (F9), no sign-in prompt. ──
 
         [Fact]
-        public async Task RefreshAsync_Failure_SurfacesSignInRequired()
+        public async Task RefreshAsync_TransientFailure_StaysSignedIn_DoesNotSurfaceSignInRequired()
         {
             NewStore().Write(Seed(expiresAt: DateTimeOffset.UtcNow.AddHours(1)));
-            var refresher = new FakeTokenRefresher(TokenRefreshResult.Failure("refresh token expired"));
+            var refresher = new FakeTokenRefresher(TokenRefreshResult.Failure("as unreachable")); // Transient by default
+
+            using var provider = new PluginCredentialProvider(NewStore(), refresher);
+
+            var signInRequiredFired = false;
+            using var _ = provider.OnSignInRequired.Subscribe(__ => { signInRequiredFired = true; });
+
+            (await provider.RefreshAsync()).ShouldBeFalse(); // this attempt failed — retry-later semantics
+            provider.State.CurrentValue.ShouldBe(AuthState.SignedIn);
+            signInRequiredFired.ShouldBeFalse();
+            (await provider.GetAccessTokenAsync()).ShouldBe(SeededAccessToken); // existing credential kept
+        }
+
+        [Fact]
+        public async Task RefreshAsync_InvalidGrant_SurfacesSignInRequired()
+        {
+            // The one failure kind that reaches SignInRequired: invalid_grant, confirmed dead by
+            // the post-failure re-read (nobody else rotated the family).
+            NewStore().Write(Seed(expiresAt: DateTimeOffset.UtcNow.AddHours(1)));
+            var refresher = new FakeTokenRefresher(
+                TokenRefreshResult.Failure("refresh token expired", TokenRefreshFailureKind.InvalidGrant));
 
             using var provider = new PluginCredentialProvider(NewStore(), refresher);
 
@@ -182,15 +204,19 @@ namespace com.IvanMurzak.McpPlugin.Tests.Network.Connection.Credentials
         }
 
         [Fact]
-        public async Task RefreshAsync_ThrowingRefresher_SurfacesSignInRequired_WithoutLeaking()
+        public async Task RefreshAsync_ThrowingRefresher_StaysSignedIn_WithoutLeaking()
         {
             NewStore().Write(Seed(expiresAt: DateTimeOffset.UtcNow.AddHours(1)));
             var refresher = new FakeTokenRefresher(_ => throw new InvalidOperationException("network down"));
 
             using var provider = new PluginCredentialProvider(NewStore(), refresher);
 
+            var signInRequiredFired = false;
+            using var _ = provider.OnSignInRequired.Subscribe(__ => { signInRequiredFired = true; });
+
             (await provider.RefreshAsync()).ShouldBeFalse();
-            provider.State.CurrentValue.ShouldBe(AuthState.SignInRequired);
+            provider.State.CurrentValue.ShouldBe(AuthState.SignedIn); // an exception is transient — retry later
+            signInRequiredFired.ShouldBeFalse();
         }
 
         [Fact]

--- a/McpPlugin.Tests/Network/Connection/Credentials/TokenExchangeClientTests.cs
+++ b/McpPlugin.Tests/Network/Connection/Credentials/TokenExchangeClientTests.cs
@@ -1,0 +1,124 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.Tests.Infrastructure;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.Tests.Network.Connection.Credentials
+{
+    /// <summary>
+    /// Wire-contract coverage for <see cref="TokenExchangeClient"/> against the a5-frozen RFC 8693
+    /// exchange shape (unified-machine-auth 04 §4; server merged on AGS dev, PR #592). The shape is
+    /// pinned parameter-by-parameter because the server validates it strictly (`invalid_scope` for
+    /// any scope other than <c>mcp:plugin</c>; <c>audience</c>/<c>resource</c> accepted only as the
+    /// exact <c>urn:agd:hub</c> — omitting both is the contract-safe choice this client makes).
+    /// </summary>
+    public sealed class TokenExchangeClientTests
+    {
+        const string OwnClientId = "unity-mcp-plugin";
+        const string AgentAccessToken = "eyJ.AGENT-ES256.sig";
+        const string ServerTarget = "https://ai-game.dev";
+
+        static readonly string SuccessJson =
+            "{\"access_token\":\"eyJ.PLUGIN.sig\",\"issued_token_type\":\"urn:ietf:params:oauth:token-type:access_token\"," +
+            "\"token_type\":\"Bearer\",\"expires_in\":3600,\"refresh_token\":\"RT-plugin-new\",\"scope\":\"mcp:plugin\",\"sub\":\"usr_123\"}";
+
+        static TokenExchangeClient NewClient(RecordingHttpMessageHandler handler, Func<DateTimeOffset>? clock = null)
+            => new TokenExchangeClient(ServerTarget, OwnClientId, new HttpClient(handler), clock, timeoutMs: null);
+
+        [Fact]
+        public async Task Exchange_SendsExactlyTheFrozenA5WireShape()
+        {
+            var handler = new RecordingHttpMessageHandler().RespondWith(HttpStatusCode.OK, SuccessJson);
+            var client = NewClient(handler);
+
+            var result = await client.ExchangeAsync(AgentAccessToken, ServerTarget);
+
+            result.Succeeded.ShouldBeTrue();
+            var request = handler.Requests.ShouldHaveSingleItem();
+            request.Url.ShouldBe("https://ai-game.dev/oauth/token");
+            var form = request.Form;
+            form["grant_type"].ShouldBe("urn:ietf:params:oauth:grant-type:token-exchange");
+            form["subject_token"].ShouldBe(AgentAccessToken);
+            form["subject_token_type"].ShouldBe("urn:ietf:params:oauth:token-type:access_token"); // the exact URN
+            form["client_id"].ShouldBe(OwnClientId);
+            form["scope"].ShouldBe("mcp:plugin");
+            // audience/resource: only the exact "urn:agd:hub" would be accepted — this client omits
+            // both rather than relying on the server's current trailing-slash leniency.
+            form.ContainsKey("audience").ShouldBeFalse();
+            form.ContainsKey("resource").ShouldBeFalse();
+            form.Keys.ShouldBe(new[] { "grant_type", "subject_token", "subject_token_type", "client_id", "scope" }, ignoreOrder: true);
+        }
+
+        [Fact]
+        public async Task Exchange_Success_CarriesTheFullA5ResponseContract()
+        {
+            var now = new DateTimeOffset(2026, 8, 15, 12, 0, 0, TimeSpan.Zero);
+            var handler = new RecordingHttpMessageHandler().RespondWith(HttpStatusCode.OK, SuccessJson);
+            var client = NewClient(handler, clock: () => now);
+
+            var result = await client.ExchangeAsync(AgentAccessToken, ServerTarget);
+
+            result.Succeeded.ShouldBeTrue();
+            result.AccessToken.ShouldBe("eyJ.PLUGIN.sig");
+            result.RefreshToken.ShouldBe("RT-plugin-new"); // RFC 8693 §2.2.1 documented exception
+            result.ExpiresAt.ShouldBe(now.AddSeconds(3600));
+            result.Scope.ShouldBe("mcp:plugin");
+            result.Subject.ShouldBe("usr_123"); // O5 — no path writes a subject-less credential
+            result.IssuedTokenType.ShouldBe("urn:ietf:params:oauth:token-type:access_token");
+        }
+
+        [Fact]
+        public async Task Exchange_OAuthError_FailsClosedWithTheErrorText()
+        {
+            var handler = new RecordingHttpMessageHandler()
+                .RespondWith(HttpStatusCode.BadRequest, "{\"error\":\"invalid_scope\",\"error_description\":\"only mcp:plugin\"}");
+            var client = NewClient(handler);
+
+            var result = await client.ExchangeAsync(AgentAccessToken, ServerTarget);
+
+            result.Succeeded.ShouldBeFalse();
+            result.AccessToken.ShouldBeNull();
+            result.FailureReason.ShouldContain("invalid_scope");
+        }
+
+        [Fact]
+        public async Task Exchange_NoSubjectToken_FailsClosedWithoutANetworkCall()
+        {
+            var handler = new RecordingHttpMessageHandler().RespondWith(HttpStatusCode.OK, SuccessJson);
+            var client = NewClient(handler);
+
+            var result = await client.ExchangeAsync("", ServerTarget);
+
+            result.Succeeded.ShouldBeFalse();
+            handler.Requests.ShouldBeEmpty();
+        }
+
+        [Fact]
+        public void Construction_EnforcesTheA5ClientIdLengthCap()
+        {
+            var tooLong = new string('a', TokenExchangeClient.MaxClientIdLength + 1);
+            Should.Throw<ArgumentException>(() => new TokenExchangeClient(ServerTarget, tooLong));
+            // And the cap itself is the frozen value.
+            TokenExchangeClient.MaxClientIdLength.ShouldBe(64);
+        }
+
+        [Fact]
+        public void ClientId_IsExposed_SoTheCommitHelperStampsTheFamilyWithThePresentedId()
+        {
+            var client = new TokenExchangeClient(ServerTarget, OwnClientId);
+            client.ClientId.ShouldBe(OwnClientId); // design D8: stamp what was actually presented
+        }
+    }
+}

--- a/McpPlugin/src/McpPlugin/Network/Connection/Credentials/HttpTokenRefresher.cs
+++ b/McpPlugin/src/McpPlugin/Network/Connection/Credentials/HttpTokenRefresher.cs
@@ -1,0 +1,291 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.AgentConfig;
+
+namespace com.IvanMurzak.McpPlugin
+{
+    /// <summary>
+    /// The ONE shared <see cref="ITokenRefresher"/> for all engine plugins (unified-machine-auth
+    /// 04 §3, task b3) — replaces the per-engine refreshers (Unity's <c>UnityTokenRefresher</c>
+    /// et al., which send a component-default <c>scope</c> on every refresh: the P0-3 defect).
+    /// Exchanges a refresh token for a fresh access token at <c>{serverTarget}/oauth/token</c>
+    /// (<c>grant_type=refresh_token</c>), obeying the shared refresh rules:
+    /// <list type="bullet">
+    ///   <item><b>Stored <c>clientId</c> (04 §3.2):</b> the request presents the family's stored
+    ///   <c>clientId</c> verbatim when the <see cref="TokenRefreshRequest"/> carries one; only a
+    ///   legacy family of unknown id (<see cref="TokenRefreshRequest.ClientId"/> null) falls back
+    ///   to the component default (04 §3.7).</item>
+    ///   <item><b>No scope, no resource (04 §3.3, P0-3):</b> the wire request omits both
+    ///   parameters entirely — the server falls back to the stored grant; sending a component
+    ///   default would permanently narrow an agent family.</item>
+    ///   <item><b>Rotation without a new refresh token (04 §3.4):</b> a success response missing
+    ///   <c>refresh_token</c> yields <see cref="TokenRefreshResult.RefreshToken"/> null, telling
+    ///   the caller to keep the previous one.</item>
+    ///   <item><b>Rate discipline (04 §3.6):</b> at most one network attempt per family per skew
+    ///   window per refresher instance (families are keyed by the refresh token presented — each
+    ///   family owns a distinct rotation chain). A repeat call inside the window shares/replays the
+    ///   window's single attempt instead of hitting the AS again, so reactive-401 storms cannot
+    ///   hammer the token endpoint.</item>
+    ///   <item><b>15 s HTTP timeout (04 §2):</b> <see cref="MachineCredentialLock.REFRESH_HTTP_TIMEOUT"/>
+    ///   is applied per call — explicitly, because .NET's 100 s default would outlive
+    ///   <see cref="MachineCredentialLock.LOCK_STALE_MS"/> and let a live lock holder be declared
+    ///   stale mid-refresh. A timeout is a <see cref="TokenRefreshFailureKind.Transient"/> failure,
+    ///   never an unclassified exception.</item>
+    ///   <item><b><c>invalid_grant</c> classification (04 §3.5):</b> an OAuth error response of
+    ///   exactly <c>invalid_grant</c> is returned as
+    ///   <see cref="TokenRefreshFailureKind.InvalidGrant"/>; every other failure (network, 5xx,
+    ///   other OAuth errors, malformed JSON) is <see cref="TokenRefreshFailureKind.Transient"/>.</item>
+    /// </list>
+    /// Fails closed — any error returns <see cref="TokenRefreshResult.Failure(string?)"/>, never a
+    /// partial or fabricated token — and never logs token material.
+    /// </summary>
+    public sealed class HttpTokenRefresher : ITokenRefresher
+    {
+        /// <summary>
+        /// Per-call HTTP timeout in ms — the shared cross-language contract value
+        /// (<see cref="MachineCredentialLock.REFRESH_HTTP_TIMEOUT"/> = 15 s, 04 §2).
+        /// </summary>
+        public const int HttpTimeoutMs = MachineCredentialLock.REFRESH_HTTP_TIMEOUT;
+
+        /// <summary>
+        /// Default rate-discipline window (04 §3.6): one network attempt per family per this window,
+        /// matching the proactive-refresh skew (<see cref="PluginCredentialProvider.DefaultRefreshSkew"/>).
+        /// </summary>
+        public static readonly TimeSpan DefaultAttemptWindow = TimeSpan.FromSeconds(60);
+
+        static readonly HttpClient _sharedHttpClient = new HttpClient();
+
+        readonly string _defaultServerTarget;
+        readonly string _componentClientId;
+        readonly HttpClient _httpClient;
+        readonly Func<DateTimeOffset> _clock;
+        readonly TimeSpan _attemptWindow;
+        readonly int _timeoutMs;
+
+        // Rate discipline (04 §3.6): refresh-token → the window's single shared attempt. Guarded by
+        // _attemptGate; pruned on every call (a process holds ≤3 families, so this stays tiny).
+        readonly object _attemptGate = new object();
+        readonly Dictionary<string, AttemptEntry> _attempts = new Dictionary<string, AttemptEntry>();
+
+        sealed class AttemptEntry
+        {
+            public DateTimeOffset StartedAt;
+            public Task<TokenRefreshResult> Task = null!;
+        }
+
+        /// <summary>
+        /// <paramref name="defaultServerTarget"/> — the AS root used when a request carries no
+        /// <see cref="TokenRefreshRequest.ServerTarget"/> (e.g. <c>https://ai-game.dev</c>).
+        /// <paramref name="componentClientId"/> — this component's own OAuth client id, presented
+        /// ONLY for legacy families of unknown id (04 §3.7); a family with a stored id always wins.
+        /// <paramref name="httpClient"/> — optional injection for tests; defaults to a shared client.
+        /// </summary>
+        public HttpTokenRefresher(string defaultServerTarget, string componentClientId, HttpClient? httpClient = null)
+            : this(defaultServerTarget, componentClientId, httpClient, clock: null, attemptWindow: null, timeoutMs: null)
+        {
+        }
+
+        /// <summary>
+        /// Test seam (InternalsVisibleTo: McpPlugin.Tests): override the clock, the rate-discipline
+        /// window, and the HTTP timeout so unit tests do not consume real wall-clock time.
+        /// Production callers use the public constructor, which pins the contract values.
+        /// </summary>
+        internal HttpTokenRefresher(
+            string defaultServerTarget,
+            string componentClientId,
+            HttpClient? httpClient,
+            Func<DateTimeOffset>? clock,
+            TimeSpan? attemptWindow,
+            int? timeoutMs)
+        {
+            if (string.IsNullOrWhiteSpace(componentClientId))
+                throw new ArgumentException("The component's own client id is required (used for legacy families of unknown id, 04 §3.7).", nameof(componentClientId));
+
+            _defaultServerTarget = NormalizeServerTarget(defaultServerTarget) ?? string.Empty;
+            _componentClientId = componentClientId;
+            _httpClient = httpClient ?? _sharedHttpClient;
+            _clock = clock ?? (() => DateTimeOffset.UtcNow);
+            _attemptWindow = attemptWindow ?? DefaultAttemptWindow;
+            _timeoutMs = timeoutMs ?? HttpTimeoutMs;
+        }
+
+        /// <summary>The component-default client id presented for legacy families of unknown id (04 §3.7).</summary>
+        public string ComponentClientId => _componentClientId;
+
+        /// <summary>
+        /// Legacy v1 API: no family context, so the component-default <c>clientId</c> is presented
+        /// (the 04 §3.7 legacy rule) and — unlike the pre-b3 engine refreshers — <c>scope</c> is
+        /// still omitted from the wire request.
+        /// </summary>
+        public Task<TokenRefreshResult> RefreshAsync(string refreshToken, string? serverTarget, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrEmpty(refreshToken))
+                return Task.FromResult(TokenRefreshResult.Failure("no refresh token"));
+            return RefreshAsync(new TokenRefreshRequest(refreshToken, serverTarget, clientId: null), cancellationToken);
+        }
+
+        /// <summary>The family-aware refresh (see the class docs for the rules it enforces).</summary>
+        public Task<TokenRefreshResult> RefreshAsync(TokenRefreshRequest request, CancellationToken cancellationToken = default)
+        {
+            if (request == null)
+                throw new ArgumentNullException(nameof(request));
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var baseUrl = NormalizeServerTarget(request.ServerTarget) ?? _defaultServerTarget;
+            if (string.IsNullOrEmpty(baseUrl))
+                return Task.FromResult(TokenRefreshResult.Failure("no server target"));
+
+            // Rate discipline (04 §3.6): inside the window, every caller presenting the same
+            // refresh token shares the window's single attempt (in-flight or memoized). The shared
+            // task deliberately ignores the individual caller's CancellationToken — one caller
+            // aborting must not kill the attempt for its peers — and is bounded by the HTTP
+            // timeout, so nobody waits more than ~15 s.
+            lock (_attemptGate)
+            {
+                PruneExpiredAttempts();
+
+                if (_attempts.TryGetValue(request.RefreshToken, out var existing)
+                    && _clock() - existing.StartedAt < _attemptWindow)
+                    return existing.Task;
+
+                var entry = new AttemptEntry { StartedAt = _clock() };
+                entry.Task = RefreshOverHttpAsync(baseUrl, request);
+                _attempts[request.RefreshToken] = entry;
+                return entry.Task;
+            }
+        }
+
+        // MUST be called with _attemptGate held.
+        void PruneExpiredAttempts()
+        {
+            List<string>? expired = null;
+            var now = _clock();
+            foreach (var pair in _attempts)
+            {
+                if (now - pair.Value.StartedAt >= _attemptWindow)
+                    (expired ??= new List<string>()).Add(pair.Key);
+            }
+            if (expired != null)
+            {
+                foreach (var key in expired)
+                    _attempts.Remove(key);
+            }
+        }
+
+        async Task<TokenRefreshResult> RefreshOverHttpAsync(string baseUrl, TokenRefreshRequest request)
+        {
+            // The 04 §3 wire contract: grant_type + refresh_token + client_id and NOTHING else.
+            // No scope (P0-3: a component default permanently narrows an agent family) and no
+            // resource — the server falls back to the stored grant for both.
+            var form = new List<KeyValuePair<string, string>>
+            {
+                new KeyValuePair<string, string>("grant_type", "refresh_token"),
+                new KeyValuePair<string, string>("refresh_token", request.RefreshToken),
+                new KeyValuePair<string, string>("client_id", request.ClientId ?? _componentClientId),
+            };
+
+            using var timeout = new CancellationTokenSource(_timeoutMs);
+            try
+            {
+                using var content = new FormUrlEncodedContent(form);
+                using var response = await _httpClient.PostAsync(baseUrl + "/oauth/token", content, timeout.Token).ConfigureAwait(false);
+                var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                return ParseTokenResponse(response.IsSuccessStatusCode, (int)response.StatusCode, json, _clock);
+            }
+            catch (OperationCanceledException) when (timeout.IsCancellationRequested)
+            {
+                // The 15 s contract timeout fired (04 §2) — a transient failure, never an
+                // unclassified exception: the caller keeps its credential and retries later.
+                return TokenRefreshResult.Failure("refresh HTTP call timed out after " + _timeoutMs + " ms");
+            }
+            catch (Exception ex)
+            {
+                return TokenRefreshResult.Failure(ex.Message); // never token material
+            }
+        }
+
+        /// <summary>
+        /// Parse an <c>/oauth/token</c> refresh response (pure, unit-testable). A success without
+        /// <c>refresh_token</c> keeps <see cref="TokenRefreshResult.RefreshToken"/> null (04 §3.4);
+        /// an OAuth error of exactly <c>invalid_grant</c> is classified
+        /// <see cref="TokenRefreshFailureKind.InvalidGrant"/>, everything else transient.
+        /// </summary>
+        internal static TokenRefreshResult ParseTokenResponse(bool isSuccessStatusCode, int statusCode, string json, Func<DateTimeOffset> clock)
+        {
+            string? accessToken = null;
+            string? refreshToken = null;
+            long expiresInSeconds = 0;
+            string? error = null;
+            string? errorDescription = null;
+
+            try
+            {
+                using var document = JsonDocument.Parse(json);
+                var root = document.RootElement;
+                if (root.ValueKind == JsonValueKind.Object)
+                {
+                    if (root.TryGetProperty("access_token", out var at) && at.ValueKind == JsonValueKind.String)
+                        accessToken = at.GetString();
+                    if (root.TryGetProperty("refresh_token", out var rt) && rt.ValueKind == JsonValueKind.String)
+                        refreshToken = rt.GetString();
+                    if (root.TryGetProperty("expires_in", out var exp) && exp.ValueKind == JsonValueKind.Number)
+                        expiresInSeconds = exp.GetInt64();
+                    if (root.TryGetProperty("error", out var err) && err.ValueKind == JsonValueKind.String)
+                        error = err.GetString();
+                    if (root.TryGetProperty("error_description", out var desc) && desc.ValueKind == JsonValueKind.String)
+                        errorDescription = desc.GetString();
+                }
+            }
+            catch (JsonException)
+            {
+                return TokenRefreshResult.Failure("malformed token response (HTTP " + statusCode + ")");
+            }
+
+            if (!isSuccessStatusCode || string.IsNullOrEmpty(accessToken))
+            {
+                var kind = string.Equals(error, "invalid_grant", StringComparison.Ordinal)
+                    ? TokenRefreshFailureKind.InvalidGrant
+                    : TokenRefreshFailureKind.Transient;
+                var reason = error != null
+                    ? (errorDescription != null ? error + ": " + errorDescription : error)
+                    : "refresh failed (HTTP " + statusCode + ")";
+                return TokenRefreshResult.Failure(reason, kind);
+            }
+
+            DateTimeOffset? expiresAt = expiresInSeconds > 0
+                ? clock().AddSeconds(expiresInSeconds)
+                : (DateTimeOffset?)null;
+            return TokenRefreshResult.Success(accessToken!, refreshToken, expiresAt);
+        }
+
+        /// <summary>
+        /// Normalize a stored server target to the AS root: trim whitespace, a trailing slash, and
+        /// a trailing <c>/mcp</c> hub segment so <c>/oauth/token</c> resolves on the
+        /// authorization-server root (same rule as the engines' historical refreshers).
+        /// </summary>
+        internal static string? NormalizeServerTarget(string? serverTarget)
+        {
+            if (string.IsNullOrWhiteSpace(serverTarget))
+                return null;
+            var s = serverTarget!.Trim().TrimEnd('/');
+            if (s.EndsWith("/mcp", StringComparison.OrdinalIgnoreCase))
+                s = s.Substring(0, s.Length - "/mcp".Length);
+            return s;
+        }
+    }
+}

--- a/McpPlugin/src/McpPlugin/Network/Connection/Credentials/ITokenRefresher.cs
+++ b/McpPlugin/src/McpPlugin/Network/Connection/Credentials/ITokenRefresher.cs
@@ -16,10 +16,33 @@ using System.Threading.Tasks;
 namespace com.IvanMurzak.McpPlugin
 {
     /// <summary>
+    /// How a failed refresh should be classified by the caller (unified-machine-auth 04 §3.5). The
+    /// distinction is behavioral: <see cref="InvalidGrant"/> is the ONLY kind that may declare a
+    /// credential family dead (after the mandatory post-failure re-read); everything else is
+    /// retryable and must never destroy local state.
+    /// </summary>
+    public enum TokenRefreshFailureKind
+    {
+        /// <summary>
+        /// A retryable failure: network error, timeout, 5xx, rate limit, malformed response. The
+        /// caller keeps the existing credential and may try again later.
+        /// </summary>
+        Transient = 0,
+
+        /// <summary>
+        /// The authorization server answered <c>invalid_grant</c> — the refresh token is expired,
+        /// revoked, or reuse-revoked. After a post-failure re-read confirms no peer rotated it, the
+        /// family is dead: surface sign-in-required, never loop, never delete other families.
+        /// </summary>
+        InvalidGrant = 1,
+    }
+
+    /// <summary>
     /// The outcome of a token refresh (mcp-authorize b7). On success it carries the freshly minted access
     /// token (and, if the AS rotated it, a new refresh token) plus the new absolute expiry; on failure it
-    /// carries only a <see cref="FailureReason"/>. Never carries partial success — a failed refresh leaves
-    /// the caller to surface the "sign in again" state and keep the old (rejected) credential untouched.
+    /// carries only a <see cref="FailureReason"/> and a <see cref="FailureKind"/>. Never carries partial
+    /// success — a failed refresh leaves the caller to surface the "sign in again" state and keep the old
+    /// (rejected) credential untouched.
     /// </summary>
     public sealed class TokenRefreshResult
     {
@@ -38,13 +61,22 @@ namespace com.IvanMurzak.McpPlugin
         /// <summary>A short human-facing reason when <see cref="Succeeded"/> is false (e.g. "refresh token expired").</summary>
         public string? FailureReason { get; }
 
-        TokenRefreshResult(bool succeeded, string? accessToken, string? refreshToken, DateTimeOffset? expiresAt, string? failureReason)
+        /// <summary>
+        /// Classification of the failure when <see cref="Succeeded"/> is false (unified-machine-auth
+        /// 04 §3.5): only <see cref="TokenRefreshFailureKind.InvalidGrant"/> may lead the caller to
+        /// declare the credential family dead. <see cref="TokenRefreshFailureKind.Transient"/> for a
+        /// successful result (meaningless there).
+        /// </summary>
+        public TokenRefreshFailureKind FailureKind { get; }
+
+        TokenRefreshResult(bool succeeded, string? accessToken, string? refreshToken, DateTimeOffset? expiresAt, string? failureReason, TokenRefreshFailureKind failureKind)
         {
             Succeeded = succeeded;
             AccessToken = accessToken;
             RefreshToken = refreshToken;
             ExpiresAt = expiresAt;
             FailureReason = failureReason;
+            FailureKind = failureKind;
         }
 
         /// <summary>A successful refresh. <paramref name="refreshToken"/> null ⇒ the AS did not rotate it (keep the old one).</summary>
@@ -52,12 +84,60 @@ namespace com.IvanMurzak.McpPlugin
         {
             if (string.IsNullOrEmpty(accessToken))
                 throw new ArgumentException("A successful refresh must carry a non-empty access token.", nameof(accessToken));
-            return new TokenRefreshResult(true, accessToken, refreshToken, expiresAt, failureReason: null);
+            return new TokenRefreshResult(true, accessToken, refreshToken, expiresAt, failureReason: null, TokenRefreshFailureKind.Transient);
         }
 
-        /// <summary>A failed refresh (expired/revoked refresh token, AS unreachable, …). Fail closed — no token.</summary>
+        /// <summary>
+        /// A failed refresh (expired/revoked refresh token, AS unreachable, …). Fail closed — no token.
+        /// Classified <see cref="TokenRefreshFailureKind.Transient"/>; use the two-argument overload to
+        /// mark a definitive <c>invalid_grant</c>.
+        /// </summary>
         public static TokenRefreshResult Failure(string? reason = null)
-            => new TokenRefreshResult(false, accessToken: null, refreshToken: null, expiresAt: null, failureReason: reason);
+            => new TokenRefreshResult(false, accessToken: null, refreshToken: null, expiresAt: null, failureReason: reason, TokenRefreshFailureKind.Transient);
+
+        /// <summary>A failed refresh with an explicit classification (see <see cref="TokenRefreshFailureKind"/>).</summary>
+        public static TokenRefreshResult Failure(string? reason, TokenRefreshFailureKind kind)
+            => new TokenRefreshResult(false, accessToken: null, refreshToken: null, expiresAt: null, failureReason: reason, failureKind: kind);
+    }
+
+    /// <summary>
+    /// One refresh attempt's inputs (unified-machine-auth 04 §3) — the v2 API of
+    /// <see cref="ITokenRefresher"/>. Carries the credential family's context so the refresher can
+    /// present the <b>family's stored <c>clientId</c></b> (design D8; the P0 the old two-string API
+    /// could not express). Deliberately has NO scope and NO resource member: a refresh request must
+    /// omit both entirely so the server falls back to the stored grant — sending a component default
+    /// would permanently narrow an agent family (04 §3.3, P0-3).
+    /// </summary>
+    public sealed class TokenRefreshRequest
+    {
+        /// <summary>
+        /// <paramref name="refreshToken"/> — the family's current refresh token (required).
+        /// <paramref name="serverTarget"/> — the enrolled AS/hub target the credential was issued
+        /// for, or null to use the refresher's default. <paramref name="clientId"/> — the
+        /// <b>stored</b> <c>clientId</c> the family was minted under (04 §3.2); null means the
+        /// family does not know its id (a v1-adopted <c>families.legacy</c> credential, 04 §3.7)
+        /// and the refresher presents its component-default id instead.
+        /// </summary>
+        public TokenRefreshRequest(string refreshToken, string? serverTarget = null, string? clientId = null)
+        {
+            if (string.IsNullOrEmpty(refreshToken))
+                throw new ArgumentException("A refresh request must carry a non-empty refresh token.", nameof(refreshToken));
+            RefreshToken = refreshToken;
+            ServerTarget = serverTarget;
+            ClientId = clientId;
+        }
+
+        /// <summary>The family's current refresh token. Never logged.</summary>
+        public string RefreshToken { get; }
+
+        /// <summary>The enrolled AS/hub target the credential was issued for, or null for the refresher's default.</summary>
+        public string? ServerTarget { get; }
+
+        /// <summary>
+        /// The stored <c>clientId</c> the family was minted under, or null for a legacy family of
+        /// unknown id (the refresher then presents its component default — 04 §3.7).
+        /// </summary>
+        public string? ClientId { get; }
     }
 
     /// <summary>
@@ -75,7 +155,32 @@ namespace com.IvanMurzak.McpPlugin
         /// Attempt to mint a new access token from <paramref name="refreshToken"/>.
         /// <paramref name="serverTarget"/> is the enrolled hub/AS target the credential was issued for
         /// (hosted vs local), or null to use the implementation's default.
+        /// <para><b>Legacy v1 API (pre unified-machine-auth):</b> carries no family context, so an
+        /// implementation can only present its component-default <c>clientId</c>. Kept abstract so
+        /// existing engine implementations keep compiling; new callers use the
+        /// <see cref="RefreshAsync(TokenRefreshRequest, CancellationToken)"/> overload, and engines
+        /// migrate to the shared <see cref="HttpTokenRefresher"/> in their adoption tasks.</para>
         /// </summary>
         Task<TokenRefreshResult> RefreshAsync(string refreshToken, string? serverTarget, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Attempt to mint a new access token for one credential family (unified-machine-auth
+        /// 04 §3). The request carries the family's stored <c>clientId</c>, which the
+        /// implementation MUST present verbatim when set (design D8 — presenting a different id
+        /// cross-mints the family); scope and resource MUST be omitted from the wire request
+        /// entirely (04 §3.3, P0-3).
+        /// <para><b>Compat default:</b> this default implementation delegates to the legacy
+        /// two-string API, DROPPING the request's <c>clientId</c> — i.e. a legacy engine refresher
+        /// invoked through it keeps its status-quo (component-default) behavior. That is a
+        /// transition bridge only: the shared <see cref="HttpTokenRefresher"/> overrides it with
+        /// the family-correct implementation, and the engine cascades (d1/e1/f1) replace legacy
+        /// refreshers with it.</para>
+        /// </summary>
+        Task<TokenRefreshResult> RefreshAsync(TokenRefreshRequest request, CancellationToken cancellationToken = default)
+        {
+            if (request == null)
+                throw new ArgumentNullException(nameof(request));
+            return RefreshAsync(request.RefreshToken, request.ServerTarget, cancellationToken);
+        }
     }
 }

--- a/McpPlugin/src/McpPlugin/Network/Connection/Credentials/MachineCredentialLoginCommit.cs
+++ b/McpPlugin/src/McpPlugin/Network/Connection/Credentials/MachineCredentialLoginCommit.cs
@@ -42,13 +42,46 @@ namespace com.IvanMurzak.McpPlugin
         Busy = 3,
 
         /// <summary>
-        /// The store already belongs to a different account (<c>subject</c> mismatch — design F7/D6)
-        /// and the caller did not pass <c>overwriteDifferentSubject</c>. Nothing was written; the
-        /// caller shows the account-switch confirm dialog and retries with the flag (after
+        /// The store already belongs to a different account (<c>subject</c> mismatch — design
+        /// F7/D6; the compare fires only when BOTH subjects are known) and the caller did not pass
+        /// <c>confirmedReplaceOfSubject</c>. Nothing was written; the caller shows the
+        /// account-switch confirm dialog and retries with the confirmed displaced subject (after
         /// best-effort revoking the displaced account's families) or aborts (revoking the
-        /// just-minted tokens).
+        /// just-minted tokens). Also returned when the subject CHANGED between the two holds
+        /// (an interleaved login, twin reason <c>subject-changed</c>) — the second hold
+        /// re-verifies the commit's premise and never writes a plugin family derived from
+        /// account A into account B's store (03 F7.2); no confirmation reaches the second-hold
+        /// check, because an interleaved change is a NEW conflict the user never saw. On the
+        /// hold-2 variant the orphaned derivation is best-effort revoked (twin rule 4).
         /// </summary>
         SubjectMismatch = 4,
+
+        /// <summary>
+        /// The store disappeared between the holds (a machine-wide sign-out, F6, won the race).
+        /// Nothing was written — a sign-out is never answered by recreating a signed-in store.
+        /// The just-derived plugin family (invisible to every other component) has been
+        /// best-effort revoked when a revocation client was provided; it is also carried in
+        /// <see cref="LoginCommitResult.ExchangeResult"/>. (TS twin reason: <c>store-missing</c>.)
+        /// </summary>
+        StoreSignedOut = 5,
+
+        /// <summary>
+        /// The store was unreadable at the second hold, so the commit's premise could not be
+        /// verified. Result-shaped and RETRYABLE — nothing was written, nothing was revoked (the
+        /// minted family, carried in <see cref="LoginCommitResult.ExchangeResult"/>, is what the
+        /// retry commits). (TS twin reason: <c>store-unreadable</c>.)
+        /// </summary>
+        StoreUnreadable = 6,
+
+        /// <summary>
+        /// A CONFIRMED account switch (<c>confirmedReplaceOfSubject</c>) found the store's subject
+        /// changed AGAIN since the user confirmed — the confirmation's premise is void (a third
+        /// account appeared) and silently replacing it would overwrite an account the user never
+        /// saw. Nothing was written, nothing revoked — the caller re-runs the F7 dialog against
+        /// the store's new owner and retries with the same mint. (TS twin reason:
+        /// <c>guard-premise-changed</c>, hold 1.)
+        /// </summary>
+        GuardPremiseChanged = 7,
     }
 
     /// <summary>The outcome of a login-commit sequence (see <see cref="LoginCommitStatus"/>).</summary>
@@ -92,9 +125,18 @@ namespace com.IvanMurzak.McpPlugin
         /// Run the full sequence. <paramref name="agentFamily"/> must carry the freshly minted
         /// agent tokens AND the <c>clientId</c> they were minted under (D8 — written from the value
         /// actually presented, never inferred). <paramref name="subject"/> is the account id from
-        /// the mint response (O5). <paramref name="overwriteDifferentSubject"/> false (default)
-        /// refuses to overwrite a store belonging to a different account
-        /// (<see cref="LoginCommitStatus.SubjectMismatch"/>) — the F7 guard.
+        /// the mint response (O5).
+        /// <para><b>The F7 guard (twin-converged):</b> when the store's subject and
+        /// <paramref name="subject"/> are BOTH known and differ (a no-sub side proceeds, F7.3),
+        /// the commit refuses (<see cref="LoginCommitStatus.SubjectMismatch"/>) unless
+        /// <paramref name="confirmedReplaceOfSubject"/> names the displaced account the user
+        /// confirmed replacing in the F7 dialog — and the store must STILL belong to exactly that
+        /// account when the hold is taken (exact-premise check inside the hold; drift ⇒
+        /// <see cref="LoginCommitStatus.GuardPremiseChanged"/>, nothing written, nothing revoked).
+        /// Best-effort revocation of the displaced account's families is the login surface's job
+        /// (03 F7.2). <paramref name="revocationClient"/>, when provided, is used ONLY to
+        /// best-effort revoke the just-derived plugin family on a terminal hold-2 abort (twin
+        /// rule 4).</para>
         /// </summary>
         public static async Task<LoginCommitResult> CommitAsync(
             MachineCredentialStore store,
@@ -103,7 +145,8 @@ namespace com.IvanMurzak.McpPlugin
             string? serverTarget,
             string? subject,
             ITokenExchangeClient exchangeClient,
-            bool overwriteDifferentSubject = false,
+            string? confirmedReplaceOfSubject = null,
+            ITokenRevocationClient? revocationClient = null,
             ILogger? logger = null,
             CancellationToken cancellationToken = default)
         {
@@ -121,21 +164,38 @@ namespace com.IvanMurzak.McpPlugin
             if (firstHold == null)
                 return new LoginCommitResult(LoginCommitStatus.Busy, null, "credential lock busy (first hold)");
 
+            string? premiseSubject;
             using (firstHold)
             {
                 var read = store.TryRead();
 
                 // Subject guard (F7/D6): never silently overwrite another account's machine store.
-                // An unreadable store cannot prove a subject, and login IS the explicit user
-                // re-authorization that 04 §1 requires before replacing one — so Unreadable falls
-                // through to a fresh document.
+                // The compare fires only when BOTH subjects are known (a pre-a6/no-sub credential
+                // proceeds, F7.3 — twin-converged). An unreadable store cannot prove a subject,
+                // and login IS the explicit user re-authorization that 04 §1 requires before
+                // replacing one — so Unreadable falls through to a fresh document.
                 var existing = read.Status == MachineCredentialStoreStatus.Ok ? read.Credentials : null;
-                if (!overwriteDifferentSubject
-                    && existing?.Subject != null && subject != null
+                if (existing?.Subject != null && subject != null
                     && !string.Equals(existing.Subject, subject, StringComparison.Ordinal))
                 {
-                    return new LoginCommitResult(LoginCommitStatus.SubjectMismatch, null,
-                        "the machine store belongs to a different account");
+                    if (confirmedReplaceOfSubject == null)
+                    {
+                        return new LoginCommitResult(LoginCommitStatus.SubjectMismatch, null,
+                            "the machine store belongs to a different account");
+                    }
+                    if (!string.Equals(existing.Subject, confirmedReplaceOfSubject, StringComparison.Ordinal))
+                    {
+                        // Exact-premise check INSIDE the hold (twin: guard-premise-changed): the
+                        // user confirmed replacing one specific account, and the store's owner
+                        // changed again since that dialog — a third account the user never saw.
+                        // Nothing written, nothing revoked; the caller re-runs the F7 dialog and
+                        // retries with this same mint.
+                        return new LoginCommitResult(LoginCommitStatus.GuardPremiseChanged, null,
+                            "the store's subject changed since the account-switch was confirmed; re-confirm against its current owner");
+                    }
+                    // A confirmed switch whose premise held — proceed to replace. Best-effort
+                    // revocation of the displaced account's families is the login surface's job
+                    // (03 F7.2), before or after this commit.
                 }
 
                 var document = existing ?? new MachineCredentials();
@@ -149,6 +209,11 @@ namespace com.IvanMurzak.McpPlugin
                 if (!firstHold.IsStillOwned()) // b2 review A1: verify ownership immediately before the write
                     return new LoginCommitResult(LoginCommitStatus.Busy, null, "credential lock lost before the agent-family write");
                 store.Write(document);
+
+                // The commit's premise for the second hold (review B1): whatever subject this
+                // write established is what the store must still carry when the plugin family
+                // lands — an interleaved login/sign-out between the holds voids the premise.
+                premiseSubject = document.Subject;
             }
 
             // ── Exchange, between the holds (03 F1.4). ───────────────────────────────────────────
@@ -171,23 +236,42 @@ namespace com.IvanMurzak.McpPlugin
                 return new LoginCommitResult(LoginCommitStatus.AgentOnly, exchange, exchange?.FailureReason ?? "token exchange failed");
 
             // ── Second hold: commit the plugin family (+ mirror via the write contract). ─────────
-            return await CommitPluginFamilyAsync(store, credentialLock, exchange, exchangeClient.ClientId, serverTarget, logger, cancellationToken).ConfigureAwait(false);
+            return await CommitPluginFamilyAsync(store, credentialLock, exchange, exchangeClient.ClientId, premiseSubject, serverTarget, revocationClient, logger, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
         /// The second phase alone: commit an already-minted plugin family under one lock hold.
         /// Public so a <see cref="LoginCommitStatus.PluginCommitBusy"/> outcome can be retried
-        /// without re-running the exchange, and so a tools-only (O10) login — which mints a plugin
-        /// family directly — commits through the same path. The family is stamped with
+        /// without re-running the exchange. The family is stamped with
         /// <paramref name="presentedClientId"/> (the id actually presented at derivation, D8) and
         /// the exchange response's scope.
+        /// <para><b>The F7 guard holds at THIS hold too (review B1, twin-converged):</b> the
+        /// exchange ran lock-free, so before writing, the commit's premise is re-verified against
+        /// the re-read store. The subject compare fires only when BOTH
+        /// <paramref name="expectedSubject"/> and the store's subject are known (pre-a6/no-sub ⇒
+        /// proceed, F7.3); when both are known and differ, the premise is void ⇒
+        /// <see cref="LoginCommitStatus.SubjectMismatch"/> — no confirmation flag reaches this
+        /// check, because an interleaved change is a conflict the user never saw. The store must
+        /// still exist (a machine-wide sign-out between the holds wins ⇒
+        /// <see cref="LoginCommitStatus.StoreSignedOut"/>, never recreated), and an unreadable
+        /// store is a result-shaped retry (<see cref="LoginCommitStatus.StoreUnreadable"/>) —
+        /// never a write, never an escaping throw. On a terminal hold-2 abort (subject-changed /
+        /// store-missing) the just-derived plugin family — invisible to every other component —
+        /// is best-effort revoked via <paramref name="revocationClient"/> (refresh-token
+        /// preferred); the retryable unreadable outcome revokes nothing, because the retry commits
+        /// that same mint. The response's <c>sub</c> is backfilled into the document
+        /// only-when-absent. Because a missing store aborts, this entry point is NOT suitable for
+        /// a first commit onto an empty machine (a tools-only O10 first login commits its plugin
+        /// family the way <see cref="CommitAsync"/>'s first hold commits the agent family).</para>
         /// </summary>
         public static async Task<LoginCommitResult> CommitPluginFamilyAsync(
             MachineCredentialStore store,
             MachineCredentialLock credentialLock,
             TokenExchangeResult exchange,
             string presentedClientId,
+            string? expectedSubject,
             string? serverTarget = null,
+            ITokenRevocationClient? revocationClient = null,
             ILogger? logger = null,
             CancellationToken cancellationToken = default)
         {
@@ -203,33 +287,126 @@ namespace com.IvanMurzak.McpPlugin
             if (hold == null)
                 return new LoginCommitResult(LoginCommitStatus.PluginCommitBusy, exchange, "credential lock busy (second hold)");
 
+            // Re-verify the commit's premise under the second hold (review B1, 03 F7.2): the
+            // exchange ran lock-free, so an interleaved login or a machine-wide sign-out may have
+            // voided it. A plugin family derived from account A must never land in a store that is
+            // no longer A's.
+            LoginCommitResult result;
             using (hold)
             {
-                var read = store.TryRead();
-                var document = read.Status == MachineCredentialStoreStatus.Ok && read.Credentials != null
-                    ? read.Credentials
-                    : new MachineCredentials(); // Missing/Unreadable mid-login: this login is the explicit re-auth (04 §1)
-                var families = document.Families ?? (document.Families = new MachineCredentialFamilies());
+                result = CommitPluginFamilyUnderHold(store, hold, exchange, presentedClientId, expectedSubject, serverTarget, logger);
+            }
 
-                families.Plugin = new MachineCredentialFamily
-                {
-                    AccessToken = exchange.AccessToken,
-                    RefreshToken = exchange.RefreshToken,
-                    ExpiresAt = exchange.ExpiresAt,
-                    ClientId = presentedClientId,
-                    Scope = exchange.Scope ?? TokenExchangeClient.PluginScope,
-                };
-                if (serverTarget != null && document.ServerTarget == null)
-                    document.ServerTarget = serverTarget;
-                if (exchange.Subject != null && document.Subject == null)
-                    document.Subject = exchange.Subject; // O5: no path writes a subject-less credential
+            // Orphan revocation OUTSIDE the critical section (04 §2: the hold stays short) and only
+            // for the TERMINAL hold-2 aborts — the just-derived family is invisible to every other
+            // component, so nobody else can revoke or use it. Retryable outcomes (busy/unreadable)
+            // revoke nothing: the retry commits this same mint. Hold-1 premise aborts never reach
+            // this method at all, so they revoke nothing either (twin rule 4).
+            if (result.Status == LoginCommitStatus.StoreSignedOut || result.Status == LoginCommitStatus.SubjectMismatch)
+                await RevokeOrphanedFamilyAsync(revocationClient, exchange, presentedClientId, serverTarget, logger, cancellationToken).ConfigureAwait(false);
 
-                if (!hold.IsStillOwned()) // b2 review A1
-                    return new LoginCommitResult(LoginCommitStatus.PluginCommitBusy, exchange, "credential lock lost before the plugin-family write");
-                store.Write(document); // the v1 compat mirror of families.plugin is stamped by the write contract
+            return result;
+        }
 
-                logger?.LogInformation("Login commit complete: agent + plugin families persisted to the machine store.");
-                return new LoginCommitResult(LoginCommitStatus.FullyCommitted, exchange, null);
+        // The hold-2 critical section (store I/O only — no network). MUST be called with the hold held.
+        static LoginCommitResult CommitPluginFamilyUnderHold(
+            MachineCredentialStore store,
+            MachineCredentialLockHandle hold,
+            TokenExchangeResult exchange,
+            string presentedClientId,
+            string? expectedSubject,
+            string? serverTarget,
+            ILogger? logger)
+        {
+            var read = store.TryRead();
+            if (read.Status == MachineCredentialStoreStatus.Unreadable)
+            {
+                // The premise cannot be verified against a store that cannot be read: a
+                // result-shaped, RETRYABLE outcome — never a write, never an escaping throw,
+                // and NO revocation (the retry commits this same mint). Twin: store-unreadable.
+                logger?.LogWarning("Plugin-family commit deferred: store unreadable at the second hold ({error}).", read.Error);
+                return new LoginCommitResult(LoginCommitStatus.StoreUnreadable, exchange,
+                    "credential store unreadable at the second hold; retry the plugin-family commit");
+            }
+            if (read.Status == MachineCredentialStoreStatus.Missing || read.Credentials == null)
+            {
+                // A machine-wide sign-out (F6) landed between the holds — the sign-out wins.
+                // Never answer it by recreating a signed-in store. Twin: store-missing.
+                logger?.LogWarning("Plugin-family commit aborted: the store was signed out between the holds.");
+                return new LoginCommitResult(LoginCommitStatus.StoreSignedOut, exchange,
+                    "the machine was signed out between the holds; the plugin family was not committed");
+            }
+
+            var document = read.Credentials;
+            if (document.Subject != null && expectedSubject != null
+                && !string.Equals(document.Subject, expectedSubject, StringComparison.Ordinal))
+            {
+                // Interleaved login (03 F7.2): the store's subject is no longer the commit's
+                // premise. Fires only when BOTH subjects are known (pre-a6/no-sub proceeds,
+                // F7.3 — twin-converged); no confirmation flag reaches here, because this
+                // conflict postdates the user's answer. Twin: subject-changed.
+                logger?.LogWarning("Plugin-family commit aborted: the store's subject changed between the holds.");
+                return new LoginCommitResult(LoginCommitStatus.SubjectMismatch, exchange,
+                    "the store's subject changed between the holds (interleaved login); the plugin family was not committed");
+            }
+
+            var families = document.Families ?? (document.Families = new MachineCredentialFamilies());
+
+            families.Plugin = new MachineCredentialFamily
+            {
+                AccessToken = exchange.AccessToken,
+                RefreshToken = exchange.RefreshToken,
+                ExpiresAt = exchange.ExpiresAt,
+                ClientId = presentedClientId,
+                Scope = exchange.Scope ?? TokenExchangeClient.PluginScope,
+            };
+            if (serverTarget != null && document.ServerTarget == null)
+                document.ServerTarget = serverTarget;
+            if (exchange.Subject != null && document.Subject == null)
+                document.Subject = exchange.Subject; // O5 sub backfill — only-when-absent (twin rule 5)
+
+            if (!hold.IsStillOwned()) // b2 review A1
+                return new LoginCommitResult(LoginCommitStatus.PluginCommitBusy, exchange, "credential lock lost before the plugin-family write");
+            store.Write(document); // the v1 compat mirror of families.plugin is stamped by the write contract
+
+            logger?.LogInformation("Login commit complete: agent + plugin families persisted to the machine store.");
+            return new LoginCommitResult(LoginCommitStatus.FullyCommitted, exchange, null);
+        }
+
+        /// <summary>
+        /// Best-effort RFC 7009 revocation of a derived-but-never-committed plugin family
+        /// (twin rule 4): refresh token preferred (revoking it kills the family), falling back to
+        /// the access token; single attempt, failures only logged — the family also dies naturally
+        /// at its own expiry, and the abort result still carries it for the caller.
+        /// </summary>
+        static async Task RevokeOrphanedFamilyAsync(
+            ITokenRevocationClient? revocationClient,
+            TokenExchangeResult exchange,
+            string presentedClientId,
+            string? serverTarget,
+            ILogger? logger,
+            CancellationToken cancellationToken)
+        {
+            if (revocationClient == null)
+                return;
+
+            var token = !string.IsNullOrEmpty(exchange.RefreshToken) ? exchange.RefreshToken : exchange.AccessToken;
+            if (string.IsNullOrEmpty(token))
+                return;
+
+            try
+            {
+                var acknowledged = await revocationClient.RevokeAsync(token!, presentedClientId, serverTarget, cancellationToken).ConfigureAwait(false);
+                if (!acknowledged)
+                    logger?.LogWarning("Best-effort revocation of the orphaned plugin family was not acknowledged; it expires naturally.");
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                logger?.LogWarning("Best-effort revocation of the orphaned plugin family threw: {message}", ex.Message); // never token material
             }
         }
     }

--- a/McpPlugin/src/McpPlugin/Network/Connection/Credentials/MachineCredentialLoginCommit.cs
+++ b/McpPlugin/src/McpPlugin/Network/Connection/Credentials/MachineCredentialLoginCommit.cs
@@ -1,0 +1,236 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.AgentConfig;
+using Microsoft.Extensions.Logging;
+
+namespace com.IvanMurzak.McpPlugin
+{
+    /// <summary>Outcome status of a <see cref="MachineCredentialLoginCommit"/> sequence.</summary>
+    public enum LoginCommitStatus
+    {
+        /// <summary>Agent family committed, exchange succeeded, plugin family + mirror committed.</summary>
+        FullyCommitted = 0,
+
+        /// <summary>
+        /// Agent family committed but the token exchange failed — the F1 failure path: the caller
+        /// retries the exchange with backoff and surfaces "partially authorized, retrying". The
+        /// agent family stays committed (that is why the sequence uses two separate lock holds).
+        /// </summary>
+        AgentOnly = 1,
+
+        /// <summary>
+        /// Agent family committed and the exchange succeeded, but the second lock hold failed
+        /// (busy) — the minted plugin family is carried in
+        /// <see cref="LoginCommitResult.ExchangeResult"/> so the caller can retry
+        /// <see cref="MachineCredentialLoginCommit.CommitPluginFamilyAsync"/> without re-exchanging.
+        /// </summary>
+        PluginCommitBusy = 2,
+
+        /// <summary>The first lock hold failed (busy) — nothing was written; retry the whole commit.</summary>
+        Busy = 3,
+
+        /// <summary>
+        /// The store already belongs to a different account (<c>subject</c> mismatch — design F7/D6)
+        /// and the caller did not pass <c>overwriteDifferentSubject</c>. Nothing was written; the
+        /// caller shows the account-switch confirm dialog and retries with the flag (after
+        /// best-effort revoking the displaced account's families) or aborts (revoking the
+        /// just-minted tokens).
+        /// </summary>
+        SubjectMismatch = 4,
+    }
+
+    /// <summary>The outcome of a login-commit sequence (see <see cref="LoginCommitStatus"/>).</summary>
+    public sealed class LoginCommitResult
+    {
+        internal LoginCommitResult(LoginCommitStatus status, TokenExchangeResult? exchangeResult, string? detail)
+        {
+            Status = status;
+            ExchangeResult = exchangeResult;
+            Detail = detail;
+        }
+
+        /// <summary>What the sequence achieved.</summary>
+        public LoginCommitStatus Status { get; }
+
+        /// <summary>The exchange outcome (null when the exchange was never reached). Carries the minted plugin family on <see cref="LoginCommitStatus.PluginCommitBusy"/>.</summary>
+        public TokenExchangeResult? ExchangeResult { get; }
+
+        /// <summary>Human-facing detail (busy path, exchange failure reason, …). Never token material.</summary>
+        public string? Detail { get; }
+    }
+
+    /// <summary>
+    /// The two-lock-hold login commit sequence (unified-machine-auth 04 §4, design 03 F1 steps
+    /// 3–4), exposed as ONE helper so all three engines implement F1 uniformly:
+    /// <list type="number">
+    ///   <item><b>First hold:</b> acquire the 04 §2 lock → re-read → subject guard (F7) → write the
+    ///   freshly minted AGENT family (with the <c>clientId</c> it was minted under, D8) → release.</item>
+    ///   <item><b>Exchange (no lock held):</b> RFC 8693 token exchange, agent access token →
+    ///   plugin family, the exchanging component's own <c>client_id</c>.</item>
+    ///   <item><b>Second hold:</b> acquire → re-read → write the PLUGIN family; the v1 compat
+    ///   mirror follows automatically from the store's write contract → release.</item>
+    /// </list>
+    /// Two separate holds by design: a failed exchange leaves a valid, committed agent family
+    /// (the F1 failure path), and no network call ever runs inside the lock's critical section
+    /// beyond the §2-bounded refresh (the exchange here runs BETWEEN the holds).
+    /// </summary>
+    public static class MachineCredentialLoginCommit
+    {
+        /// <summary>
+        /// Run the full sequence. <paramref name="agentFamily"/> must carry the freshly minted
+        /// agent tokens AND the <c>clientId</c> they were minted under (D8 — written from the value
+        /// actually presented, never inferred). <paramref name="subject"/> is the account id from
+        /// the mint response (O5). <paramref name="overwriteDifferentSubject"/> false (default)
+        /// refuses to overwrite a store belonging to a different account
+        /// (<see cref="LoginCommitStatus.SubjectMismatch"/>) — the F7 guard.
+        /// </summary>
+        public static async Task<LoginCommitResult> CommitAsync(
+            MachineCredentialStore store,
+            MachineCredentialLock credentialLock,
+            MachineCredentialFamily agentFamily,
+            string? serverTarget,
+            string? subject,
+            ITokenExchangeClient exchangeClient,
+            bool overwriteDifferentSubject = false,
+            ILogger? logger = null,
+            CancellationToken cancellationToken = default)
+        {
+            if (store == null) throw new ArgumentNullException(nameof(store));
+            if (credentialLock == null) throw new ArgumentNullException(nameof(credentialLock));
+            if (agentFamily == null) throw new ArgumentNullException(nameof(agentFamily));
+            if (exchangeClient == null) throw new ArgumentNullException(nameof(exchangeClient));
+            if (string.IsNullOrEmpty(agentFamily.AccessToken))
+                throw new ArgumentException("The agent family must carry an access token (it is the exchange subject).", nameof(agentFamily));
+            if (string.IsNullOrEmpty(agentFamily.ClientId))
+                throw new ArgumentException("The agent family must carry the clientId it was minted under (design D8).", nameof(agentFamily));
+
+            // ── First hold: commit the agent family. ─────────────────────────────────────────────
+            var firstHold = await Task.Run(() => credentialLock.TryAcquire(), cancellationToken).ConfigureAwait(false);
+            if (firstHold == null)
+                return new LoginCommitResult(LoginCommitStatus.Busy, null, "credential lock busy (first hold)");
+
+            using (firstHold)
+            {
+                var read = store.TryRead();
+
+                // Subject guard (F7/D6): never silently overwrite another account's machine store.
+                // An unreadable store cannot prove a subject, and login IS the explicit user
+                // re-authorization that 04 §1 requires before replacing one — so Unreadable falls
+                // through to a fresh document.
+                var existing = read.Status == MachineCredentialStoreStatus.Ok ? read.Credentials : null;
+                if (!overwriteDifferentSubject
+                    && existing?.Subject != null && subject != null
+                    && !string.Equals(existing.Subject, subject, StringComparison.Ordinal))
+                {
+                    return new LoginCommitResult(LoginCommitStatus.SubjectMismatch, null,
+                        "the machine store belongs to a different account");
+                }
+
+                var document = existing ?? new MachineCredentials();
+                var families = document.Families ?? (document.Families = new MachineCredentialFamilies());
+                families.Agent = agentFamily;
+                if (serverTarget != null)
+                    document.ServerTarget = serverTarget;
+                if (subject != null)
+                    document.Subject = subject;
+
+                if (!firstHold.IsStillOwned()) // b2 review A1: verify ownership immediately before the write
+                    return new LoginCommitResult(LoginCommitStatus.Busy, null, "credential lock lost before the agent-family write");
+                store.Write(document);
+            }
+
+            // ── Exchange, between the holds (03 F1.4). ───────────────────────────────────────────
+            TokenExchangeResult exchange;
+            try
+            {
+                exchange = await exchangeClient.ExchangeAsync(agentFamily.AccessToken!, serverTarget, cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                logger?.LogWarning("Token exchange threw: {message}", ex.Message); // never token material
+                return new LoginCommitResult(LoginCommitStatus.AgentOnly, null, ex.Message);
+            }
+
+            if (exchange == null || !exchange.Succeeded || string.IsNullOrEmpty(exchange.AccessToken))
+                return new LoginCommitResult(LoginCommitStatus.AgentOnly, exchange, exchange?.FailureReason ?? "token exchange failed");
+
+            // ── Second hold: commit the plugin family (+ mirror via the write contract). ─────────
+            return await CommitPluginFamilyAsync(store, credentialLock, exchange, exchangeClient.ClientId, serverTarget, logger, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// The second phase alone: commit an already-minted plugin family under one lock hold.
+        /// Public so a <see cref="LoginCommitStatus.PluginCommitBusy"/> outcome can be retried
+        /// without re-running the exchange, and so a tools-only (O10) login — which mints a plugin
+        /// family directly — commits through the same path. The family is stamped with
+        /// <paramref name="presentedClientId"/> (the id actually presented at derivation, D8) and
+        /// the exchange response's scope.
+        /// </summary>
+        public static async Task<LoginCommitResult> CommitPluginFamilyAsync(
+            MachineCredentialStore store,
+            MachineCredentialLock credentialLock,
+            TokenExchangeResult exchange,
+            string presentedClientId,
+            string? serverTarget = null,
+            ILogger? logger = null,
+            CancellationToken cancellationToken = default)
+        {
+            if (store == null) throw new ArgumentNullException(nameof(store));
+            if (credentialLock == null) throw new ArgumentNullException(nameof(credentialLock));
+            if (exchange == null) throw new ArgumentNullException(nameof(exchange));
+            if (!exchange.Succeeded || string.IsNullOrEmpty(exchange.AccessToken))
+                throw new ArgumentException("Only a successful exchange result can be committed.", nameof(exchange));
+            if (string.IsNullOrEmpty(presentedClientId))
+                throw new ArgumentException("The clientId actually presented at derivation is required (design D8).", nameof(presentedClientId));
+
+            var hold = await Task.Run(() => credentialLock.TryAcquire(), cancellationToken).ConfigureAwait(false);
+            if (hold == null)
+                return new LoginCommitResult(LoginCommitStatus.PluginCommitBusy, exchange, "credential lock busy (second hold)");
+
+            using (hold)
+            {
+                var read = store.TryRead();
+                var document = read.Status == MachineCredentialStoreStatus.Ok && read.Credentials != null
+                    ? read.Credentials
+                    : new MachineCredentials(); // Missing/Unreadable mid-login: this login is the explicit re-auth (04 §1)
+                var families = document.Families ?? (document.Families = new MachineCredentialFamilies());
+
+                families.Plugin = new MachineCredentialFamily
+                {
+                    AccessToken = exchange.AccessToken,
+                    RefreshToken = exchange.RefreshToken,
+                    ExpiresAt = exchange.ExpiresAt,
+                    ClientId = presentedClientId,
+                    Scope = exchange.Scope ?? TokenExchangeClient.PluginScope,
+                };
+                if (serverTarget != null && document.ServerTarget == null)
+                    document.ServerTarget = serverTarget;
+                if (exchange.Subject != null && document.Subject == null)
+                    document.Subject = exchange.Subject; // O5: no path writes a subject-less credential
+
+                if (!hold.IsStillOwned()) // b2 review A1
+                    return new LoginCommitResult(LoginCommitStatus.PluginCommitBusy, exchange, "credential lock lost before the plugin-family write");
+                store.Write(document); // the v1 compat mirror of families.plugin is stamped by the write contract
+
+                logger?.LogInformation("Login commit complete: agent + plugin families persisted to the machine store.");
+                return new LoginCommitResult(LoginCommitStatus.FullyCommitted, exchange, null);
+            }
+        }
+    }
+}

--- a/McpPlugin/src/McpPlugin/Network/Connection/Credentials/MachineWideSignOut.cs
+++ b/McpPlugin/src/McpPlugin/Network/Connection/Credentials/MachineWideSignOut.cs
@@ -1,0 +1,172 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.AgentConfig;
+using Microsoft.Extensions.Logging;
+
+namespace com.IvanMurzak.McpPlugin
+{
+    /// <summary>The outcome of a machine-wide sign-out (see <see cref="MachineWideSignOut"/>).</summary>
+    public sealed class MachineSignOutResult
+    {
+        internal MachineSignOutResult(bool storeDeleted, bool busy, int familiesRevoked, int revocationsFailed, string? detail)
+        {
+            StoreDeleted = storeDeleted;
+            Busy = busy;
+            FamiliesRevoked = familiesRevoked;
+            RevocationsFailed = revocationsFailed;
+            Detail = detail;
+        }
+
+        /// <summary>True when the credential store file was deleted (the machine is signed out).</summary>
+        public bool StoreDeleted { get; }
+
+        /// <summary>True when the lock-protocol delete path was busy — the store is untouched; retry.</summary>
+        public bool Busy { get; }
+
+        /// <summary>How many families the server acknowledged revoking.</summary>
+        public int FamiliesRevoked { get; }
+
+        /// <summary>
+        /// How many families could not be revoked after bounded retries (offline sign-out — F6.4:
+        /// the store is still deleted; unrevoked families die naturally at ≤30 d and remain listed
+        /// on the website until then).
+        /// </summary>
+        public int RevocationsFailed { get; }
+
+        /// <summary>Human-facing detail. Never token material.</summary>
+        public string? Detail { get; }
+    }
+
+    /// <summary>
+    /// Machine-wide sign-out (unified-machine-auth design 03 F6, task b3): best-effort RFC 7009
+    /// revocation of EVERY stored family's refresh token — the agent and plugin families with their
+    /// stored <c>clientId</c>s, a legacy family with the component-default id (F6.2) — each with
+    /// bounded retries, followed by the 04 §2 lock-protocol delete path (acquire → unlink store →
+    /// release → unlink lock). Revocation failures never block the local sign-out (F6.4); a busy
+    /// lock DOES (the store must never be unlinked outside the lock protocol).
+    /// </summary>
+    public static class MachineWideSignOut
+    {
+        /// <summary>Bounded revocation retries per family (best-effort — F6).</summary>
+        public const int RevokeAttemptsPerFamily = 3;
+
+        /// <summary>Backoff between revocation retries, in ms (kept short — sign-out is user-facing).</summary>
+        public const int RevokeRetryDelayMs = 250;
+
+        /// <summary>
+        /// Run the full sequence. <paramref name="componentClientId"/> is this component's own
+        /// OAuth client id, presented when revoking a legacy family of unknown id (F6.2 —
+        /// RFC 7009 answers 200 even for a mismatched id/unknown token, so this can never make
+        /// sign-out worse). An unreadable store skips revocation (its tokens cannot be read) but is
+        /// still deleted: sign-out is the explicit user action that authorizes replacing/removing
+        /// an unreadable store (04 §1).
+        /// </summary>
+        public static async Task<MachineSignOutResult> SignOutAsync(
+            MachineCredentialStore store,
+            MachineCredentialLock credentialLock,
+            ITokenRevocationClient revocationClient,
+            string componentClientId,
+            ILogger? logger = null,
+            CancellationToken cancellationToken = default)
+        {
+            if (store == null) throw new ArgumentNullException(nameof(store));
+            if (credentialLock == null) throw new ArgumentNullException(nameof(credentialLock));
+            if (revocationClient == null) throw new ArgumentNullException(nameof(revocationClient));
+            if (string.IsNullOrEmpty(componentClientId))
+                throw new ArgumentException("The component's own client id is required (legacy-family revocation, F6.2).", nameof(componentClientId));
+
+            // ── Server-side revocation FIRST (03 F6.2) — before the tokens are unlinked locally. ──
+            var revoked = 0;
+            var failed = 0;
+            var read = store.TryRead();
+            if (read.Status == MachineCredentialStoreStatus.Ok && read.Credentials != null)
+            {
+                var credentials = read.Credentials;
+                var serverTarget = credentials.ServerTarget;
+                foreach (var target in EnumerateRevocationTargets(credentials, componentClientId))
+                {
+                    if (await RevokeWithRetriesAsync(revocationClient, target.Key, target.Value, serverTarget, logger, cancellationToken).ConfigureAwait(false))
+                        revoked++;
+                    else
+                        failed++;
+                }
+            }
+            else if (read.Status == MachineCredentialStoreStatus.Unreadable)
+            {
+                logger?.LogWarning("Sign-out: credential store is unreadable ({error}); skipping server-side revocation and deleting locally.", read.Error);
+            }
+
+            // ── Lock-protocol delete path (04 §2): acquire → unlink store → release. ─────────────
+            var deleted = await Task.Run(() => credentialLock.TryDeleteStore(store), cancellationToken).ConfigureAwait(false);
+            if (!deleted)
+            {
+                return new MachineSignOutResult(storeDeleted: false, busy: true, revoked, failed,
+                    "credential lock busy — the store was not deleted; retry sign-out");
+            }
+
+            return new MachineSignOutResult(storeDeleted: true, busy: false, revoked, failed,
+                failed > 0 ? "some families could not be revoked server-side; they expire naturally (≤30 d)" : null);
+        }
+
+        /// <summary>
+        /// The refresh tokens to revoke, paired with the client id to present: each family's stored
+        /// <c>clientId</c>; the component default for a legacy family (unknown by definition, F6.2).
+        /// </summary>
+        static IEnumerable<KeyValuePair<string, string>> EnumerateRevocationTargets(MachineCredentials credentials, string componentClientId)
+        {
+            var families = credentials.Families;
+            if (families == null)
+                yield break;
+
+            if (families.Agent?.RefreshToken != null)
+                yield return new KeyValuePair<string, string>(families.Agent.RefreshToken!, families.Agent.ClientId ?? componentClientId);
+            if (families.Plugin?.RefreshToken != null)
+                yield return new KeyValuePair<string, string>(families.Plugin.RefreshToken!, families.Plugin.ClientId ?? componentClientId);
+            if (families.Legacy?.RefreshToken != null)
+                yield return new KeyValuePair<string, string>(families.Legacy.RefreshToken!, families.Legacy.ClientId ?? componentClientId);
+        }
+
+        static async Task<bool> RevokeWithRetriesAsync(
+            ITokenRevocationClient revocationClient,
+            string refreshToken,
+            string clientId,
+            string? serverTarget,
+            ILogger? logger,
+            CancellationToken cancellationToken)
+        {
+            for (var attempt = 1; attempt <= RevokeAttemptsPerFamily; attempt++)
+            {
+                try
+                {
+                    if (await revocationClient.RevokeAsync(refreshToken, clientId, serverTarget, cancellationToken).ConfigureAwait(false))
+                        return true;
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    logger?.LogWarning("Token revocation attempt {attempt} threw: {message}", attempt, ex.Message); // never token material
+                }
+
+                if (attempt < RevokeAttemptsPerFamily)
+                    await Task.Delay(RevokeRetryDelayMs, cancellationToken).ConfigureAwait(false);
+            }
+            return false;
+        }
+    }
+}

--- a/McpPlugin/src/McpPlugin/Network/Connection/Credentials/PluginCredentialProvider.cs
+++ b/McpPlugin/src/McpPlugin/Network/Connection/Credentials/PluginCredentialProvider.cs
@@ -43,12 +43,14 @@ namespace com.IvanMurzak.McpPlugin
     ///   read-modify-<see cref="MachineCredentialStore.Write"/> under the lock — never through
     ///   <see cref="MachineCredentialStore.Rotate"/> (b1 review A3: its plugin/legacy fallback is
     ///   not family-explicit and its unreadable-refusal throw is the wrong shape mid-lock).</item>
-    ///   <item><b>Dead family (04 §3.5, 03 F3.5):</b> <c>invalid_grant</c> followed by a
-    ///   post-failure re-read that shows nobody else rotated the family ⇒ the family is dead:
-    ///   <see cref="AuthState.SignInRequired"/> is surfaced, ONE structured telemetry event is
-    ///   emitted (per family death, not per retry), other families are never deleted, and the
-    ///   provider never loops — one network attempt per call, rate-bounded across calls by the
-    ///   refresher (04 §3.6).</item>
+    ///   <item><b>Failure-state split (04 §3.5, 03 F3.5/F9):</b> <see cref="AuthState.SignInRequired"/>
+    ///   is the DEAD-FAMILY verdict only — <c>invalid_grant</c> followed by a post-failure re-read
+    ///   that shows nobody else rotated the family. Then ONE structured telemetry event is emitted
+    ///   (per family death, not per retry), other families are never deleted, and the provider
+    ///   never loops — one network attempt per call, rate-bounded across calls by the refresher
+    ///   (04 §3.6). Every OTHER failure — AS unreachable, 5xx, timeout, a thrown refresher — is
+    ///   <b>transient</b>: the provider stays <see cref="AuthState.SignedIn"/> on its current
+    ///   credential and retries later (F9: offline self-heals silently, no sign-in prompt).</item>
     /// </list>
     /// The actual token-endpoint HTTP exchange is delegated to an injected <see cref="ITokenRefresher"/>
     /// (the shared <see cref="HttpTokenRefresher"/> in production); this class never talks to the
@@ -168,8 +170,11 @@ namespace com.IvanMurzak.McpPlugin
         /// <summary>
         /// Refresh the access token now (driven by the connection layer's <c>_authorizationRejected</c>
         /// signal). Returns true when a fresh token was persisted (or adopted from a peer's refresh);
-        /// false when refresh failed, is impossible (in which case <see cref="AuthState.SignInRequired"/>
-        /// has been surfaced), or the machine-wide lock was busy (transient — no state change).
+        /// false when this attempt did not produce one. A false return surfaces
+        /// <see cref="AuthState.SignInRequired"/> ONLY for a dead family (<c>invalid_grant</c>
+        /// confirmed by the post-failure re-read) or when refresh is impossible (no refresh token /
+        /// no refresher); transient failures and a busy machine-wide lock leave the state untouched
+        /// (retry-later semantics — review B2).
         /// </summary>
         public async Task<bool> RefreshAsync(CancellationToken cancellationToken = default)
         {
@@ -337,8 +342,9 @@ namespace com.IvanMurzak.McpPlugin
                 }
                 catch (Exception ex)
                 {
-                    _logger?.LogWarning("Token refresh threw: {message}", ex.Message); // never log token material
-                    SurfaceSignInRequired("refresh error");
+                    // A thrown refresh (network down, DNS, TLS) is TRANSIENT (review B2): keep the
+                    // current credential and state, retry later — offline self-heals silently (F9).
+                    _logger?.LogWarning("Token refresh threw ({message}); staying signed in, will retry.", ex.Message); // never log token material
                     return false;
                 }
 
@@ -412,7 +418,12 @@ namespace com.IvanMurzak.McpPlugin
                 return false;
             }
 
-            SurfaceSignInRequired(result?.FailureReason);
+            // TRANSIENT failure (review B2): SignInRequired is the dead-family verdict ONLY
+            // (03 F3.5); everything else — AS unreachable, 5xx, timeout, other OAuth errors —
+            // keeps the current credential and state and retries later (F9: offline self-heals
+            // silently; rate discipline in the refresher bounds the retries).
+            _logger?.LogWarning("Token refresh failed transiently ({reason}); staying signed in, will retry.",
+                result?.FailureReason ?? "unknown");
             return false;
         }
 

--- a/McpPlugin/src/McpPlugin/Network/Connection/Credentials/PluginCredentialProvider.cs
+++ b/McpPlugin/src/McpPlugin/Network/Connection/Credentials/PluginCredentialProvider.cs
@@ -19,23 +19,40 @@ using R3;
 namespace com.IvanMurzak.McpPlugin
 {
     /// <summary>
-    /// The engine-side account credential provider (mcp-authorize b7, design 03 Flow B / design 06). It
-    /// owns the machine-store-backed account credential and is the source of the access token the SignalR
-    /// connection presents. Three behaviours:
+    /// The engine-side account credential provider (mcp-authorize b7, unified-machine-auth b3). It
+    /// owns the machine-store-backed <b>plugin-plane</b> credential (v2 <c>families.plugin</c>,
+    /// falling back to a v1-adopted <c>families.legacy</c>) and is the source of the access token
+    /// the SignalR connection presents. Behaviours:
     /// <list type="bullet">
     ///   <item><b>Machine-store auto-adopt (the zero-button rule):</b> the machine credential store is read
-    ///   at construction. If a credential exists the provider is <see cref="AuthState.SignedIn"/> with
-    ///   <b>zero</b> UI interaction — engines connect signed-in on boot without any editor click.</item>
-    ///   <item><b>Proactive refresh:</b> <see cref="GetAccessTokenAsync"/> refreshes the token before its
-    ///   <c>exp</c> (within a skew window) so a valid JWT is always presented on (re)connect.</item>
-    ///   <item><b>Reactive refresh + sign-in-again:</b> <see cref="RefreshAsync"/> (driven by the connection
-    ///   layer's <c>_authorizationRejected</c> 3-strike signal) mints a new token and persists it; a refresh
-    ///   failure transitions to <see cref="AuthState.SignInRequired"/> and fires <see cref="OnSignInRequired"/>
-    ///   so the engine UI can prompt "Session expired — sign in again".</item>
+    ///   at construction. If a plugin-plane credential exists the provider is <see cref="AuthState.SignedIn"/>
+    ///   with <b>zero</b> UI interaction — engines connect signed-in on boot without any editor click.</item>
+    ///   <item><b>Lock-integrated double-checked refresh (04 §2/§3, design 03 F3):</b> both the
+    ///   proactive path (<see cref="GetAccessTokenAsync"/>, 60 s expiry skew) and the reactive path
+    ///   (<see cref="RefreshAsync"/>, driven by the connection layer's 401 3-strike signal) run
+    ///   under the cross-process <see cref="MachineCredentialLock"/> and <b>re-read the store
+    ///   first</b>: a peer that already refreshed is adopted without a network call. A lock budget
+    ///   exhausted, or a store that reads back <see cref="MachineCredentialStoreStatus.Unreadable"/>
+    ///   mid-refresh, fails the attempt as <b>busy</b> (transient — no sign-in-required, no
+    ///   overwrite, never lock-free).</item>
+    ///   <item><b>Family rules (04 §3):</b> the refresher is handed the family's stored
+    ///   <c>clientId</c> (null for a legacy family — the refresher presents its component default,
+    ///   §3.7); a rotation response without a new refresh token keeps the previous one; a
+    ///   successful legacy-family refresh rewrites the document as v2 <c>families.legacy</c>
+    ///   (+ v1 mirror) via the normal write contract. Family-aware writes go through
+    ///   read-modify-<see cref="MachineCredentialStore.Write"/> under the lock — never through
+    ///   <see cref="MachineCredentialStore.Rotate"/> (b1 review A3: its plugin/legacy fallback is
+    ///   not family-explicit and its unreadable-refusal throw is the wrong shape mid-lock).</item>
+    ///   <item><b>Dead family (04 §3.5, 03 F3.5):</b> <c>invalid_grant</c> followed by a
+    ///   post-failure re-read that shows nobody else rotated the family ⇒ the family is dead:
+    ///   <see cref="AuthState.SignInRequired"/> is surfaced, ONE structured telemetry event is
+    ///   emitted (per family death, not per retry), other families are never deleted, and the
+    ///   provider never loops — one network attempt per call, rate-bounded across calls by the
+    ///   refresher (04 §3.6).</item>
     /// </list>
     /// The actual token-endpoint HTTP exchange is delegated to an injected <see cref="ITokenRefresher"/>
-    /// (each engine/CLI owns it); this class never talks to the network directly and never logs token
-    /// material.
+    /// (the shared <see cref="HttpTokenRefresher"/> in production); this class never talks to the
+    /// network directly and never logs token material.
     /// </summary>
     public sealed class PluginCredentialProvider : IDisposable
     {
@@ -43,6 +60,7 @@ namespace com.IvanMurzak.McpPlugin
         public static readonly TimeSpan DefaultRefreshSkew = TimeSpan.FromSeconds(60);
 
         readonly MachineCredentialStore _store;
+        readonly MachineCredentialLock _lock;
         readonly ITokenRefresher? _refresher;
         readonly ILogger? _logger;
         readonly TimeSpan _refreshSkew;
@@ -53,30 +71,45 @@ namespace com.IvanMurzak.McpPlugin
         readonly ReadOnlyReactiveProperty<AuthState> _stateReadOnly;
         readonly Subject<Unit> _signInRequired = new Subject<Unit>();
         MachineCredentials? _current;
+        bool _familyDeadTelemetryEmitted;
         volatile bool _disposed;
 
         /// <summary>
         /// Construct over a machine credential store. <paramref name="refresher"/> null ⇒ no refresh is
         /// possible (proactive/reactive refresh become no-ops that surface sign-in-required). The optional
         /// <paramref name="clock"/> exists for deterministic expiry tests.
+        /// <paramref name="credentialLock"/> — the cross-process lock guarding refresh writes
+        /// (04 §2); null creates the default lock rooted at the store's own directory, so
+        /// production callers get cross-process safety without wiring anything.
         /// </summary>
         public PluginCredentialProvider(
             MachineCredentialStore store,
             ITokenRefresher? refresher = null,
             ILogger? logger = null,
             TimeSpan? refreshSkew = null,
-            Func<DateTimeOffset>? clock = null)
+            Func<DateTimeOffset>? clock = null,
+            MachineCredentialLock? credentialLock = null)
         {
             _store = store ?? throw new ArgumentNullException(nameof(store));
+            _lock = credentialLock ?? new MachineCredentialLock(store.BaseDirectory);
             _refresher = refresher;
             _logger = logger;
             _refreshSkew = refreshSkew ?? DefaultRefreshSkew;
             _clock = clock ?? (() => DateTimeOffset.UtcNow);
 
-            // Auto-adopt: read the machine store now. No UI, no device flow. If a credential exists the
-            // plugin is already signed in (the zero-button rule — design 06).
-            _current = SafeRead();
-            _state = new ReactiveProperty<AuthState>(_current?.AccessToken != null ? AuthState.SignedIn : AuthState.SignedOut);
+            // Auto-adopt: read the machine store now. No UI, no device flow. If a plugin-plane
+            // credential exists the plugin is already signed in (the zero-button rule — design 06).
+            // An unreadable store is NOT signed-out (04 §1): boot into SignInRequired so the UI
+            // shows "sign in required (store unreadable)" instead of pretending the machine is
+            // clean — and never touch the file.
+            var read = SafeRead();
+            _current = read.Credentials;
+            var initialState = PluginPlaneFamily(_current)?.AccessToken != null
+                ? AuthState.SignedIn
+                : read.Status == MachineCredentialStoreStatus.Unreadable
+                    ? AuthState.SignInRequired
+                    : AuthState.SignedOut;
+            _state = new ReactiveProperty<AuthState>(initialState);
             _stateReadOnly = _state.ToReadOnlyReactiveProperty();
         }
 
@@ -86,8 +119,8 @@ namespace com.IvanMurzak.McpPlugin
         /// <summary>Fires when a refresh failed and the user must sign in again (design 06).</summary>
         public Observable<Unit> OnSignInRequired => _signInRequired;
 
-        /// <summary>True when a usable credential is present.</summary>
-        public bool IsSignedIn => _state.CurrentValue == AuthState.SignedIn && _current?.AccessToken != null;
+        /// <summary>True when a usable plugin-plane credential is present.</summary>
+        public bool IsSignedIn => _state.CurrentValue == AuthState.SignedIn && PluginPlaneFamily(_current)?.AccessToken != null;
 
         /// <summary>The enrolled server target the current credential was issued for (hosted vs local), if known.</summary>
         public string? ServerTarget => _current?.ServerTarget;
@@ -117,13 +150,14 @@ namespace com.IvanMurzak.McpPlugin
             await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
-                if (_current?.AccessToken == null)
+                var family = PluginPlaneFamily(_current);
+                if (family?.AccessToken == null)
                     return null;
 
-                if (ShouldRefresh(_current))
+                if (ShouldRefresh(family))
                     await RefreshCoreAsync(cancellationToken).ConfigureAwait(false);
 
-                return _current?.AccessToken;
+                return PluginPlaneFamily(_current)?.AccessToken;
             }
             finally
             {
@@ -133,8 +167,9 @@ namespace com.IvanMurzak.McpPlugin
 
         /// <summary>
         /// Refresh the access token now (driven by the connection layer's <c>_authorizationRejected</c>
-        /// signal). Returns true when a fresh token was persisted; false when refresh failed or is
-        /// impossible (in which case <see cref="AuthState.SignInRequired"/> has been surfaced).
+        /// signal). Returns true when a fresh token was persisted (or adopted from a peer's refresh);
+        /// false when refresh failed, is impossible (in which case <see cref="AuthState.SignInRequired"/>
+        /// has been surfaced), or the machine-wide lock was busy (transient — no state change).
         /// </summary>
         public async Task<bool> RefreshAsync(CancellationToken cancellationToken = default)
         {
@@ -155,6 +190,11 @@ namespace com.IvanMurzak.McpPlugin
         /// <summary>
         /// Adopt a freshly obtained credential (e.g. after an in-editor device-flow sign-in). Persists it to
         /// the machine store and transitions to <see cref="AuthState.SignedIn"/>.
+        /// <para>Behavioral seam (b1 review A1, pinned by test): <see cref="MachineCredentialStore.Write"/>
+        /// normalizes its ARGUMENT in place (v1 adoption → <c>families.legacy</c>, version upgrade,
+        /// mirror stamp), and this method deliberately keeps that same mutated instance as the
+        /// provider's current credential — so a caller passing top-level-only token material ends up
+        /// with a family-shaped <c>_current</c> the refresh path can operate on.</para>
         /// </summary>
         public void Adopt(MachineCredentials credentials)
         {
@@ -166,7 +206,8 @@ namespace com.IvanMurzak.McpPlugin
             {
                 _store.Write(credentials);
                 _current = credentials;
-                _state.Value = credentials.AccessToken != null ? AuthState.SignedIn : AuthState.SignedOut;
+                _familyDeadTelemetryEmitted = false;
+                _state.Value = PluginPlaneFamily(credentials)?.AccessToken != null ? AuthState.SignedIn : AuthState.SignedOut;
             }
             finally
             {
@@ -174,15 +215,25 @@ namespace com.IvanMurzak.McpPlugin
             }
         }
 
-        /// <summary>Sign out: delete the stored credential and reset to <see cref="AuthState.SignedOut"/>.</summary>
+        /// <summary>
+        /// Sign out this provider: delete the stored credential (via the 04 §2 lock-protocol delete
+        /// path) and reset to <see cref="AuthState.SignedOut"/>. When the lock is busy the file is
+        /// left for the holder (the local state still signs out); machine-wide sign-out with
+        /// server-side revocation is <see cref="MachineWideSignOut"/> (F6).
+        /// </summary>
         public void SignOut()
         {
             _gate.Wait();
             try
             {
-                try { _store.Delete(); }
+                try
+                {
+                    if (!_lock.TryDeleteStore(_store))
+                        _logger?.LogWarning("Credential store delete skipped: the machine-wide credential lock is busy.");
+                }
                 catch (Exception ex) { _logger?.LogWarning("Deleting stored credential failed: {message}", ex.Message); }
                 _current = null;
+                _familyDeadTelemetryEmitted = false;
                 _state.Value = AuthState.SignedOut;
             }
             finally
@@ -191,72 +242,195 @@ namespace com.IvanMurzak.McpPlugin
             }
         }
 
-        // MUST be called with _gate held.
+        /// <summary>
+        /// The plugin-plane family of a credential document (04 §1): <c>families.plugin</c>,
+        /// falling back to <c>families.legacy</c> (a v1-adopted document's only plugin-plane
+        /// credential). Defensively adopts top-level v1 token material first (idempotent), so even
+        /// a document that skipped the store's read path is family-shaped.
+        /// </summary>
+        static MachineCredentialFamily? PluginPlaneFamily(MachineCredentials? credentials)
+        {
+            if (credentials == null)
+                return null;
+            credentials.AdoptLegacyTokens();
+            return credentials.Families?.Plugin ?? credentials.Families?.Legacy;
+        }
+
+        // MUST be called with _gate held. One network attempt maximum — never loops (04 §3.5).
         async Task<bool> RefreshCoreAsync(CancellationToken cancellationToken)
         {
             var current = _current;
-            if (current?.RefreshToken == null || _refresher == null)
+            var family = PluginPlaneFamily(current);
+            if (current == null || family?.RefreshToken == null || _refresher == null)
             {
                 SurfaceSignInRequired("no refresh token or refresher configured");
                 return false;
             }
 
-            TokenRefreshResult result;
+            // Cross-process lock (04 §2). TryAcquire blocks (jittered backoff, ≤75 s budget), so it
+            // runs on the pool — never on an engine main thread. Budget exhausted ⇒ busy: fail THIS
+            // attempt, no state change, never proceed lock-free (D9 REVISED).
+            MachineCredentialLockHandle? lockHandle;
             try
             {
-                result = await _refresher.RefreshAsync(current.RefreshToken, current.ServerTarget, cancellationToken).ConfigureAwait(false);
+                lockHandle = await Task.Run(() => _lock.TryAcquire(), cancellationToken).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {
                 throw;
             }
-            catch (Exception ex)
+            if (lockHandle == null)
             {
-                _logger?.LogWarning("Token refresh threw: {message}", ex.Message); // never log token material
-                SurfaceSignInRequired("refresh error");
+                _logger?.LogInformation("Token refresh skipped: the machine-wide credential lock is busy (a peer is refreshing). Will retry next cycle.");
                 return false;
             }
 
-            if (result == null || !result.Succeeded || string.IsNullOrEmpty(result.AccessToken))
+            using (lockHandle)
             {
-                SurfaceSignInRequired(result?.FailureReason);
-                return false;
-            }
-
-            var refreshToken = string.IsNullOrEmpty(result.RefreshToken) ? current.RefreshToken! : result.RefreshToken!;
-
-            MachineCredentials rotated;
-            try
-            {
-                // Rotate() preserves the stored identity fields (ServerTarget / Subject) and persists.
-                rotated = _store.Rotate(result.AccessToken!, refreshToken, result.ExpiresAt);
-            }
-            catch (Exception ex)
-            {
-                _logger?.LogWarning("Persisting refreshed credential failed: {message}", ex.Message);
-                // Keep the refreshed token in memory even if the disk write failed — the connection can proceed.
-                rotated = new MachineCredentials
+                // Double-checked (03 F3.2): RE-READ the store under the lock before any network.
+                var reread = _store.TryRead();
+                if (reread.Status == MachineCredentialStoreStatus.Unreadable)
                 {
-                    AccessToken = result.AccessToken,
-                    RefreshToken = refreshToken,
-                    ExpiresAt = result.ExpiresAt,
-                    ServerTarget = current.ServerTarget,
-                    Subject = current.Subject
-                };
-            }
+                    // Unreadable ≠ dead (b1 review A3): transient contention (a concurrent atomic
+                    // replace, AV holding the file) or a real DPAPI loss — either way: busy/retry,
+                    // never signed-out from here, and NEVER overwrite the file.
+                    _logger?.LogWarning("Token refresh skipped: credential store unreadable right now ({error}); treating as busy.", reread.Error);
+                    return false;
+                }
+                if (reread.Status == MachineCredentialStoreStatus.Missing || reread.Credentials == null)
+                {
+                    // A peer signed the machine out (F6.3) — adopt the signed-out state, quietly.
+                    _current = null;
+                    _state.Value = AuthState.SignedOut;
+                    return false;
+                }
 
-            _current = rotated;
-            _state.Value = AuthState.SignedIn;
-            return true;
+                var latest = reread.Credentials;
+                var latestFamily = PluginPlaneFamily(latest);
+                if (latestFamily?.AccessToken != null && latestFamily.AccessToken != family.AccessToken)
+                {
+                    // A peer already refreshed — adopt its tokens, no network call (03 F3.2).
+                    AdoptInMemory(latest);
+                    return true;
+                }
+                if (latestFamily?.RefreshToken == null)
+                {
+                    SurfaceSignInRequired("stored credential has no refresh token");
+                    return false;
+                }
+
+                // Still stale — one network attempt, presenting the family's STORED clientId
+                // (04 §3.2; null for legacy ⇒ the refresher's component default, §3.7).
+                var request = new TokenRefreshRequest(
+                    latestFamily.RefreshToken!,
+                    latest.ServerTarget ?? current.ServerTarget,
+                    latestFamily.ClientId);
+
+                TokenRefreshResult result;
+                try
+                {
+                    result = await _refresher.RefreshAsync(request, cancellationToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    _logger?.LogWarning("Token refresh threw: {message}", ex.Message); // never log token material
+                    SurfaceSignInRequired("refresh error");
+                    return false;
+                }
+
+                if (result == null || !result.Succeeded || string.IsNullOrEmpty(result.AccessToken))
+                    return HandleRefreshFailure(result, latestFamily);
+
+                // Success: family-aware write (NOT Store.Rotate — b1 review A3). Rotation response
+                // without a new refresh token keeps the previous one (04 §3.4). For a v1-adopted
+                // document this mutates families.legacy and Write() upgrades it to a v2 document
+                // (+ v1 mirror) — the §3.7 rewrite — while never touching other families.
+                var refreshToken = string.IsNullOrEmpty(result.RefreshToken) ? latestFamily.RefreshToken! : result.RefreshToken!;
+                latestFamily.AccessToken = result.AccessToken;
+                latestFamily.RefreshToken = refreshToken;
+                latestFamily.ExpiresAt = result.ExpiresAt;
+
+                try
+                {
+                    // Verify the lock is still ours immediately before the write (b2 review A1) —
+                    // a (clock-skew) stale takeover mid-call must not be answered with a write.
+                    if (lockHandle.IsStillOwned())
+                        _store.Write(latest);
+                    else
+                        _logger?.LogWarning("Credential lock was taken over mid-refresh; keeping the refreshed token in memory and skipping the disk write.");
+                }
+                catch (Exception ex)
+                {
+                    _logger?.LogWarning("Persisting refreshed credential failed: {message}", ex.Message);
+                    // Keep the refreshed token in memory even if the disk write failed — the connection can proceed.
+                }
+
+                AdoptInMemory(latest);
+                return true;
+            }
         }
 
-        bool ShouldRefresh(MachineCredentials credentials)
+        // MUST be called with _gate held, INSIDE the lock's using scope.
+        bool HandleRefreshFailure(TokenRefreshResult? result, MachineCredentialFamily attemptedFamily)
+        {
+            if (result?.FailureKind == TokenRefreshFailureKind.InvalidGrant)
+            {
+                // 03 F3.5: re-read once more — a racer may have won legitimately (its rotation
+                // revoked our just-presented token, which the AS reports as invalid_grant).
+                var post = _store.TryRead();
+                if (post.Status == MachineCredentialStoreStatus.Unreadable)
+                {
+                    _logger?.LogWarning("Post-failure store re-read is unreadable ({error}); treating as busy.", post.Error);
+                    return false; // busy/retry, never a dead-family verdict off an unreadable read (b1 A3)
+                }
+                if (post.Status == MachineCredentialStoreStatus.Ok && post.Credentials != null)
+                {
+                    var postFamily = PluginPlaneFamily(post.Credentials);
+                    if (postFamily?.RefreshToken != null && postFamily.RefreshToken != attemptedFamily.RefreshToken)
+                    {
+                        AdoptInMemory(post.Credentials); // the racer's rotation is the live credential
+                        return true;
+                    }
+                }
+
+                // Family dead (04 §3.5): ONE structured telemetry event; never delete other
+                // families (the store is not touched at all); never loop.
+                if (!_familyDeadTelemetryEmitted)
+                {
+                    _familyDeadTelemetryEmitted = true;
+                    _logger?.LogWarning(
+                        "Credential family dead: refresh returned invalid_grant and no peer rotated it. family={family} clientIdKnown={clientIdKnown} reason={reason}",
+                        attemptedFamily.ClientId != null ? "plugin" : "legacy",
+                        attemptedFamily.ClientId != null,
+                        result?.FailureReason ?? "invalid_grant");
+                }
+                SurfaceSignInRequired(result?.FailureReason ?? "invalid_grant");
+                return false;
+            }
+
+            SurfaceSignInRequired(result?.FailureReason);
+            return false;
+        }
+
+        // MUST be called with _gate held.
+        void AdoptInMemory(MachineCredentials credentials)
+        {
+            _current = credentials;
+            _familyDeadTelemetryEmitted = false;
+            _state.Value = AuthState.SignedIn;
+        }
+
+        bool ShouldRefresh(MachineCredentialFamily family)
         {
             if (_refresher == null)
                 return false;
-            if (credentials.ExpiresAt == null)
+            if (family.ExpiresAt == null)
                 return false; // unknown expiry — recover reactively on server rejection instead
-            return credentials.ExpiresAt.Value - _clock() <= _refreshSkew;
+            return family.ExpiresAt.Value - _clock() <= _refreshSkew;
         }
 
         void SurfaceSignInRequired(string? reason)
@@ -268,16 +442,16 @@ namespace com.IvanMurzak.McpPlugin
             _signInRequired.OnNext(Unit.Default);
         }
 
-        MachineCredentials? SafeRead()
+        MachineCredentialReadResult SafeRead()
         {
             try
             {
-                return _store.Read();
+                return _store.TryRead();
             }
             catch (Exception ex)
             {
                 _logger?.LogWarning("Reading the machine credential store failed: {message}", ex.Message);
-                return null;
+                return MachineCredentialReadResult.Unreadable(ex.Message);
             }
         }
 

--- a/McpPlugin/src/McpPlugin/Network/Connection/Credentials/TokenExchangeClient.cs
+++ b/McpPlugin/src/McpPlugin/Network/Connection/Credentials/TokenExchangeClient.cs
@@ -1,0 +1,265 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.AgentConfig;
+
+namespace com.IvanMurzak.McpPlugin
+{
+    /// <summary>
+    /// The outcome of an RFC 8693 token exchange (unified-machine-auth 04 §4). On success it
+    /// carries the freshly minted plugin-family token material plus the response's <c>scope</c>
+    /// and <c>sub</c> (the a5 exchange response contract); on failure only a
+    /// <see cref="FailureReason"/>. Fails closed — never partial.
+    /// </summary>
+    public sealed class TokenExchangeResult
+    {
+        /// <summary>True when the exchange minted a plugin-family credential.</summary>
+        public bool Succeeded { get; }
+
+        /// <summary>The new plugin-plane access token (ES256 JWT). Non-null on success.</summary>
+        public string? AccessToken { get; }
+
+        /// <summary>The new plugin family's refresh token (RFC 8693 §2.2.1 documented exception — the a5 response always carries one).</summary>
+        public string? RefreshToken { get; }
+
+        /// <summary>Absolute expiry of <see cref="AccessToken"/> (from the response's <c>expires_in</c>).</summary>
+        public DateTimeOffset? ExpiresAt { get; }
+
+        /// <summary>The granted scope (<c>mcp:plugin</c>) as echoed by the server.</summary>
+        public string? Scope { get; }
+
+        /// <summary>The account id (<c>sub</c>) the minted family resolves to (O5 — no path writes a subject-less credential).</summary>
+        public string? Subject { get; }
+
+        /// <summary>The response's <c>issued_token_type</c> (the access-token URN).</summary>
+        public string? IssuedTokenType { get; }
+
+        /// <summary>A short human-facing reason when <see cref="Succeeded"/> is false. Never token material.</summary>
+        public string? FailureReason { get; }
+
+        TokenExchangeResult(bool succeeded, string? accessToken, string? refreshToken, DateTimeOffset? expiresAt,
+            string? scope, string? subject, string? issuedTokenType, string? failureReason)
+        {
+            Succeeded = succeeded;
+            AccessToken = accessToken;
+            RefreshToken = refreshToken;
+            ExpiresAt = expiresAt;
+            Scope = scope;
+            Subject = subject;
+            IssuedTokenType = issuedTokenType;
+            FailureReason = failureReason;
+        }
+
+        /// <summary>A successful exchange.</summary>
+        public static TokenExchangeResult Success(string accessToken, string? refreshToken, DateTimeOffset? expiresAt,
+            string? scope, string? subject, string? issuedTokenType)
+        {
+            if (string.IsNullOrEmpty(accessToken))
+                throw new ArgumentException("A successful exchange must carry a non-empty access token.", nameof(accessToken));
+            return new TokenExchangeResult(true, accessToken, refreshToken, expiresAt, scope, subject, issuedTokenType, failureReason: null);
+        }
+
+        /// <summary>A failed exchange. Fail closed — no token.</summary>
+        public static TokenExchangeResult Failure(string? reason = null)
+            => new TokenExchangeResult(false, null, null, null, null, null, null, reason);
+    }
+
+    /// <summary>
+    /// The RFC 8693 token-exchange seam (unified-machine-auth 04 §4): derives a plugin family from
+    /// an agent access token, presenting the exchanging component's own <c>client_id</c>. Injected
+    /// so tests (and the login-commit helper's tests) substitute a fake;
+    /// <see cref="TokenExchangeClient"/> is the production implementation.
+    /// </summary>
+    public interface ITokenExchangeClient
+    {
+        /// <summary>
+        /// The OAuth client id this exchanger presents — and therefore the id the minted plugin
+        /// family is stamped with (design D8: written from the value actually presented).
+        /// </summary>
+        string ClientId { get; }
+
+        /// <summary>
+        /// Exchange <paramref name="subjectAccessToken"/> (a FRESH agent-plane ES256 access token —
+        /// PATs are rejected by the server) for a plugin-family credential.
+        /// <paramref name="serverTarget"/> null uses the implementation's default.
+        /// </summary>
+        Task<TokenExchangeResult> ExchangeAsync(string subjectAccessToken, string? serverTarget, CancellationToken cancellationToken = default);
+    }
+
+    /// <summary>
+    /// Production RFC 8693 token-exchange client (unified-machine-auth 04 §4, shape frozen by a5):
+    /// POSTs to <c>{serverTarget}/oauth/token</c> with
+    /// <c>grant_type=urn:ietf:params:oauth:grant-type:token-exchange</c>,
+    /// <c>subject_token=&lt;agent access token&gt;</c>,
+    /// <c>subject_token_type=urn:ietf:params:oauth:token-type:access_token</c>,
+    /// <c>client_id=&lt;own id, ≤64 chars&gt;</c>, <c>scope=mcp:plugin</c>. <c>audience</c> and
+    /// <c>resource</c> are deliberately OMITTED (the server accepts them only as the exact
+    /// <c>urn:agd:hub</c>; omitting is the frozen-contract-safe choice). Applies the shared 15 s
+    /// HTTP timeout. Fails closed; never logs token material.
+    /// </summary>
+    public sealed class TokenExchangeClient : ITokenExchangeClient
+    {
+        /// <summary>The RFC 8693 grant type URN (a5 frozen shape).</summary>
+        public const string GrantType = "urn:ietf:params:oauth:grant-type:token-exchange";
+
+        /// <summary>The exact subject-token-type URN the server requires (a5 frozen shape).</summary>
+        public const string SubjectTokenType = "urn:ietf:params:oauth:token-type:access_token";
+
+        /// <summary>The scope requested for the derived family (a5: omit → defaults; anything else → <c>invalid_scope</c>).</summary>
+        public const string PluginScope = "mcp:plugin";
+
+        /// <summary>Maximum accepted <c>client_id</c> length (a5 frozen shape).</summary>
+        public const int MaxClientIdLength = 64;
+
+        /// <summary>Per-call HTTP timeout in ms — the shared contract value (04 §2).</summary>
+        public const int HttpTimeoutMs = MachineCredentialLock.REFRESH_HTTP_TIMEOUT;
+
+        static readonly HttpClient _sharedHttpClient = new HttpClient();
+
+        readonly string _defaultServerTarget;
+        readonly string _clientId;
+        readonly HttpClient _httpClient;
+        readonly Func<DateTimeOffset> _clock;
+        readonly int _timeoutMs;
+
+        /// <summary>
+        /// <paramref name="defaultServerTarget"/> — the AS root used when a call passes no target.
+        /// <paramref name="clientId"/> — this component's own OAuth client id (≤64 chars, a5).
+        /// </summary>
+        public TokenExchangeClient(string defaultServerTarget, string clientId, HttpClient? httpClient = null)
+            : this(defaultServerTarget, clientId, httpClient, clock: null, timeoutMs: null)
+        {
+        }
+
+        /// <summary>Test seam (InternalsVisibleTo: McpPlugin.Tests): override clock/timeout.</summary>
+        internal TokenExchangeClient(string defaultServerTarget, string clientId, HttpClient? httpClient, Func<DateTimeOffset>? clock, int? timeoutMs)
+        {
+            if (string.IsNullOrWhiteSpace(clientId))
+                throw new ArgumentException("The exchanging component's own client id is required (RFC 8693, design O2).", nameof(clientId));
+            if (clientId.Length > MaxClientIdLength)
+                throw new ArgumentException("client_id must be at most " + MaxClientIdLength + " characters (a5 exchange contract).", nameof(clientId));
+
+            _defaultServerTarget = HttpTokenRefresher.NormalizeServerTarget(defaultServerTarget) ?? string.Empty;
+            _clientId = clientId;
+            _httpClient = httpClient ?? _sharedHttpClient;
+            _clock = clock ?? (() => DateTimeOffset.UtcNow);
+            _timeoutMs = timeoutMs ?? HttpTimeoutMs;
+        }
+
+        /// <inheritdoc/>
+        public string ClientId => _clientId;
+
+        /// <inheritdoc/>
+        public async Task<TokenExchangeResult> ExchangeAsync(string subjectAccessToken, string? serverTarget, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrEmpty(subjectAccessToken))
+                return TokenExchangeResult.Failure("no subject access token");
+
+            var baseUrl = HttpTokenRefresher.NormalizeServerTarget(serverTarget) ?? _defaultServerTarget;
+            if (string.IsNullOrEmpty(baseUrl))
+                return TokenExchangeResult.Failure("no server target");
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // The a5 frozen wire shape — exactly these five parameters; audience/resource omitted.
+            var form = new List<KeyValuePair<string, string>>
+            {
+                new KeyValuePair<string, string>("grant_type", GrantType),
+                new KeyValuePair<string, string>("subject_token", subjectAccessToken),
+                new KeyValuePair<string, string>("subject_token_type", SubjectTokenType),
+                new KeyValuePair<string, string>("client_id", _clientId),
+                new KeyValuePair<string, string>("scope", PluginScope),
+            };
+
+            using var timeout = new CancellationTokenSource(_timeoutMs);
+            try
+            {
+                using var content = new FormUrlEncodedContent(form);
+                using var response = await _httpClient.PostAsync(baseUrl + "/oauth/token", content, timeout.Token).ConfigureAwait(false);
+                var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                return ParseExchangeResponse(response.IsSuccessStatusCode, (int)response.StatusCode, json, _clock);
+            }
+            catch (OperationCanceledException) when (timeout.IsCancellationRequested)
+            {
+                return TokenExchangeResult.Failure("token exchange timed out after " + _timeoutMs + " ms");
+            }
+            catch (Exception ex)
+            {
+                return TokenExchangeResult.Failure(ex.Message); // never token material
+            }
+        }
+
+        /// <summary>
+        /// Parse an a5 exchange response (pure, unit-testable). Response keys:
+        /// <c>access_token</c>, <c>issued_token_type</c>, <c>token_type=Bearer</c>,
+        /// <c>expires_in</c>, <c>refresh_token</c>, <c>scope</c>, <c>sub</c>.
+        /// </summary>
+        internal static TokenExchangeResult ParseExchangeResponse(bool isSuccessStatusCode, int statusCode, string json, Func<DateTimeOffset> clock)
+        {
+            string? accessToken = null;
+            string? refreshToken = null;
+            long expiresInSeconds = 0;
+            string? scope = null;
+            string? subject = null;
+            string? issuedTokenType = null;
+            string? error = null;
+            string? errorDescription = null;
+
+            try
+            {
+                using var document = JsonDocument.Parse(json);
+                var root = document.RootElement;
+                if (root.ValueKind == JsonValueKind.Object)
+                {
+                    if (root.TryGetProperty("access_token", out var at) && at.ValueKind == JsonValueKind.String)
+                        accessToken = at.GetString();
+                    if (root.TryGetProperty("refresh_token", out var rt) && rt.ValueKind == JsonValueKind.String)
+                        refreshToken = rt.GetString();
+                    if (root.TryGetProperty("expires_in", out var exp) && exp.ValueKind == JsonValueKind.Number)
+                        expiresInSeconds = exp.GetInt64();
+                    if (root.TryGetProperty("scope", out var sc) && sc.ValueKind == JsonValueKind.String)
+                        scope = sc.GetString();
+                    if (root.TryGetProperty("sub", out var sub) && sub.ValueKind == JsonValueKind.String)
+                        subject = sub.GetString();
+                    if (root.TryGetProperty("issued_token_type", out var itt) && itt.ValueKind == JsonValueKind.String)
+                        issuedTokenType = itt.GetString();
+                    if (root.TryGetProperty("error", out var err) && err.ValueKind == JsonValueKind.String)
+                        error = err.GetString();
+                    if (root.TryGetProperty("error_description", out var desc) && desc.ValueKind == JsonValueKind.String)
+                        errorDescription = desc.GetString();
+                }
+            }
+            catch (JsonException)
+            {
+                return TokenExchangeResult.Failure("malformed exchange response (HTTP " + statusCode + ")");
+            }
+
+            if (!isSuccessStatusCode || string.IsNullOrEmpty(accessToken))
+            {
+                var reason = error != null
+                    ? (errorDescription != null ? error + ": " + errorDescription : error)
+                    : "token exchange failed (HTTP " + statusCode + ")";
+                return TokenExchangeResult.Failure(reason);
+            }
+
+            DateTimeOffset? expiresAt = expiresInSeconds > 0
+                ? clock().AddSeconds(expiresInSeconds)
+                : (DateTimeOffset?)null;
+            return TokenExchangeResult.Success(accessToken!, refreshToken, expiresAt, scope, subject, issuedTokenType);
+        }
+    }
+}

--- a/McpPlugin/src/McpPlugin/Network/Connection/Credentials/TokenRevocationClient.cs
+++ b/McpPlugin/src/McpPlugin/Network/Connection/Credentials/TokenRevocationClient.cs
@@ -1,0 +1,107 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.AgentConfig;
+
+namespace com.IvanMurzak.McpPlugin
+{
+    /// <summary>
+    /// The RFC 7009 revocation seam (unified-machine-auth F6): revokes one credential family's
+    /// refresh token at <c>{serverTarget}/oauth/revoke</c>. Injected so the machine-wide sign-out
+    /// helper's tests substitute a fake; <see cref="TokenRevocationClient"/> is the production
+    /// implementation.
+    /// </summary>
+    public interface ITokenRevocationClient
+    {
+        /// <summary>
+        /// Revoke <paramref name="token"/> (a refresh token), presenting <paramref name="clientId"/>
+        /// when known (a legacy family of unknown id presents the component default — F6.2). Returns
+        /// true when the server acknowledged (RFC 7009 answers 200 even for an unknown token, so
+        /// true means "the server heard us", not "the token existed"); false on any transport or
+        /// server failure — the caller decides how often to retry.
+        /// </summary>
+        Task<bool> RevokeAsync(string token, string? clientId, string? serverTarget, CancellationToken cancellationToken = default);
+    }
+
+    /// <summary>
+    /// Production RFC 7009 client: POSTs <c>token</c> + <c>token_type_hint=refresh_token</c>
+    /// (+ <c>client_id</c> when known) to <c>{serverTarget}/oauth/revoke</c> with the shared 15 s
+    /// HTTP timeout. Fails soft (false) — revocation is best-effort by design (F6.4: offline
+    /// sign-out still deletes the local store; families die naturally at ≤30 d).
+    /// </summary>
+    public sealed class TokenRevocationClient : ITokenRevocationClient
+    {
+        /// <summary>Per-call HTTP timeout in ms — the shared contract value (04 §2).</summary>
+        public const int HttpTimeoutMs = MachineCredentialLock.REFRESH_HTTP_TIMEOUT;
+
+        static readonly HttpClient _sharedHttpClient = new HttpClient();
+
+        readonly string _defaultServerTarget;
+        readonly HttpClient _httpClient;
+        readonly int _timeoutMs;
+
+        /// <summary><paramref name="defaultServerTarget"/> — the AS root used when a call passes no target.</summary>
+        public TokenRevocationClient(string defaultServerTarget, HttpClient? httpClient = null)
+            : this(defaultServerTarget, httpClient, timeoutMs: null)
+        {
+        }
+
+        /// <summary>Test seam (InternalsVisibleTo: McpPlugin.Tests): override the timeout.</summary>
+        internal TokenRevocationClient(string defaultServerTarget, HttpClient? httpClient, int? timeoutMs)
+        {
+            _defaultServerTarget = HttpTokenRefresher.NormalizeServerTarget(defaultServerTarget) ?? string.Empty;
+            _httpClient = httpClient ?? _sharedHttpClient;
+            _timeoutMs = timeoutMs ?? HttpTimeoutMs;
+        }
+
+        /// <inheritdoc/>
+        public async Task<bool> RevokeAsync(string token, string? clientId, string? serverTarget, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrEmpty(token))
+                return true; // nothing to revoke — vacuously acknowledged
+
+            var baseUrl = HttpTokenRefresher.NormalizeServerTarget(serverTarget) ?? _defaultServerTarget;
+            if (string.IsNullOrEmpty(baseUrl))
+                return false;
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var form = new List<KeyValuePair<string, string>>
+            {
+                new KeyValuePair<string, string>("token", token),
+                new KeyValuePair<string, string>("token_type_hint", "refresh_token"),
+            };
+            if (!string.IsNullOrEmpty(clientId))
+                form.Add(new KeyValuePair<string, string>("client_id", clientId!));
+
+            using var timeout = new CancellationTokenSource(_timeoutMs);
+            try
+            {
+                using var content = new FormUrlEncodedContent(form);
+                using var response = await _httpClient.PostAsync(baseUrl + "/oauth/revoke", content, timeout.Token).ConfigureAwait(false);
+                return response.IsSuccessStatusCode;
+            }
+            catch (OperationCanceledException) when (timeout.IsCancellationRequested)
+            {
+                return false;
+            }
+            catch (Exception)
+            {
+                return false; // best-effort by design (F6.4); never token material in any log
+            }
+        }
+    }
+}


### PR DESCRIPTION
unified-machine-auth **b3-cs-refresher** — the ONE shared C# refresh implementation for all three engine plugins (design 04 §3), the RFC 8693 exchange client (04 §4, a5-frozen shape), the F1 two-lock-hold login-commit helper, the F6 machine-wide sign-out helper, and the lock-integrated double-checked refresh path in `PluginCredentialProvider`.

## What changed

- **`ITokenRefresher` (published NuGet public API)** — new family-aware `RefreshAsync(TokenRefreshRequest, CancellationToken)` overload added as a **default interface method**; the legacy two-string method stays abstract and unchanged. `TokenRefreshResult` gains `FailureKind` (`InvalidGrant` vs `Transient`) via a new `Failure(reason, kind)` overload.
- **`HttpTokenRefresher` (new, shared)** — presents the family's **stored `clientId`** (component default only for a legacy family of unknown id, 04 §3.7); **omits `scope` and `resource` entirely** (04 §3.3 / P0-3 — the server falls back to the stored grant); success without `refresh_token` ⇒ caller keeps the previous one (04 §3.4); **one network attempt per family per skew window per process** (04 §3.6, keyed by refresh token, in-flight attempt shared); **15 s HTTP timeout** (= `REFRESH_HTTP_TIMEOUT`, 04 §2); `invalid_grant` classified distinctly (04 §3.5).
- **`TokenExchangeClient` (new)** — RFC 8693 agent→plugin derivation, exactly the a5-frozen wire shape (`grant_type`/`subject_token`/`subject_token_type` URNs, `client_id` ≤64, `scope=mcp:plugin`); `audience`/`resource` deliberately omitted. **`TokenRevocationClient` (new)** — RFC 7009, fail-soft.
- **`PluginCredentialProvider`** — refresh (proactive 60 s skew + reactive 401) now runs under the cross-process `MachineCredentialLock` with **re-read-first double-checking** (peer rotations adopted without a network call); `Unreadable` mid-refresh = **busy/retry**, never signed-out, never overwrite (b1 review A3); `IsStillOwned()` checked immediately before the store write (b2 review A1); `invalid_grant` → post-failure re-read → **dead-family verdict** with ONE structured telemetry event, other families never deleted, never loops (03 F3.5); family-aware read-modify-`Write()` — **never `Store.Rotate()`**; legacy §3.7 rewrite to v2 (+mirror) on first successful refresh; `SignOut()` routes through the 04 §2 lock delete path; boot on an unreadable store now surfaces `SignInRequired` (not `SignedOut`).
- **`MachineCredentialLoginCommit` (new)** — the F1 sequence: agent family (first hold) → exchange (no lock) → plugin family + v1 mirror (second hold); failed exchange leaves the committed agent family (`AgentOnly`); F7 subject guard refuses silent cross-account overwrite. **`MachineWideSignOut` (new)** — F6: revoke every family (stored `clientId`s; component default for legacy) with bounded retries, then the lock-protocol delete; offline sign-out still deletes locally.

## ⚠ Cascade note — public NuGet API change (for d1 Unity / e1 Godot / f1 Unreal)

**Compat strategy: default-interface-method overload — chosen over an in-place signature change** so all three engine repos compile unmodified against this release (verified below). Consequences:

1. **Nothing breaks at compile time.** The legacy `RefreshAsync(string, string?, CancellationToken)` is untouched and still abstract; `UnityTokenRefresher`, `GodotTokenRefresher`, and the Unreal bridge `OAuthTokenRefresher` keep compiling as-is.
2. **`PluginCredentialProvider` now calls the NEW overload.** For an un-migrated engine refresher, the DIM delegates to the legacy method — i.e. status-quo behavior (component-default `client_id`; Unity additionally still sends `scope`, the P0-3 defect). **b3 makes the cascade non-breaking; it does not deliver the engine-side fixes — d1/e1/f1 must still replace the engine refreshers with `new HttpTokenRefresher(defaultServerTarget, componentClientId)`** (delete or thin-adapter the local ones).
3. **Test-suite gotcha (hit in this repo, will hit engines):** Moq/Castle **intercepts the DIM**, so a loose `Mock<ITokenRefresher>` returns a null `Task` to the provider unless you add `Setup(r => r.RefreshAsync(It.IsAny<TokenRefreshRequest>(), It.IsAny<CancellationToken>()))`. Engine test suites that mock `ITokenRefresher` need the same one-line setup.
4. **`PluginCredentialProvider` ctor** gained trailing optional parameters (`credentialLock`) — source-compatible, binary-breaking (engines recompile against the package, so this is automatic; no call-site change needed unless injecting a custom lock).
5. **Behavior engines inherit by recompiling:** refresh under the machine-wide file lock with double-checked re-read; lock-busy = transient false (no `SignInRequired`); unreadable-store boot = `SignInRequired`; `SignOut()` via the lock delete path.
6. **New helpers to adopt in the cascades:** F1 login → `MachineCredentialLoginCommit.CommitAsync(store, lock, agentFamily, serverTarget, subject, new TokenExchangeClient(target, ownClientId))`; F6 sign-out → `MachineWideSignOut.SignOutAsync(store, lock, new TokenRevocationClient(target), componentClientId)`.
7. **TFM/profile:** all new API compiles on `netstandard2.1` + `LangVersion 9` (Unity 2022.3+ supports default interface methods; verified by the Unity-profile smoke below).

## Evidence

- `dotnet test McpPlugin.Tests` — **933/933 green on net8.0 AND net9.0** (66 new tests across `HttpTokenRefresherTests`, `TokenExchangeClientTests`, `PluginCredentialProviderFamilyRefreshTests`, `MachineCredentialLoginCommitTests`, `MachineWideSignOutTests`, plus the b1-A1 `Adopt`/`Write` mutation-seam pin). `McpPlugin.Server.Tests` — 684/684 green both TFMs. Full solution builds (netstandard2.1 leg included).
- **Mandated plants (G-SEC-1), RED-verified then reverted:**
  - Plant A (`client_id` ← component default, ignoring the stored id): `Refresh_PresentsTheFamilysStoredClientId_NeverTheComponentDefault` **RED** (1 failed / 18 passed) — the cross-mint discriminator, mirrors probe Q1.
  - Plant B (`scope=mcp:plugin` added to the refresh form): `Refresh_OmitsScopeAndResourceEntirely` **and** `Refresh_LegacyTwoStringApi_PresentsTheComponentDefault_AndStillOmitsScope` **RED** (2 failed / 17 passed) — the P0-3 discriminator.
- **Engine smoke-compiles (scratch copies, engines untouched):** Godot-MCP full plugin project against the locally-packed `com.IvanMurzak.McpPlugin 99.0.0-b3smoke` — **Build succeeded**; Unreal bridge sidecar via its own `-p:UseLocalMcpPlugin=true` source-reference mechanism against this branch — **Build succeeded**; Unity's real `UnityTokenRefresher.cs` + `DeviceAuthService.cs` compiled verbatim under the Unity profile (`netstandard2.1`, C# 9) against the packed package — **Build succeeded**.

Release/versioning is task b4 — this PR intentionally does not touch `<Version>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017azy3BykDQDSpxc5F51GAF
