### PR TITLE
test: RefreshHarness console harness for the x2 mixed-language concurrency suite

### DIFF
--- a/McpPlugin.Tests.RefreshHarness/McpPlugin.Tests.RefreshHarness.csproj
+++ b/McpPlugin.Tests.RefreshHarness/McpPlugin.Tests.RefreshHarness.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!-- Real-subprocess harness for the mixed-language refresh concurrency suite
+       (unified-machine-auth 04 §5 "Concurrency - real processes, not threads", task x2).
+       Exposes the REAL McpPlugin credential stack - MachineCredentialStore,
+       MachineCredentialLock, HttpTokenRefresher, PluginCredentialProvider - as a console
+       process so the cross-language suite in AI-Game-Dev-CLI-Core
+       (test/concurrency-suite.subprocess.test.ts) can spawn C# workers next to Node workers
+       against one shared store and a local fake authorization server.
+       Test infrastructure only - never packed. -->
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>11.0</LangVersion>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>com.IvanMurzak.McpPlugin.Tests.RefreshHarness</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../McpPlugin/McpPlugin.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/McpPlugin.Tests.RefreshHarness/Program.cs
+++ b/McpPlugin.Tests.RefreshHarness/Program.cs
@@ -11,10 +11,12 @@
 #nullable enable
 using System;
 using System.IO;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using com.IvanMurzak.McpPlugin;
 using com.IvanMurzak.McpPlugin.AgentConfig;
+using Microsoft.Extensions.Logging;
 
 namespace com.IvanMurzak.McpPlugin.Tests.RefreshHarness
 {
@@ -68,6 +70,35 @@ namespace com.IvanMurzak.McpPlugin.Tests.RefreshHarness
         {
             Console.Out.WriteLine(line);
             Console.Out.Flush(); // the parent driver reacts to lines in real time — never buffer
+        }
+
+        /// <summary>
+        /// Minimal <see cref="ILogger"/> surfacing the provider's warnings as machine-parseable
+        /// stdout lines: <c>WARN t=&lt;unixMs&gt; m=&lt;base64 rendered message&gt;</c>. These are the
+        /// C# side's client-visible LOSS records — "Persisting refreshed credential failed" /
+        /// "Credential lock was taken over mid-refresh" mean a received rotation was NOT persisted
+        /// (the store still holds the AS-revoked predecessor); "Token refresh threw/failed
+        /// transiently" records a failed attempt that may have committed at the AS. The x2 driver
+        /// correlates them against the fake AS's grant-decision log to ATTRIBUTE every green-run
+        /// D10 grace hit; a grace hit no worker can account for is a serialization finding.
+        /// </summary>
+        private sealed class StdoutWarningLogger : ILogger
+        {
+            public static readonly StdoutWarningLogger Instance = new StdoutWarningLogger();
+
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+            public bool IsEnabled(LogLevel logLevel) => logLevel >= LogLevel.Warning;
+
+            public void Log<TState>(
+                LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+                Func<TState, Exception?, string> formatter)
+            {
+                if (!IsEnabled(logLevel))
+                    return;
+                var message = formatter(state, exception);
+                Report("WARN t=" + NowUnixMs + " m=" + Convert.ToBase64String(Encoding.UTF8.GetBytes(message)));
+            }
         }
 
         private static async Task<int> Main(string[] args)
@@ -170,7 +201,7 @@ namespace com.IvanMurzak.McpPlugin.Tests.RefreshHarness
                 using var provider = new PluginCredentialProvider(
                     store,
                     counting,
-                    logger: null,
+                    logger: StdoutWarningLogger.Instance,
                     refreshSkew: TimeSpan.FromMilliseconds(skewMs),
                     clock: null,
                     credentialLock: new MachineCredentialLock(baseDir));
@@ -292,7 +323,8 @@ namespace com.IvanMurzak.McpPlugin.Tests.RefreshHarness
 
             var counting = new CountingRefresher(httpRefresher);
             using var provider = new PluginCredentialProvider(
-                store, counting, logger: null, refreshSkew: null, clock: null, credentialLock: credentialLock);
+                store, counting, logger: StdoutWarningLogger.Instance,
+                refreshSkew: null, clock: null, credentialLock: credentialLock);
 
             Report("READY t=" + NowUnixMs + " pid=" + Environment.ProcessId + " mode=once" + (scaled != null ? "-scaled" : ""));
 

--- a/McpPlugin.Tests.RefreshHarness/Program.cs
+++ b/McpPlugin.Tests.RefreshHarness/Program.cs
@@ -1,0 +1,307 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.McpPlugin.AgentConfig;
+
+namespace com.IvanMurzak.McpPlugin.Tests.RefreshHarness
+{
+    /// <summary>
+    /// Subprocess harness for the mixed-language refresh concurrency suite (unified-machine-auth
+    /// 04 §5 — real OS processes, not threads; task x2). Spawned by the cross-language driver in
+    /// AI-Game-Dev-CLI-Core (<c>test/concurrency-suite.subprocess.test.ts</c>) next to Node
+    /// worker processes, all contending on ONE shared machine credential store against a local
+    /// fake authorization server. Every event is a machine-parseable stdout line, flushed
+    /// immediately.
+    ///
+    /// <para>The store runs in the internal plaintext-for-testing mode (the C# counterpart of the
+    /// TS <c>identityCredentialCodec</c>) so both languages share one at-rest format; DPAPI
+    /// cross-implementation parity is proven separately (task x1).</para>
+    ///
+    /// <para>Commands:</para>
+    /// <list type="bullet">
+    ///   <item><c>hammer &lt;baseDir&gt; &lt;serverBase&gt; &lt;clientId&gt; &lt;skewMs&gt;
+    ///         &lt;loopDelayMs&gt; &lt;maxDurationMs&gt; &lt;stopFile&gt;</c> — the REAL stack
+    ///         (<see cref="PluginCredentialProvider"/> over the public
+    ///         <see cref="MachineCredentialLock"/> with the real 15/60/75 s contract constants),
+    ///         looping <see cref="PluginCredentialProvider.GetAccessTokenAsync"/> until the stop
+    ///         file appears. Exit 0 = clean; 5 = the family died (sign-in required).</item>
+    ///   <item><c>hammer-nolock …same args…</c> — the LOCK-DISABLED plant composition: the same
+    ///         real store + real <see cref="HttpTokenRefresher"/>, driven directly WITHOUT the
+    ///         cross-process lock (read → refresh → write, racing everyone). Exists to prove the
+    ///         suite goes red / redundant when the lock control is removed (04 §5 mandated
+    ///         plants). Exit 5 on invalid_grant (the family-revoke signal the plant watches
+    ///         for).</item>
+    ///   <item><c>once &lt;baseDir&gt; &lt;serverBase&gt; &lt;clientId&gt;
+    ///         [--scaled t,s,b]</c> — a single forced
+    ///         <see cref="PluginCredentialProvider.RefreshAsync"/>. The kill-victim and the
+    ///         lost-response retry of the D10 grace-window plant. <c>--scaled</c> shrinks the
+    ///         HTTP-timeout / lock-stale / acquire-budget trio (internal test ctors) so a crashed
+    ///         peer's orphan lock is taken over WITHIN the 30 s grace window; the ordering
+    ///         invariant <c>timeout &lt; stale &lt; budget</c> is asserted before use (04 §2 —
+    ///         scaled-down variants must preserve it). Exit 0 = refreshed; 5 = sign-in required;
+    ///         7 = attempt failed.</item>
+    /// </list>
+    /// </summary>
+    internal static class Program
+    {
+        private const int ExitOk = 0;
+        private const int ExitUsage = 1;
+        private const int ExitDead = 5;
+        private const int ExitOnceFailed = 7;
+
+        private static long NowUnixMs => DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+
+        private static void Report(string line)
+        {
+            Console.Out.WriteLine(line);
+            Console.Out.Flush(); // the parent driver reacts to lines in real time — never buffer
+        }
+
+        private static async Task<int> Main(string[] args)
+        {
+            try
+            {
+                if (args.Length < 4)
+                    return Usage();
+
+                var command = args[0];
+                var baseDir = args[1];
+                var serverBase = args[2];
+                var clientId = args[3];
+
+                switch (command)
+                {
+                    case "hammer":
+                    case "hammer-nolock":
+                        if (args.Length != 8)
+                            return Usage();
+                        return await Hammer(
+                            baseDir, serverBase, clientId,
+                            skewMs: int.Parse(args[4]),
+                            loopDelayMs: int.Parse(args[5]),
+                            maxDurationMs: int.Parse(args[6]),
+                            stopFile: args[7],
+                            useLock: command == "hammer").ConfigureAwait(false);
+                    case "once":
+                        string? scaled = null;
+                        if (args.Length == 6 && args[4] == "--scaled")
+                            scaled = args[5];
+                        else if (args.Length != 4)
+                            return Usage();
+                        return await Once(baseDir, serverBase, clientId, scaled).ConfigureAwait(false);
+                    default:
+                        Console.Error.WriteLine("unknown command: " + command);
+                        return ExitUsage;
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine("ERR " + ex);
+                return ExitUsage;
+            }
+        }
+
+        private static int Usage()
+        {
+            Console.Error.WriteLine(
+                "usage: hammer|hammer-nolock <baseDir> <serverBase> <clientId> <skewMs> <loopDelayMs> <maxDurationMs> <stopFile>\n" +
+                "       once <baseDir> <serverBase> <clientId> [--scaled <httpTimeoutMs>,<staleMs>,<budgetMs>]");
+            return ExitUsage;
+        }
+
+        /// <summary>Counts successful refresh responses so the driver can attribute per-language
+        /// rotation work from the <c>DONE refreshes=…</c> line (the fake AS's counters stay the
+        /// authoritative cross-check).</summary>
+        private sealed class CountingRefresher : ITokenRefresher
+        {
+            private readonly ITokenRefresher _inner;
+            private int _successCount;
+
+            public CountingRefresher(ITokenRefresher inner)
+            {
+                _inner = inner;
+            }
+
+            public int SuccessCount => Volatile.Read(ref _successCount);
+
+            public Task<TokenRefreshResult> RefreshAsync(string refreshToken, string? serverTarget, CancellationToken cancellationToken = default)
+                => CountAsync(_inner.RefreshAsync(refreshToken, serverTarget, cancellationToken));
+
+            public Task<TokenRefreshResult> RefreshAsync(TokenRefreshRequest request, CancellationToken cancellationToken = default)
+                => CountAsync(_inner.RefreshAsync(request, cancellationToken));
+
+            private async Task<TokenRefreshResult> CountAsync(Task<TokenRefreshResult> attempt)
+            {
+                var result = await attempt.ConfigureAwait(false);
+                if (result != null && result.Succeeded)
+                    Interlocked.Increment(ref _successCount);
+                return result!;
+            }
+        }
+
+        private static async Task<int> Hammer(
+            string baseDir, string serverBase, string clientId,
+            int skewMs, int loopDelayMs, int maxDurationMs, string stopFile, bool useLock)
+        {
+            var store = new MachineCredentialStore(baseDir, plaintextForTesting: true);
+            var counting = new CountingRefresher(new HttpTokenRefresher(serverBase, clientId));
+
+            Report("READY t=" + NowUnixMs + " pid=" + Environment.ProcessId + " mode=" + (useLock ? "hammer" : "hammer-nolock"));
+
+            var deadline = DateTimeOffset.UtcNow.AddMilliseconds(maxDurationMs);
+            string? lastToken = null;
+            var distinct = 0;
+
+            if (useLock)
+            {
+                using var provider = new PluginCredentialProvider(
+                    store,
+                    counting,
+                    logger: null,
+                    refreshSkew: TimeSpan.FromMilliseconds(skewMs),
+                    clock: null,
+                    credentialLock: new MachineCredentialLock(baseDir));
+
+                while (DateTimeOffset.UtcNow < deadline && !File.Exists(stopFile))
+                {
+                    var token = await provider.GetAccessTokenAsync(CancellationToken.None).ConfigureAwait(false);
+                    if (provider.State.CurrentValue == AuthState.SignInRequired)
+                    {
+                        Report("GRANT-DEAD t=" + NowUnixMs + " refreshes=" + counting.SuccessCount);
+                        return ExitDead;
+                    }
+                    if (token == null)
+                    {
+                        Report("GRANT-DEAD t=" + NowUnixMs + " reason=no-token refreshes=" + counting.SuccessCount);
+                        return ExitDead;
+                    }
+                    if (token != lastToken)
+                    {
+                        lastToken = token;
+                        distinct++;
+                        Report("TOKEN t=" + NowUnixMs + " v=" + token);
+                    }
+                    await Task.Delay(loopDelayMs).ConfigureAwait(false);
+                }
+
+                Report("DONE t=" + NowUnixMs + " refreshes=" + counting.SuccessCount + " distinct=" + distinct);
+                return ExitOk;
+            }
+
+            // Lock-DISABLED composition (mandated plant): real store + real refresher, no mutual
+            // exclusion. Re-reads immediately before each attempt (mirroring the provider's
+            // re-read-first discipline) so the raced presents are predecessors, not stale
+            // generations — the case the D10 grace window is specified to absorb.
+            while (DateTimeOffset.UtcNow < deadline && !File.Exists(stopFile))
+            {
+                var read = store.TryRead();
+                if (read.Status != MachineCredentialStoreStatus.Ok || read.Credentials == null)
+                {
+                    // Transient mid-replace read or a vanished store — retry next cycle.
+                    await Task.Delay(loopDelayMs).ConfigureAwait(false);
+                    continue;
+                }
+
+                var credentials = read.Credentials;
+                var family = credentials.Families?.Plugin ?? credentials.Families?.Legacy;
+                if (family?.RefreshToken == null)
+                {
+                    Report("GRANT-DEAD t=" + NowUnixMs + " reason=no-refresh-token refreshes=" + counting.SuccessCount);
+                    return ExitDead;
+                }
+
+                var withinSkew = family.ExpiresAt == null
+                    || family.ExpiresAt.Value - DateTimeOffset.UtcNow <= TimeSpan.FromMilliseconds(skewMs);
+                if (withinSkew)
+                {
+                    var request = new TokenRefreshRequest(family.RefreshToken!, serverBase, family.ClientId);
+                    var result = await counting.RefreshAsync(request, CancellationToken.None).ConfigureAwait(false);
+                    if (result.Succeeded)
+                    {
+                        family.AccessToken = result.AccessToken;
+                        family.RefreshToken = string.IsNullOrEmpty(result.RefreshToken) ? family.RefreshToken : result.RefreshToken;
+                        family.ExpiresAt = result.ExpiresAt;
+                        store.Write(credentials); // NO LOCK — the control this plant removes
+                        if (result.AccessToken != lastToken)
+                        {
+                            lastToken = result.AccessToken;
+                            distinct++;
+                            Report("TOKEN t=" + NowUnixMs + " v=" + result.AccessToken);
+                        }
+                    }
+                    else if (result.FailureKind == TokenRefreshFailureKind.InvalidGrant)
+                    {
+                        Report("GRANT-DEAD t=" + NowUnixMs + " reason=" + (result.FailureReason ?? "invalid_grant") + " refreshes=" + counting.SuccessCount);
+                        return ExitDead;
+                    }
+                    // Transient failures: retry next cycle.
+                }
+
+                await Task.Delay(loopDelayMs).ConfigureAwait(false);
+            }
+
+            Report("DONE t=" + NowUnixMs + " refreshes=" + counting.SuccessCount + " distinct=" + distinct);
+            return ExitOk;
+        }
+
+        private static async Task<int> Once(string baseDir, string serverBase, string clientId, string? scaled)
+        {
+            var store = new MachineCredentialStore(baseDir, plaintextForTesting: true);
+
+            HttpTokenRefresher httpRefresher;
+            MachineCredentialLock credentialLock;
+            if (scaled != null)
+            {
+                var parts = scaled.Split(',');
+                if (parts.Length != 3)
+                    return Usage();
+                var timeoutMs = int.Parse(parts[0]);
+                var staleMs = int.Parse(parts[1]);
+                var budgetMs = int.Parse(parts[2]);
+
+                // 04 §2: a scaled-down variant is acceptable ONLY when the ordering invariant
+                // (HTTP timeout < lock-stale < acquire-budget) is preserved — assert it.
+                if (!(timeoutMs < staleMs && staleMs < budgetMs))
+                    throw new InvalidOperationException(
+                        "scaled constants must preserve the ordering invariant timeout < stale < budget, got: " + scaled);
+
+                httpRefresher = new HttpTokenRefresher(
+                    serverBase, clientId, httpClient: null, clock: null, attemptWindow: null, timeoutMs: timeoutMs);
+                credentialLock = new MachineCredentialLock(
+                    baseDir, hostId: null, acquireBudgetMs: budgetMs, staleMs: staleMs,
+                    foreignStaleMs: MachineCredentialLock.FOREIGN_HOST_STALE_MS);
+            }
+            else
+            {
+                httpRefresher = new HttpTokenRefresher(serverBase, clientId);
+                credentialLock = new MachineCredentialLock(baseDir);
+            }
+
+            var counting = new CountingRefresher(httpRefresher);
+            using var provider = new PluginCredentialProvider(
+                store, counting, logger: null, refreshSkew: null, clock: null, credentialLock: credentialLock);
+
+            Report("READY t=" + NowUnixMs + " pid=" + Environment.ProcessId + " mode=once" + (scaled != null ? "-scaled" : ""));
+
+            var ok = await provider.RefreshAsync(CancellationToken.None).ConfigureAwait(false);
+            Report("ONCE t=" + NowUnixMs + " ok=" + (ok ? "true" : "false") + " refreshes=" + counting.SuccessCount);
+
+            if (provider.State.CurrentValue == AuthState.SignInRequired)
+                return ExitDead;
+            return ok ? ExitOk : ExitOnceFailed;
+        }
+    }
+}

--- a/McpPlugin.sln
+++ b/McpPlugin.sln
@@ -19,6 +19,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DemoWebApp", "DemoWebApp\De
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "McpPlugin.Tests.LockHarness", "McpPlugin.Tests.LockHarness\McpPlugin.Tests.LockHarness.csproj", "{ED1FA9D0-232B-4947-B182-E3ED3EA04A11}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "McpPlugin.Tests.RefreshHarness", "McpPlugin.Tests.RefreshHarness\McpPlugin.Tests.RefreshHarness.csproj", "{FAD5619B-90A6-4EC9-8ADF-8FF91572B459}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -125,6 +127,18 @@ Global
 		{ED1FA9D0-232B-4947-B182-E3ED3EA04A11}.Release|x64.Build.0 = Release|Any CPU
 		{ED1FA9D0-232B-4947-B182-E3ED3EA04A11}.Release|x86.ActiveCfg = Release|Any CPU
 		{ED1FA9D0-232B-4947-B182-E3ED3EA04A11}.Release|x86.Build.0 = Release|Any CPU
+		{FAD5619B-90A6-4EC9-8ADF-8FF91572B459}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FAD5619B-90A6-4EC9-8ADF-8FF91572B459}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FAD5619B-90A6-4EC9-8ADF-8FF91572B459}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FAD5619B-90A6-4EC9-8ADF-8FF91572B459}.Debug|x64.Build.0 = Debug|Any CPU
+		{FAD5619B-90A6-4EC9-8ADF-8FF91572B459}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FAD5619B-90A6-4EC9-8ADF-8FF91572B459}.Debug|x86.Build.0 = Debug|Any CPU
+		{FAD5619B-90A6-4EC9-8ADF-8FF91572B459}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FAD5619B-90A6-4EC9-8ADF-8FF91572B459}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FAD5619B-90A6-4EC9-8ADF-8FF91572B459}.Release|x64.ActiveCfg = Release|Any CPU
+		{FAD5619B-90A6-4EC9-8ADF-8FF91572B459}.Release|x64.Build.0 = Release|Any CPU
+		{FAD5619B-90A6-4EC9-8ADF-8FF91572B459}.Release|x86.ActiveCfg = Release|Any CPU
+		{FAD5619B-90A6-4EC9-8ADF-8FF91572B459}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/McpPlugin/McpPlugin.csproj
+++ b/McpPlugin/McpPlugin.csproj
@@ -2,6 +2,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="McpPlugin.Tests" />
+    <InternalsVisibleTo Include="McpPlugin.Tests.RefreshHarness" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/McpPlugin/src/AgentConfig/MachineCredentialStore.cs
+++ b/McpPlugin/src/AgentConfig/MachineCredentialStore.cs
@@ -91,6 +91,7 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
         };
 
         private readonly string _baseDirectory;
+        private readonly bool _plaintextForTesting;
 
         /// <summary>
         /// Create a store rooted at <paramref name="baseDirectory"/>, or at <c>~/.ai-game-dev</c> when
@@ -98,10 +99,26 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
         /// callers use the default machine store.
         /// </summary>
         public MachineCredentialStore(string? baseDirectory = null)
+            : this(baseDirectory, plaintextForTesting: false)
+        {
+        }
+
+        /// <summary>
+        /// Test seam (InternalsVisibleTo: McpPlugin.Tests / McpPlugin.Tests.RefreshHarness):
+        /// <paramref name="plaintextForTesting"/> true skips the Windows DPAPI codec so the on-disk
+        /// document is plaintext JSON on every OS — the same escape the TypeScript twin exposes
+        /// publicly as <c>identityCredentialCodec</c> (cli-core <c>machine-credentials.ts</c>). The
+        /// mixed-language concurrency suite (unified-machine-auth 04 §5, task x2) shares one store
+        /// between C# and Node worker processes, which is only practical with a common at-rest
+        /// format; DPAPI cross-implementation parity is proven separately (task x1). Never used in
+        /// production: the public constructor pins the platform codec.
+        /// </summary>
+        internal MachineCredentialStore(string? baseDirectory, bool plaintextForTesting)
         {
             _baseDirectory = baseDirectory ?? Path.Combine(
                 Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
                 DirectoryName);
+            _plaintextForTesting = plaintextForTesting;
         }
 
         /// <summary>Absolute path of the store directory.</summary>
@@ -164,7 +181,7 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
                 return MachineCredentialReadResult.Unreadable("credential file is empty");
 
             byte[] plaintext;
-            if (IsWindows)
+            if (IsWindows && !_plaintextForTesting)
             {
                 try
                 {
@@ -295,7 +312,7 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
                 return null;
 
             var raw = File.ReadAllBytes(CredentialsPath);
-            var plaintext = IsWindows ? Unprotect(raw) : raw;
+            var plaintext = IsWindows && !_plaintextForTesting ? Unprotect(raw) : raw;
             return Encoding.UTF8.GetString(plaintext);
         }
 
@@ -327,7 +344,7 @@ namespace com.IvanMurzak.McpPlugin.AgentConfig
         private void WriteProtected(string json)
         {
             var plaintext = Encoding.UTF8.GetBytes(json);
-            var bytes = IsWindows ? Protect(plaintext) : plaintext;
+            var bytes = IsWindows && !_plaintextForTesting ? Protect(plaintext) : plaintext;
             WriteFileAtomic(CredentialsPath, bytes);
             SetPosixPermissions(CredentialsPath, PosixFilePermissions);
         }


### PR DESCRIPTION
C# half of the **x2 mixed-language concurrency suite** (taskflow `unified-machine-auth`, 04 §5 "Concurrency — real processes, not threads" / 03 F8). Coordinated PR pair with `AI-Game-Dev-CLI-Core#worktree-x2-concurrency-suite`, which holds the driver, the fake AS, and the suite's one CI home.

## What this adds

- **`McpPlugin.Tests.RefreshHarness/`** — a console exe (modeled on `McpPlugin.Tests.LockHarness`) exposing the REAL credential stack — `MachineCredentialStore`, `MachineCredentialLock`, `HttpTokenRefresher`, `PluginCredentialProvider` — as an OS worker process. The cli-core driver spawns it next to Node workers, all contending on ONE shared machine store against a local fake authorization server (line-cited mirror of `oauth_token_service.py` rotation + reuse⇒family-revoke + D10 grace window). Modes:
  - `hammer` — the real locked refresh loop (`GetAccessTokenAsync`), public ctors only, REAL 15/60/75 s contract constants;
  - `hammer-nolock` — the lock-DISABLED plant composition (same store + refresher, no mutual exclusion) for the mandated falsifiability plants;
  - `once [--scaled t,s,b]` — the lost-response plant's kill-victim and its retry; scaled constants go through the internal test ctors and the `timeout < stale < budget` ordering invariant is asserted before use (04 §2).
- **`MachineCredentialStore`: internal `plaintextForTesting` ctor overload** — the C# counterpart of the TS `identityCredentialCodec`. The mixed suite shares one store file between C# and Node processes, which needs a common at-rest format; the TS DPAPI codec shells PowerShell per operation (~1–2 s), which would make a ≥100-rotation hammer unrunnable. DPAPI↔DPAPI cross-implementation parity stays proven by the x1 suite. **No production behavior change**: the public constructor pins the platform codec exactly as before; the seam is `internal` + `InternalsVisibleTo`.
- Solution registration (fresh GUID, full config matrix) so the root `dotnet build` builds the harness on every CI leg.

## CI home (documented per the task's DoD)

The suite itself runs in **cli-core's `.github/workflows/concurrency-suite.yml`** — one CI home invoking both toolchains on 3 hosted OS legs (ubuntu / windows / macos), cloning this repo by ref (this branch, falling back to `main` after merge). This repo's own CI builds the harness (via the sln) and runs its full test suite unchanged.

## Evidence (local, Windows)

- Full solution test suite with the seam in place: `McpPlugin.Tests` 943 passed ×(net8+net9), `McpPlugin.Server.Tests` 684 passed ×2, 0 failed.
- Mixed suite 6/6 green via the cli-core driver: acceptance 111 rotations / **0 family revokes / 0 grace hits** at N=4 (2 C# + 2 TS); all three plants red-verified — incl. plant 3 both directions (a killed TS client's orphan lock taken over by this harness with scaled constants inside the D10 window, and vice versa, identical successor pair by value).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017azy3BykDQDSpxc5F51GAF


---

## Round 7 (resume): WARN stdout channel for the x2 grace-hit attribution

`1bd964e` — the harness previously passed `logger: null`, so a rotation received but **not persisted** (a Windows sharing-violation on the store write) was invisible from outside the process. A minimal `ILogger` now renders the provider's warnings as `WARN t=<unixMs> m=<base64 message>` stdout lines; the cli-core driver (PR IvanMurzak/AI-Game-Dev-CLI-Core#11) parses and classifies them (`Persisting … failed` / `lock was taken over` ⇒ LOST-WRITE; `refresh threw` / `failed transiently` ⇒ LOST-RESPONSE) to attribute every green-run D10 grace hit to a recorded client-side loss. No behavioral change to the credential stack — the C# store already implements the 04 §1 rename-retry contract and recorded **zero** losses under the suite's pressure runs; the root cause (the TS store missing that contractual retry) is fixed in the sibling PR.
