### PR TITLE
feat(server): server-side MCP replace-by-identity rule (W5.4 / D10.2)

### DIFF
--- a/McpPlugin.Common/McpPlugin.Common.csproj
+++ b/McpPlugin.Common/McpPlugin.Common.csproj
@@ -11,7 +11,7 @@
     <!-- NuGet Package Information -->
     <IsPackable>true</IsPackable>
     <PackageId>com.IvanMurzak.McpPlugin.Common</PackageId>
-    <Version>8.1.0</Version>
+    <Version>8.2.0</Version>
     <Authors>Ivan Murzak</Authors>
     <Company>Ivan Murzak</Company>
     <Copyright>Copyright © Ivan Murzak 2025</Copyright>

--- a/McpPlugin.Common/src/Utils/Consts.MCP.cs
+++ b/McpPlugin.Common/src/Utils/Consts.MCP.cs
@@ -274,6 +274,23 @@ namespace com.IvanMurzak.McpPlugin.Common
 
                     /// <summary>Value the trusted-client header must carry to opt in.</summary>
                     public const string TrustedInternalClientOptInValue = "1";
+
+                    /// <summary>
+                    /// Per-installation MCP instance identity (design 07 §2.3, D10.2). The value is
+                    /// <c>HMAC-SHA256(key = installId, msg = accountSub)</c> truncated to 128 bits and
+                    /// hex-encoded — i.e. exactly 32 lower-case hex characters. It is stable per
+                    /// <c>(installation, account)</c> and unlinkable across accounts, because the server
+                    /// never sees <c>installId</c>.
+                    ///
+                    /// <para><b>No <c>X-</c> prefix, per RFC 6648.</b> The name must match the client's
+                    /// byte-for-byte; see <c>InstanceIdentityHeader</c> for the validation contract.</para>
+                    ///
+                    /// <para><b>This is a routing key, never an authenticator.</b> It is only ever used
+                    /// WITHIN the <c>accountSub</c> scope the bearer credential already established, so a
+                    /// spoofed value can evict only the spoofer's own sessions. Absent is a supported
+                    /// state: a client that never sends it keeps the pre-existing behaviour exactly.</para>
+                    /// </summary>
+                    public const string InstanceId = "AI-Game-Dev-Instance-Id";
                 }
             }
         }

--- a/McpPlugin.Common/src/Utils/Consts.cs
+++ b/McpPlugin.Common/src/Utils/Consts.cs
@@ -12,7 +12,7 @@ namespace com.IvanMurzak.McpPlugin.Common
     public static partial class Consts
     {
         public const string ApiVersion = "2.0.0";
-        public const string PluginVersion = "8.1.0";
+        public const string PluginVersion = "8.2.0";
 
         public static class Guid
         {

--- a/McpPlugin.Server.Tests/InstanceIdentityHeaderTests.cs
+++ b/McpPlugin.Server.Tests/InstanceIdentityHeaderTests.cs
@@ -1,0 +1,228 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Linq;
+using com.IvanMurzak.McpPlugin.Common;
+using com.IvanMurzak.McpPlugin.Server.Auth;
+using Microsoft.AspNetCore.Http;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.Server.Tests
+{
+    /// <summary>
+    /// The opaque-token contract for <c>AI-Game-Dev-Instance-Id</c> (design 07 §2.3, D10.2).
+    ///
+    /// <para>Everything here exists because the value is <b>client-supplied and untrusted</b>. It is
+    /// validated to a fixed length over a closed charset BEFORE it is used anywhere, which is what makes
+    /// every downstream use safe by construction instead of safe by remembering to escape.</para>
+    ///
+    /// <para><b>The tri-state is the point.</b> ABSENT and MALFORMED must not collapse into each other:
+    /// absent is every currently released client and must behave exactly as it does today, while malformed
+    /// is a client that believes it is participating in the replace rule and would otherwise silently
+    /// stack sessions forever.</para>
+    /// </summary>
+    public sealed class InstanceIdentityHeaderTests
+    {
+        // A well-formed value: 128 bits of HMAC output, hex ⇒ exactly 32 chars.
+        const string ValidId = "0123456789abcdef0123456789abcdef";
+
+        [Fact]
+        public void HeaderName_IsExactlyTheContractedName_WithNoXPrefix()
+        {
+            // DoD 9 / RFC 6648. This is pinned as a test rather than trusted to review because the name is
+            // half of a cross-repository contract: the app (W3.3) must send this byte-for-byte, and a
+            // mismatch fails OPEN — the header is simply not seen, no replace happens, and the only symptom
+            // is the six-hour session pile-up the rule exists to end.
+            InstanceIdentityHeader.HeaderName.ShouldBe("AI-Game-Dev-Instance-Id");
+            InstanceIdentityHeader.HeaderName.ShouldBe(Consts.MCP.Server.Headers.InstanceId);
+            InstanceIdentityHeader.HeaderName.StartsWith("X-", StringComparison.OrdinalIgnoreCase)
+                .ShouldBeFalse("RFC 6648 deprecates the X- prefix, and the client does not send one");
+        }
+
+        [Fact]
+        public void ExpectedLength_Is32_Because128BitsHexIs32Chars()
+        {
+            // 128 bits ⇒ 16 bytes ⇒ 32 hex chars. Pinned so a "let's allow 64 too" relaxation is a
+            // deliberate, visible change rather than a quiet widening of an opaque-token contract.
+            InstanceIdentityHeader.ExpectedLength.ShouldBe(32);
+            ValidId.Length.ShouldBe(InstanceIdentityHeader.ExpectedLength);
+        }
+
+        // ───────────────────────────── accepted ─────────────────────────────
+
+        [Fact]
+        public void LowerCaseHex_IsValid_AndPreserved()
+        {
+            InstanceIdentityHeader.TryParse(ValidId, out var parsed).ShouldBe(InstanceIdentityParse.Valid);
+            parsed.ShouldBe(ValidId);
+        }
+
+        [Fact]
+        public void UpperCaseHex_IsValid_AndNormalisedToLowerCase()
+        {
+            // Normalisation matters for the KEY, not for politeness: "ABCD…" and "abcd…" are the same
+            // installation, and an un-normalised key would give one installation two slots — so its two
+            // sessions would never replace each other and the pile-up would survive for that client.
+            InstanceIdentityHeader.TryParse(ValidId.ToUpperInvariant(), out var parsed)
+                .ShouldBe(InstanceIdentityParse.Valid);
+            parsed.ShouldBe(ValidId);
+        }
+
+        // ───────────────────────────── rejected ─────────────────────────────
+
+        [Theory]
+        // Over-length — one char over, and a full 64-char (256-bit) value that is otherwise perfect hex.
+        [InlineData("0123456789abcdef0123456789abcdef0")]
+        [InlineData("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")]
+        // Under-length: a TRUNCATED value is the dangerous near-miss, because it still looks like hex.
+        [InlineData("0123456789abcdef0123456789abcde")]
+        [InlineData("0")]
+        // Non-hex charset, at the start, middle and end — 'g' is the first letter past 'f'.
+        [InlineData("g123456789abcdef0123456789abcdef")]
+        [InlineData("0123456789abcdefg123456789abcdef")]
+        [InlineData("0123456789abcdef0123456789abcdeg")]
+        // Structural characters that would matter if the value were ever concatenated into something.
+        [InlineData("0123456789abcdef0123456789abcd..")]
+        [InlineData("../123456789abcdef0123456789abcd")]
+        [InlineData("0123456789abcdef0123456789ab'--")]
+        // Whitespace padding is REJECTED, not trimmed: silently repairing it would make client and server
+        // disagree about what the identity is, which is how a replace rule evicts the wrong session.
+        [InlineData(" 123456789abcdef0123456789abcdef")]
+        [InlineData("0123456789abcdef0123456789abcde ")]
+        // Empty and whitespace-only.
+        [InlineData("")]
+        [InlineData("                                ")]
+        public void MalformedValues_AreRejected(string raw)
+        {
+            InstanceIdentityHeader.TryParse(raw, out var parsed).ShouldBe(InstanceIdentityParse.Malformed);
+            parsed.ShouldBeNull("a rejected value must never be handed onward in any repaired form");
+        }
+
+        [Theory]
+        // CR/LF and friends in the arrangements a log-injection or response-splitting attempt would use.
+        // EVERY case here is EXACTLY 32 characters long, so the length check cannot be what rejects it —
+        // the charset check has to do the work. That padding discipline is the whole value of this Theory:
+        // unpadded inputs would be rejected on length and would prove nothing at all about CR/LF handling,
+        // and the test would stay green with the charset loop deleted.
+        [InlineData("0123456789abcdef\r\n6789abcdef0123")]  // 16 + 2 + 14
+        [InlineData("0123456789abcdef\n0123456789abcde")]    // 16 + 1 + 15
+        [InlineData("0123456789abcdef\r0123456789abcde")]    // 16 + 1 + 15
+        [InlineData("\r\n23456789abcdef0123456789abcdef")]  // 2 + 30, leading
+        [InlineData("0123456789abcdef0123456789abcd\r\n")]  // 30 + 2, trailing
+        [InlineData("0123456789abcdef\00123456789abcde")]    // NUL
+        [InlineData("0123456789abcdef\t0123456789abcde")]    // TAB
+        public void ControlCharacters_AreRejectedByCharsetNotByLength(string raw)
+        {
+            // The discriminator, asserted inline so it cannot rot: if a future edit changed one of these
+            // inputs to the wrong length, this line fails loudly instead of the case quietly degrading into
+            // a length test that happens to pass.
+            raw.Length.ShouldBe(InstanceIdentityHeader.ExpectedLength,
+                "this case must be rejected by the CHARSET check, so it must have the VALID length");
+
+            InstanceIdentityHeader.TryParse(raw, out var parsed).ShouldBe(InstanceIdentityParse.Malformed);
+            parsed.ShouldBeNull("a rejected value must never be handed onward in any repaired form");
+        }
+
+        [Fact]
+        public void NullValue_IsMalformed_NotAbsent()
+        {
+            // TryParse is only reached when the header was PRESENT. A present header with a null value is a
+            // client that asked to participate and sent nothing — malformed, not absent.
+            InstanceIdentityHeader.TryParse(null, out var parsed).ShouldBe(InstanceIdentityParse.Malformed);
+            parsed.ShouldBeNull();
+        }
+
+        // ───────────────────────────── header dictionary reads ─────────────────────────────
+
+        [Fact]
+        public void NoHeaderAtAll_IsAbsent_WhichIsTheReleasedClientPath()
+        {
+            var headers = new HeaderDictionary();
+            InstanceIdentityHeader.TryRead(headers, out var parsed).ShouldBe(InstanceIdentityParse.Absent);
+            parsed.ShouldBeNull();
+        }
+
+        [Fact]
+        public void NullHeaderDictionary_IsAbsent()
+        {
+            InstanceIdentityHeader.TryRead(null, out var parsed).ShouldBe(InstanceIdentityParse.Absent);
+            parsed.ShouldBeNull();
+        }
+
+        [Fact]
+        public void HeaderPresentWithValidValue_IsValid_AndCaseInsensitiveOnTheNAME()
+        {
+            // HTTP header names are case-insensitive, and IHeaderDictionary honours that. Asserted so a
+            // client that sends "ai-game-dev-instance-id" is not silently treated as sending nothing.
+            var headers = new HeaderDictionary { { "ai-game-dev-instance-id", ValidId } };
+            InstanceIdentityHeader.TryRead(headers, out var parsed).ShouldBe(InstanceIdentityParse.Valid);
+            parsed.ShouldBe(ValidId);
+        }
+
+        [Fact]
+        public void HeaderSentTwice_IsMalformed_NotFirstWins()
+        {
+            // Two values mean the caller's intent is ambiguous. Taking the first would let a caller smuggle
+            // a second identity past anyone reading only the first, and would make which session gets
+            // evicted depend on header ordering.
+            var headers = new HeaderDictionary
+            {
+                { InstanceIdentityHeader.HeaderName, new Microsoft.Extensions.Primitives.StringValues(new[] { ValidId, "fedcba9876543210fedcba9876543210" }) }
+            };
+            InstanceIdentityHeader.TryRead(headers, out var parsed).ShouldBe(InstanceIdentityParse.Malformed);
+            parsed.ShouldBeNull();
+        }
+
+        [Fact]
+        public void HeaderPresentWithEmptyValue_IsMalformed()
+        {
+            var headers = new HeaderDictionary { { InstanceIdentityHeader.HeaderName, string.Empty } };
+            InstanceIdentityHeader.TryRead(headers, out var parsed).ShouldBe(InstanceIdentityParse.Malformed);
+            parsed.ShouldBeNull();
+        }
+
+        // ───────────────────────────── fingerprint ─────────────────────────────
+
+        [Fact]
+        public void Fingerprint_NeverReturnsTheValue_AndIsShortHex()
+        {
+            var fingerprint = InstanceIdentityHeader.Fingerprint(ValidId);
+
+            fingerprint.ShouldNotBe(ValidId, "the log-safe form must not be the identifier itself");
+            ValidId.Contains(fingerprint, StringComparison.Ordinal).ShouldBeFalse(
+                "the fingerprint must not be a substring of the id — a prefix would leak the id's own bytes");
+            fingerprint.Length.ShouldBe(8);
+            fingerprint.All(c => (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void Fingerprint_IsStableForOneIdAndDiffersAcrossIds()
+        {
+            // Both halves matter: stable makes it useful for correlating two log lines about one
+            // installation; different makes it useful for telling two installations apart. A constant would
+            // pass "stable" alone and be worthless.
+            InstanceIdentityHeader.Fingerprint(ValidId).ShouldBe(InstanceIdentityHeader.Fingerprint(ValidId));
+            InstanceIdentityHeader.Fingerprint(ValidId)
+                .ShouldNotBe(InstanceIdentityHeader.Fingerprint("fedcba9876543210fedcba9876543210"));
+        }
+
+        [Fact]
+        public void Fingerprint_OfNothing_IsAPlaceholder_NotAnException()
+        {
+            // The log path must never be able to throw: a logging failure inside a session teardown would
+            // turn a clean replace into a fault.
+            InstanceIdentityHeader.Fingerprint(null).ShouldBe("none");
+            InstanceIdentityHeader.Fingerprint(string.Empty).ShouldBe("none");
+        }
+    }
+}

--- a/McpPlugin.Server.Tests/McpReplaceByIdentityOverHttpTests.cs
+++ b/McpPlugin.Server.Tests/McpReplaceByIdentityOverHttpTests.cs
@@ -170,6 +170,46 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
                 .ShouldBe(HttpStatusCode.OK);
         }
 
+        /// <summary>
+        /// ONE account with TWO different installations — the everyday desktop-plus-laptop case — stacks.
+        /// Both sessions stay live, and each still replaces only its own predecessor.
+        ///
+        /// <para>This is the most user-visible way the rule could go wrong: a key that ignored the instance
+        /// id would make signing in on a laptop silently kill the session on the desktop, which reads as a
+        /// network fault to the user. Covered at the unit level too, but asserted here because this is the
+        /// path production actually takes.</para>
+        /// </summary>
+        [Fact]
+        public async Task OneAccountWithTwoInstallations_StacksAndEachReplacesOnlyItsOwn()
+        {
+            await using var host = await StartOAuthHostAsync();
+            var tracker = host.Services.GetRequiredService<IMcpSessionTracker>();
+            using var client = NewClient();
+
+            var desktop = await host.InitializeAsync(client, AccountA, InstanceX);
+            var laptop = await host.InitializeAsync(client, AccountA, InstanceY);
+
+            laptop.ShouldNotBe(desktop);
+            tracker.ActiveSessionCount.ShouldBe(2, "two installations of one account are two sessions");
+
+            // Neither displaced the other.
+            (await host.SendAsync(client, AccountA, desktop, InstanceX, Ping(id: 2))).Status
+                .ShouldBe(HttpStatusCode.OK, "the desktop session must survive the laptop connecting");
+            (await host.SendAsync(client, AccountA, laptop, InstanceY, Ping(id: 3))).Status
+                .ShouldBe(HttpStatusCode.OK);
+
+            // The laptop reconnecting replaces ONLY the laptop's session.
+            var laptop2 = await host.InitializeAsync(client, AccountA, InstanceY);
+            (await host.SendAsync(client, AccountA, laptop, InstanceY, Ping(id: 4))).Status
+                .ShouldBe(HttpStatusCode.NotFound, "the laptop's own earlier session is replaced");
+            (await host.SendAsync(client, AccountA, desktop, InstanceX, Ping(id: 5))).Status
+                .ShouldBe(HttpStatusCode.OK, "the desktop must be untouched by the laptop's reconnect");
+            (await host.SendAsync(client, AccountA, laptop2, InstanceY, Ping(id: 6))).Status
+                .ShouldBe(HttpStatusCode.OK);
+
+            tracker.ActiveSessionCount.ShouldBe(2);
+        }
+
         // ───────────────────────────── the compatibility path (DoD 3) ─────────────────────────────
 
         /// <summary>

--- a/McpPlugin.Server.Tests/McpReplaceByIdentityOverHttpTests.cs
+++ b/McpPlugin.Server.Tests/McpReplaceByIdentityOverHttpTests.cs
@@ -244,7 +244,11 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
         [InlineData("' OR 1=1 --0123456789abcdef01234", "quote/comment payload, valid length")]
         public async Task MalformedInstanceId_IsRejectedWith400_AndNoSessionIsEstablished(string malformed, string why)
         {
-            await using var host = await StartOAuthHostAsync();
+            // Log capture is on because the REJECTION path is the one carrying arbitrary client input, and
+            // therefore the one where an unescaped interpolation would actually matter. The replace path is
+            // covered separately; without this, "nothing derived from the value reaches a log line" would be
+            // asserted only for values that already passed validation.
+            await using var host = await StartOAuthHostAsync(captureLogs: true, captureAllLevels: true);
             var tracker = host.Services.GetRequiredService<IMcpSessionTracker>();
             var reaper = host.Services.GetRequiredService<IMcpSessionReaper>();
             using var client = NewClient();
@@ -266,6 +270,15 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
             // response body is how an injection payload gets a second delivery channel.
             response.Body.ShouldNotContain(malformed, Case.Sensitive,
                 "the rejected value must not be echoed into the response body");
+
+            // …and it does not reach a log line either. This is the half that matters most: the value is
+            // arbitrary client input, so an unescaped interpolation here is a log-injection primitive.
+            host.AllLogText.ShouldNotContain(malformed, Case.Sensitive,
+                "the rejected instance id must not be written to any log record");
+
+            // Guard against vacuity: the sink must actually have observed this request's processing. A dead
+            // sink would satisfy the assertion above with the value being logged in full.
+            host.AllLogText.ShouldNotBeNullOrEmpty("the log sink captured nothing at all — it is not wired up");
         }
 
         /// <summary>

--- a/McpPlugin.Server.Tests/McpReplaceByIdentityOverHttpTests.cs
+++ b/McpPlugin.Server.Tests/McpReplaceByIdentityOverHttpTests.cs
@@ -1,0 +1,609 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Sockets;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.Common.Utils;
+using com.IvanMurzak.McpPlugin.Server.Auth;
+using com.IvanMurzak.McpPlugin.Server.Auth.OAuth;
+using com.IvanMurzak.McpPlugin.Server.Tests.OAuth;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.Server.Tests
+{
+    /// <summary>
+    /// End-to-end cover for the server-side <b>replace-by-identity</b> rule (design 07 §2.3, D10.2).
+    ///
+    /// <para>These drive a REAL loopback Kestrel host with the REAL <c>WithMcpServer</c> +
+    /// <c>WithMcpPluginServer</c> wiring over the REAL Streamable HTTP transport and the REAL OAuth
+    /// resource-server path, and they reach the rule the only way production does: through an actual MCP
+    /// <c>initialize</c> handshake carrying an actual <c>AI-Game-Dev-Instance-Id</c> header.</para>
+    ///
+    /// <para><b>Why a real host is not optional here.</b> The thing under test is what happens to a session
+    /// the MCP SDK owns. Verified against <c>ModelContextProtocol.AspNetCore</c> 1.4.0: NOTHING in the SDK
+    /// removes a session from its store when that session's <c>RunSessionHandler</c> returns, so a replace
+    /// rule built on cancelling our own token would drop our tracker row, look fixed, and leave the SDK's
+    /// session — and the memory it pins — in place until the 6 h idle timeout. A test that asserted only
+    /// "the tracker row disappeared" would be GREEN for that broken implementation. So the load-bearing
+    /// assertion in this file is the one no in-process fake can make: <b>a request bearing the replaced
+    /// session id is answered 404 by the SDK itself</b>, which is only possible if the SDK's own session
+    /// store no longer holds it.</para>
+    /// </summary>
+    [Collection("McpPlugin.Server")]
+    public sealed class McpReplaceByIdentityOverHttpTests
+    {
+        const string Kid = "replace-by-identity-kid";
+        const string AccountA = "acct-replace-a";
+        const string AccountB = "acct-replace-b";
+        const string InstanceX = "0123456789abcdef0123456789abcdef";
+        const string InstanceY = "fedcba9876543210fedcba9876543210";
+
+        // ───────────────────────────── the mechanism (DoD 1) ─────────────────────────────
+
+        /// <summary>
+        /// The tripwire for an SDK bump. The eviction seam reaches an <c>internal</c> SDK type by
+        /// reflection because 1.4.0 exposes no public or DI-typed way to evict a session by id. If a future
+        /// bump moves or renames that seam, replace-by-identity silently stops terminating SDK sessions and
+        /// the six-hour pile-up returns <b>with no functional symptom</b>. This test is what turns that
+        /// silent regression into a red build.
+        /// </summary>
+        [Fact]
+        public void SdkEvictionSeam_IsBoundToTheRunningSdk()
+        {
+            McpSdkSessionEvictor.IsBindingResolved.ShouldBeTrue(
+                "replace-by-identity cannot terminate SDK-owned MCP sessions unless this seam binds. " +
+                "Diagnostic: " + McpSdkSessionEvictor.StaticBindingDiagnostic);
+
+            McpSdkSessionEvictor.StaticBindingDiagnostic.ShouldStartWith("BOUND:");
+        }
+
+        /// <summary>
+        /// <b>The positive control, and the proof of termination.</b> A second connection with the same
+        /// account AND the same instance id replaces the first: the old session is gone from the SDK's own
+        /// store, the new one is live, and our tracker count falls back to one.
+        /// </summary>
+        [Fact]
+        public async Task SecondConnection_SameAccountAndInstance_ReplacesTheFirst_AndTheSdkReleasesIt()
+        {
+            await using var host = await StartOAuthHostAsync();
+            var tracker = host.Services.GetRequiredService<IMcpSessionTracker>();
+            var reaper = host.Services.GetRequiredService<IMcpSessionReaper>();
+            using var client = NewClient();
+
+            var first = await host.InitializeAsync(client, AccountA, InstanceX);
+            first.ShouldNotBeNullOrEmpty("the server must mint an Mcp-Session-Id on initialize");
+            tracker.ActiveSessionCount.ShouldBe(1);
+            reaper.CurrentSessionIdFor(AccountA, InstanceX, null).ShouldBe(first);
+
+            // Prove the first session is genuinely USABLE before it is replaced. Without this, a later
+            // "the old id 404s" assertion could be satisfied by an id that never worked in the first place.
+            var beforeReplace = await host.SendAsync(client, AccountA, first, InstanceX, Ping(id: 2));
+            beforeReplace.Status.ShouldBe(HttpStatusCode.OK, "the first session must work before it is replaced");
+
+            var second = await host.InitializeAsync(client, AccountA, InstanceX);
+            second.ShouldNotBeNullOrEmpty();
+            second.ShouldNotBe(first, "every initialize mints a fresh MCP session id — that is why the " +
+                                     "session id alone can never be a replace key");
+
+            // ── THE load-bearing assertion. 404 comes from the SDK's own session lookup, so it can only
+            // ── be produced if the SDK's session store no longer holds the id. A rule that merely dropped
+            // ── our tracker row would answer this request normally and fail here.
+            var afterReplace = await host.SendAsync(client, AccountA, first, InstanceX, Ping(id: 3));
+            afterReplace.Status.ShouldBe(HttpStatusCode.NotFound,
+                $"the replaced session must be gone from the SDK's session store, not merely from our " +
+                $"tracker; got {(int)afterReplace.Status} with body: {afterReplace.Body}");
+
+            // And the SDK says WHY, which distinguishes "session evicted" from "route not found" — a 404
+            // for the wrong reason would otherwise satisfy the line above.
+            afterReplace.Body.ShouldContain("-32001", Case.Sensitive,
+                "the 404 must be the MCP SDK's 'Session not found', not a routing 404");
+
+            // The replacement is live.
+            var newSessionWorks = await host.SendAsync(client, AccountA, second, InstanceX, Ping(id: 4));
+            newSessionWorks.Status.ShouldBe(HttpStatusCode.OK, "the replacement session must be usable");
+
+            // Our own bookkeeping settled too: one identity, one session — not two.
+            tracker.ActiveSessionCount.ShouldBe(1,
+                "the displaced session's tracker row must be removed, leaving exactly one live session");
+            reaper.CurrentSessionIdFor(AccountA, InstanceX, null).ShouldBe(second);
+            reaper.TrackedIdentityCount.ShouldBe(1);
+        }
+
+        // ───────────────────────────── cross-account isolation (DoD 2) ─────────────────────────────
+
+        /// <summary>
+        /// Two DIFFERENT accounts presenting the SAME instance id do not affect each other's sessions.
+        /// The account comes from the validated bearer credential, so a spoofed instance id can only ever
+        /// reach the spoofer's own sessions.
+        /// </summary>
+        [Fact]
+        public async Task TwoDifferentAccounts_SendingTheSameInstanceId_DoNotAffectEachOther()
+        {
+            await using var host = await StartOAuthHostAsync();
+            var tracker = host.Services.GetRequiredService<IMcpSessionTracker>();
+            using var client = NewClient();
+
+            var sessionA = await host.InitializeAsync(client, AccountA, InstanceX);
+            var sessionB = await host.InitializeAsync(client, AccountB, InstanceX);
+
+            sessionA.ShouldNotBeNullOrEmpty();
+            sessionB.ShouldNotBeNullOrEmpty();
+            sessionB.ShouldNotBe(sessionA);
+
+            // Neither displaced the other: BOTH are still served.
+            (await host.SendAsync(client, AccountA, sessionA, InstanceX, Ping(id: 2))).Status
+                .ShouldBe(HttpStatusCode.OK, "account A's session must survive account B connecting with the same instance id");
+            (await host.SendAsync(client, AccountB, sessionB, InstanceX, Ping(id: 3))).Status
+                .ShouldBe(HttpStatusCode.OK);
+
+            tracker.ActiveSessionCount.ShouldBe(2, "two accounts hold two independent sessions");
+
+            // Now make account B replace ITS OWN session and confirm the blast radius stops at B.
+            var sessionB2 = await host.InitializeAsync(client, AccountB, InstanceX);
+            (await host.SendAsync(client, AccountB, sessionB, InstanceX, Ping(id: 4))).Status
+                .ShouldBe(HttpStatusCode.NotFound, "B's own earlier session is the one that gets replaced");
+            (await host.SendAsync(client, AccountA, sessionA, InstanceX, Ping(id: 5))).Status
+                .ShouldBe(HttpStatusCode.OK, "A's session must be untouched by B's replace");
+            (await host.SendAsync(client, AccountB, sessionB2, InstanceX, Ping(id: 6))).Status
+                .ShouldBe(HttpStatusCode.OK);
+        }
+
+        // ───────────────────────────── the compatibility path (DoD 3) ─────────────────────────────
+
+        /// <summary>
+        /// A client that sends NO instance id behaves exactly as it does today: its session is tracked, it
+        /// is not replaced, it is not rejected, and nothing warns.
+        ///
+        /// <para><b>This is the property that makes the container deployable with every released client
+        /// unchanged</b> — no synchronised app release. Read together with
+        /// <see cref="SecondConnection_SameAccountAndInstance_ReplacesTheFirst_AndTheSdkReleasesIt"/>: on
+        /// its own, this test would be satisfied by a rule that never replaces anything.</para>
+        /// </summary>
+        [Fact]
+        public async Task NoInstanceIdHeader_SessionsStackExactlyAsToday_AndNothingWarns()
+        {
+            await using var host = await StartOAuthHostAsync(captureLogs: true);
+            var tracker = host.Services.GetRequiredService<IMcpSessionTracker>();
+            var reaper = host.Services.GetRequiredService<IMcpSessionReaper>();
+            using var client = NewClient();
+
+            // Same account, three connections, NO instance id on any of them.
+            var s1 = await host.InitializeAsync(client, AccountA, instanceId: null);
+            var s2 = await host.InitializeAsync(client, AccountA, instanceId: null);
+            var s3 = await host.InitializeAsync(client, AccountA, instanceId: null);
+
+            new[] { s1, s2, s3 }.Distinct().Count().ShouldBe(3, "three distinct sessions");
+
+            // Not replaced: all three are still served. This is today's stacking behaviour, unchanged.
+            foreach (var session in new[] { s1, s2, s3 })
+            {
+                var response = await host.SendAsync(client, AccountA, session, instanceId: null, payload: Ping(id: 9));
+                response.Status.ShouldBe(HttpStatusCode.OK,
+                    $"a header-less client must not be replaced or rejected; session {session} got " +
+                    $"{(int)response.Status} with body: {response.Body}");
+            }
+
+            tracker.ActiveSessionCount.ShouldBe(3, "header-less sessions stack, exactly as before this change");
+            reaper.TrackedIdentityCount.ShouldBe(0,
+                "no identity was presented, so the reaper must hold nothing at all — not an empty-string slot");
+
+            // ── No error or warning storm FROM THIS CHANGE. ────────────────────────────────────────────
+            // Scoped by CATEGORY on purpose. An unscoped "no warnings at all" assertion is what this test
+            // originally had, and it failed on pre-existing `tools/list` retry warnings that have nothing to
+            // do with the header-less path — asserting a property of the whole test environment rather than
+            // of the change. Scoping keeps it falsifiable: any warning or error raised by the reaper or the
+            // evictor on a path where no identity was ever presented is a genuine defect.
+            var fromThisChange = host.WarningsAndErrorsFrom(
+                nameof(McpSessionReaper), nameof(McpSdkSessionEvictor),
+                nameof(Server.Transport.StreamableHttpTransportLayer));
+            fromThisChange.ShouldBeEmpty(
+                "the header-less path must produce no warning or error from the replace-by-identity code; got: " +
+                string.Join(" | ", fromThisChange));
+
+            // ── The guard that keeps the assertion above from being vacuous. ───────────────────────────
+            // A sink that captures nothing satisfies "empty" while the code logs a storm, so prove the sink
+            // is alive AND that it observes the Warning level specifically. The probe is emitted through the
+            // host's own ILoggerFactory under a sentinel category, so it exercises the real pipeline without
+            // polluting the category-scoped assertion above.
+            host.AllLogText.ShouldNotBeNullOrEmpty("the log sink captured nothing at all — it is not wired up");
+            const string sentinel = "replace-by-identity-sink-liveness-probe";
+            host.EmitProbeWarning(sentinel);
+            string.Join(" | ", host.WarningsAndErrors).ShouldContain(sentinel, Case.Sensitive,
+                "the sink must be able to observe Warning-level records, or the emptiness assertion above proves nothing");
+        }
+
+        // ───────────────────────────── opaque-token validation over the wire (DoD 7) ─────────────────
+
+        [Theory]
+        [InlineData("0123456789abcdef0123456789abcdef0123456789abcdef", "over-length")]
+        [InlineData("0123456789abcdef0123456789abcde", "under-length")]
+        [InlineData("zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz", "non-hex, valid length")]
+        [InlineData("../../etc/passwd0123456789abcdef", "path traversal, valid length")]
+        [InlineData("' OR 1=1 --0123456789abcdef01234", "quote/comment payload, valid length")]
+        public async Task MalformedInstanceId_IsRejectedWith400_AndNoSessionIsEstablished(string malformed, string why)
+        {
+            await using var host = await StartOAuthHostAsync();
+            var tracker = host.Services.GetRequiredService<IMcpSessionTracker>();
+            var reaper = host.Services.GetRequiredService<IMcpSessionReaper>();
+            using var client = NewClient();
+
+            var response = await host.SendRawAsync(client, AccountA, sessionId: null, instanceId: malformed,
+                payload: InitializePayload());
+
+            response.Status.ShouldBe(HttpStatusCode.BadRequest,
+                $"a present-but-malformed instance id ({why}) must be rejected, never silently ignored; " +
+                $"got {(int)response.Status} with body: {response.Body}");
+            response.Body.ShouldContain(InstanceIdentityHeader.InvalidInstanceIdError, Case.Sensitive);
+
+            // Terminal: the request never reached a handler, so no session exists and no slot was claimed.
+            response.SessionId.ShouldBeNullOrEmpty("a rejected request must not mint a session id");
+            tracker.ActiveSessionCount.ShouldBe(0, "no MCP session may be established for a rejected request");
+            reaper.TrackedIdentityCount.ShouldBe(0);
+
+            // The offending value is NOT echoed back — reflecting an unvalidated client string into a
+            // response body is how an injection payload gets a second delivery channel.
+            response.Body.ShouldNotContain(malformed, Case.Sensitive,
+                "the rejected value must not be echoed into the response body");
+        }
+
+        /// <summary>
+        /// A CR/LF-bearing value is rejected. Kestrel refuses illegal header bytes at the protocol level, so
+        /// this asserts the OUTCOME — the request does not produce a working session — rather than a
+        /// specific status code, and the charset gate itself is pinned exactly in
+        /// <c>InstanceIdentityHeaderTests</c> where the value can be handed in directly.
+        /// </summary>
+        [Fact]
+        public async Task InstanceIdContainingCrLf_NeverProducesAWorkingSession()
+        {
+            await using var host = await StartOAuthHostAsync();
+            var tracker = host.Services.GetRequiredService<IMcpSessionTracker>();
+            using var client = NewClient();
+
+            // Exactly the valid LENGTH, so only the charset can reject it.
+            const string crlf = "0123456789abcdef\r\n6789abcdef0123";
+            crlf.Length.ShouldBe(InstanceIdentityHeader.ExpectedLength);
+
+            HttpStatusCode? status = null;
+            try
+            {
+                var response = await host.SendRawAsync(client, AccountA, sessionId: null, instanceId: crlf,
+                    payload: InitializePayload());
+                status = response.Status;
+            }
+            catch (HttpRequestException)
+            {
+                // Also acceptable: the client/server stack refused to transmit the illegal header at all.
+            }
+
+            if (status.HasValue)
+            {
+                ((int)status.Value).ShouldBeGreaterThanOrEqualTo(400,
+                    $"a CR/LF-bearing instance id must never be accepted; got {(int)status.Value}");
+            }
+
+            tracker.ActiveSessionCount.ShouldBe(0, "no session may be established for a CR/LF-bearing value");
+        }
+
+        // ───────────────────────────── log hygiene (DoD 8) ─────────────────────────────
+
+        /// <summary>
+        /// The instance id is never written to a log line — not on the replace path, not beside the bearer
+        /// credential, not anywhere. Logs carry only a truncated, non-reversible fingerprint.
+        /// </summary>
+        [Fact]
+        public async Task Replace_NeverWritesTheInstanceIdOrTheBearerTokenToALogLine()
+        {
+            await using var host = await StartOAuthHostAsync(captureLogs: true, captureAllLevels: true);
+            using var client = NewClient();
+
+            await host.InitializeAsync(client, AccountA, InstanceX);
+            var second = await host.InitializeAsync(client, AccountA, InstanceX);
+            second.ShouldNotBeNullOrEmpty();
+
+            var log = host.AllLogText;
+
+            // The replace really happened — otherwise this test would pass by logging nothing at all, which
+            // is the vacuous way to satisfy "the value never appears".
+            log.ShouldContain("MCP session replaced by identity", Case.Sensitive,
+                "the replace path must have run for this assertion to mean anything");
+
+            log.ShouldNotContain(InstanceX, Case.Insensitive,
+                "the raw instance id must never reach a log line");
+            log.ShouldNotContain(host.TokenFor(AccountA), Case.Sensitive,
+                "the bearer credential must never reach a log line");
+
+            // What IS logged is the fingerprint, and it is genuinely present — so the operator-facing
+            // correlation handle exists rather than the id having simply been dropped.
+            log.ShouldContain(InstanceIdentityHeader.Fingerprint(InstanceX), Case.Sensitive,
+                "the log must carry the non-reversible fingerprint so two installations can be told apart");
+        }
+
+        // ───────────────────────────── harness ─────────────────────────────
+
+        static HttpClient NewClient() => new HttpClient { Timeout = TimeSpan.FromSeconds(120) };
+
+        static object InitializePayload() => new
+        {
+            jsonrpc = "2.0",
+            id = 1,
+            method = "initialize",
+            @params = new
+            {
+                protocolVersion = "2024-11-05",
+                capabilities = new { },
+                clientInfo = new { name = "replace-by-identity-test", version = "1.0.0" }
+            }
+        };
+
+        /// <summary>
+        /// The liveness probe. <c>ping</c> is deliberate: it is handled entirely inside the MCP session, so
+        /// it answers 200 for a live session and the SDK's <c>404 / -32001</c> for an evicted one, which is
+        /// exactly the discrimination these tests need.
+        ///
+        /// <para><c>tools/list</c> was the obvious choice and is the wrong one here: with no engine plugin
+        /// attached it retries ten times and emits ten pre-existing WARNINGs plus an ERROR per call —
+        /// noise unrelated to this change that took 10 s per probe and swamped the log-hygiene assertions.</para>
+        /// </summary>
+        static object Ping(int id) => new { jsonrpc = "2.0", id, method = "ping" };
+
+        static async Task<OAuthHost> StartOAuthHostAsync(bool captureLogs = false, bool captureAllLevels = false)
+        {
+            var port = FreeLoopbackPort();
+            const string issuer = "https://as.example";              // never fetched: the JWKS provider is replaced below
+            var publicUrl = $"http://127.0.0.1:{port}/mcp";
+
+            var key = TestJwt.CreateKey();
+
+            var dataArguments = new DataArguments(new[]
+            {
+                $"port={port}",
+                "client-transport=streamableHttp",
+                "auth=oauth",
+                $"auth-issuer={issuer}",
+                $"public-url={publicUrl}",
+            });
+
+            var builder = WebApplication.CreateBuilder();
+            builder.Logging.ClearProviders();
+
+            var sink = new ListLoggerProvider();
+            if (captureLogs)
+            {
+                builder.Logging.AddProvider(sink);
+                builder.Logging.SetMinimumLevel(captureAllLevels ? LogLevel.Trace : LogLevel.Debug);
+            }
+
+            builder.Services
+                .WithMcpServer(dataArguments)
+                .WithMcpPluginServer(dataArguments);
+
+            // Hermetic: serve the signing key from memory instead of fetching the AS over HTTP.
+            builder.Services.AddSingleton<IJwksKeyProvider>(new FakeJwksKeyProvider().Add(Kid, key));
+
+            var app = builder.Build();
+            app.Urls.Add($"http://127.0.0.1:{port}");
+            app.UseMcpPluginServer(dataArguments);
+            await app.StartAsync();
+
+            return new OAuthHost(app, $"http://127.0.0.1:{port}", issuer, publicUrl, key, sink);
+        }
+
+        sealed class OAuthHost : IAsyncDisposable
+        {
+            readonly WebApplication _app;
+            readonly ECDsa _key;
+            readonly string _baseUrl;
+            readonly string _issuer;
+            readonly string _audience;
+            readonly ListLoggerProvider _sink;
+            readonly ConcurrentDictionary<string, string> _tokens = new ConcurrentDictionary<string, string>();
+
+            public OAuthHost(WebApplication app, string baseUrl, string issuer, string audience, ECDsa key, ListLoggerProvider sink)
+            {
+                _app = app;
+                _baseUrl = baseUrl;
+                _issuer = issuer;
+                _audience = audience;
+                _key = key;
+                _sink = sink;
+            }
+
+            public IServiceProvider Services => _app.Services;
+
+            /// <summary>A distinct agent token per account, so `sub` is the only thing that differs.</summary>
+            public string TokenFor(string accountSub) => _tokens.GetOrAdd(accountSub, sub =>
+                TestJwt.SignEs256(_key, Kid, TestJwt.Claims(
+                    _issuer, _audience, DateTimeOffset.UtcNow.AddHours(1),
+                    sub: sub, scope: ConnectionIdentity.ScopeAgent)));
+
+            public IReadOnlyList<string> WarningsAndErrors => _sink.AtOrAbove(LogLevel.Warning);
+
+            /// <summary>
+            /// Warning-or-worse records whose logger CATEGORY mentions one of <paramref name="categoryFragments"/>.
+            /// Scoping by category is what makes a "nothing warned" assertion about THIS change rather than
+            /// about the whole test environment.
+            /// </summary>
+            public IReadOnlyList<string> WarningsAndErrorsFrom(params string[] categoryFragments)
+                => _sink.AtOrAbove(LogLevel.Warning, categoryFragments);
+
+            public string AllLogText => _sink.AllText;
+
+            /// <summary>
+            /// Emits a Warning through the host's REAL logger factory, so a test can prove the sink observes
+            /// that level before relying on the sink being empty.
+            /// </summary>
+            public void EmitProbeWarning(string message)
+            {
+                var factory = _app.Services.GetRequiredService<ILoggerFactory>();
+                factory.CreateLogger("SinkLivenessProbe").LogWarning("{probe}", message);
+            }
+
+            /// <summary>Runs a full initialize + initialized handshake and returns the minted session id.</summary>
+            public async Task<string> InitializeAsync(HttpClient client, string accountSub, string? instanceId)
+            {
+                var response = await SendRawAsync(client, accountSub, sessionId: null, instanceId: instanceId,
+                    payload: InitializePayload());
+
+                response.Status.ShouldBe(HttpStatusCode.OK,
+                    $"initialize must succeed; got {(int)response.Status} with body: {response.Body}");
+                response.SessionId.ShouldNotBeNullOrEmpty("initialize must mint an Mcp-Session-Id");
+
+                var initialized = await SendRawAsync(client, accountSub, response.SessionId, instanceId,
+                    new { jsonrpc = "2.0", method = "notifications/initialized" });
+                initialized.Status.ShouldBe(HttpStatusCode.Accepted,
+                    $"notifications/initialized must be accepted; got {(int)initialized.Status}: {initialized.Body}");
+
+                return response.SessionId!;
+            }
+
+            /// <summary>Sends a request and asserts nothing about the outcome — the caller does that.</summary>
+            public Task<Response> SendAsync(HttpClient client, string accountSub, string? sessionId, string? instanceId, object payload)
+                => SendRawAsync(client, accountSub, sessionId, instanceId, payload);
+
+            public async Task<Response> SendRawAsync(HttpClient client, string accountSub, string? sessionId, string? instanceId, object payload)
+            {
+                using var request = new HttpRequestMessage(HttpMethod.Post, _baseUrl + "/mcp");
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", TokenFor(accountSub));
+                request.Headers.Accept.ParseAdd("application/json");
+                request.Headers.Accept.ParseAdd("text/event-stream");
+                if (!string.IsNullOrEmpty(sessionId))
+                    request.Headers.TryAddWithoutValidation("Mcp-Session-Id", sessionId);
+                if (instanceId != null)
+                    request.Headers.TryAddWithoutValidation(InstanceIdentityHeader.HeaderName, instanceId);
+                request.Content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
+
+                using var response = await client.SendAsync(request);
+                var body = await response.Content.ReadAsStringAsync();
+                var issued = response.Headers.TryGetValues("Mcp-Session-Id", out var values) ? values.FirstOrDefault() : null;
+                return new Response(response.StatusCode, Unwrap(body), issued);
+            }
+
+            public async ValueTask DisposeAsync()
+            {
+                await _app.StopAsync();
+                await _app.DisposeAsync();
+                _key.Dispose();
+            }
+        }
+
+        sealed class Response
+        {
+            public Response(HttpStatusCode status, string body, string? sessionId)
+            {
+                Status = status;
+                Body = body;
+                SessionId = sessionId;
+            }
+
+            public HttpStatusCode Status { get; }
+            public string Body { get; }
+            public string? SessionId { get; }
+        }
+
+        /// <summary>
+        /// Minimal in-memory Microsoft.Extensions.Logging sink. The host clears every provider, so without
+        /// this the reaper's and evictor's records are invisible — and a log-hygiene assertion wired to a
+        /// sink that sees nothing would pass with the value being logged in full.
+        /// </summary>
+        sealed class ListLoggerProvider : ILoggerProvider
+        {
+            readonly ConcurrentQueue<(LogLevel Level, string Category, string Message)> _records =
+                new ConcurrentQueue<(LogLevel, string, string)>();
+
+            public ILogger CreateLogger(string categoryName) => new ListLogger(_records, categoryName);
+
+            public IReadOnlyList<string> AtOrAbove(LogLevel level)
+                => _records.Where(r => r.Level >= level).Select(Format).ToArray();
+
+            /// <summary>
+            /// Warning-or-worse records from categories matching any fragment. An EMPTY
+            /// <paramref name="categoryFragments"/> matches nothing rather than everything — the opposite
+            /// default would silently turn a scoped assertion back into an unscoped one if the argument list
+            /// were ever dropped.
+            /// </summary>
+            public IReadOnlyList<string> AtOrAbove(LogLevel level, string[] categoryFragments)
+                => _records
+                    .Where(r => r.Level >= level)
+                    .Where(r => categoryFragments.Any(f => r.Category.IndexOf(f, StringComparison.OrdinalIgnoreCase) >= 0))
+                    .Select(Format)
+                    .ToArray();
+
+            public string AllText => string.Join(Environment.NewLine, _records.Select(Format));
+
+            static string Format((LogLevel Level, string Category, string Message) r)
+                => $"[{r.Level}] {r.Category}: {r.Message}";
+
+            public void Dispose() { }
+
+            sealed class ListLogger : ILogger
+            {
+                readonly ConcurrentQueue<(LogLevel, string, string)> _records;
+                readonly string _category;
+
+                public ListLogger(ConcurrentQueue<(LogLevel, string, string)> records, string category)
+                {
+                    _records = records;
+                    _category = category;
+                }
+
+                public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+                public bool IsEnabled(LogLevel logLevel) => true;
+
+                public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+                    Func<TState, Exception?, string> formatter)
+                {
+                    var message = formatter(state, exception);
+                    if (exception != null)
+                        message += " || " + exception;
+                    _records.Enqueue((logLevel, _category, message));
+                }
+            }
+        }
+
+        static int FreeLoopbackPort()
+        {
+            var probe = new TcpListener(IPAddress.Loopback, 0);
+            probe.Start();
+            var port = ((IPEndPoint)probe.LocalEndpoint).Port;
+            probe.Stop();
+            return port;
+        }
+
+        /// <summary>The streamable-HTTP reply is an SSE frame; pull the JSON out of its data: lines.</summary>
+        static string Unwrap(string body)
+        {
+            if (!body.Contains("data:", StringComparison.Ordinal))
+                return body;
+            var sb = new StringBuilder();
+            foreach (var line in body.Split('\n'))
+            {
+                var trimmed = line.TrimEnd('\r');
+                if (trimmed.StartsWith("data:", StringComparison.Ordinal))
+                    sb.Append(trimmed.Substring(5).Trim());
+            }
+            return sb.Length > 0 ? sb.ToString() : body;
+        }
+    }
+}

--- a/McpPlugin.Server.Tests/McpSessionReaperTests.cs
+++ b/McpPlugin.Server.Tests/McpSessionReaperTests.cs
@@ -1,0 +1,342 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.Server.Tests
+{
+    /// <summary>
+    /// The replace-by-identity ALGEBRA: which connection displaces which, and — more important — which
+    /// connections must never be able to touch each other.
+    ///
+    /// <para>These drive <see cref="McpSessionReaper"/> against a recording fake evictor, so every
+    /// assertion is about the rule itself rather than about a live Kestrel host. The termination MECHANISM
+    /// (that the SDK really releases the displaced session) cannot be proven here by construction and is
+    /// proven separately over a real host in <c>McpReplaceByIdentityOverHttpTests</c>. Both are needed: a
+    /// fake evictor could report a replace that never terminated anything, and a live host is too coarse
+    /// to enumerate the key algebra.</para>
+    /// </summary>
+    public sealed class McpSessionReaperTests
+    {
+        const string AccountA = "acct-aaaa";
+        const string AccountB = "acct-bbbb";
+        const string InstanceX = "0123456789abcdef0123456789abcdef";
+        const string InstanceY = "fedcba9876543210fedcba9876543210";
+
+        /// <summary>
+        /// Records every eviction request so a test can assert on WHAT was evicted, not just how many.
+        ///
+        /// <para><b>The recording is locked, and it has to be.</b> <see cref="McpSessionReaper"/> calls
+        /// <see cref="Evict"/> OUTSIDE its own claim lock — deliberately, so a claim never holds a lock
+        /// across foreign code — so concurrent claims reach this method concurrently. An unsynchronised
+        /// <see cref="List{T}"/> here lost and duplicated entries under
+        /// <see cref="ConcurrentClaimsForOneIdentity_ConvergeOnASingleSlot"/>, producing a flake that read
+        /// as a race in the production code and was not one.</para>
+        /// </summary>
+        sealed class RecordingEvictor : IMcpSdkSessionEvictor
+        {
+            readonly object _lock = new object();
+            readonly List<string> _evicted = new List<string>();
+
+            public bool IsSupported => true;
+            public string BindingDiagnostic => "fake";
+
+            /// <summary>A stable snapshot, ordered as the evictions arrived.</summary>
+            public IReadOnlyList<string> Evicted
+            {
+                get { lock (_lock) { return _evicted.ToArray(); } }
+            }
+
+            public SdkEvictionHandle Evict(string mcpSessionId)
+            {
+                lock (_lock) { _evicted.Add(mcpSessionId); }
+                return new SdkEvictionHandle(SdkEvictionOutcome.Evicted, Task.CompletedTask);
+            }
+        }
+
+        static (McpSessionReaper Reaper, RecordingEvictor Evictor) Build()
+        {
+            var evictor = new RecordingEvictor();
+            return (new McpSessionReaper(evictor), evictor);
+        }
+
+        // ───────────────────────────── the positive control (DoD 4) ─────────────────────────────
+
+        [Fact]
+        public void SameAccountSameInstance_SecondConnectionReplacesTheFirst()
+        {
+            // This is the REQUIRED positive control. Without it, "clients that send no identity are
+            // unaffected" would be satisfied by a rule that never replaces anything, and the whole change
+            // would score green while doing nothing at all.
+            var (reaper, evictor) = Build();
+
+            var first = reaper.Claim(AccountA, InstanceX, projectPin: null, mcpSessionId: "session-1");
+            first.ShouldNotBeNull();
+            evictor.Evicted.ShouldBeEmpty("a first connection has no predecessor to displace");
+            reaper.CurrentSessionIdFor(AccountA, InstanceX, null).ShouldBe("session-1");
+
+            var second = reaper.Claim(AccountA, InstanceX, projectPin: null, mcpSessionId: "session-2");
+            second.ShouldNotBeNull();
+
+            // Both halves: the OLD session was the one evicted, and the NEW one holds the slot.
+            evictor.Evicted.ShouldBe(new[] { "session-1" });
+            reaper.CurrentSessionIdFor(AccountA, InstanceX, null).ShouldBe("session-2");
+            reaper.TrackedIdentityCount.ShouldBe(1, "a replace must not leave two slots for one identity");
+
+            first!.Displaced.ShouldBeTrue("the displaced session must be able to tell that its shutdown is orderly");
+            second!.Displaced.ShouldBeFalse();
+            second.DisplacedPredecessor.ShouldNotBeNull();
+            second.DisplacedPredecessor!.Outcome.ShouldBe(SdkEvictionOutcome.Evicted);
+        }
+
+        // ───────────────────────────── cross-account isolation (DoD 2) ─────────────────────────────
+
+        [Fact]
+        public void TwoDifferentAccountsSendingTheSameInstanceId_DoNotAffectEachOther()
+        {
+            // The security property. The instance id is client-supplied and therefore spoofable; the
+            // account comes from the validated credential. So a spoofed instance id must be able to evict
+            // only the spoofer's OWN sessions. If this ever fails, any authenticated user can terminate any
+            // other user's MCP session by guessing nothing at all.
+            var (reaper, evictor) = Build();
+
+            reaper.Claim(AccountA, InstanceX, projectPin: null, mcpSessionId: "session-a").ShouldNotBeNull();
+            reaper.Claim(AccountB, InstanceX, projectPin: null, mcpSessionId: "session-b").ShouldNotBeNull();
+
+            evictor.Evicted.ShouldBeEmpty("one account's identity slot is not the other's, so nothing is displaced");
+            reaper.CurrentSessionIdFor(AccountA, InstanceX, null).ShouldBe("session-a");
+            reaper.CurrentSessionIdFor(AccountB, InstanceX, null).ShouldBe("session-b");
+            reaper.TrackedIdentityCount.ShouldBe(2);
+
+            // And a third connection on account B replaces only B's session, never A's.
+            reaper.Claim(AccountB, InstanceX, projectPin: null, mcpSessionId: "session-b2").ShouldNotBeNull();
+            evictor.Evicted.ShouldBe(new[] { "session-b" });
+            reaper.CurrentSessionIdFor(AccountA, InstanceX, null).ShouldBe("session-a",
+                "account A's session must survive account B's replace");
+        }
+
+        [Fact]
+        public void SameAccountDifferentInstances_DoNotAffectEachOther()
+        {
+            // One account legitimately runs several installations (desktop + laptop). They must stack.
+            var (reaper, evictor) = Build();
+
+            reaper.Claim(AccountA, InstanceX, projectPin: null, mcpSessionId: "session-x");
+            reaper.Claim(AccountA, InstanceY, projectPin: null, mcpSessionId: "session-y");
+
+            evictor.Evicted.ShouldBeEmpty();
+            reaper.TrackedIdentityCount.ShouldBe(2);
+            reaper.CurrentSessionIdFor(AccountA, InstanceX, null).ShouldBe("session-x");
+            reaper.CurrentSessionIdFor(AccountA, InstanceY, null).ShouldBe("session-y");
+        }
+
+        // ───────────────────────────── the pin component (07 §2.5 / T25 / SG-14) ─────────────────────
+
+        [Fact]
+        public void SameAccountAndInstanceButDifferentProjectPins_DoNotAffectEachOther()
+        {
+            // 07-security.md's copied-installation row: a home directory cloned by a VM image or a
+            // OneDrive sync genuinely SHARES one installId, so two clones working on different projects
+            // would otherwise evict each other forever — a permanent mutual-eviction flap that looks like a
+            // network fault to both users. Including the pin in the key is what prevents it.
+            var (reaper, evictor) = Build();
+
+            reaper.Claim(AccountA, InstanceX, projectPin: "aaa111", mcpSessionId: "session-p1");
+            reaper.Claim(AccountA, InstanceX, projectPin: "bbb222", mcpSessionId: "session-p2");
+
+            evictor.Evicted.ShouldBeEmpty("different projects are different slots");
+            reaper.TrackedIdentityCount.ShouldBe(2);
+
+            // Same project ⇒ still replaces. Without this half the test above would be satisfied by a rule
+            // that never replaces anything once a pin is present.
+            reaper.Claim(AccountA, InstanceX, projectPin: "aaa111", mcpSessionId: "session-p1b");
+            evictor.Evicted.ShouldBe(new[] { "session-p1" });
+            reaper.CurrentSessionIdFor(AccountA, InstanceX, "bbb222").ShouldBe("session-p2",
+                "the other project's session must be untouched");
+        }
+
+        [Fact]
+        public void UnpinnedAndPinned_AreDifferentSlots()
+        {
+            var (reaper, evictor) = Build();
+
+            reaper.Claim(AccountA, InstanceX, projectPin: null, mcpSessionId: "session-unpinned");
+            reaper.Claim(AccountA, InstanceX, projectPin: "aaa111", mcpSessionId: "session-pinned");
+
+            evictor.Evicted.ShouldBeEmpty();
+            reaper.TrackedIdentityCount.ShouldBe(2);
+        }
+
+        // ───────────────────────────── the compatibility path (DoD 3) ─────────────────────────────
+
+        [Fact]
+        public void NoInstanceId_ClaimsNothing_ReplacesNothing_AndDoesNotThrow()
+        {
+            // Every currently released client lands here. It must be a total no-op — no slot, no eviction,
+            // no exception — so the container can be deployed with every client still on the old behaviour.
+            var (reaper, evictor) = Build();
+
+            reaper.Claim(AccountA, null, projectPin: null, mcpSessionId: "session-1").ShouldBeNull();
+            reaper.Claim(AccountA, string.Empty, projectPin: null, mcpSessionId: "session-2").ShouldBeNull();
+
+            evictor.Evicted.ShouldBeEmpty();
+            reaper.TrackedIdentityCount.ShouldBe(0);
+        }
+
+        [Fact]
+        public void NoAccount_ClaimsNothing_EvenWhenAnInstanceIdIsPresent()
+        {
+            // no-auth / local-token modes resolve no account. An instance id alone must NOT create a slot:
+            // an account-less key would pool unrelated clients together and each new connection would evict
+            // a stranger's session — a bug that would look exactly like the feature working.
+            var (reaper, evictor) = Build();
+
+            reaper.Claim(null, InstanceX, projectPin: null, mcpSessionId: "session-1").ShouldBeNull();
+            reaper.Claim(string.Empty, InstanceX, projectPin: null, mcpSessionId: "session-2").ShouldBeNull();
+
+            evictor.Evicted.ShouldBeEmpty();
+            reaper.TrackedIdentityCount.ShouldBe(0);
+        }
+
+        [Fact]
+        public void NoSessionId_ClaimsNothing()
+        {
+            var (reaper, evictor) = Build();
+            reaper.Claim(AccountA, InstanceX, projectPin: null, mcpSessionId: string.Empty).ShouldBeNull();
+            evictor.Evicted.ShouldBeEmpty();
+            reaper.TrackedIdentityCount.ShouldBe(0);
+        }
+
+        [Fact]
+        public void CurrentSessionIdFor_WithNoIdentity_IsNullRatherThanAnEmptyKeyLookup()
+        {
+            var (reaper, _) = Build();
+            reaper.Claim(AccountA, InstanceX, projectPin: null, mcpSessionId: "session-1");
+            reaper.CurrentSessionIdFor(null, InstanceX, null).ShouldBeNull();
+            reaper.CurrentSessionIdFor(AccountA, null, null).ShouldBeNull();
+        }
+
+        // ───────────────────────────── lifecycle / retention ─────────────────────────────
+
+        [Fact]
+        public void DisposingTheLease_ReleasesTheSlot_SoNothingOutlivesItsSession()
+        {
+            // This is the retention guarantee, asserted rather than asserted-in-prose: the stored HMAC
+            // lives exactly as long as the session that claimed it. The transport layer disposes this lease
+            // in the same `finally` that removes the session's tracker row.
+            var (reaper, _) = Build();
+
+            var lease = reaper.Claim(AccountA, InstanceX, projectPin: null, mcpSessionId: "session-1");
+            reaper.TrackedIdentityCount.ShouldBe(1);
+
+            lease!.Dispose();
+
+            reaper.TrackedIdentityCount.ShouldBe(0, "the identity must not outlive the session it keys");
+            reaper.CurrentSessionIdFor(AccountA, InstanceX, null).ShouldBeNull();
+        }
+
+        [Fact]
+        public void DisposingTheLeaseTwice_IsIdempotent()
+        {
+            var (reaper, _) = Build();
+            var lease = reaper.Claim(AccountA, InstanceX, projectPin: null, mcpSessionId: "session-1");
+            lease!.Dispose();
+            lease.Dispose();
+            reaper.TrackedIdentityCount.ShouldBe(0);
+        }
+
+        [Fact]
+        public void ADisplacedLeaseDisposingLate_DoesNotEvictItsOwnSuccessor()
+        {
+            // THE subtle one, and the reason Release is a compare-and-remove rather than a plain
+            // TryRemove(key). A displaced session unwinds AFTER its successor has already installed itself,
+            // and its `finally` disposes its lease. An unconditional removal would delete the SUCCESSOR's
+            // slot — leaving a live session that no later connection could ever find, and therefore never
+            // replace. The leak would be back, reachable only through the code added to fix it, and every
+            // other test in this file would still pass.
+            var (reaper, evictor) = Build();
+
+            var first = reaper.Claim(AccountA, InstanceX, projectPin: null, mcpSessionId: "session-1");
+            var second = reaper.Claim(AccountA, InstanceX, projectPin: null, mcpSessionId: "session-2");
+
+            // The displaced session finishes unwinding only now — after the successor is in place.
+            first!.Dispose();
+
+            reaper.CurrentSessionIdFor(AccountA, InstanceX, null).ShouldBe("session-2",
+                "the successor's slot must survive its predecessor's late teardown");
+            reaper.TrackedIdentityCount.ShouldBe(1);
+
+            // And the successor is still replaceable — proving the slot is genuinely live, not merely present.
+            reaper.Claim(AccountA, InstanceX, projectPin: null, mcpSessionId: "session-3");
+            evictor.Evicted.ShouldBe(new[] { "session-1", "session-2" });
+            reaper.CurrentSessionIdFor(AccountA, InstanceX, null).ShouldBe("session-3");
+
+            second!.Displaced.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void SameSessionReClaimingItsOwnSlot_DoesNotEvictItself()
+        {
+            // A re-entrant claim must not terminate the very session asking to be kept.
+            var (reaper, evictor) = Build();
+
+            reaper.Claim(AccountA, InstanceX, projectPin: null, mcpSessionId: "session-1");
+            var again = reaper.Claim(AccountA, InstanceX, projectPin: null, mcpSessionId: "session-1");
+
+            evictor.Evicted.ShouldBeEmpty("a session must never evict itself");
+            again!.Displaced.ShouldBeFalse();
+            again.DisplacedPredecessor.ShouldBeNull();
+            reaper.CurrentSessionIdFor(AccountA, InstanceX, null).ShouldBe("session-1");
+            reaper.TrackedIdentityCount.ShouldBe(1);
+        }
+
+        [Fact]
+        public void AccountAndInstanceComparison_IsOrdinal_NotCultureOrCaseInsensitive()
+        {
+            // Account ids and hex tokens are opaque byte strings. A culture-sensitive or case-insensitive
+            // comparison would merge two distinct identities into one slot, making one client evict
+            // another's session. (Header VALUES are lower-cased at validation time, so a case difference
+            // reaching this far means the caller bypassed validation — which must not silently merge.)
+            var (reaper, evictor) = Build();
+
+            reaper.Claim(AccountA, InstanceX, projectPin: null, mcpSessionId: "session-lower");
+            reaper.Claim(AccountA.ToUpperInvariant(), InstanceX, projectPin: null, mcpSessionId: "session-upper");
+
+            evictor.Evicted.ShouldBeEmpty("different byte strings are different accounts");
+            reaper.TrackedIdentityCount.ShouldBe(2);
+        }
+
+        [Fact]
+        public void ConcurrentClaimsForOneIdentity_ConvergeOnASingleSlot()
+        {
+            // Two initialize requests for one identity can genuinely race. The invariant that matters is
+            // that they converge: exactly one slot survives, and every session except the survivor was
+            // evicted — so no session is left live-but-unreferenced, which no future replace could reach.
+            var (reaper, evictor) = Build();
+            const int count = 32;
+
+            Parallel.For(0, count, i => reaper.Claim(AccountA, InstanceX, projectPin: null, mcpSessionId: $"session-{i}"));
+
+            reaper.TrackedIdentityCount.ShouldBe(1);
+            var survivor = reaper.CurrentSessionIdFor(AccountA, InstanceX, null);
+            survivor.ShouldNotBeNull();
+
+            evictor.Evicted.Count.ShouldBe(count - 1,
+                "every session except the surviving one must have been evicted; a smaller number means a " +
+                "session was stranded live with nothing referencing it");
+            evictor.Evicted.ShouldNotContain(survivor!, "the surviving session must not have been evicted");
+        }
+    }
+}

--- a/McpPlugin.Server.Tests/McpSessionReaperTests.cs
+++ b/McpPlugin.Server.Tests/McpSessionReaperTests.cs
@@ -287,12 +287,12 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
         }
 
         [Fact]
-        public void SameSessionReClaimingItsOwnSlot_DoesNotEvictItself()
+        public void SameSessionReClaimingItsOwnSlot_DoesNotEvictItself_AndFlagsNeitherLease()
         {
             // A re-entrant claim must not terminate the very session asking to be kept.
             var (reaper, evictor) = Build();
 
-            reaper.Claim(AccountA, InstanceX, projectPin: null, mcpSessionId: "session-1");
+            var first = reaper.Claim(AccountA, InstanceX, projectPin: null, mcpSessionId: "session-1");
             var again = reaper.Claim(AccountA, InstanceX, projectPin: null, mcpSessionId: "session-1");
 
             evictor.Evicted.ShouldBeEmpty("a session must never evict itself");
@@ -300,6 +300,13 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
             again.DisplacedPredecessor.ShouldBeNull();
             reaper.CurrentSessionIdFor(AccountA, InstanceX, null).ShouldBe("session-1");
             reaper.TrackedIdentityCount.ShouldBe(1);
+
+            // The OUTGOING lease must not be flagged either. Asserting only the incoming one missed a real
+            // defect: the same-session check used to run AFTER MarkDisplaced, so this lease was flagged
+            // `Displaced` and the session's handler would then report an ordinary cancellation as "displaced
+            // by replace-by-identity" — a wrong attribution an operator would chase.
+            first!.Displaced.ShouldBeFalse(
+                "no session was displaced, so neither lease may claim it was");
         }
 
         [Fact]

--- a/McpPlugin.Server/McpPlugin.Server.csproj
+++ b/McpPlugin.Server/McpPlugin.Server.csproj
@@ -11,7 +11,7 @@
     <!-- NuGet Package Information -->
     <IsPackable>true</IsPackable>
     <PackageId>com.IvanMurzak.McpPlugin.Server</PackageId>
-    <Version>8.1.0</Version>
+    <Version>8.2.0</Version>
     <Authors>Ivan Murzak</Authors>
     <Company>Ivan Murzak</Company>
     <Copyright>Copyright © Ivan Murzak 2025</Copyright>

--- a/McpPlugin.Server/server.json
+++ b/McpPlugin.Server/server.json
@@ -8,13 +8,13 @@
     "source": "github",
     "subfolder": "McpPlugin.Server"
   },
-  "version": "8.1.0",
+  "version": "8.2.0",
   "packages": [
     {
       "registry_type": "oci",
       "registry_base_url": "https://docker.io",
       "identifier": "ivanmurzakdev/mcp-plugin-server",
-      "version": "8.1.0",
+      "version": "8.2.0",
       "transport": {
         "type": "stdio"
       },

--- a/McpPlugin.Server/src/Auth/InstanceIdentityHeader.cs
+++ b/McpPlugin.Server/src/Auth/InstanceIdentityHeader.cs
@@ -1,0 +1,170 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Security.Cryptography;
+using System.Text;
+using com.IvanMurzak.McpPlugin.Common;
+using Microsoft.AspNetCore.Http;
+
+namespace com.IvanMurzak.McpPlugin.Server.Auth
+{
+    /// <summary>
+    /// The outcome of reading the <c>AI-Game-Dev-Instance-Id</c> request header.
+    /// The three states are deliberately distinct for the same reason
+    /// <see cref="ProjectPinParse"/>'s are: <b>absent is not malformed</b>.
+    /// </summary>
+    public enum InstanceIdentityParse
+    {
+        /// <summary>
+        /// No <c>AI-Game-Dev-Instance-Id</c> header at all. A supported, unprivileged state —
+        /// EVERY currently released client is such a client. The session is tracked exactly as it is
+        /// today: nothing is replaced, nothing is rejected, nothing warns.
+        /// </summary>
+        Absent = 0,
+
+        /// <summary>A well-formed opaque instance id (exactly 32 hex chars) was captured.</summary>
+        Valid = 1,
+
+        /// <summary>
+        /// The header is PRESENT but its value is not a well-formed opaque token. The request MUST be
+        /// rejected — silently downgrading it to <see cref="Absent"/> would turn a client that believes
+        /// it is participating in the replace rule into one that stacks sessions forever, with no
+        /// symptom short of the 6 h idle timeout.
+        /// </summary>
+        Malformed = 2,
+    }
+
+    /// <summary>
+    /// Reads and validates the per-installation MCP instance identity carried in the
+    /// <c>AI-Game-Dev-Instance-Id</c> request header (design 07 §2.3, D10.2).
+    ///
+    /// <para><b>What the value is.</b> The client computes
+    /// <c>HMAC-SHA256(key = installId, msg = accountSub)</c>, truncates it to 128 bits and hex-encodes
+    /// it — so the wire value is exactly <see cref="ExpectedLength"/> hex characters. The server never
+    /// sees <c>installId</c>, which is what makes the value unlinkable across accounts.
+    /// <b>Do not "simplify" the key/message order</b>: the key is the SECRET <c>installId</c> and the
+    /// message is the PUBLIC <c>accountSub</c>. (Independently re-verified twice; inverting it would
+    /// require a 128-bit brute force to undo.)</para>
+    ///
+    /// <para><b>Why it is validated as an opaque token, and validated FIRST.</b> The value is
+    /// client-supplied and therefore untrusted. Validating it to a fixed length over a closed charset
+    /// before it is used anywhere means every downstream use is safe <i>by construction</i> rather than
+    /// by remembering to escape: a 32-char hex string cannot carry a CR/LF log-injection payload, cannot
+    /// traverse a path, and cannot terminate a quoted literal. This class is the only place the raw
+    /// header value is read.</para>
+    ///
+    /// <para><b>It is a routing key, never an authenticator.</b> The account scope comes from the bearer
+    /// credential (<see cref="ConnectionIdentity.FromPrincipal"/>); this value only ever selects among
+    /// sessions <i>inside</i> that scope. A spoofed value can evict only the spoofer's own sessions.</para>
+    /// </summary>
+    public static class InstanceIdentityHeader
+    {
+        /// <summary>The header name, used byte-for-byte. No <c>X-</c> prefix (RFC 6648).</summary>
+        public const string HeaderName = Consts.MCP.Server.Headers.InstanceId;
+
+        /// <summary>
+        /// Exact number of hex characters in a well-formed value: 128 bits ⇒ 16 bytes ⇒ 32 hex chars.
+        /// FIXED, not a maximum — a length range would admit a truncated value that still parses, and
+        /// the contract with the client is exact.
+        /// </summary>
+        public const int ExpectedLength = 32;
+
+        /// <summary>Machine-readable error code returned when a present instance id cannot be parsed.</summary>
+        public const string InvalidInstanceIdError = "invalid_instance_id";
+
+        /// <summary>
+        /// Reads the header from a request. Returns <see cref="InstanceIdentityParse.Absent"/> when the
+        /// header is not present at all (the released-client case), <see cref="InstanceIdentityParse.Valid"/>
+        /// with a lower-cased value, or <see cref="InstanceIdentityParse.Malformed"/>.
+        ///
+        /// <para>A header present more than once is <b>malformed</b>, not "take the first": two values
+        /// mean the caller's intent is ambiguous, and picking one silently would let a caller smuggle a
+        /// second identity past a reviewer reading only the first.</para>
+        /// </summary>
+        public static InstanceIdentityParse TryRead(IHeaderDictionary? headers, out string? instanceId)
+        {
+            instanceId = null;
+            if (headers == null)
+                return InstanceIdentityParse.Absent;
+
+            if (!headers.TryGetValue(HeaderName, out var values))
+                return InstanceIdentityParse.Absent;
+
+            // Count == 0 happens for a header present with no value at all; that is malformed, not absent.
+            if (values.Count == 0)
+                return InstanceIdentityParse.Malformed;
+
+            if (values.Count > 1)
+                return InstanceIdentityParse.Malformed;
+
+            return TryParse(values[0], out instanceId);
+        }
+
+        /// <summary>
+        /// Validates a raw header value as an opaque instance id.
+        ///
+        /// <para>Note what is deliberately NOT done: the input is not trimmed and control characters are
+        /// not stripped. A value with surrounding whitespace, an embedded CR/LF, or a NUL is
+        /// <b>rejected</b>, not repaired. Repairing it would mean a client and the server disagree about
+        /// what the identity is, which is precisely the class of bug that makes a replace rule evict the
+        /// wrong session.</para>
+        /// </summary>
+        public static InstanceIdentityParse TryParse(string? raw, out string? instanceId)
+        {
+            instanceId = null;
+
+            // A present-but-empty header value is malformed: the client asked to participate and sent
+            // nothing. Treating it as Absent would be the silent downgrade this tri-state exists to stop.
+            if (raw == null || raw.Length == 0)
+                return InstanceIdentityParse.Malformed;
+
+            if (raw.Length != ExpectedLength)
+                return InstanceIdentityParse.Malformed;
+
+            for (var i = 0; i < raw.Length; i++)
+            {
+                var c = raw[i];
+                var isHex = (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+                if (!isHex)
+                    return InstanceIdentityParse.Malformed;
+            }
+
+            instanceId = raw.ToLowerInvariant();
+            return InstanceIdentityParse.Valid;
+        }
+
+        /// <summary>
+        /// A short, non-reversible fingerprint of a validated instance id, for log correlation.
+        ///
+        /// <para><b>The raw instance id is never logged.</b> Operators debugging a reconnect flap need to
+        /// tell two installations apart; they do not need the identifier itself. This returns the first 8
+        /// hex chars of <c>SHA-256(instanceId)</c> — 32 bits, deliberately collision-prone, enough to
+        /// correlate two log lines from one process and not enough to be a durable identifier in a log
+        /// aggregator. Pass only values that already parsed <see cref="InstanceIdentityParse.Valid"/>.</para>
+        /// </summary>
+        public static string Fingerprint(string? instanceId)
+        {
+            if (string.IsNullOrEmpty(instanceId))
+                return "none";
+#if NET5_0_OR_GREATER
+            var hash = SHA256.HashData(Encoding.ASCII.GetBytes(instanceId!));
+#else
+            using var sha = SHA256.Create();
+            var hash = sha.ComputeHash(Encoding.ASCII.GetBytes(instanceId!));
+#endif
+            var sb = new StringBuilder(8);
+            for (var i = 0; i < 4; i++)
+                sb.Append(hash[i].ToString("x2"));
+            return sb.ToString();
+        }
+    }
+}

--- a/McpPlugin.Server/src/Auth/McpSessionTokenMiddleware.cs
+++ b/McpPlugin.Server/src/Auth/McpSessionTokenMiddleware.cs
@@ -91,6 +91,21 @@ namespace com.IvanMurzak.McpPlugin.Server.Auth
                 return;
             }
 
+            // ── Instance-identity gate (design 07 §2.3, D10.2) — same fail-closed shape as the pin. ──
+            // ABSENT is a supported state and is NOT touched here: every currently released client sends
+            // no AI-Game-Dev-Instance-Id header, and those requests must behave exactly as they do today.
+            // A header that is PRESENT but not a well-formed opaque token is REJECTED rather than ignored,
+            // for the same reason a malformed pin is: ignoring it would leave a client that believes it is
+            // participating in the replace rule silently stacking sessions instead — and the only symptom
+            // would be the six-hour pile-up this rule was written to end. Validating here, before the value
+            // is used or stored anywhere, is also what makes every downstream use injection-proof by
+            // construction rather than by remembering to escape.
+            if (InstanceIdentityHeader.TryRead(context.Request.Headers, out _) == InstanceIdentityParse.Malformed)
+            {
+                await WriteInvalidInstanceIdAsync(context).ConfigureAwait(false);
+                return;
+            }
+
             var tokenClaim = context.User?.FindFirst(TokenAuthenticationHandler.TokenClaimType);
             if (tokenClaim != null)
             {
@@ -218,6 +233,27 @@ namespace com.IvanMurzak.McpPlugin.Server.Auth
             {
                 error = InvalidProjectPinError,
                 message = "The project pin path segment is malformed; expected 1-64 hexadecimal characters."
+            }, context.RequestAborted);
+        }
+
+        /// <summary>
+        /// Rejects a request whose <c>AI-Game-Dev-Instance-Id</c> header is present but not a well-formed
+        /// opaque token. Terminal, exactly like the pin rejection — the pipeline is NOT continued, so no
+        /// handler, hub, session tracker or log formatter ever observes the offending value.
+        ///
+        /// <para><b>The rejected value is deliberately not echoed.</b> Reflecting an unvalidated,
+        /// arbitrary-length client string back into a response body is how a log-injection or a
+        /// response-splitting payload gets a second chance; the caller already knows what it sent, and the
+        /// error code plus the expected shape is everything a client needs to fix itself.</para>
+        /// </summary>
+        static Task WriteInvalidInstanceIdAsync(HttpContext context)
+        {
+            context.Response.StatusCode = StatusCodes.Status400BadRequest;
+            return context.Response.WriteAsJsonAsync(new
+            {
+                error = InstanceIdentityHeader.InvalidInstanceIdError,
+                message = $"The {InstanceIdentityHeader.HeaderName} header is malformed; expected exactly " +
+                          $"{InstanceIdentityHeader.ExpectedLength} hexadecimal characters, sent at most once."
             }, context.RequestAborted);
         }
 

--- a/McpPlugin.Server/src/Extension/ExtensionsMcpServerBuilder.cs
+++ b/McpPlugin.Server/src/Extension/ExtensionsMcpServerBuilder.cs
@@ -227,6 +227,17 @@ namespace com.IvanMurzak.McpPlugin.Server
             mcpServerBuilder.Services.AddSingleton<HubEventResourcesChange>();
             mcpServerBuilder.Services.AddSingleton<IRequestTrackingService, RequestTrackingService>();
             mcpServerBuilder.Services.AddSingleton<IMcpSessionTracker, McpSessionTracker>();
+
+            // Replace-by-identity (design 07 §2.3, D10.2). Registered in ALL auth modes and for ALL
+            // transports: the reaper is inert unless a client sends AI-Game-Dev-Instance-Id AND the
+            // credential resolves an account, so registering it unconditionally costs one idle singleton
+            // and avoids a mode-shaped hole where the rule silently does not exist.
+            mcpServerBuilder.Services.AddSingleton<IMcpSdkSessionEvictor>(sp => new McpSdkSessionEvictor(
+                sp,
+                sp.GetService<ILogger<McpSdkSessionEvictor>>()));
+            mcpServerBuilder.Services.AddSingleton<IMcpSessionReaper>(sp => new McpSessionReaper(
+                sp.GetRequiredService<IMcpSdkSessionEvictor>(),
+                sp.GetService<ILogger<McpSessionReaper>>()));
             mcpServerBuilder.Services.AddSingleton<McpGracefulShutdownService>();
             mcpServerBuilder.Services.AddHostedService(sp => sp.GetRequiredService<McpGracefulShutdownService>());
 

--- a/McpPlugin.Server/src/IMcpSdkSessionEvictor.cs
+++ b/McpPlugin.Server/src/IMcpSdkSessionEvictor.cs
@@ -1,0 +1,120 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System.Threading.Tasks;
+
+namespace com.IvanMurzak.McpPlugin.Server
+{
+    /// <summary>What happened when an SDK-owned MCP session was asked to go away.</summary>
+    public enum SdkEvictionOutcome
+    {
+        /// <summary>
+        /// The session was found in the SDK's session manager and removed from it. This is the outcome
+        /// that actually stops the leak — see <see cref="IMcpSdkSessionEvictor"/>.
+        /// </summary>
+        Evicted = 0,
+
+        /// <summary>
+        /// The SDK's session manager did not hold that id. Benign and expected: a session that already
+        /// ended (client <c>DELETE</c>, idle timeout, process-level shutdown) is already gone.
+        /// </summary>
+        NotFound = 1,
+
+        /// <summary>
+        /// The eviction seam could not be bound at all — the SDK's shape changed under us.
+        /// <b>This is the failure mode that silently restores the six-hour session pile-up</b>, so it is
+        /// logged LOUDLY (once) rather than swallowed, and it is asserted by a test.
+        /// </summary>
+        Unsupported = 2,
+
+        /// <summary>The seam is bound but the call threw. Logged with the exception; never swallowed.</summary>
+        Failed = 3,
+    }
+
+    /// <summary>
+    /// The result of one eviction attempt. Deliberately splits the two halves, because they have very
+    /// different timing and very different consequences:
+    ///
+    /// <list type="bullet">
+    /// <item><description><see cref="Outcome"/> is decided <b>synchronously</b>. Removal from the SDK's
+    /// session dictionary is what makes the old session unreachable (subsequent requests bearing its id
+    /// get <c>404 / -32001 Session not found</c>) and is what stops it being retained — i.e. the leak is
+    /// fixed the instant <see cref="Outcome"/> is <see cref="SdkEvictionOutcome.Evicted"/>.</description></item>
+    /// <item><description><see cref="DisposeCompletion"/> is the <b>asynchronous</b> half: it completes
+    /// when the removed session's transport, SSE writer and <c>McpServer</c> have been disposed, which is
+    /// also what cancels the displaced session's <c>RunSessionHandler</c> and therefore what removes its
+    /// <see cref="IMcpSessionTracker"/> row. A caller may await it with a bound and continue on timeout
+    /// WITHOUT reintroducing the leak, precisely because the synchronous half already ran.</description></item>
+    /// </list>
+    /// </summary>
+    public sealed class SdkEvictionHandle
+    {
+        public static readonly SdkEvictionHandle Unsupported = new SdkEvictionHandle(SdkEvictionOutcome.Unsupported, Task.CompletedTask);
+        public static readonly SdkEvictionHandle NotFound = new SdkEvictionHandle(SdkEvictionOutcome.NotFound, Task.CompletedTask);
+
+        public SdkEvictionHandle(SdkEvictionOutcome outcome, Task disposeCompletion)
+        {
+            Outcome = outcome;
+            DisposeCompletion = disposeCompletion ?? Task.CompletedTask;
+        }
+
+        /// <summary>Decided synchronously by <see cref="IMcpSdkSessionEvictor.Evict"/>.</summary>
+        public SdkEvictionOutcome Outcome { get; }
+
+        /// <summary>
+        /// Completes when the evicted session has finished disposing. <see cref="Task.CompletedTask"/>
+        /// when there was nothing to dispose. Never faults — a dispose failure is logged and folded in.
+        /// </summary>
+        public Task DisposeCompletion { get; }
+    }
+
+    /// <summary>
+    /// Terminates an MCP session that the <c>ModelContextProtocol.AspNetCore</c> SDK owns.
+    ///
+    /// <para><b>Why this seam exists at all.</b> MCP session lifetime is SDK-owned, and — verified
+    /// against <c>ModelContextProtocol.AspNetCore</c> <b>1.4.0</b> — <i>nothing in the SDK removes a
+    /// session from its dictionary when that session's <c>RunSessionHandler</c> returns.</i> Returning
+    /// early from the handler, or cancelling the token it was handed, therefore ends OUR bookkeeping and
+    /// leaves the SDK's <c>StatefulSessionManager</c> entry in place until <c>IdleTimeout</c> or
+    /// <c>MaxIdleSessionCount</c> prunes it. That shape is the trap this task was written to avoid: a
+    /// replace rule built on cancellation alone would drop tracker rows, look fixed, and leave the actual
+    /// pile-up untouched. The only operation that genuinely evicts is the one the SDK's own <c>DELETE</c>
+    /// handler performs: <c>StatefulSessionManager.TryRemove(id, out session)</c> followed by
+    /// <c>session.DisposeAsync()</c>.</para>
+    ///
+    /// <para><b>Why an interface.</b> The implementation has to reach an <c>internal</c> SDK type by
+    /// reflection (see <see cref="McpSdkSessionEvictor"/>). Keeping it behind a seam lets the
+    /// replace-by-identity ALGEBRA — which account and which installation displace which session — be
+    /// tested without a live Kestrel host, while the real seam is proven separately against the real SDK.
+    /// </para>
+    /// </summary>
+    public interface IMcpSdkSessionEvictor
+    {
+        /// <summary>
+        /// Whether the eviction seam is bound to the running SDK. <c>false</c> means a replace can no
+        /// longer terminate the SDK's session and the leak is back — treat it as a release blocker, not a
+        /// degraded mode. Asserted by a test so an SDK bump fails CI instead of failing production.
+        /// </summary>
+        bool IsSupported { get; }
+
+        /// <summary>
+        /// Human-readable description of how the binding resolved (or why it did not). Safe to log: it
+        /// contains type and member names only, never a session id, a credential, or an instance id.
+        /// </summary>
+        string BindingDiagnostic { get; }
+
+        /// <summary>
+        /// Removes <paramref name="mcpSessionId"/> from the SDK's session manager synchronously and
+        /// starts disposing it. Never throws — every failure is reported through the returned handle.
+        /// </summary>
+        SdkEvictionHandle Evict(string mcpSessionId);
+    }
+}

--- a/McpPlugin.Server/src/IMcpSessionReaper.cs
+++ b/McpPlugin.Server/src/IMcpSessionReaper.cs
@@ -1,0 +1,113 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+
+namespace com.IvanMurzak.McpPlugin.Server
+{
+    /// <summary>
+    /// A session's hold on one installation identity slot. Disposing it releases the slot — but only if
+    /// this session still owns it (see <see cref="IMcpSessionReaper.Claim"/>).
+    /// </summary>
+    public interface IMcpSessionIdentityLease : IDisposable
+    {
+        /// <summary>The MCP session id that holds the slot.</summary>
+        string McpSessionId { get; }
+
+        /// <summary>
+        /// True once a LATER connection with the same identity took this slot away. The displaced
+        /// session's own unwinding is then an expected, orderly shutdown rather than a fault — which is
+        /// why it is logged at debug and not as an error.
+        /// </summary>
+        bool Displaced { get; }
+
+        /// <summary>
+        /// The eviction of the predecessor this claim displaced, or <c>null</c> when there was none
+        /// (the overwhelmingly common case: a first connection). Its
+        /// <see cref="SdkEvictionHandle.Outcome"/> is already decided when <see cref="IMcpSessionReaper.Claim"/>
+        /// returns; its <see cref="SdkEvictionHandle.DisposeCompletion"/> may still be running.
+        /// </summary>
+        SdkEvictionHandle? DisplacedPredecessor { get; }
+    }
+
+    /// <summary>
+    /// The <b>replace-by-identity</b> rule (design 07 §2.3 / D10.2): when an installation that already
+    /// has a live MCP session connects again with the same identity, the previous session is
+    /// <b>replaced</b> rather than <b>stacked</b>.
+    ///
+    /// <para><b>The case this exists for is the one nothing else can reach.</b> A cleanly-closing client
+    /// sends an MCP <c>DELETE</c> and the SDK reaps its session. A client that <b>crashed or was
+    /// force-killed</b> sends nothing, by construction — so no client-side change can ever reap those
+    /// sessions, and today they survive until the production idle timeout of 21600 s (6 h). That is the
+    /// pile-up this rule ends: the next <c>initialize</c> from the same installation reaps its own
+    /// predecessor.</para>
+    ///
+    /// <para><b>Why <c>initialize</c> creates a new entry today.</b>
+    /// <c>McpServerService.StartAsync</c> composes its tracker key as
+    /// <c>"&lt;accountSub&gt;:&lt;mcpSessionId&gt;"</c>, and the MCP session id is freshly minted by every
+    /// <c>initialize</c>. So the key is different every time by construction, and sessions can only ever
+    /// stack. Replacing needs a key that is stable across reconnects — which is exactly what the
+    /// installation identity supplies, and why it had to be introduced.</para>
+    ///
+    /// <para><b>The key, and a deliberate deviation worth reading.</b> The slot is keyed on
+    /// <c>(accountSub, instanceId, projectPin)</c>. The task specification for this change says
+    /// <c>(accountSub, instanceId)</c>; <c>07-security.md</c> (§2.5 copied-installation row, threat T25,
+    /// gate SG-14) says <c>(accountSub, instanceId, <b>pin</b>)</c> and gives the reason: a home directory
+    /// copied by a VM image or a OneDrive sync genuinely shares one <c>installId</c>, so two clones
+    /// working on <i>different projects</i> would otherwise evict each other forever in a mutual flap.
+    /// Including the pin is a strict superset of the two-part key — same account + same installation +
+    /// same project still replaces, and two different accounts still cannot touch each other — so it
+    /// satisfies the task's requirements as written and additionally honours SG-14. Dropping the pin would
+    /// satisfy the task and violate the design.</para>
+    ///
+    /// <para><b>What is NOT a key.</b> <c>accountSub</c> comes from the validated bearer credential
+    /// (<c>ConnectionIdentity.FromPrincipal</c>) and never from a client-supplied body field, so the
+    /// client-supplied <c>instanceId</c> can only ever select among sessions <i>inside</i> the account the
+    /// credential already proved. A spoofed instance id evicts only the spoofer's own sessions; it cannot
+    /// name, reach, or reason about another account's.</para>
+    ///
+    /// <para><b>Retention (pinned here for the privacy clause).</b> The transmitted HMAC is held in this
+    /// object's in-memory dictionary and <b>nowhere else</b>: not in a database, not on disk, not in a
+    /// webhook payload, and not in a log line (logs carry a truncated, non-reversible fingerprint — see
+    /// <c>InstanceIdentityHeader.Fingerprint</c>). The entry is removed when the session that claimed it
+    /// ends, in the same <c>finally</c> that removes the session's tracker row, or when a newer session
+    /// with the same identity replaces it, or when the process exits. <b>It therefore never outlives the
+    /// session it keys, and there is no retention period to state because nothing is retained.</b></para>
+    /// </summary>
+    public interface IMcpSessionReaper
+    {
+        /// <summary>
+        /// Claims the identity slot for <paramref name="mcpSessionId"/>, replacing and terminating any
+        /// prior holder of the same <c>(accountSub, instanceId, projectPin)</c>.
+        ///
+        /// <para>Returns <c>null</c> — claiming nothing, replacing nothing — when
+        /// <paramref name="accountSub"/> or <paramref name="instanceId"/> is null/empty. <b>That null is
+        /// the compatibility path, and it is load-bearing:</b> every currently released client sends no
+        /// instance id, so it must land here and behave exactly as it does today. No replace, no
+        /// rejection, no warning.</para>
+        ///
+        /// <para>The SDK-side removal of the predecessor happens <b>before this method returns</b>, so on
+        /// return the old session id is already unreachable. Only the predecessor's resource dispose may
+        /// still be in flight; await <see cref="IMcpSessionIdentityLease.DisplacedPredecessor"/>'s
+        /// <see cref="SdkEvictionHandle.DisposeCompletion"/> if you need it finished.</para>
+        /// </summary>
+        IMcpSessionIdentityLease? Claim(string? accountSub, string? instanceId, string? projectPin, string mcpSessionId);
+
+        /// <summary>Number of identity slots currently held. Zero when no client sends an instance id.</summary>
+        int TrackedIdentityCount { get; }
+
+        /// <summary>
+        /// The MCP session id currently holding a slot, or <c>null</c>. Diagnostic: it is what lets a test
+        /// assert that two accounts presenting the SAME instance id hold two independent slots.
+        /// </summary>
+        string? CurrentSessionIdFor(string? accountSub, string? instanceId, string? projectPin);
+    }
+}

--- a/McpPlugin.Server/src/McpSdkSessionEvictor.cs
+++ b/McpPlugin.Server/src/McpSdkSessionEvictor.cs
@@ -1,0 +1,245 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.AspNetCore;
+
+namespace com.IvanMurzak.McpPlugin.Server
+{
+    /// <summary>
+    /// Evicts an SDK-owned MCP session by performing exactly what the SDK's own <c>DELETE</c> handler
+    /// performs — <c>StatefulSessionManager.TryRemove(id, out session)</c> then
+    /// <c>session.DisposeAsync()</c> — reaching the manager by reflection because the type is
+    /// <c>internal</c>.
+    ///
+    /// <para><b>Verified against <c>ModelContextProtocol.AspNetCore</c> 1.4.0</b>
+    /// (<c>1.4.0+06e3604dd12fbfc08c8f9d316325380ec2a2989b</c>), by reading the tagged source AND by
+    /// reflecting over the shipped IL:</para>
+    /// <list type="bullet">
+    /// <item><description><c>internal sealed class StatefulSessionManager</c> holds
+    /// <c>ConcurrentDictionary&lt;string, StreamableHttpSession&gt; _sessions</c> and is registered as a DI
+    /// singleton by <c>WithHttpTransport</c> (<c>TryAddSingleton&lt;StatefulSessionManager&gt;()</c>), so it
+    /// IS resolvable — <c>IServiceProvider.GetService(Type)</c> does not require a public type.</description></item>
+    /// <item><description><c>public bool TryRemove(string key, out StreamableHttpSession value)</c> is
+    /// public on that internal type, hence reachable only by reflection.</description></item>
+    /// <item><description><c>internal sealed class StreamableHttpSession : IAsyncDisposable</c> — the
+    /// interface is PUBLIC, so once the object is in hand the dispose needs no reflection at all. Its
+    /// <c>DisposeAsync</c> disposes the transport (completing the incoming channel, releasing the pending
+    /// SSE <c>GET</c>, disposing the <c>SseEventWriter</c> buffer that leaked multi-GB in production),
+    /// cancels the session's <c>SessionClosed</c> token, awaits <c>ServerRunTask</c>, then disposes the
+    /// <c>McpServer</c>.</description></item>
+    /// </list>
+    ///
+    /// <para><b>Cancelling <c>SessionClosed</c> is a consequence of the dispose, not a substitute for
+    /// it.</b> Because <c>RunSessionHandler</c> is invoked with <c>session.SessionClosed</c> as its
+    /// cancellation token, disposing the session is also what unwinds our
+    /// <c>StreamableHttpTransportLayer</c> handler and therefore what removes the
+    /// <see cref="IMcpSessionTracker"/> row. Doing it the other way round — cancelling our own token and
+    /// hoping the SDK notices — does NOT work: nothing in 1.4.0 attaches a continuation to
+    /// <c>ServerRunTask</c> that removes the session, so the entry would survive in
+    /// <c>_sessions</c> until the idle reaper ran.</para>
+    ///
+    /// <para><b>Reflection here is a deliberate, loud dependency, not a shortcut.</b> There is no public
+    /// or DI-typed API in 1.4.0 to evict a session by id, and no <c>InternalsVisibleTo</c>. The
+    /// alternatives were (a) wait for the client to send <c>DELETE</c> — which is precisely what a crashed
+    /// or force-killed app can never do, i.e. the case this whole rule exists for — or (b) wait for the
+    /// idle reaper, i.e. keep the six-hour pile-up. So the binding is resolved ONCE, its failure is
+    /// reported through <see cref="IsSupported"/>/<see cref="BindingDiagnostic"/>, logged at
+    /// <c>Error</c>, and <b>asserted by a test</b> so that an SDK bump which moves this seam breaks CI
+    /// instead of silently restoring the leak.</para>
+    /// </summary>
+    public sealed class McpSdkSessionEvictor : IMcpSdkSessionEvictor
+    {
+        /// <summary>Fully-qualified name of the SDK's internal session store.</summary>
+        public const string SessionManagerTypeName = "ModelContextProtocol.AspNetCore.StatefulSessionManager";
+
+        /// <summary>The method that removes a session from the store — the leak-stopping half.</summary>
+        public const string TryRemoveMethodName = "TryRemove";
+
+        // Resolved once per process against the loaded SDK assembly. A static failure here is a
+        // dependency-shape change, not a per-request condition, so it is computed once and reported.
+        static readonly Type? _sessionManagerType;
+        static readonly MethodInfo? _tryRemove;
+        static readonly string _bindingDiagnostic;
+
+        static McpSdkSessionEvictor()
+        {
+            // Anchor on a PUBLIC type from the same assembly so the assembly reference is a compile-time
+            // fact rather than a string to be got wrong.
+            var sdkAssembly = typeof(HttpServerTransportOptions).Assembly;
+            _sessionManagerType = sdkAssembly.GetType(SessionManagerTypeName, throwOnError: false);
+
+            if (_sessionManagerType == null)
+            {
+                _bindingDiagnostic =
+                    $"UNBOUND: type '{SessionManagerTypeName}' not found in {sdkAssembly.GetName().Name} " +
+                    $"{sdkAssembly.GetName().Version}. The MCP SDK's session store moved or was renamed; " +
+                    "replace-by-identity can no longer terminate SDK sessions.";
+                return;
+            }
+
+            // Bind by name + parameter shape (string, out <session>) rather than by an exact type list, so
+            // a rename of the SESSION type alone does not break a seam that does not care about it.
+            foreach (var candidate in _sessionManagerType.GetMethods(BindingFlags.Public | BindingFlags.Instance))
+            {
+                if (!string.Equals(candidate.Name, TryRemoveMethodName, StringComparison.Ordinal))
+                    continue;
+                if (candidate.ReturnType != typeof(bool))
+                    continue;
+                var parameters = candidate.GetParameters();
+                if (parameters.Length != 2)
+                    continue;
+                if (parameters[0].ParameterType != typeof(string))
+                    continue;
+                if (!parameters[1].IsOut)
+                    continue;
+                _tryRemove = candidate;
+                break;
+            }
+
+            _bindingDiagnostic = _tryRemove != null
+                ? $"BOUND: {SessionManagerTypeName}.{TryRemoveMethodName}(string, out {_tryRemove.GetParameters()[1].ParameterType.Name}) " +
+                  $"via {sdkAssembly.GetName().Name} {sdkAssembly.GetName().Version}; dispose via public IAsyncDisposable."
+                : $"UNBOUND: '{SessionManagerTypeName}' was found but has no 'bool {TryRemoveMethodName}(string, out …)'. " +
+                  "The MCP SDK changed its eviction contract; replace-by-identity can no longer terminate SDK sessions.";
+        }
+
+        readonly IServiceProvider _services;
+        readonly ILogger<McpSdkSessionEvictor>? _logger;
+        int _unsupportedReported;
+
+        public McpSdkSessionEvictor(IServiceProvider services, ILogger<McpSdkSessionEvictor>? logger = null)
+        {
+            _services = services ?? throw new ArgumentNullException(nameof(services));
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Whether the seam bound. Static, so a test can assert it without constructing a host — and that
+        /// test is the tripwire for an SDK bump.
+        /// </summary>
+        public static bool IsBindingResolved => _tryRemove != null;
+
+        /// <summary>Static counterpart of <see cref="BindingDiagnostic"/>. Contains no session data.</summary>
+        public static string StaticBindingDiagnostic => _bindingDiagnostic;
+
+        public bool IsSupported => _tryRemove != null;
+
+        public string BindingDiagnostic => _bindingDiagnostic;
+
+        public SdkEvictionHandle Evict(string mcpSessionId)
+        {
+            if (string.IsNullOrEmpty(mcpSessionId))
+                return SdkEvictionHandle.NotFound;
+
+            if (_tryRemove == null || _sessionManagerType == null)
+            {
+                ReportUnsupportedOnce();
+                return SdkEvictionHandle.Unsupported;
+            }
+
+            object? manager;
+            try
+            {
+                manager = _services.GetService(_sessionManagerType);
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogError(ex, "Failed to resolve the MCP SDK session manager from DI. {diagnostic}", _bindingDiagnostic);
+                return new SdkEvictionHandle(SdkEvictionOutcome.Failed, Task.CompletedTask);
+            }
+
+            if (manager == null)
+            {
+                // Reachable in a host that never called WithHttpTransport (stdio-only). Not an error there:
+                // there are no HTTP sessions to evict in the first place.
+                _logger?.LogDebug("MCP SDK session manager is not registered; nothing to evict. SessionId: {sessionId}.", mcpSessionId);
+                return SdkEvictionHandle.NotFound;
+            }
+
+            object? session;
+            try
+            {
+                // args[1] receives the out parameter.
+                var args = new object?[] { mcpSessionId, null };
+                var removed = _tryRemove.Invoke(manager, args) is bool b && b;
+                session = args[1];
+                if (!removed || session == null)
+                    return SdkEvictionHandle.NotFound;
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogError(ex, "MCP SDK session eviction threw. SessionId: {sessionId}. {diagnostic}", mcpSessionId, _bindingDiagnostic);
+                return new SdkEvictionHandle(SdkEvictionOutcome.Failed, Task.CompletedTask);
+            }
+
+            // Removal already happened above and is what stops the leak. The dispose is the resource half;
+            // it is started here and surfaced as a task so the caller can bound its wait.
+            return new SdkEvictionHandle(SdkEvictionOutcome.Evicted, DisposeAsync(session, mcpSessionId));
+        }
+
+        /// <summary>
+        /// Disposes an evicted session through the PUBLIC <see cref="IAsyncDisposable"/> the SDK's session
+        /// type implements — no reflection needed past the lookup. Never faults the returned task: the
+        /// session is already unreachable, so a dispose failure must not propagate into the caller's
+        /// request path.
+        /// </summary>
+        async Task DisposeAsync(object session, string mcpSessionId)
+        {
+            try
+            {
+                if (session is IAsyncDisposable asyncDisposable)
+                {
+                    await asyncDisposable.DisposeAsync().ConfigureAwait(false);
+                }
+                else if (session is IDisposable disposable)
+                {
+                    disposable.Dispose();
+                }
+                else
+                {
+                    _logger?.LogWarning(
+                        "Evicted MCP session is neither IAsyncDisposable nor IDisposable ({type}); its transport buffers " +
+                        "will not be released until the process exits. SessionId: {sessionId}.",
+                        session.GetType().FullName, mcpSessionId);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning(ex,
+                    "Disposing the evicted MCP session failed; it is already removed from the SDK session store, " +
+                    "so it can no longer be reached, but its buffers may linger. SessionId: {sessionId}.",
+                    mcpSessionId);
+            }
+        }
+
+        void ReportUnsupportedOnce()
+        {
+            if (System.Threading.Interlocked.Exchange(ref _unsupportedReported, 1) != 0)
+            {
+                _logger?.LogDebug("MCP SDK session eviction remains unsupported. {diagnostic}", _bindingDiagnostic);
+                return;
+            }
+
+            // LOUD, exactly once. This is the only signal that replace-by-identity has stopped
+            // terminating SDK sessions — the same reasoning as design 07 SG-15's loud 405: a silent
+            // degradation here restores the six-hour session pile-up with no functional symptom.
+            _logger?.LogError(
+                "MCP replace-by-identity can no longer terminate SDK-owned sessions: the eviction seam did not bind. " +
+                "Displaced sessions will linger until the idle timeout prunes them. {diagnostic}",
+                _bindingDiagnostic);
+        }
+    }
+}

--- a/McpPlugin.Server/src/McpSessionReaper.cs
+++ b/McpPlugin.Server/src/McpSessionReaper.cs
@@ -1,0 +1,185 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using com.IvanMurzak.McpPlugin.Server.Auth;
+using Microsoft.Extensions.Logging;
+
+namespace com.IvanMurzak.McpPlugin.Server
+{
+    /// <summary>
+    /// In-memory implementation of the replace-by-identity rule. See <see cref="IMcpSessionReaper"/> for
+    /// the rule, the key shape, and the retention statement — this file is the mechanics.
+    /// </summary>
+    public sealed class McpSessionReaper : IMcpSessionReaper
+    {
+        /// <summary>
+        /// The slot key. A <c>record</c> so equality is structural, and every component is compared with
+        /// the default string comparer, i.e. <b>ordinal</b> — never culture-sensitive. Culture-sensitive
+        /// comparison on an account id or a hex token is how two distinct identities become one.
+        /// </summary>
+        sealed record IdentityKey(string AccountSub, string InstanceId, string? ProjectPin);
+
+        readonly ILogger<McpSessionReaper>? _logger;
+        readonly IMcpSdkSessionEvictor _evictor;
+
+        // Value is the lease object itself, so releasing can be an ATOMIC compare-and-remove on reference
+        // identity. See Lease.Dispose for why anything weaker is wrong.
+        readonly ConcurrentDictionary<IdentityKey, Lease> _slots = new ConcurrentDictionary<IdentityKey, Lease>();
+
+        // Serialises claim-and-displace. The window it closes is real: two initialize requests for the
+        // same identity arriving concurrently could otherwise both read "no predecessor", both install
+        // themselves, and leave one session live but unreferenced — a leaked session that no future
+        // replace can ever reach, which is the exact failure this class exists to prevent.
+        readonly object _claimLock = new object();
+
+        public McpSessionReaper(IMcpSdkSessionEvictor evictor, ILogger<McpSessionReaper>? logger = null)
+        {
+            _evictor = evictor ?? throw new ArgumentNullException(nameof(evictor));
+            _logger = logger;
+        }
+
+        public int TrackedIdentityCount => _slots.Count;
+
+        public string? CurrentSessionIdFor(string? accountSub, string? instanceId, string? projectPin)
+        {
+            if (string.IsNullOrEmpty(accountSub) || string.IsNullOrEmpty(instanceId))
+                return null;
+            return _slots.TryGetValue(new IdentityKey(accountSub!, instanceId!, projectPin), out var lease)
+                ? lease.McpSessionId
+                : null;
+        }
+
+        public IMcpSessionIdentityLease? Claim(string? accountSub, string? instanceId, string? projectPin, string mcpSessionId)
+        {
+            // ── The compatibility path. Every released client lands here. ──────────────────────────────
+            // No identity ⇒ no slot, no replace, no rejection, no log noise. Behaviour is byte-for-byte
+            // today's. This is checked FIRST and returns null rather than, say, keying on an empty string:
+            // an empty-string key would silently pool every anonymous client into ONE slot, and each new
+            // anonymous connection would then evict an unrelated user's session. That bug would look
+            // exactly like the feature working.
+            if (string.IsNullOrEmpty(accountSub) || string.IsNullOrEmpty(instanceId))
+                return null;
+
+            if (string.IsNullOrEmpty(mcpSessionId))
+                return null;
+
+            var key = new IdentityKey(accountSub!, instanceId!, projectPin);
+            var lease = new Lease(this, key, mcpSessionId);
+
+            Lease? predecessor = null;
+            lock (_claimLock)
+            {
+                if (_slots.TryGetValue(key, out var existing) && !ReferenceEquals(existing, lease))
+                    predecessor = existing;
+
+                _slots[key] = lease;
+
+                if (predecessor != null)
+                {
+                    // Flag BEFORE evicting: the displaced session's handler observes cancellation as a
+                    // direct consequence of the eviction below, and it must already be able to tell that
+                    // its shutdown is an orderly replace rather than a fault.
+                    predecessor.MarkDisplaced();
+                }
+            }
+
+            if (predecessor == null)
+            {
+                _logger?.LogDebug(
+                    "MCP identity slot claimed. Instance: {instanceFingerprint}, Pin: {pin}, SessionId: {sessionId}, Slots: {slots}.",
+                    InstanceIdentityHeader.Fingerprint(instanceId), projectPin ?? "none", mcpSessionId, _slots.Count);
+                return lease;
+            }
+
+            if (string.Equals(predecessor.McpSessionId, mcpSessionId, StringComparison.Ordinal))
+            {
+                // Same session re-claiming its own slot. Nothing to terminate; terminating here would kill
+                // the live session that just asked to be kept.
+                _logger?.LogDebug(
+                    "MCP identity slot re-claimed by the same session. Instance: {instanceFingerprint}, SessionId: {sessionId}.",
+                    InstanceIdentityHeader.Fingerprint(instanceId), mcpSessionId);
+                return lease;
+            }
+
+            var eviction = _evictor.Evict(predecessor.McpSessionId);
+            lease.SetDisplacedPredecessor(eviction);
+
+            // The instance id NEVER appears here — only its truncated fingerprint — and this line carries
+            // no credential, so the id is never logged beside the bearer header.
+            _logger?.LogInformation(
+                "MCP session replaced by identity. Instance: {instanceFingerprint}, Pin: {pin}, " +
+                "ReplacedSessionId: {replacedSessionId}, NewSessionId: {newSessionId}, Eviction: {outcome}, Slots: {slots}.",
+                InstanceIdentityHeader.Fingerprint(instanceId), projectPin ?? "none",
+                predecessor.McpSessionId, mcpSessionId, eviction.Outcome, _slots.Count);
+
+            return lease;
+        }
+
+        /// <summary>
+        /// Releases a slot, but ONLY if <paramref name="lease"/> still holds it.
+        ///
+        /// <para>The conditional matters and is not defensive padding. A displaced session unwinds
+        /// <i>after</i> its successor has already installed itself, and its <c>finally</c> disposes its own
+        /// lease. An unconditional <c>TryRemove(key)</c> would then delete the SUCCESSOR's slot, leaving a
+        /// live session that no later connection can find and therefore can never replace — the leak, back,
+        /// reachable only through the code that was added to fix it. <c>ConcurrentDictionary</c>'s
+        /// key/value <c>TryRemove</c> overload does the compare-and-remove atomically on reference identity.</para>
+        /// </summary>
+        void Release(Lease lease)
+        {
+            var removed = ((ICollection<KeyValuePair<IdentityKey, Lease>>)_slots)
+                .Remove(new KeyValuePair<IdentityKey, Lease>(lease.Key, lease));
+
+            _logger?.LogDebug(
+                "MCP identity slot release. Instance: {instanceFingerprint}, SessionId: {sessionId}, " +
+                "Released: {released}, Displaced: {displaced}, Slots: {slots}.",
+                InstanceIdentityHeader.Fingerprint(lease.Key.InstanceId), lease.McpSessionId,
+                removed, lease.Displaced, _slots.Count);
+        }
+
+        sealed class Lease : IMcpSessionIdentityLease
+        {
+            readonly McpSessionReaper _owner;
+            int _disposed;
+            volatile bool _displaced;
+            volatile SdkEvictionHandle? _displacedPredecessor;
+
+            internal Lease(McpSessionReaper owner, IdentityKey key, string mcpSessionId)
+            {
+                _owner = owner;
+                Key = key;
+                McpSessionId = mcpSessionId;
+            }
+
+            internal IdentityKey Key { get; }
+
+            public string McpSessionId { get; }
+
+            public bool Displaced => _displaced;
+
+            public SdkEvictionHandle? DisplacedPredecessor => _displacedPredecessor;
+
+            internal void MarkDisplaced() => _displaced = true;
+
+            internal void SetDisplacedPredecessor(SdkEvictionHandle handle) => _displacedPredecessor = handle;
+
+            public void Dispose()
+            {
+                if (System.Threading.Interlocked.Exchange(ref _disposed, 1) != 0)
+                    return;
+                _owner.Release(this);
+            }
+        }
+    }
+}

--- a/McpPlugin.Server/src/McpSessionReaper.cs
+++ b/McpPlugin.Server/src/McpSessionReaper.cs
@@ -77,21 +77,42 @@ namespace com.IvanMurzak.McpPlugin.Server
             var key = new IdentityKey(accountSub!, instanceId!, projectPin);
             var lease = new Lease(this, key, mcpSessionId);
 
+            // The same-session check lives INSIDE the lock, together with MarkDisplaced. It used to sit
+            // after the lock, which meant a same-session re-claim marked the OUTGOING lease `Displaced`
+            // before discovering it was the same session — so that session's handler would later report an
+            // ordinary cancellation as "displaced by replace-by-identity". Cosmetic, but it is exactly the
+            // kind of wrong attribution an operator would then chase.
             Lease? predecessor = null;
+            var sameSessionReclaim = false;
             lock (_claimLock)
             {
-                if (_slots.TryGetValue(key, out var existing) && !ReferenceEquals(existing, lease))
-                    predecessor = existing;
+                if (_slots.TryGetValue(key, out var existing))
+                {
+                    if (string.Equals(existing.McpSessionId, mcpSessionId, StringComparison.Ordinal))
+                    {
+                        // Same session re-claiming its own slot. Nothing to terminate — terminating here
+                        // would kill the live session that just asked to be kept — and nothing to flag.
+                        sameSessionReclaim = true;
+                    }
+                    else
+                    {
+                        predecessor = existing;
+                        // Flag BEFORE evicting: the displaced session's handler observes cancellation as a
+                        // direct consequence of the eviction below, and it must already be able to tell
+                        // that its shutdown is an orderly replace rather than a fault.
+                        predecessor.MarkDisplaced();
+                    }
+                }
 
                 _slots[key] = lease;
+            }
 
-                if (predecessor != null)
-                {
-                    // Flag BEFORE evicting: the displaced session's handler observes cancellation as a
-                    // direct consequence of the eviction below, and it must already be able to tell that
-                    // its shutdown is an orderly replace rather than a fault.
-                    predecessor.MarkDisplaced();
-                }
+            if (sameSessionReclaim)
+            {
+                _logger?.LogDebug(
+                    "MCP identity slot re-claimed by the same session. Instance: {instanceFingerprint}, SessionId: {sessionId}.",
+                    InstanceIdentityHeader.Fingerprint(instanceId), mcpSessionId);
+                return lease;
             }
 
             if (predecessor == null)
@@ -99,16 +120,6 @@ namespace com.IvanMurzak.McpPlugin.Server
                 _logger?.LogDebug(
                     "MCP identity slot claimed. Instance: {instanceFingerprint}, Pin: {pin}, SessionId: {sessionId}, Slots: {slots}.",
                     InstanceIdentityHeader.Fingerprint(instanceId), projectPin ?? "none", mcpSessionId, _slots.Count);
-                return lease;
-            }
-
-            if (string.Equals(predecessor.McpSessionId, mcpSessionId, StringComparison.Ordinal))
-            {
-                // Same session re-claiming its own slot. Nothing to terminate; terminating here would kill
-                // the live session that just asked to be kept.
-                _logger?.LogDebug(
-                    "MCP identity slot re-claimed by the same session. Instance: {instanceFingerprint}, SessionId: {sessionId}.",
-                    InstanceIdentityHeader.Fingerprint(instanceId), mcpSessionId);
                 return lease;
             }
 

--- a/McpPlugin.Server/src/Transport/StreamableHttpTransportLayer.cs
+++ b/McpPlugin.Server/src/Transport/StreamableHttpTransportLayer.cs
@@ -130,14 +130,22 @@ namespace com.IvanMurzak.McpPlugin.Server.Transport
                                 // indefinitely behind another session's teardown would turn a reconnect into
                                 // a hang. Timing out here is safe — the predecessor is already evicted from
                                 // the SDK's session store — so it is logged and stepped over, not retried.
-                                var completed = await Task.WhenAny(
-                                    predecessor.DisposeCompletion,
-                                    Task.Delay(DisplacedSessionDisposeTimeout, linkedToken)).ConfigureAwait(false);
-                                if (completed != predecessor.DisposeCompletion)
+                                //
+                                // The timer is cancelled on the happy path rather than left to expire: a
+                                // replace normally settles in milliseconds, and an abandoned Task.Delay would
+                                // hold a live timer for the full timeout after every single reconnect.
+                                using (var waitCts = CancellationTokenSource.CreateLinkedTokenSource(linkedToken))
                                 {
-                                    logger?.Warn("Displaced MCP session did not finish disposing within {timeout}; " +
-                                        "it is already evicted from the SDK session store, continuing. Session ID: {sessionId}",
-                                        DisplacedSessionDisposeTimeout, mcpClientSessionId);
+                                    var completed = await Task.WhenAny(
+                                        predecessor.DisposeCompletion,
+                                        Task.Delay(DisplacedSessionDisposeTimeout, waitCts.Token)).ConfigureAwait(false);
+                                    waitCts.Cancel();
+                                    if (completed != predecessor.DisposeCompletion)
+                                    {
+                                        logger?.Warn("Displaced MCP session did not finish disposing within {timeout}; " +
+                                            "it is already evicted from the SDK session store, continuing. Session ID: {sessionId}",
+                                            DisplacedSessionDisposeTimeout, mcpClientSessionId);
+                                    }
                                 }
                             }
                         }

--- a/McpPlugin.Server/src/Transport/StreamableHttpTransportLayer.cs
+++ b/McpPlugin.Server/src/Transport/StreamableHttpTransportLayer.cs
@@ -10,6 +10,7 @@
 
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 using com.IvanMurzak.McpPlugin.Common;
 using com.IvanMurzak.McpPlugin.Common.Hub.Client;
 using com.IvanMurzak.McpPlugin.Common.Utils;
@@ -25,6 +26,16 @@ namespace com.IvanMurzak.McpPlugin.Server.Transport
 {
     public class StreamableHttpTransportLayer : ITransportLayer
     {
+        /// <summary>
+        /// How long a NEW session waits for the session it displaced to finish disposing before it stops
+        /// waiting and proceeds. This is a latency bound on <c>initialize</c>, not a correctness bound:
+        /// the displaced session is removed from the SDK's session store synchronously inside
+        /// <c>IMcpSessionReaper.Claim</c>, so exceeding this timeout cannot leave a reachable session or
+        /// reintroduce the pile-up. The wait exists only so the common case is fully settled — and
+        /// therefore deterministic — before the replacement starts serving.
+        /// </summary>
+        public static readonly TimeSpan DisplacedSessionDisposeTimeout = TimeSpan.FromSeconds(10);
+
         public Consts.MCP.Server.TransportMethod TransportMethod
             => Consts.MCP.Server.TransportMethod.streamableHttp;
 
@@ -80,6 +91,74 @@ namespace com.IvanMurzak.McpPlugin.Server.Transport
                     // saw SessionId == null and select_engine_instance failed 100% of the time.
                     McpSessionTokenContext.CurrentSessionId = mcpClientSessionId;
 
+                    // ── Replace-by-identity (design 07 §2.3, D10.2) ────────────────────────────────────
+                    // This is the only place the rule can run. The installation identity rides on the
+                    // `initialize` request, and this handler is the one hook that sees BOTH that request's
+                    // HttpContext and the freshly minted session id it is about to be keyed under.
+                    //
+                    // Ordering is deliberate: the claim happens BEFORE `server.RunAsync` below, so a
+                    // predecessor is already unreachable by the time this session starts answering. The
+                    // claim itself is synchronous; only the predecessor's resource dispose is awaited, and
+                    // that wait is bounded because the leak-stopping half already completed inside Claim().
+                    //
+                    // Absent header ⇒ `identityLease` stays null ⇒ every line below is skipped and the
+                    // session behaves exactly as it does today. That is the released-client path.
+                    IMcpSessionIdentityLease? identityLease = null;
+                    try
+                    {
+                        var instanceParse = InstanceIdentityHeader.TryRead(context.Request.Headers, out var instanceId);
+                        if (instanceParse == InstanceIdentityParse.Valid)
+                        {
+                            // accountSub comes from the VALIDATED credential, never from a client-supplied
+                            // field — that is what confines a client-supplied instance id to its own account.
+                            var identity = ConnectionIdentity.FromPrincipal(context.User)
+                                        ?? McpSessionTokenContext.CurrentIdentity;
+
+                            // The pin is re-parsed from the original request path rather than read from
+                            // ambient state, so the key never depends on AsyncLocal flow. Malformed pins
+                            // were already rejected upstream by McpSessionTokenMiddleware.
+                            McpSessionTokenMiddleware.TryExtractProjectPin(context.Request.Path.Value, out var projectPin);
+
+                            var reaper = server.Services?.GetService<IMcpSessionReaper>();
+                            identityLease = reaper?.Claim(identity?.AccountId, instanceId, projectPin, mcpClientSessionId);
+
+                            var predecessor = identityLease?.DisplacedPredecessor;
+                            if (predecessor != null && !predecessor.DisposeCompletion.IsCompleted)
+                            {
+                                // Bounded: the predecessor's dispose awaits ITS RunSessionHandler, which in
+                                // turn awaits a SignalR disconnect notification. Blocking `initialize`
+                                // indefinitely behind another session's teardown would turn a reconnect into
+                                // a hang. Timing out here is safe — the predecessor is already evicted from
+                                // the SDK's session store — so it is logged and stepped over, not retried.
+                                var completed = await Task.WhenAny(
+                                    predecessor.DisposeCompletion,
+                                    Task.Delay(DisplacedSessionDisposeTimeout, linkedToken)).ConfigureAwait(false);
+                                if (completed != predecessor.DisposeCompletion)
+                                {
+                                    logger?.Warn("Displaced MCP session did not finish disposing within {timeout}; " +
+                                        "it is already evicted from the SDK session store, continuing. Session ID: {sessionId}",
+                                        DisplacedSessionDisposeTimeout, mcpClientSessionId);
+                                }
+                            }
+                        }
+                        else if (instanceParse == InstanceIdentityParse.Malformed)
+                        {
+                            // Defence in depth. McpSessionTokenMiddleware rejects a malformed value with
+                            // 400 before routing, so this branch should be unreachable over HTTP; if it is
+                            // ever reached, the session is still established (never rejected here, where
+                            // rejecting would mean failing an already-minted session) but claims no slot.
+                            logger?.Warn("Malformed {header} reached the session handler; no identity slot claimed. Session ID: {sessionId}",
+                                InstanceIdentityHeader.HeaderName, mcpClientSessionId);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        // The replace rule must never be able to prevent a session from starting. A client
+                        // that cannot connect is strictly worse than one whose predecessor lingers until the
+                        // idle timeout, so this degrades to today's behaviour instead of failing the session.
+                        logger?.Error(ex, $"Replace-by-identity failed; continuing without it. Session ID: {mcpClientSessionId}.");
+                    }
+
                     try
                     {
                         var services = server.Services ?? throw new InvalidOperationException("MCP Server services are not available.");
@@ -112,12 +191,34 @@ namespace com.IvanMurzak.McpPlugin.Server.Transport
                             await service.StopAsync(CancellationToken.None);
                         }
                     }
+                    catch (OperationCanceledException) when (identityLease?.Displaced == true)
+                    {
+                        // Displaced by a newer connection carrying the same installation identity. This is
+                        // the rule working, so it must not be logged as a fault: an orderly replace that
+                        // reports itself as an error trains operators to ignore the log, and a reconnect
+                        // loop would fill it. The tracker row was already removed by StopAsync above.
+                        logger?.Debug("MCP session displaced by replace-by-identity; terminated cleanly. Session ID: {sessionId}",
+                            mcpClientSessionId);
+                    }
+                    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                    {
+                        // The SDK cancelled the session's own token: a client DELETE, an idle-timeout
+                        // eviction, or host shutdown. Definitionally an orderly end of session, not an error.
+                        logger?.Debug("MCP session cancelled by the transport; terminated cleanly. Session ID: {sessionId}",
+                            mcpClientSessionId);
+                    }
                     catch (Exception ex)
                     {
                         logger?.Error(ex, $"Error occurred while processing HTTP transport session. Session ID: {mcpClientSessionId}.");
                     }
                     finally
                     {
+                        // Release the identity slot LAST, and only if this session still holds it: a
+                        // displaced session unwinds after its successor installed itself, so an
+                        // unconditional release here would delete the successor's slot and strand a live
+                        // session that no later connection could ever replace. McpSessionReaper.Release
+                        // does that compare-and-remove atomically.
+                        identityLease?.Dispose();
                         logger?.Debug($"-------------------------------------------------\nSession handler for HTTP transport completed. Session ID: {mcpClientSessionId}\n------------------------");
                     }
                 };

--- a/McpPlugin/McpPlugin.csproj
+++ b/McpPlugin/McpPlugin.csproj
@@ -16,7 +16,7 @@
     <!-- NuGet Package Information -->
     <IsPackable>true</IsPackable>
     <PackageId>com.IvanMurzak.McpPlugin</PackageId>
-    <Version>8.1.0</Version>
+    <Version>8.2.0</Version>
     <Authors>Ivan Murzak</Authors>
     <Company>Ivan Murzak</Company>
     <Copyright>Copyright © Ivan Murzak 2025</Copyright>


### PR DESCRIPTION
## Summary

Taskflow task **W5.4** (`.taskflow/2026-08-11-gamedev-app-ux-v2/tasks/w5-4-mcp-replace-by-identity.md`, `software` repo). Gate **`G-SERVER-MCP`** — a different gate, repository and deploy from `G-SERVER-CACHE`; approving one says nothing about the other.

Gives the MCP server a **replace-by-identity** rule: when an installation that already has a live session connects again with the same identity, the previous session is **replaced** rather than **stacked**.

This is the half of D10 that reaps sessions orphaned by a **crashed or force-killed** app. Those never send a `DELETE` — by construction, so no client-side change can ever reach them — and today they survive until the production idle timeout of **21600 s = 6 h** (`cloud/AI-Game-Dev-Server/docker-compose.yml:132`), which is the six-hour pile-up the owner reported.

---

## 1. The termination mechanism — established, and it is NOT what the obvious design assumes

**DoD 1.** The task flagged this as a hypothesis to settle before designing the rule. Settled by reading the SDK and by test, and the answer inverts the intuitive design.

Verified against `ModelContextProtocol.AspNetCore` **1.4.0** (`1.4.0+06e3604dd12fbfc08c8f9d316325380ec2a2989b`; read at that commit SHA and cross-checked by reflecting over the shipped IL in `lib/net9.0/`):

| Fact | Consequence |
|---|---|
| Session storage is **not** `StreamableHttpHandler._sessions` any more. It is `internal sealed class StatefulSessionManager` holding `ConcurrentDictionary<string, StreamableHttpSession> _sessions`. `HttpMcpSession<T>`, `TryRemoveSession` and `ActiveSessions` **do not exist** in 1.4.0. | The shape named in the task description is from an older SDK. |
| **Nothing in the SDK attaches a continuation to `ServerRunTask` that removes a session when it completes.** | ⚠️ **Returning early from `RunSessionHandler`, or cancelling the token it was handed, does NOT evict the session.** The entry survives in `_sessions` until `IdleTimeout` or `MaxIdleSessionCount` prunes it. |
| The only operation that evicts is the one the SDK's own `DELETE` handler performs: `StatefulSessionManager.TryRemove(id, out session)` then `session.DisposeAsync()`. | That is what this PR does. |
| `TryRemove`/`TryGetValue` are `public` **on an `internal` type**; `StatefulSessionManager` is a DI singleton (`TryAddSingleton` in `WithHttpTransport`); there is no `InternalsVisibleTo`. | The manager is resolved from DI **by reflection on the type handle** (`IServiceProvider.GetService(Type)` does not require a public type). |
| `internal sealed class StreamableHttpSession : IAsyncDisposable` — the interface is **public**. | Only the *lookup* needs reflection. The dispose goes through public `IAsyncDisposable`. |
| `StreamableHttpSession.DisposeAsync` disposes the transport, cancels `_disposeCts` (== the `SessionClosed` token handed to `RunSessionHandler`), awaits `ServerRunTask`, then disposes the `McpServer`. `StreamableHttpServerTransport.DisposeAsync` completes the incoming channel, releases the pending SSE `GET`, and disposes the `SseEventWriter`. | Cancelling our handler is a **consequence** of the dispose, not a substitute for it — and it is also what removes the `IMcpSessionTracker` row, since the row is removed in that handler's `finally`. |

**The trap this avoided is exactly the one the task warned about.** A rule built on "cancel our own token and let the tracker row go" would have dropped the row, looked fixed, and left the SDK session and the `SseEventWriter` buffer in place — the leak untouched, with no functional symptom. **A test asserting only "the tracker row disappeared" would have been GREEN for that broken implementation.**

### How the falling session count is proven

The load-bearing assertion is one no in-process fake can make: after a replace, a POST bearing the **replaced** session id is answered **`404` with JSON-RPC `-32001`** by the SDK's own session lookup. That is only possible if the SDK's store no longer holds the id.

`McpReplaceByIdentityOverHttpTests.SecondConnection_SameAccountAndInstance_ReplacesTheFirst_AndTheSdkReleasesIt`, over a real loopback Kestrel host with the real OAuth resource-server path, asserts in order:

1. the first session is **usable** before the replace (`ping` → 200) — otherwise "the old id 404s" could be satisfied by an id that never worked;
2. the second `initialize` mints a **different** session id;
3. the old id → **404**, and the body contains **`-32001`** (so it is "Session not found", not a routing 404);
4. the new id → **200**;
5. `IMcpSessionTracker.ActiveSessionCount` is back to **1**, not 2.

### The reflection dependency is loud, and it is a tripwire

Reflection on an internal type is a real risk, so it is made **detectable rather than latent**:

- The binding resolves **once** per process, by name **and parameter shape** (`bool (string, out …)`), anchored on the public `HttpServerTransportOptions` assembly so the assembly reference is a compile-time fact.
- Failure surfaces as `IsSupported == false` + a `BindingDiagnostic` string, and is logged **once at `Error`** — the same reasoning as `SG-15`'s loud `405`: a silent degradation here restores the six-hour pile-up with no symptom.
- **`SdkEvictionSeam_IsBoundToTheRunningSdk` asserts the binding.** An SDK bump that moves this seam **fails CI** instead of failing production. Plant **P9** proves that test discriminates (it reddens the tripwire *and* the functional replace test).
- A failed binding degrades to today's behaviour (predecessor lingers to the idle timeout); it never fails the new session's `initialize`.

---

## 2. The key — and a deliberate, documented deviation from the task spec

**DoD 2.** The slot is keyed on **`(accountSub, instanceId, projectPin)`**.

`accountSub` comes from **`ConnectionIdentity.FromPrincipal(context.User)`** — the validated credential — never from a client-supplied body field. So a client-supplied (and therefore spoofable) `instanceId` can only ever select among sessions *inside* the account the bearer token already proved: **a spoofed value evicts only the spoofer's own sessions.**

> **⚠️ Deviation, stated plainly: the task spec says `(accountSub, instanceId)`; `07-security.md` says `(accountSub, instanceId, pin)`.**
>
> - Task spec DoD 2: *"Replace is keyed on `(accountSub, instanceId)`"*.
> - `07-security.md` §2.5 copied-installation row, threat **T25**, gate **SG-14**: *"The server rule replaces on `(accountSub, instanceId, **pin**)` — two clones working on different projects then never collide."*
>
> **I implemented the three-part key**, because it is a **strict superset** that satisfies the task's DoD as written *and* honours the design:
> - same account + same installation + same project → **still replaces** (DoD 4 ✔, test + plant P1);
> - two different accounts, same instance id → **still isolated** (DoD 2 ✔, test + plant P3);
> - two clones of one copied home directory on **different projects** → no longer evict each other forever (**SG-14** ✔, test + plant P4).
>
> Dropping the pin would satisfy the task and **violate the design**, producing the permanent mutual-eviction flap T25 describes. Flagging it rather than silently choosing.

---

## 3. Released clients are unaffected — no synchronised app release

**DoD 3, DoD 6.** **The container can be deployed with every released client still on the old behaviour, and nothing regresses.** Every currently released app sends no `AI-Game-Dev-Instance-Id` header, so:

- `InstanceIdentityHeader.TryRead` returns **`Absent`** — a supported state, distinct from `Malformed`;
- `IMcpSessionReaper.Claim` is never reached, so no slot is claimed, nothing is replaced, nothing is rejected, and **nothing is logged**;
- sessions stack exactly as they do today.

`NoInstanceIdHeader_SessionsStackExactlyAsToday_AndNothingWarns` drives three header-less sessions on one account, proves all three still serve, pins `ActiveSessionCount == 3` and `TrackedIdentityCount == 0`, and asserts **no warning or error from the reaper / evictor / transport categories**.

Two things about that test worth reading:

- The warning assertion is **category-scoped**. An earlier unscoped "no warnings at all" version failed on pre-existing `tools/list` retry warnings that have nothing to do with this change — it was asserting a property of the whole test environment.
- It carries an **anti-vacuity guard**: the sink is proven non-empty, and a probe warning is emitted through the host's real `ILoggerFactory` and asserted visible. A dead sink would otherwise satisfy "empty" while the code logged a storm.

The header can also **never become mandatory**: `Absent` is a first-class state in the tri-state enum, and the compatibility path is asserted by tests and by plants P2 and P10.

---

## 4. Opaque-token validation

**DoD 7, DoD 9.** The header name is used **exactly**: `AI-Game-Dev-Instance-Id`, **no `X-` prefix** (RFC 6648), pinned as a test (`HeaderName_IsExactlyTheContractedName_WithNoXPrefix`) against both the literal and `Consts.MCP.Server.Headers.InstanceId`, because the name is half of a cross-repository contract with `w3-3` and a mismatch **fails open** (header unseen → no replace → the pile-up, silently).

### The HMAC contract, recorded verbatim for `w3-3`

```
mcpInstanceId = HMAC-SHA256(key = installId, msg = accountSub)   truncated to 128 bits, hex
```

- **key = the SECRET `installId`** (128-bit CSPRNG, persisted in `~/.ai-game-dev/config.json`)
- **msg = the PUBLIC `accountSub`**
- truncated to **128 bits** ⇒ 16 bytes ⇒ **exactly 32 hex characters** on the wire
- **Do NOT invert the key/message order.** It was independently re-verified twice and is deliberate; inverting it would require a 128-bit brute force to undo.

The server validates the value as an **opaque token** and nothing more: exactly 32 characters, hex charset, sent **at most once**. Rejected otherwise.

| Input class | Result |
|---|---|
| Absent | `Absent` — today's behaviour, untouched |
| 32 hex (any case) | `Valid`, lower-cased (an un-normalised key would give one installation two slots) |
| Over-length (33, 64) / under-length (31, 1) | **`Malformed`** |
| Non-hex at start / middle / end | **`Malformed`** |
| Contains CR, LF, CRLF, NUL, TAB | **`Malformed`** |
| Leading / trailing whitespace | **`Malformed`** — rejected, **not trimmed** |
| Present but empty | **`Malformed`** |
| Header sent **twice** | **`Malformed`** — not "first wins" |
| `../../etc/passwd…`, `' OR 1=1 --…` at valid length | **`Malformed`** |

**A present-but-malformed value is REJECTED with `400 invalid_instance_id`, not ignored** — `McpSessionTokenMiddleware`, immediately after the existing malformed-pin gate and for the same fail-closed reason. Silently ignoring it would leave a client that believes it participates in the replace rule stacking sessions forever, with no symptom short of the 6 h pile-up. The rejection is **terminal** (no handler, hub, tracker or log formatter sees the value) and **does not echo the offending value** into the response body.

**Nothing derived from the value reaches a path, a filename, or a query/LINQ predicate.** It is used for exactly two things: as a dictionary key component in `McpSessionReaper`, and as input to `Fingerprint`. Because it is validated to a closed charset *before* first use, every downstream use is safe **by construction** rather than by remembering to escape.

**And nothing reaches a log line — including on the REJECTION path.** That distinction matters: the rejection path is the one carrying *arbitrary* client input, so it is the one where an unescaped interpolation would actually be a log-injection primitive. `MalformedInstanceId_IsRejectedWith400_AndNoSessionIsEstablished` captures every record at `Trace` and asserts the malformed value appears in no log record, with a sink-liveness guard. Plant **P11** confirms it discriminates — logging the raw value there reddens all five cases. Asserting log hygiene only for values that already *passed* validation would have covered the safe half and left the dangerous half unasserted.

CR/LF cases are asserted in `InstanceIdentityHeaderTests` where the value can be handed in directly. **Every CR/LF case is padded to exactly 32 characters, with the length asserted inline**, so the **charset** check — not the length check — is what rejects it. Unpadded inputs would have been rejected on length and would have proven nothing about CR/LF handling; plant **P6** confirms this (removing the charset loop reddens 18 tests). Over the wire Kestrel refuses illegal header bytes at the protocol level, so `InstanceIdContainingCrLf_NeverProducesAWorkingSession` asserts the *outcome* rather than a specific status code.

---

## 5. Where the id is logged, and in what form

**DoD 8.** **The raw instance id is never written to any log line, and never appears beside the bearer credential.**

What *is* logged is `InstanceIdentityHeader.Fingerprint(instanceId)`: the **first 8 hex chars of `SHA-256(instanceId)`** — 32 bits, deliberately collision-prone. Enough to correlate two lines from one process and tell two installations apart during a reconnect flap; not enough to be a durable identifier in a log aggregator. It is asserted to differ from the id, not to be a substring of it, to be stable per id, and to differ across ids.

| Site | Level | Contents |
|---|---|---|
| `McpSessionReaper.Claim` — slot claimed / re-claimed | `Debug` | fingerprint, pin, MCP session id, slot count |
| `McpSessionReaper.Claim` — **session replaced** | `Information` | fingerprint, pin, replaced + new MCP session id, eviction outcome, slot count |
| `McpSessionReaper.Release` | `Debug` | fingerprint, MCP session id, released/displaced flags |
| `McpSdkSessionEvictor` — binding unsupported | `Error` (once) | binding diagnostic only (type/member names) |
| `StreamableHttpTransportLayer` — displaced cleanly | `Debug` | MCP session id only |

No credential appears on any of these lines. The value is **not** added to webhook payloads (`OnAiAgentConnected` metadata is untouched) and not to `McpClientData`.

`Replace_NeverWritesTheInstanceIdOrTheBearerTokenToALogLine` captures **every** record at `Trace` through a real MEL provider and asserts the raw id and the bearer token are absent while the fingerprint is present — and first asserts the replace actually ran, so it cannot pass by logging nothing. Plant **P7** confirms it discriminates.

---

## 6. RETENTION LIFECYCLE OF THE STORED HMAC — the answer for `w5-6`

**DoD 10.** **The honest answer is that there is no retention, and therefore no retention period to state.**

| Question | Answer |
|---|---|
| Where is it stored server-side? | **Process memory only** — one `ConcurrentDictionary` inside the `McpSessionReaper` singleton (`McpPlugin.Server/src/McpSessionReaper.cs`). |
| Is it persisted? | **No.** No database, no disk, no cache, no Redis, no webhook payload, no `McpClientData`, no log line (logs carry only the 32-bit non-reversible fingerprint). |
| For how long does it survive? | Exactly the lifetime of the MCP session that presented it. |
| What removes it? | (a) the session ending — the lease is disposed in the same `finally` that removes the session's `IMcpSessionTracker` row, covering client `DELETE`, idle-timeout eviction, transport loss and host shutdown; (b) a newer session with the same identity replacing it; (c) process exit / container restart. |
| Does it outlive the session it keys? | **No.** Asserted by `DisposingTheLease_ReleasesTheSlot_SoNothingOutlivesItsSession`. |
| Any bounded retention period? | **None, because nothing is retained.** There is no store to expire and no sweep to schedule. |
| Residual caveat, stated rather than omitted | If the container runs at `Debug`/`Information` level, the **fingerprint** (not the value) appears in the container log, subject to that log's normal `json-file` rotation. The identifier itself never does. |

**`w5-6` (PR IvanMurzak/AI-Game-Dev-Server#599) is already MERGED, and it correctly did not invent a period** — its body states *"No retention period is stated. The server-side HMAC retention lifecycle is unverified pending `w5-4-mcp-replace-by-identity`."* That was the right call and the answer above confirms it needs no amendment: a policy that states purpose and storage location, and claims no period, is accurate for this implementation. **This answer has been posted as a comment on #599** so the record lives where `w5-6` is, not only here.

---

## 7. Delivery chain — hop by hop, and a correction

**DoD 11.** ⚠️ **This change is NOT in production when this PR merges.** It is in production only when hop 4 lands.

| Hop | What | Owner | Status |
|---|---|---|---|
| **1** | `MCP-Plugin-dotnet` merge to `main` → `release.yml` (version read from `McpPlugin/McpPlugin.csproj`, now **8.2.0**) → GitHub release → `deploy.yml` on `release: released` → `dotnet nuget push` of **three** packages (`McpPlugin.Common`, `McpPlugin`, `McpPlugin.Server`) | **this PR, automatically on merge** | ⏳ **performed by merging this PR** |
| **2** | Bump the consuming pins from 8.1.0 → **8.2.0** — see the correction below | orchestrator / owner, **after 8.2.0 is on nuget.org** | ❌ remains |
| **3** | `GameDev-MCP-Server` release → `deploy_docker.yml` on `release: published` → push `aigamedeveloper/mcp-server:<new tag>` to Docker Hub | orchestrator / owner | ❌ remains |
| **4** | `cloud/AI-Game-Dev-Server/docker-compose.yml:64` — bump `aigamedeveloper/mcp-server:9.2.5` to the new tag. **Merging that to `main` IS the production deploy** (full restart, ~4 min, expected nginx 502 window). | orchestrator / owner | ❌ remains |

> ### ⚠️ Correction to the task spec's hop 2 — there are TWO pin sites, not one
>
> The task spec names only `shared/GameDev-MCP-Server/com.IvanMurzak.GameDev.MCP.Server.csproj:60,67`. Verified against the repositories, there is a **second** consumer, and the last real bump (`AI-Game-Dev-Server#597`, for 8.1.0) touched only that one:
>
> | Pin site | Role | Currently |
> |---|---|---|
> | `shared/GameDev-MCP-Server/com.IvanMurzak.GameDev.MCP.Server.csproj:60,67` | **The production path** — builds `aigamedeveloper/mcp-server` | 8.1.0 |
> | `cloud/AI-Game-Dev-Server/mcp-server/McpServer.csproj:26,27` (+ the `ModelContextProtocol.AspNetCore` "tracks the transitive version" comment) | Vendored **reference/fallback** source, built only by `docker-compose.local.yml`. Not production — prod pulls the published image. | 8.1.0 |
>
> Production is gated by the **first** row only, so the second cannot block the deploy. But `#597` bumped it in lockstep, and leaving it behind makes the local/fallback build silently diverge from prod. **Bump both.**
>
> Also stale in the task spec: it states all three packages and the `GameDev-MCP-Server` pins are at **8.0.0**. They were at **8.1.0** (HEAD is `1e2eda1 chore: release MCP-Plugin-dotnet 8.1.0 (#209)`); this PR moves them to 8.2.0.

**DoD 12 — version bumps are deliberate and lockstepped.** All three moved together via `commands/bump-version.ps1`, the repo's single lever (it also updates `server.json` and `Consts.PluginVersion`). 8.1.0 → **8.2.0**, minor because this adds a header contract and new public seams without changing behaviour for any client that does not send the header.

> **A re-push of an already-published NuGet version is a SILENT no-op** under `dotnet nuget push --skip-duplicate`. Tag `8.1.0` already exists, so **without this bump, merging would have produced no release, no publish, and no way to ever ship this rule under 8.1.0.** A NuGet publish is a third irreversible publication class: 8.2.0 cannot be replaced once pushed.

---

## 8. Rollback — and the SG-5 coupling

**DoD 13.** Reverse order: revert the rule → publish a new version (**never re-push 8.2.0**; it is irreversible and `--skip-duplicate` would no-op) → bump both pin sites back → rebuild and re-tag the image → bump `docker-compose.yml:64` back and merge (another full restart).

> ### ⚠️ **`w3-3` must be held or reverted WITH this — do not revert one half alone.**
>
> Under **SG-5**, *an identifier ships only together with a server-side consumer, or not at all*. `w5-4` **is** that consumer. Reverting the server rule while `w3-3` still ships the identifier leaves a persisted device identifier transmitted to a server that does nothing with it — no benefit, and it re-opens the `G-PRIVACY` exposure that `w5-6` was merged to close. Conversely, `w3-3` merging before this reaches production merely means the header is sent and ignored, which is harmless and is the intended ordering.
>
> Cheaper mitigation before reaching for a rollback: the rule is **inert for any client that does not send the header**, so holding or reverting `w3-3` alone disables it in practice without touching this repository.

**DoD 14 — `G-SERVER-MCP`.** Respected. This is a different gate, a different repository and a different deploy from `G-SERVER-CACHE` (which covers `w5-1`/`w5-3`/`w5-5`/`w5-6` in `cloud/AI-Game-Dev-Server`). Approving one says nothing about the other.

---

## 9. Test plan and the plant round

**DoD 15.** Full solution build and test suite, on the final tree, both target frameworks:

```
dotnet build McpPlugin.sln          -> Build succeeded, 0 errors
                                       12 warnings == the 12 on the baseline commit; none in changed files
dotnet test  McpPlugin.sln
  McpPlugin.Server.Tests  net8.0 -> Passed: 745, Failed: 0
  McpPlugin.Server.Tests  net9.0 -> Passed: 745, Failed: 0
  McpPlugin.Tests         net8.0 -> Passed: 943, Failed: 0
  McpPlugin.Tests         net9.0 -> Passed: 943, Failed: 0
```

The new integration tests bind loopback ports and run real Kestrel hosts, so the CI OS matrix is load-bearing rather than incidental: **`test (ubuntu-latest)` and `test (macos-latest)` both pass**, which is the evidence that the eviction seam and the real-host harness are not Windows-only.

Baseline on `1e2eda1` before any change was `McpPlugin.Server.Tests` **684** passing on both TFMs, so **+61 new tests** and no pre-existing failures to disentangle.

### Plant round — 13 plants, 13 RED

**DoD 5** asks for two plants. Thirteen were run, because the unit of verification is a **claim**, not a test, and `N/N RED` for a suite says nothing about which claim each test can actually fail on. Each plant was applied as an exact source edit against the verified-green commit, tested, and reverted (`git status --porcelain` clean after every one).

| # | Break planted | Claim it attacks | Verdict | Tests reddened |
|---|---|---|---|---|
| **P1** | Reaper never calls `Evict` | **DoD 4 + 1** — a second connection replaces the first | 🔴 RED | 7 |
| **P2** | `Claim`'s null-identity guard removed (empty-string pooling) | **DoD 3** — the rule must not fire on a null identity | 🔴 RED | 2 |
| **P3** | `accountSub` dropped from the key | **DoD 2** — cross-account isolation | 🔴 RED | 3 |
| **P4** | `projectPin` dropped from the key | **07 T25 / SG-14** — copied-installation flap | 🔴 RED | 2 |
| **P5** | Middleware ignores a malformed header instead of rejecting | **DoD 7** — malformed is rejected, not ignored | 🔴 RED | 5 |
| **P6** | Hex charset loop removed (length only) | **DoD 7** — the *charset* gate rejects CR/LF and payloads | 🔴 RED | 18 |
| **P7** | Log the raw instance id instead of the fingerprint | **DoD 8** — the id never reaches a log line | 🔴 RED | 1 |
| **P8** | `Release` made an unconditional `TryRemove(key)` | a displaced session must not delete its successor's slot | 🔴 RED | 2 |
| **P9** | SDK type name changed (binding broken) | **DoD 1** — the SDK-bump tripwire fires | 🔴 RED | 3 |
| **P10** | Transport treats **every** session as carrying an identity | **DoD 3 at the HTTP level** | 🔴 RED | 3 |
| **P11** | Log the raw client value on the **rejection** path | **DoD 7/8** — the id never reaches a log line, incl. rejected input | 🔴 RED | 5 |
| **P12** | `instanceId` dropped from the key | one account's two installations must stack (desktop + laptop) | 🔴 RED | 2 |
| **P13** | Flag the outgoing lease on a same-session re-claim | a re-claim must mis-attribute nothing | 🔴 RED | 1 (exactly the target) |

**Restored → GREEN**: 745/745 both TFMs (§9 above).

> **P10 exists because P2 was not sufficient, and that is the interesting result.** P2 broke `Claim`'s null-identity guard and reddened only the **unit** tests — the HTTP compatibility test `NoInstanceIdHeader_SessionsStackExactlyAsToday_AndNothingWarns` **stayed green**, because over HTTP the transport never calls `Claim` at all when the header is absent, so P2 could not reach that path. A test that survives the break aimed at it has not been shown to discriminate. **P10 breaks it where it actually lives** — making the transport treat every session as carrying a valid identity, so header-less clients pool onto one slot per account and evict each other — and the DoD-3 HTTP test goes red. Without P10, DoD 5's second half would have been proven only at the unit level while reading as fully proven.

### Three defects found before review

- `ConcurrentClaimsForOneIdentity_ConvergeOnASingleSlot` flaked in a combined run and passed in isolation. Cause was the **test's own** `List<string>` recorder being unsynchronised — the reaper calls `Evict` outside its claim lock on purpose (never hold a lock across foreign code), so concurrent claims reach the fake concurrently. Read as a race in the production code and was not one; the recorder is now locked.
- An unused `InstanceY` constant in the HTTP suite looked like dead code and was actually a **coverage gap**: nothing exercised one account with two installations — the everyday desktop-plus-laptop case, and the most user-visible way this rule could go wrong. Adding the test (rather than deleting the constant) closed it; plant **P12** confirms it discriminates.
- **A real defect in the shipped code, found by re-reading the diff as a reviewer would.** The same-session-re-claim check ran *after* `MarkDisplaced`, so a re-entrant claim flagged the **outgoing** lease `Displaced` and only then discovered it was the same session. No session was evicted — that part was correct — but the flag made that session's handler report an ordinary cancellation as *"displaced by replace-by-identity"*. **Wrong attribution is worse than none:** it sends an operator chasing a replace that never happened. The existing test asserted only the *incoming* lease's flag, which is exactly why it missed it. Both the check and `MarkDisplaced` now live inside the claim lock (which also deleted a dead `!ReferenceEquals(existing, lease)` guard that could never be false), the test asserts both leases, and it was confirmed by running the new assertion **against the unfixed code**, where it fails with its own message — stronger evidence than a plant, because the defect was real rather than injected.
- The DoD-3 warning assertion was originally unscoped (`no warnings at all`) and failed on pre-existing `tools/list` retry noise. It also drove liveness with `tools/list`, which with no engine plugin attached retries ten times per call — 10 s per probe, 10 warnings and an error each. Switched to `ping` (handled inside the MCP session, so it cleanly discriminates live-vs-evicted): the HTTP suite went from ~100 s to ~1.5 s and the log assertions became meaningful.

---

## 10. Files changed

**New**

| File | Purpose |
|---|---|
| `McpPlugin.Server/src/Auth/InstanceIdentityHeader.cs` | Header name, tri-state opaque-token validation, log fingerprint |
| `McpPlugin.Server/src/IMcpSessionReaper.cs` | The rule's contract, key shape, and the retention statement |
| `McpPlugin.Server/src/McpSessionReaper.cs` | In-memory slot registry; claim-and-displace; ABA-safe release |
| `McpPlugin.Server/src/IMcpSdkSessionEvictor.cs` | Eviction seam; splits the synchronous leak-stopping half from the async dispose |
| `McpPlugin.Server/src/McpSdkSessionEvictor.cs` | `TryRemove` + `DisposeAsync` against the SDK, with the loud binding diagnostic |
| `McpPlugin.Server.Tests/InstanceIdentityHeaderTests.cs` | 38 tests — validation, header reads, fingerprint |
| `McpPlugin.Server.Tests/McpSessionReaperTests.cs` | 11 tests — the key algebra against a recording fake evictor |
| `McpPlugin.Server.Tests/McpReplaceByIdentityOverHttpTests.cs` | 12 tests — real Kestrel + real OAuth + real MCP handshake |

**Modified**

| File | Change |
|---|---|
| `McpPlugin.Common/src/Utils/Consts.MCP.cs` | `Headers.InstanceId = "AI-Game-Dev-Instance-Id"` |
| `McpPlugin.Server/src/Auth/McpSessionTokenMiddleware.cs` | Fail-closed instance-id gate (`400 invalid_instance_id`) beside the pin gate |
| `McpPlugin.Server/src/Transport/StreamableHttpTransportLayer.cs` | Claim the slot in `RunSessionHandler`; bounded wait on the predecessor's dispose; release the lease in `finally`; orderly cancellation logged at `Debug` not `Error` |
| `McpPlugin.Server/src/Extension/ExtensionsMcpServerBuilder.cs` | Register both singletons in all modes |
| 5 files | Lockstepped 8.1.0 → 8.2.0 |

### Three implementation details worth a reviewer's attention

1. **`Release` is a compare-and-remove, not `TryRemove(key)`.** A displaced session unwinds *after* its successor installed itself, and its `finally` disposes its lease. An unconditional removal would delete the **successor's** slot, stranding a live session that no later connection could find and therefore never replace — the leak back, reachable only through the code added to fix it, with every other test still passing. Plant **P8** covers it.
2. **The wait on the predecessor's dispose is bounded (10 s), and that is safe.** `TryRemove` — the leak-stopping half — completes **synchronously inside `Claim`**, so a timeout cannot leave a reachable session or reintroduce the pile-up. The wait exists only so the common case is fully settled (and deterministic for tests) before the replacement starts serving. Unbounded would let one session's teardown, which awaits a SignalR disconnect notification, hang another's `initialize`.
3. **The rule can never prevent a session from starting.** The whole claim block is wrapped: any failure logs and degrades to today's behaviour. A client that cannot connect is strictly worse than one whose predecessor lingers until the idle timeout.

---

## Out of scope, untouched

`w3-3` (app-side identifier), `w3-5` (Settings reset), `w3-1` (client `DELETE`), the SG-3 verification read, and **any change to `IdleTimeout` or `MaxIdleSessionCount`** — both still read from `DataArguments` exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014wEWRDnWNQMPgKEiTz7SMj
