### PR TITLE
a1: InvalidTarget terminal kind + fake-clock proof of the attempt-window seam

### DIFF
--- a/McpPlugin.Tests/Network/Connection/Credentials/HttpTokenRefresherTests.cs
+++ b/McpPlugin.Tests/Network/Connection/Credentials/HttpTokenRefresherTests.cs
@@ -168,6 +168,28 @@ namespace com.IvanMurzak.McpPlugin.Tests.Network.Connection.Credentials
             result.FailureReason.ShouldContain("invalid_grant");
         }
 
+        [Fact]
+        public async Task Refresh_InvalidTarget_IsClassifiedInvalidTarget()
+        {
+            // The RFC 8707 §2 wire shape: HTTP 400 with the standard OAuth error body. Defensive
+            // hardening (oauth-client-error-hygiene C2): our refresh form sends no `resource`, so
+            // current clients cannot receive this — but a future RFC 8707 adopter inherits the
+            // terminal classification instead of a retry loop.
+            var handler = new RecordingHttpMessageHandler()
+                .RespondWith(HttpStatusCode.BadRequest,
+                    "{\"error\":\"invalid_target\",\"error_description\":\"The requested resource is invalid, missing, unknown, or malformed.\"}");
+            var refresher = NewRefresher(handler);
+
+            var result = await refresher.RefreshAsync(new TokenRefreshRequest(RefreshToken, ServerTarget, StoredClientId));
+
+            result.Succeeded.ShouldBeFalse();
+            result.FailureKind.ShouldBe(TokenRefreshFailureKind.InvalidTarget);
+            // Distinct reason strings preserved end-to-end (C2): the raw error code AND the
+            // server's description both survive into FailureReason for telemetry.
+            result.FailureReason.ShouldContain("invalid_target");
+            result.FailureReason.ShouldContain("The requested resource is invalid");
+        }
+
         [Theory]
         [InlineData(HttpStatusCode.BadRequest, "{\"error\":\"invalid_client\"}")]         // a DIFFERENT OAuth error
         [InlineData(HttpStatusCode.InternalServerError, "{\"detail\":\"boom\"}")]          // 5xx
@@ -246,6 +268,30 @@ namespace com.IvanMurzak.McpPlugin.Tests.Network.Connection.Credentials
             await refresher.RefreshAsync(new TokenRefreshRequest("RT-family-plugin", ServerTarget, StoredClientId));
 
             handler.Requests.Count.ShouldBe(2); // distinct refresh tokens = distinct families
+        }
+
+        [Fact]
+        public async Task Refresh_AttemptWindow_IsDrivenPurelyByTheInjectedClock()
+        {
+            // Both halves of the 60 s rate-discipline window (04 §3.6) through the fake clock
+            // alone — no wall-clock time, no overridden window: this pins the PRODUCTION
+            // DefaultAttemptWindow (60 s) via the clock seam. Within the window ⇒ memoized (the
+            // shared attempt is replayed); past it ⇒ a fresh network attempt.
+            var now = new DateTimeOffset(2026, 8, 15, 12, 0, 0, TimeSpan.Zero);
+            var handler = new RecordingHttpMessageHandler().RespondWith(HttpStatusCode.OK, SuccessJson);
+            var refresher = NewRefresher(handler, clock: () => now); // default 60 s window
+
+            var first = await refresher.RefreshAsync(new TokenRefreshRequest(RefreshToken, ServerTarget, StoredClientId));
+
+            now = now.AddSeconds(59); // still inside the 60 s window
+            var second = await refresher.RefreshAsync(new TokenRefreshRequest(RefreshToken, ServerTarget, StoredClientId));
+            handler.Requests.Count.ShouldBe(1); // memoized — no second network attempt
+            second.ShouldBeSameAs(first);
+
+            now = now.AddSeconds(2); // 61 s after the attempt started — window elapsed
+            var third = await refresher.RefreshAsync(new TokenRefreshRequest(RefreshToken, ServerTarget, StoredClientId));
+            handler.Requests.Count.ShouldBe(2); // fresh network attempt
+            third.ShouldNotBeSameAs(first);
         }
 
         [Fact]

--- a/McpPlugin/src/McpPlugin/Network/Connection/Credentials/HttpTokenRefresher.cs
+++ b/McpPlugin/src/McpPlugin/Network/Connection/Credentials/HttpTokenRefresher.cs
@@ -46,10 +46,13 @@ namespace com.IvanMurzak.McpPlugin
     ///   <see cref="MachineCredentialLock.LOCK_STALE_MS"/> and let a live lock holder be declared
     ///   stale mid-refresh. A timeout is a <see cref="TokenRefreshFailureKind.Transient"/> failure,
     ///   never an unclassified exception.</item>
-    ///   <item><b><c>invalid_grant</c> classification (04 §3.5):</b> an OAuth error response of
-    ///   exactly <c>invalid_grant</c> is returned as
-    ///   <see cref="TokenRefreshFailureKind.InvalidGrant"/>; every other failure (network, 5xx,
-    ///   other OAuth errors, malformed JSON) is <see cref="TokenRefreshFailureKind.Transient"/>.</item>
+    ///   <item><b>Terminal-error classification (04 §3.5):</b> an OAuth error response of exactly
+    ///   <c>invalid_grant</c> is returned as <see cref="TokenRefreshFailureKind.InvalidGrant"/>,
+    ///   and exactly <c>invalid_target</c> (RFC 8707 §2) as
+    ///   <see cref="TokenRefreshFailureKind.InvalidTarget"/> — defensive hardening: our refresh
+    ///   requests send no <c>resource</c>, so current clients cannot receive it; every other
+    ///   failure (network, 5xx, other OAuth errors, malformed JSON) is
+    ///   <see cref="TokenRefreshFailureKind.Transient"/>.</item>
     /// </list>
     /// Fails closed — any error returns <see cref="TokenRefreshResult.Failure(string?)"/>, never a
     /// partial or fabricated token — and never logs token material.
@@ -223,7 +226,11 @@ namespace com.IvanMurzak.McpPlugin
         /// Parse an <c>/oauth/token</c> refresh response (pure, unit-testable). A success without
         /// <c>refresh_token</c> keeps <see cref="TokenRefreshResult.RefreshToken"/> null (04 §3.4);
         /// an OAuth error of exactly <c>invalid_grant</c> is classified
-        /// <see cref="TokenRefreshFailureKind.InvalidGrant"/>, everything else transient.
+        /// <see cref="TokenRefreshFailureKind.InvalidGrant"/>, exactly <c>invalid_target</c>
+        /// (RFC 8707 §2) is <see cref="TokenRefreshFailureKind.InvalidTarget"/>, everything else
+        /// transient. The raw <c>error</c> (and <c>error_description</c> when present) is preserved
+        /// verbatim in <see cref="TokenRefreshResult.FailureReason"/> so telemetry keeps distinct
+        /// reason strings per error code.
         /// </summary>
         internal static TokenRefreshResult ParseTokenResponse(bool isSuccessStatusCode, int statusCode, string json, Func<DateTimeOffset> clock)
         {
@@ -260,7 +267,9 @@ namespace com.IvanMurzak.McpPlugin
             {
                 var kind = string.Equals(error, "invalid_grant", StringComparison.Ordinal)
                     ? TokenRefreshFailureKind.InvalidGrant
-                    : TokenRefreshFailureKind.Transient;
+                    : string.Equals(error, "invalid_target", StringComparison.Ordinal)
+                        ? TokenRefreshFailureKind.InvalidTarget
+                        : TokenRefreshFailureKind.Transient;
                 var reason = error != null
                     ? (errorDescription != null ? error + ": " + errorDescription : error)
                     : "refresh failed (HTTP " + statusCode + ")";

--- a/McpPlugin/src/McpPlugin/Network/Connection/Credentials/ITokenRefresher.cs
+++ b/McpPlugin/src/McpPlugin/Network/Connection/Credentials/ITokenRefresher.cs
@@ -17,9 +17,10 @@ namespace com.IvanMurzak.McpPlugin
 {
     /// <summary>
     /// How a failed refresh should be classified by the caller (unified-machine-auth 04 §3.5). The
-    /// distinction is behavioral: <see cref="InvalidGrant"/> is the ONLY kind that may declare a
-    /// credential family dead (after the mandatory post-failure re-read); everything else is
-    /// retryable and must never destroy local state.
+    /// distinction is behavioral: <see cref="InvalidGrant"/> and <see cref="InvalidTarget"/> are
+    /// the only terminal kinds — the only ones that may declare a credential family dead (after
+    /// the mandatory post-failure re-read); everything else is retryable and must never destroy
+    /// local state.
     /// </summary>
     public enum TokenRefreshFailureKind
     {
@@ -35,6 +36,17 @@ namespace com.IvanMurzak.McpPlugin
         /// family is dead: surface sign-in-required, never loop, never delete other families.
         /// </summary>
         InvalidGrant = 1,
+
+        /// <summary>
+        /// The authorization server answered <c>invalid_target</c> (RFC 8707 §2): the requested
+        /// resource is invalid, missing, unknown, or malformed. Terminal like
+        /// <see cref="InvalidGrant"/>, but a server-side audience/resource mismatch — re-auth does
+        /// not reliably cure it, so the caller surfaces a configuration error instead of
+        /// retry-looping. Defensive hardening today: our refresh requests send no <c>resource</c>
+        /// parameter, so current clients cannot receive this error; it exists so a future client
+        /// that adopts RFC 8707 resource indicators inherits sane terminal behavior.
+        /// </summary>
+        InvalidTarget = 2,
     }
 
     /// <summary>


### PR DESCRIPTION
Taskflow `2026-08-24-oauth-client-error-hygiene` task `a1-refresher-classification` (02 §C2).

## What

- **`TokenRefreshFailureKind.InvalidTarget`** (RFC 8707 §2): an OAuth error of exactly `invalid_target` (Ordinal, same style as the existing `invalid_grant` match) now classifies as a distinct terminal kind instead of `Transient`. The raw `error` + `error_description` are preserved verbatim in `FailureReason`, so telemetry keeps distinct reason strings per error code.
- **Attempt-window clock seam**: the injectable `Func<DateTimeOffset>` clock (internal test ctor, repo style matching `PluginCredentialProvider._clock`) already existed on `main`; this PR adds the missing proof — a both-halves test driving the **production 60 s** `DefaultAttemptWindow` purely through the fake clock (within 60 s ⇒ memoized shared attempt; past 60 s ⇒ fresh network attempt), which task a2's dead-family memo will build on.
- **Deliberately NOT done** (02 §C2): no `resource` parameter added to the refresh form — it stays exactly `grant_type + refresh_token + client_id` (pinned by `Refresh_OmitsScopeAndResourceEntirely`). Our clients cannot receive `invalid_target` today; this is defensive hardening for a future RFC 8707 adopter. Consumer behavior is unchanged: `PluginCredentialProvider`'s dead-family check remains `== InvalidGrant` (a2 wires `InvalidTarget`).

## Evidence

- Plant 1 — mapping reverted: `Refresh_InvalidTarget_IsClassifiedInvalidTarget` went RED with actual = `TokenRefreshFailureKind.Transient` (the exact vacuity path the DoD names); `invalid_grant` + the Transient theory stayed green under the plant. Restored.
- Plant 2 — memo check bypassed the seam to `DateTimeOffset.UtcNow`: the fake-clock window test went RED (memoized half broke). Restored.
- `dotnet build McpPlugin.sln` green; `dotnet test` **3380/3380 green** (McpPlugin.Tests 945×net8.0/net9.0, McpPlugin.Server.Tests 745×net8.0/net9.0). No pre-existing red baseline.
- No version bump (release task r1 owns it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVipj7Xi4HouAmmdCYSdmz