### PR TITLE
a2: dead-family memo gating the network call + peer wake-up store re-check

### DIFF
--- a/McpPlugin.Tests/Network/Connection/Credentials/PluginCredentialProviderDeadFamilyMemoTests.cs
+++ b/McpPlugin.Tests/Network/Connection/Credentials/PluginCredentialProviderDeadFamilyMemoTests.cs
@@ -1,0 +1,405 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.AgentConfig;
+using com.IvanMurzak.McpPlugin.Tests.Infrastructure;
+using Microsoft.Extensions.Logging;
+using R3;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.Tests.Network.Connection.Credentials
+{
+    /// <summary>
+    /// The oauth-client-error-hygiene a2 behaviours (02 §C1/§C2/§C3.3, standing 04 §3.5 "never
+    /// loop" ruling): the dead-family memo that gates the NETWORK call after the in-lock store
+    /// re-read, its re-arm from the machine store (never from <c>_current</c>), the
+    /// <c>invalid_target</c> terminal path with its distinct "server configuration error" reason,
+    /// and the low-frequency peer wake-up store re-check that recovers a parked provider when a
+    /// peer surface signs in. Every "nothing happened" assertion here has a same-fixture positive
+    /// control (binding testing strategy, 02).
+    /// </summary>
+    public sealed class PluginCredentialProviderDeadFamilyMemoTests : IDisposable
+    {
+        const string StoredClientId = "app-dcr-4f2a9c31";
+        const string ServerTarget = "https://ai-game.dev";
+        const string SeededPluginAccess = "eyJ.PLUGIN.sig";
+        const string SeededPluginRefresh = "RT-plugin-aaa";
+
+        static readonly DateTimeOffset Start = new DateTimeOffset(2026, 8, 24, 12, 0, 0, TimeSpan.Zero);
+        static readonly TimeSpan ShortRecheckPeriod = TimeSpan.FromMilliseconds(100);
+
+        readonly string _baseDir;
+        DateTimeOffset _now = Start; // the fake clock (a1 seam style): tests move it explicitly
+
+        public PluginCredentialProviderDeadFamilyMemoTests()
+        {
+            _baseDir = Path.Combine(Path.GetTempPath(), "agd-credmemo-" + Guid.NewGuid().ToString("N"), ".ai-game-dev");
+        }
+
+        public void Dispose()
+        {
+            var parent = Path.GetDirectoryName(_baseDir);
+            if (parent != null && Directory.Exists(parent))
+                Directory.Delete(parent, recursive: true);
+        }
+
+        MachineCredentialStore NewStore() => new MachineCredentialStore(_baseDir);
+
+        void SeedV2(DateTimeOffset? pluginExpiresAt = null)
+        {
+            NewStore().Write(new MachineCredentials
+            {
+                ServerTarget = ServerTarget,
+                Subject = "usr_123",
+                Families = new MachineCredentialFamilies
+                {
+                    Plugin = new MachineCredentialFamily
+                    {
+                        AccessToken = SeededPluginAccess,
+                        RefreshToken = SeededPluginRefresh,
+                        ExpiresAt = pluginExpiresAt ?? Start.AddMinutes(30),
+                        ClientId = StoredClientId,
+                        Scope = "mcp:plugin",
+                    },
+                },
+            });
+        }
+
+        static TokenRefreshResult InvalidGrant() =>
+            TokenRefreshResult.Failure("invalid_grant: revoked", TokenRefreshFailureKind.InvalidGrant);
+
+        static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
+        {
+            var sw = Stopwatch.StartNew();
+            while (sw.Elapsed < timeout)
+            {
+                if (condition())
+                    return;
+                await Task.Delay(20);
+            }
+            condition().ShouldBeTrue($"condition not reached within {timeout.TotalSeconds:0.#}s");
+        }
+
+        // ── Dead ⇒ silent (02 §C1): after the terminal verdict, the memo — not the refresher's
+        //    60 s attempt window — blocks every further network attempt this process makes. ──
+
+        [Fact]
+        public async Task DeadVerdict_MemoSuppressesEveryFurtherNetworkAttempt_PastTheAttemptWindow()
+        {
+            SeedV2(pluginExpiresAt: Start.AddMinutes(30));
+            var refresher = new FakeTokenRefresher(InvalidGrant());
+            var logger = new CapturingLogger();
+            using var provider = new PluginCredentialProvider(NewStore(), refresher, logger, clock: () => _now);
+
+            var signInRequiredCount = 0;
+            using var _ = provider.OnSignInRequired.Subscribe(__ => { signInRequiredCount++; });
+
+            // The verdict: ONE network attempt, dead family confirmed by the post-failure re-read.
+            (await provider.RefreshAsync()).ShouldBeFalse();
+            provider.State.CurrentValue.ShouldBe(AuthState.SignInRequired);
+            refresher.Requests.Count.ShouldBe(1);
+            signInRequiredCount.ShouldBe(1);
+            // invalid_grant reason is the raw one — no "server configuration error" class (02 §C2).
+            provider.SignInRequiredReason.ShouldBe("invalid_grant: revoked");
+
+            // Advance the fake clock PAST expiry and PAST the production 60 s attempt window
+            // (a1 seam): from here every GetAccessTokenAsync enters the proactive-refresh path,
+            // and the counting fake has NO rate window — only the memo can block the network.
+            _now = Start.AddHours(2);
+            for (var i = 0; i < 5; i++)
+                (await provider.GetAccessTokenAsync()).ShouldBe(SeededPluginAccess); // stale token, existing contract
+            (await provider.RefreshAsync()).ShouldBeFalse();
+            (await provider.RefreshAsync()).ShouldBeFalse();
+
+            // ZERO further network attempts — the memo, not the window, blocks (04 §3.5).
+            refresher.Requests.Count.ShouldBe(1);
+            provider.State.CurrentValue.ShouldBe(AuthState.SignInRequired);
+
+            // ONE structured telemetry event per family death, and no repeated sign-in prompts.
+            logger.Warnings.Count(w => w.Contains("Credential family dead")).ShouldBe(1);
+            signInRequiredCount.ShouldBe(1);
+        }
+
+        // ── Re-arm ⇒ recovery (02 §C1): the comparison is against the freshly-READ store token,
+        //    so a peer's differing token clears the memo and refresh proceeds. ──
+
+        [Fact]
+        public async Task Rearm_StoreHoldsDifferentRefreshToken_OneNetworkRefresh_ReachesSignedIn()
+        {
+            SeedV2();
+            var next = InvalidGrant();
+            var refresher = new FakeTokenRefresher(_ => next);
+            using var provider = new PluginCredentialProvider(NewStore(), refresher, clock: () => _now);
+
+            (await provider.RefreshAsync()).ShouldBeFalse(); // the verdict
+            refresher.Requests.Count.ShouldBe(1);
+            provider.State.CurrentValue.ShouldBe(AuthState.SignInRequired);
+
+            // A peer rotates ONLY the refresh token (same access token) — this isolates the memo
+            // re-arm from the pre-existing peer-adoption path, which keys on the access token.
+            var peer = NewStore().Read()!;
+            peer.Families!.Plugin!.RefreshToken = "RT-plugin-peer";
+            NewStore().Write(peer);
+
+            next = TokenRefreshResult.Success("eyJ.FRESH.sig", "RT-plugin-fresh2", _now.AddHours(1));
+
+            (await provider.RefreshAsync()).ShouldBeTrue();
+
+            refresher.Requests.Count.ShouldBe(2); // the re-armed attempt DID go out
+            refresher.Requests[1].RefreshToken.ShouldBe("RT-plugin-peer"); // presenting the STORE's token, not the memoized dead one
+            provider.State.CurrentValue.ShouldBe(AuthState.SignedIn);
+            provider.SignInRequiredReason.ShouldBeNull();
+            (await provider.GetAccessTokenAsync()).ShouldBe("eyJ.FRESH.sig");
+        }
+
+        [Fact]
+        public async Task Rearm_Control_StoreUnchanged_SameFixtureProducesZeroFurtherAttempts()
+        {
+            // Vacuity guard for the re-arm test: IDENTICAL fixture, the refresher would even
+            // SUCCEED if presented — the only difference is that no peer rewrote the store.
+            SeedV2();
+            var next = InvalidGrant();
+            var refresher = new FakeTokenRefresher(_ => next);
+            using var provider = new PluginCredentialProvider(NewStore(), refresher, clock: () => _now);
+
+            (await provider.RefreshAsync()).ShouldBeFalse(); // the verdict
+            refresher.Requests.Count.ShouldBe(1);
+
+            next = TokenRefreshResult.Success("eyJ.WOULD-WORK.sig", "RT-would-work", _now.AddHours(1));
+
+            (await provider.RefreshAsync()).ShouldBeFalse(); // still suppressed — store unchanged
+
+            refresher.Requests.Count.ShouldBe(1);
+            provider.State.CurrentValue.ShouldBe(AuthState.SignInRequired);
+        }
+
+        [Fact]
+        public async Task PeerFullLogin_AdoptedWithoutNetworkCall_SignedIn()
+        {
+            // The pre-existing peer-adoption path (03 F3.2) is unchanged by the memo: a full fresh
+            // login (new access + refresh token) is adopted from the in-lock re-read, no network.
+            SeedV2();
+            var next = InvalidGrant();
+            var refresher = new FakeTokenRefresher(_ => next);
+            using var provider = new PluginCredentialProvider(NewStore(), refresher, clock: () => _now);
+
+            (await provider.RefreshAsync()).ShouldBeFalse(); // the verdict
+            refresher.Requests.Count.ShouldBe(1);
+
+            var peer = NewStore().Read()!;
+            peer.Families!.Plugin!.AccessToken = "eyJ.PEER-FRESH.sig";
+            peer.Families.Plugin.RefreshToken = "RT-plugin-peer-login";
+            peer.Families.Plugin.ExpiresAt = _now.AddHours(1);
+            NewStore().Write(peer);
+
+            next = TokenRefreshResult.Failure("must not be called");
+
+            (await provider.RefreshAsync()).ShouldBeTrue();
+
+            refresher.Requests.Count.ShouldBe(1); // adopted, not refreshed
+            provider.State.CurrentValue.ShouldBe(AuthState.SignedIn);
+            (await provider.GetAccessTokenAsync()).ShouldBe("eyJ.PEER-FRESH.sig");
+        }
+
+        // ── invalid_target (a1 kind, 02 §C2): same terminal/memo behavior, distinct
+        //    "server configuration error" reason in state + telemetry. ──
+
+        [Fact]
+        public async Task InvalidTarget_IsTerminal_DistinctServerConfigurationErrorReason_AndMemoBlocks()
+        {
+            SeedV2(pluginExpiresAt: Start.AddMinutes(30));
+            var refresher = new FakeTokenRefresher(
+                TokenRefreshResult.Failure("invalid_target: audience mismatch", TokenRefreshFailureKind.InvalidTarget));
+            var logger = new CapturingLogger();
+            using var provider = new PluginCredentialProvider(NewStore(), refresher, logger, clock: () => _now);
+
+            var signInRequiredFired = false;
+            using var _ = provider.OnSignInRequired.Subscribe(__ => { signInRequiredFired = true; });
+
+            (await provider.RefreshAsync()).ShouldBeFalse();
+
+            provider.State.CurrentValue.ShouldBe(AuthState.SignInRequired);
+            signInRequiredFired.ShouldBeTrue();
+            // Distinct reason class (02 §C2) with the raw OAuth error preserved verbatim after it.
+            provider.SignInRequiredReason.ShouldBe("server configuration error: invalid_target: audience mismatch");
+
+            // Same memo behavior as invalid_grant: zero further attempts past the window.
+            _now = Start.AddHours(2);
+            for (var i = 0; i < 3; i++)
+                await provider.GetAccessTokenAsync();
+            (await provider.RefreshAsync()).ShouldBeFalse();
+            refresher.Requests.Count.ShouldBe(1);
+
+            // Telemetry keeps the distinct error code (one event, per family death).
+            var dead = logger.Warnings.Where(w => w.Contains("Credential family dead")).ToList();
+            dead.Count.ShouldBe(1);
+            dead[0].ShouldContain("invalid_target");
+
+            // The store was never touched (inherited ruling): the dead material is still on disk.
+            NewStore().Read()!.Families!.Plugin!.RefreshToken.ShouldBe(SeededPluginRefresh);
+        }
+
+        [Fact]
+        public async Task InvalidTarget_Rearm_OnPeerLogin_RecoversLikeInvalidGrant()
+        {
+            SeedV2();
+            var next = TokenRefreshResult.Failure("invalid_target: audience mismatch", TokenRefreshFailureKind.InvalidTarget);
+            var refresher = new FakeTokenRefresher(_ => next);
+            using var provider = new PluginCredentialProvider(NewStore(), refresher, clock: () => _now);
+
+            (await provider.RefreshAsync()).ShouldBeFalse(); // the verdict
+            provider.State.CurrentValue.ShouldBe(AuthState.SignInRequired); // parked — invalid_target IS terminal
+
+            var peer = NewStore().Read()!;
+            peer.Families!.Plugin!.AccessToken = "eyJ.PEER-FRESH.sig";
+            peer.Families.Plugin.RefreshToken = "RT-plugin-peer-login";
+            NewStore().Write(peer);
+            next = TokenRefreshResult.Failure("must not be called");
+
+            (await provider.RefreshAsync()).ShouldBeTrue(); // adopted — same re-arm semantics
+
+            provider.State.CurrentValue.ShouldBe(AuthState.SignedIn);
+            provider.SignInRequiredReason.ShouldBeNull();
+        }
+
+        // ── Peer wake-up (02 §C3.3): a parked provider recovers within one re-check period,
+        //    with NO caller driving the token path. ──
+
+        [Fact]
+        public async Task PeerWakeUp_FullPeerLogin_AdoptedWithinRecheckPeriod_WithoutAnyCaller()
+        {
+            SeedV2();
+            var next = InvalidGrant();
+            var refresher = new FakeTokenRefresher(_ => next);
+            using var provider = new PluginCredentialProvider(
+                NewStore(), refresher, clock: () => _now, deadFamilyRecheckPeriod: ShortRecheckPeriod);
+
+            (await provider.RefreshAsync()).ShouldBeFalse(); // the verdict — provider parks
+            provider.State.CurrentValue.ShouldBe(AuthState.SignInRequired);
+            refresher.Requests.Count.ShouldBe(1);
+
+            // A peer surface signs in (full fresh credential). NOTHING calls the provider again.
+            next = TokenRefreshResult.Failure("must not be needed"); // adoption needs no network
+            var peer = NewStore().Read()!;
+            peer.Families!.Plugin!.AccessToken = "eyJ.PEER-LOGIN.sig";
+            peer.Families.Plugin.RefreshToken = "RT-plugin-peer-login";
+            peer.Families.Plugin.ExpiresAt = _now.AddHours(1);
+            NewStore().Write(peer);
+
+            await WaitUntilAsync(() => provider.State.CurrentValue == AuthState.SignedIn, TimeSpan.FromSeconds(10));
+
+            refresher.Requests.Count.ShouldBe(1); // adopted from the store — still zero extra network
+            provider.SignInRequiredReason.ShouldBeNull();
+            (await provider.GetAccessTokenAsync()).ShouldBe("eyJ.PEER-LOGIN.sig");
+        }
+
+        [Fact]
+        public async Task PeerWakeUp_RotatedRefreshTokenOnly_RearmsAndRefreshesWithinRecheckPeriod()
+        {
+            // The network flavour of the wake-up: the store holds a DIFFERENT refresh token but the
+            // same access token, so recovery must go re-arm → one network refresh → SignedIn.
+            SeedV2();
+            var next = InvalidGrant();
+            var refresher = new FakeTokenRefresher(_ => next);
+            using var provider = new PluginCredentialProvider(
+                NewStore(), refresher, clock: () => _now, deadFamilyRecheckPeriod: ShortRecheckPeriod);
+
+            (await provider.RefreshAsync()).ShouldBeFalse(); // the verdict — provider parks
+            refresher.Requests.Count.ShouldBe(1);
+
+            next = TokenRefreshResult.Success("eyJ.WOKEN.sig", "RT-plugin-fresh3", _now.AddHours(1));
+            var peer = NewStore().Read()!;
+            peer.Families!.Plugin!.RefreshToken = "RT-plugin-peer";
+            NewStore().Write(peer);
+
+            await WaitUntilAsync(() => provider.State.CurrentValue == AuthState.SignedIn, TimeSpan.FromSeconds(10));
+
+            refresher.Requests.Count.ShouldBe(2);
+            refresher.Requests[1].RefreshToken.ShouldBe("RT-plugin-peer");
+            (await provider.GetAccessTokenAsync()).ShouldBe("eyJ.WOKEN.sig");
+        }
+
+        [Fact]
+        public async Task PeerWakeUp_Control_StoreUnchanged_StaysParked_ZeroNetworkAttempts()
+        {
+            // Control for both wake-up tests: identical fixture (refresher would succeed if
+            // presented), the ONLY difference is that the store is never rewritten.
+            SeedV2();
+            var next = InvalidGrant();
+            var refresher = new FakeTokenRefresher(_ => next);
+            using var provider = new PluginCredentialProvider(
+                NewStore(), refresher, clock: () => _now, deadFamilyRecheckPeriod: ShortRecheckPeriod);
+
+            (await provider.RefreshAsync()).ShouldBeFalse(); // the verdict — provider parks
+            next = TokenRefreshResult.Success("eyJ.WOULD-WORK.sig", "RT-would-work", _now.AddHours(1));
+
+            await Task.Delay(TimeSpan.FromMilliseconds(700)); // ≥6 re-check periods
+
+            provider.State.CurrentValue.ShouldBe(AuthState.SignInRequired);
+            refresher.Requests.Count.ShouldBe(1); // the re-check is a lock-free READ — no network
+        }
+
+        [Fact]
+        public async Task PeerWakeUp_DisposedWhileParked_LoopStops()
+        {
+            // Mirror of the rotated-refresh-token wake-up: after Dispose the SAME store rewrite
+            // must produce NO further network attempt (02 §C3.3 — stops on disposal).
+            SeedV2();
+            var next = InvalidGrant();
+            var refresher = new FakeTokenRefresher(_ => next);
+            var provider = new PluginCredentialProvider(
+                NewStore(), refresher, clock: () => _now, deadFamilyRecheckPeriod: ShortRecheckPeriod);
+
+            (await provider.RefreshAsync()).ShouldBeFalse(); // the verdict — provider parks
+            refresher.Requests.Count.ShouldBe(1);
+
+            provider.Dispose();
+
+            next = TokenRefreshResult.Success("eyJ.WOULD-WORK.sig", "RT-would-work", _now.AddHours(1));
+            var peer = NewStore().Read()!;
+            peer.Families!.Plugin!.RefreshToken = "RT-plugin-peer";
+            NewStore().Write(peer);
+
+            await Task.Delay(TimeSpan.FromMilliseconds(500)); // ≥4 would-be re-check periods
+
+            refresher.Requests.Count.ShouldBe(1); // the loop is dead — nothing re-armed or refreshed
+        }
+
+        sealed class CapturingLogger : ILogger
+        {
+            readonly List<(LogLevel Level, string Message)> _entries = new List<(LogLevel, string)>();
+
+            public IEnumerable<string> Warnings
+            {
+                get { lock (_entries) return _entries.Where(e => e.Level == LogLevel.Warning).Select(e => e.Message).ToList(); }
+            }
+
+            public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+            public bool IsEnabled(LogLevel logLevel) => true;
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+            {
+                lock (_entries)
+                    _entries.Add((logLevel, formatter(state, exception)));
+            }
+
+            sealed class NullScope : IDisposable
+            {
+                public static readonly NullScope Instance = new NullScope();
+                public void Dispose() { }
+            }
+        }
+    }
+}

--- a/McpPlugin/src/McpPlugin/Network/Connection/Credentials/PluginCredentialProvider.cs
+++ b/McpPlugin/src/McpPlugin/Network/Connection/Credentials/PluginCredentialProvider.cs
@@ -44,13 +44,19 @@ namespace com.IvanMurzak.McpPlugin
     ///   <see cref="MachineCredentialStore.Rotate"/> (b1 review A3: its plugin/legacy fallback is
     ///   not family-explicit and its unreadable-refusal throw is the wrong shape mid-lock).</item>
     ///   <item><b>Failure-state split (04 §3.5, 03 F3.5/F9):</b> <see cref="AuthState.SignInRequired"/>
-    ///   is the DEAD-FAMILY verdict only — <c>invalid_grant</c> followed by a post-failure re-read
-    ///   that shows nobody else rotated the family. Then ONE structured telemetry event is emitted
-    ///   (per family death, not per retry), other families are never deleted, and the provider
-    ///   never loops — one network attempt per call, rate-bounded across calls by the refresher
-    ///   (04 §3.6). Every OTHER failure — AS unreachable, 5xx, timeout, a thrown refresher — is
-    ///   <b>transient</b>: the provider stays <see cref="AuthState.SignedIn"/> on its current
-    ///   credential and retries later (F9: offline self-heals silently, no sign-in prompt).</item>
+    ///   is the DEAD-FAMILY verdict only — a terminal refresh error (<c>invalid_grant</c>, or
+    ///   <c>invalid_target</c> as a "server configuration error") followed by a post-failure
+    ///   re-read that shows nobody else rotated the family. Then ONE structured telemetry event is
+    ///   emitted (per family death, not per retry), other families are never deleted, and the
+    ///   provider <b>never loops</b> (oauth-client-error-hygiene 02 §C1): the dead refresh token is
+    ///   memoized in-process and never re-presented to the server — re-armed only when the machine
+    ///   store holds a DIFFERENT token, i.e. a fresh login by any surface (App, CLI, another
+    ///   editor). While sign-in is required, a low-frequency store re-check (02 §C3.3,
+    ///   <see cref="DefaultDeadFamilyRecheckPeriod"/>) adopts a peer surface's fresh login so a
+    ///   stopped editor wakes up without any caller driving the token path. Every OTHER failure —
+    ///   AS unreachable, 5xx, timeout, a thrown refresher — is <b>transient</b>: the provider stays
+    ///   <see cref="AuthState.SignedIn"/> on its current credential and retries later (F9: offline
+    ///   self-heals silently, no sign-in prompt).</item>
     /// </list>
     /// The actual token-endpoint HTTP exchange is delegated to an injected <see cref="ITokenRefresher"/>
     /// (the shared <see cref="HttpTokenRefresher"/> in production); this class never talks to the
@@ -60,6 +66,14 @@ namespace com.IvanMurzak.McpPlugin
     {
         /// <summary>Default proactive-refresh skew: refresh once the token is within 60s of expiry.</summary>
         public static readonly TimeSpan DefaultRefreshSkew = TimeSpan.FromSeconds(60);
+
+        /// <summary>
+        /// Default period of the low-frequency machine-store re-check that runs while the provider
+        /// is parked in <see cref="AuthState.SignInRequired"/> after a dead-family verdict
+        /// (oauth-client-error-hygiene 02 §C3.3): a peer surface's fresh login is adopted within
+        /// one period without any caller driving the token path.
+        /// </summary>
+        public static readonly TimeSpan DefaultDeadFamilyRecheckPeriod = TimeSpan.FromSeconds(60);
 
         readonly MachineCredentialStore _store;
         readonly MachineCredentialLock _lock;
@@ -74,6 +88,23 @@ namespace com.IvanMurzak.McpPlugin
         readonly Subject<Unit> _signInRequired = new Subject<Unit>();
         MachineCredentials? _current;
         bool _familyDeadTelemetryEmitted;
+
+        /// <summary>
+        /// The dead-family memo (04 §3.5 "never loop", 02 §C1): the refresh token the server
+        /// declared dead plus the surfaced reason. ONE nullable field — the provider manages a
+        /// single plane (<c>families.plugin</c> + legacy fallback), so no map, no persistence.
+        /// Guarded by <see cref="_gate"/>. Armed only by a confirmed dead-family verdict; cleared
+        /// (re-armed) when the freshly-read store token differs, on any in-memory adoption of a
+        /// live credential, and on sign-out.
+        /// </summary>
+        (string RefreshToken, string Reason)? _deadFamilyMemo;
+
+        /// <summary>The live dead-family store re-check loop (02 §C3.3), null when not running. Guarded by <see cref="_gate"/> (see <see cref="StopDeadFamilyRecheck"/> for the Dispose exception).</summary>
+        CancellationTokenSource? _deadFamilyRecheckCts;
+        readonly TimeSpan _deadFamilyRecheckPeriod;
+
+        /// <summary>Reason behind the current SignInRequired state (reference writes are atomic; written under <see cref="_gate"/>, read lock-free by UI).</summary>
+        volatile string? _signInRequiredReason;
         volatile bool _disposed;
 
         /// <summary>
@@ -83,6 +114,10 @@ namespace com.IvanMurzak.McpPlugin
         /// <paramref name="credentialLock"/> — the cross-process lock guarding refresh writes
         /// (04 §2); null creates the default lock rooted at the store's own directory, so
         /// production callers get cross-process safety without wiring anything.
+        /// <paramref name="deadFamilyRecheckPeriod"/> — period of the low-frequency store re-check
+        /// while parked in SignInRequired after a dead-family verdict (02 §C3.3); null uses
+        /// <see cref="DefaultDeadFamilyRecheckPeriod"/> (test seam — the injected clock cannot
+        /// drive a real delay).
         /// </summary>
         public PluginCredentialProvider(
             MachineCredentialStore store,
@@ -90,8 +125,10 @@ namespace com.IvanMurzak.McpPlugin
             ILogger? logger = null,
             TimeSpan? refreshSkew = null,
             Func<DateTimeOffset>? clock = null,
-            MachineCredentialLock? credentialLock = null)
+            MachineCredentialLock? credentialLock = null,
+            TimeSpan? deadFamilyRecheckPeriod = null)
         {
+            _deadFamilyRecheckPeriod = deadFamilyRecheckPeriod ?? DefaultDeadFamilyRecheckPeriod;
             _store = store ?? throw new ArgumentNullException(nameof(store));
             _lock = credentialLock ?? new MachineCredentialLock(store.BaseDirectory);
             _refresher = refresher;
@@ -120,6 +157,17 @@ namespace com.IvanMurzak.McpPlugin
 
         /// <summary>Fires when a refresh failed and the user must sign in again (design 06).</summary>
         public Observable<Unit> OnSignInRequired => _signInRequired;
+
+        /// <summary>
+        /// The reason behind the current <see cref="AuthState.SignInRequired"/> state; null in any
+        /// other state, and null for a boot-time unreadable-store SignInRequired that predates any
+        /// refresh verdict. For an <c>invalid_target</c> dead-family verdict the reason carries the
+        /// <c>"server configuration error"</c> class prefix (oauth-client-error-hygiene 02 §C2) so
+        /// engine UIs can render the D4 step-3 status without parsing OAuth error codes; the raw
+        /// OAuth <c>error</c>/<c>error_description</c> is preserved after the prefix. Never
+        /// contains token material.
+        /// </summary>
+        public string? SignInRequiredReason => _signInRequiredReason;
 
         /// <summary>True when a usable plugin-plane credential is present.</summary>
         public bool IsSignedIn => _state.CurrentValue == AuthState.SignedIn && PluginPlaneFamily(_current)?.AccessToken != null;
@@ -171,10 +219,12 @@ namespace com.IvanMurzak.McpPlugin
         /// Refresh the access token now (driven by the connection layer's <c>_authorizationRejected</c>
         /// signal). Returns true when a fresh token was persisted (or adopted from a peer's refresh);
         /// false when this attempt did not produce one. A false return surfaces
-        /// <see cref="AuthState.SignInRequired"/> ONLY for a dead family (<c>invalid_grant</c>
-        /// confirmed by the post-failure re-read) or when refresh is impossible (no refresh token /
-        /// no refresher); transient failures and a busy machine-wide lock leave the state untouched
-        /// (retry-later semantics — review B2).
+        /// <see cref="AuthState.SignInRequired"/> ONLY for a dead family (a terminal
+        /// <c>invalid_grant</c>/<c>invalid_target</c> confirmed by the post-failure re-read) or when
+        /// refresh is impossible (no refresh token / no refresher); transient failures and a busy
+        /// machine-wide lock leave the state untouched (retry-later semantics — review B2). Once a
+        /// family is memoized dead (04 §3.5 / 02 §C1) further calls return false WITHOUT a network
+        /// attempt until the machine store holds a different token.
         /// </summary>
         public async Task<bool> RefreshAsync(CancellationToken cancellationToken = default)
         {
@@ -212,6 +262,9 @@ namespace com.IvanMurzak.McpPlugin
                 _store.Write(credentials);
                 _current = credentials;
                 _familyDeadTelemetryEmitted = false;
+                _deadFamilyMemo = null; // a fresh sign-in re-arms refresh (02 §C1)
+                _signInRequiredReason = null;
+                StopDeadFamilyRecheck();
                 _state.Value = PluginPlaneFamily(credentials)?.AccessToken != null ? AuthState.SignedIn : AuthState.SignedOut;
             }
             finally
@@ -239,6 +292,9 @@ namespace com.IvanMurzak.McpPlugin
                 catch (Exception ex) { _logger?.LogWarning("Deleting stored credential failed: {message}", ex.Message); }
                 _current = null;
                 _familyDeadTelemetryEmitted = false;
+                _deadFamilyMemo = null;
+                _signInRequiredReason = null;
+                StopDeadFamilyRecheck();
                 _state.Value = AuthState.SignedOut;
             }
             finally
@@ -306,6 +362,9 @@ namespace com.IvanMurzak.McpPlugin
                 {
                     // A peer signed the machine out (F6.3) — adopt the signed-out state, quietly.
                     _current = null;
+                    _deadFamilyMemo = null; // no credential left to memoize against
+                    _signInRequiredReason = null;
+                    StopDeadFamilyRecheck();
                     _state.Value = AuthState.SignedOut;
                     return false;
                 }
@@ -322,6 +381,24 @@ namespace com.IvanMurzak.McpPlugin
                 {
                     SurfaceSignInRequired("stored credential has no refresh token");
                     return false;
+                }
+
+                // Dead-family memo (04 §3.5 "never loop", 02 §C1): a refresh family the server
+                // declared dead is NEVER re-presented by this process. Compared against the
+                // freshly-READ store token — not _current — so a fresh login by ANY surface
+                // (App, CLI, another editor) re-arms this process naturally (the .NET adaptation
+                // of TS credential-provider Rule 5, keyed on the in-lock re-read).
+                if (_deadFamilyMemo != null)
+                {
+                    if (string.Equals(_deadFamilyMemo.Value.RefreshToken, latestFamily.RefreshToken, StringComparison.Ordinal))
+                    {
+                        // The store still holds the same dead token: no network attempt, no repeat
+                        // telemetry (the ONE structured event fired at the verdict), no state
+                        // churn. Debug on purpose — silence IS the fix for the 1,440/day loop.
+                        _logger?.LogDebug("Token refresh suppressed: this credential family was declared dead ({reason}); waiting for a new sign-in.", _deadFamilyMemo.Value.Reason);
+                        return false;
+                    }
+                    _deadFamilyMemo = null; // the store holds a DIFFERENT token — re-arm and proceed
                 }
 
                 // Still stale — one network attempt, presenting the family's STORED clientId
@@ -380,13 +457,16 @@ namespace com.IvanMurzak.McpPlugin
             }
         }
 
-        // MUST be called with _gate held, INSIDE the lock's using scope.
+        // MUST be called with _gate held, INSIDE the lock's using scope. attemptedFamily's
+        // RefreshToken is non-null — the caller verified it before the network attempt.
         bool HandleRefreshFailure(TokenRefreshResult? result, MachineCredentialFamily attemptedFamily)
         {
-            if (result?.FailureKind == TokenRefreshFailureKind.InvalidGrant)
+            var kind = result?.FailureKind ?? TokenRefreshFailureKind.Transient;
+            if (kind == TokenRefreshFailureKind.InvalidGrant || kind == TokenRefreshFailureKind.InvalidTarget)
             {
                 // 03 F3.5: re-read once more — a racer may have won legitimately (its rotation
-                // revoked our just-presented token, which the AS reports as invalid_grant).
+                // revoked our just-presented token, which the AS reports as invalid_grant). This
+                // stays FIRST: a racer's rotation still wins over the dead-family verdict.
                 var post = _store.TryRead();
                 if (post.Status == MachineCredentialStoreStatus.Unreadable)
                 {
@@ -404,17 +484,38 @@ namespace com.IvanMurzak.McpPlugin
                 }
 
                 // Family dead (04 §3.5): ONE structured telemetry event; never delete other
-                // families (the store is not touched at all); never loop.
+                // families (the store is not touched at all); never loop (memo below).
+                // invalid_target is the "server configuration error" class (02 §C2) — a server-
+                // side audience/resource mismatch that re-auth does not reliably cure — so its
+                // surfaced reason carries a distinct class prefix; the raw OAuth error string
+                // stays verbatim after it for telemetry.
+                var errorCode = kind == TokenRefreshFailureKind.InvalidTarget ? "invalid_target" : "invalid_grant";
+                var reason = kind == TokenRefreshFailureKind.InvalidTarget
+                    ? "server configuration error: " + (result?.FailureReason ?? errorCode)
+                    : result?.FailureReason ?? errorCode;
                 if (!_familyDeadTelemetryEmitted)
                 {
                     _familyDeadTelemetryEmitted = true;
                     _logger?.LogWarning(
-                        "Credential family dead: refresh returned invalid_grant and no peer rotated it. family={family} clientIdKnown={clientIdKnown} reason={reason}",
+                        "Credential family dead: refresh returned {errorCode} and no peer rotated it. family={family} clientIdKnown={clientIdKnown} reason={reason}",
+                        errorCode,
                         attemptedFamily.ClientId != null ? "plugin" : "legacy",
                         attemptedFamily.ClientId != null,
-                        result?.FailureReason ?? "invalid_grant");
+                        reason);
                 }
-                SurfaceSignInRequired(result?.FailureReason ?? "invalid_grant");
+
+                // Never loop (04 §3.5, 02 §C1): memoize the dead token — RefreshCoreAsync will not
+                // re-present it until the machine store holds a different one. In-process only;
+                // the store itself is never written or deleted on any failure path
+                // (unified-machine-auth 03-auth-flows.md:52).
+                _deadFamilyMemo = (attemptedFamily.RefreshToken!, reason);
+
+                // Peer wake-up (02 §C3.3): while parked in SignInRequired, a low-frequency store
+                // re-check adopts a peer surface's fresh login — the machine-wide "one login
+                // anywhere authorizes everywhere" model for stopped editors.
+                StartDeadFamilyRecheck();
+
+                SurfaceSignInRequired(reason);
                 return false;
             }
 
@@ -432,7 +533,114 @@ namespace com.IvanMurzak.McpPlugin
         {
             _current = credentials;
             _familyDeadTelemetryEmitted = false;
+            _deadFamilyMemo = null; // a live credential re-arms refresh (02 §C1)
+            _signInRequiredReason = null;
+            StopDeadFamilyRecheck();
             _state.Value = AuthState.SignedIn;
+        }
+
+        // MUST be called with _gate held. Starts the low-frequency dead-family store re-check
+        // (02 §C3.3) unless one is already running. Idempotent per verdict; self-terminating —
+        // the loop stops itself on any state other than SignInRequired and on disposal.
+        void StartDeadFamilyRecheck()
+        {
+            if (_deadFamilyRecheckCts != null || _disposed)
+                return;
+            var cts = new CancellationTokenSource();
+            _deadFamilyRecheckCts = cts;
+            _ = RunDeadFamilyRecheckAsync(cts);
+        }
+
+        // MUST be called with _gate held — except from Dispose, which runs after _disposed is set
+        // (the loop checks _disposed under the gate before acting, so a racing tick self-stops).
+        void StopDeadFamilyRecheck()
+        {
+            var cts = _deadFamilyRecheckCts;
+            _deadFamilyRecheckCts = null;
+            if (cts == null)
+                return;
+            try
+            {
+                cts.Cancel();
+                cts.Dispose();
+            }
+            catch (ObjectDisposedException) { }
+        }
+
+        // The peer wake-up loop (02 §C3.3): while the provider is parked in SignInRequired after a
+        // dead-family verdict, re-check the machine store once per period; when it holds token
+        // material that differs from the memoized dead family, run the normal lock-integrated
+        // refresh path (which adopts a peer's fresh credential without a network call, or — memo
+        // re-armed by the differing token — performs one refresh) and reach SignedIn. No new
+        // threads: an async Task.Delay loop in repo style, cancelled via <see cref="_deadFamilyRecheckCts"/>.
+        async Task RunDeadFamilyRecheckAsync(CancellationTokenSource owner)
+        {
+            var cancellationToken = owner.Token;
+            try
+            {
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    await Task.Delay(_deadFamilyRecheckPeriod, cancellationToken).ConfigureAwait(false);
+
+                    await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+                    bool stop;
+                    try
+                    {
+                        stop = await DeadFamilyRecheckTickAsync(owner, cancellationToken).ConfigureAwait(false);
+                    }
+                    finally
+                    {
+                        _gate.Release();
+                    }
+                    if (stop)
+                        return;
+                }
+            }
+            catch (OperationCanceledException) { }
+            catch (ObjectDisposedException) { } // disposal races the loop's own primitives — a stop, not an error
+            catch (Exception ex)
+            {
+                _logger?.LogWarning("Dead-family store re-check stopped unexpectedly: {message}", ex.Message); // never log token material
+            }
+        }
+
+        // MUST be called with _gate held (one tick of the wake-up loop). True ⇒ the loop stops.
+        async Task<bool> DeadFamilyRecheckTickAsync(CancellationTokenSource owner, CancellationToken cancellationToken)
+        {
+            if (_disposed || cancellationToken.IsCancellationRequested)
+                return true;
+            if (_state.CurrentValue != AuthState.SignInRequired)
+            {
+                // Recovered (or signed out) through another path — self-terminate.
+                if (ReferenceEquals(_deadFamilyRecheckCts, owner))
+                    StopDeadFamilyRecheck();
+                return true;
+            }
+
+            // Cheap lock-free READ first: the full cross-process-lock protocol runs only when the
+            // store actually holds something new (a peer surface's login), so ~all ticks of a
+            // parked editor cost one file read and zero lock traffic.
+            var read = SafeRead();
+            var storeFamily = PluginPlaneFamily(read.Credentials);
+            var currentFamily = PluginPlaneFamily(_current);
+            var deadToken = _deadFamilyMemo?.RefreshToken ?? currentFamily?.RefreshToken;
+            var storeHoldsSomethingNew = storeFamily != null
+                && ((storeFamily.RefreshToken != null && deadToken != null
+                        && !string.Equals(storeFamily.RefreshToken, deadToken, StringComparison.Ordinal))
+                    || (storeFamily.AccessToken != null && currentFamily?.AccessToken != null
+                        && !string.Equals(storeFamily.AccessToken, currentFamily.AccessToken, StringComparison.Ordinal)));
+            if (!storeHoldsSomethingNew)
+                return false; // nothing new — stay parked, re-check next period
+
+            // Re-arm + refresh through the normal path (re-reads under the cross-process lock;
+            // adopts, or refreshes with the store's token). Transient failures (e.g. the signing-in
+            // peer still holds the lock) leave state unchanged — retried next period.
+            await RefreshCoreAsync(cancellationToken).ConfigureAwait(false);
+            if (_state.CurrentValue != AuthState.SignedIn)
+                return false;
+            if (ReferenceEquals(_deadFamilyRecheckCts, owner))
+                StopDeadFamilyRecheck(); // normally already stopped by AdoptInMemory — belt and braces
+            return true;
         }
 
         bool ShouldRefresh(MachineCredentialFamily family)
@@ -449,6 +657,7 @@ namespace com.IvanMurzak.McpPlugin
             _logger?.LogWarning("Account credential refresh failed ({reason}); sign-in required.", reason ?? "unknown");
             if (_disposed)
                 return;
+            _signInRequiredReason = reason ?? "unknown";
             _state.Value = AuthState.SignInRequired;
             _signInRequired.OnNext(Unit.Default);
         }
@@ -472,6 +681,7 @@ namespace com.IvanMurzak.McpPlugin
                 return;
             _disposed = true;
 
+            StopDeadFamilyRecheck(); // cancels the parked wake-up loop (02 §C3.3 — stops on disposal)
             _signInRequired.Dispose();
             _stateReadOnly.Dispose();
             _state.Dispose();


### PR DESCRIPTION
## What

Implements the "never loop" half of the standing unified-machine-auth 04 §3.5 ruling in `PluginCredentialProvider` (taskflow `2026-08-24-oauth-client-error-hygiene`, task **a2**; 02 §C1/§C2/§C3.3) — killing the 1,440 `invalid_grant`/day/editor loop at its source.

- **Dead-family memo (02 §C1)**: one nullable `(refreshToken, reason)` field under the existing `_gate`, no persistence. Gates the **network call after the in-lock store re-read**, comparing against the freshly-READ store token — not `_current` — so a fresh login by any surface (App, CLI, another editor) re-arms this process naturally (.NET adaptation of TS `credential-provider.ts` Rule 5). Populated in `HandleRefreshFailure` on a confirmed terminal verdict, **after** the post-failure re-read (unchanged, stays first — a racer's rotation still wins). The store is never written or deleted on any failure path (inherited ruling, `03-auth-flows.md:52`).
- **`invalid_target` terminal path (02 §C2)**: a1's `TokenRefreshFailureKind.InvalidTarget` now takes the same dead-family path with a distinct **"server configuration error"** reason class, preserved in the single gated telemetry line and in the new read-only `SignInRequiredReason` property so engine UIs (c1/e1) can render the D4 step-3 status without parsing OAuth error codes.
- **Peer wake-up (02 §C3.3)**: while parked in `SignInRequired` after a dead verdict, a low-frequency (default 60 s, ctor-injectable for tests) async `Task.Delay` loop re-checks the machine store with a cheap lock-free read; when it holds token material differing from the memoized dead family, the normal lock-integrated refresh path runs (peer adoption without a network call, or re-arm + one refresh) and the provider reaches `SignedIn` with **no caller driving the token path**. Self-terminating: stops on any non-`SignInRequired` state and on disposal.

## Evidence (DoD)

New suite `PluginCredentialProviderDeadFamilyMemoTests` — 10 tests, every "nothing happened" assertion paired with a same-fixture positive control. Each claim plant-verified RED, attributed per-test:

| Plant | Reddened (exactly) | Stayed green (as predicted) |
|---|---|---|
| 1 — memo gate reverted | `DeadVerdict_MemoSuppressesEveryFurtherNetworkAttempt_PastTheAttemptWindow`, `Rearm_Control_StoreUnchanged…`, `InvalidTarget_IsTerminal…AndMemoBlocks` | adopt-path + wake-up tests |
| 2 — never re-arm (the "keyed on `_current`" bug class, review P1-28) | `Rearm_StoreHoldsDifferentRefreshToken…`, `PeerWakeUp_RotatedRefreshTokenOnly…` | adopt-path recoveries |
| 3 — wake-up loop never started | both positive wake-up tests | unchanged-store + disposed controls |
| 4 — `invalid_target` demoted back to transient | both `InvalidTarget` tests | all others |

Plant 4 initially exposed `InvalidTarget_Rearm_OnPeerLogin…` as non-discriminating (it never asserted the parked state); it was strengthened with a `SignInRequired` assertion and re-planted RED.

The dead⇒silent test advances the injected fake clock **past the 60 s attempt window** (a1 seam) before hammering `GetAccessTokenAsync` — with a counting fake refresher that has no rate window, so only the memo can block: it records **zero** further attempts, and exactly **one** `Credential family dead` telemetry line and one `OnSignInRequired` event across all calls.

Full suite: **3,400 green, 0 failed** (client 955 × net8.0/net9.0, server 745 × both). Peer-rotation adoption (`:390-404`) behavior unchanged — existing family-refresh tests green. **No version bump** (r1 owns the release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVipj7Xi4HouAmmdCYSdmz
