### PR TITLE
a3: coordinator stop/resume on dead credential + StatusCode-based rejection counting

### DIFF
--- a/McpPlugin.Tests/Network/Connection/ConnectionManagerRejectionTests.cs
+++ b/McpPlugin.Tests/Network/Connection/ConnectionManagerRejectionTests.cs
@@ -75,13 +75,20 @@ namespace com.IvanMurzak.McpPlugin.Tests.Network.Connection
         [Fact]
         public async Task Connect_FailedAttemptsResetRejectionCounter()
         {
-            // Arrange: alternate between "rejected" (attempt succeeds, state stays Disconnected)
-            // and "failed" (attempt returns false — server unreachable).
-            // Pattern: reject, fail, reject, fail, reject, fail — never reaches 3 consecutive rejections
-            // because each failure resets the counter.
-            // Contrast with StopsAfterConsecutiveRejections where 3 consecutive true results
-            // trigger the threshold after only 3 attempts.
-            var sequence = new[] { true, false, true, false, true, false };
+            // PROTECTIVE INTENT (kept through the C3.4 seam change): NON-AUTH failures reset the
+            // rejection counter. Alternate between "rejected" (attempt Connected, state stays
+            // Disconnected) and "failed" (attempt Failed — server unreachable, a non-auth reason).
+            // Pattern: reject, fail, reject, fail, reject, fail — never reaches 3 consecutive
+            // rejections because each non-auth failure resets the counter.
+            // Contrast with StopsAfterConsecutiveRejections where 3 consecutive Connected-then-
+            // closed results trigger the threshold after only 3 attempts. An AuthRejected outcome
+            // deliberately does NOT reset the counter — it feeds it (see the AuthRejected tests).
+            var sequence = new[]
+            {
+                ConnectionManager.ConnectionAttemptResult.Connected, ConnectionManager.ConnectionAttemptResult.Failed,
+                ConnectionManager.ConnectionAttemptResult.Connected, ConnectionManager.ConnectionAttemptResult.Failed,
+                ConnectionManager.ConnectionAttemptResult.Connected, ConnectionManager.ConnectionAttemptResult.Failed,
+            };
             await using var cm = new SequenceConnectionManager(
                 _logger, _testVersion, _testEndpoint, _mockProvider.Object,
                 attemptResults: sequence
@@ -109,10 +116,10 @@ namespace com.IvanMurzak.McpPlugin.Tests.Network.Connection
         [Fact]
         public async Task Connect_DoesNotTriggerRejection_WhenConnectionStaysAlive()
         {
-            // Arrange: AttemptConnection always fails (returns false), simulating a server
-            // that can't be reached. This should NOT trigger the rejection detection,
-            // because rejection requires AttemptConnection to return true (handshake success)
-            // followed by an immediate disconnect.
+            // PROTECTIVE INTENT (kept through the C3.4 seam change): a NON-AUTH failed attempt
+            // (ConnectionAttemptResult.Failed — server unreachable) must NOT trigger rejection
+            // detection. Rejection requires either Connected-then-immediate-close, or an
+            // explicit AuthRejected outcome (observable HTTP 401/403) — neither happens here.
             await using var cm = new NeverConnectsManager(
                 _logger, _testVersion, _testEndpoint, _mockProvider.Object
             );
@@ -126,11 +133,82 @@ namespace com.IvanMurzak.McpPlugin.Tests.Network.Connection
             var result = await cm.Connect(cts.Token);
 
             // Assert: Connect fails but OnAuthorizationRejected was never emitted, because
-            // rejection detection only fires when AttemptConnection returns true (handshake
-            // success) followed by an immediate disconnect — neither of which happened here.
+            // every attempt outcome was Failed (non-auth) — never Connected-then-closed and
+            // never AuthRejected.
             result.ShouldBeFalse("Connection should fail (server unreachable)");
-            rejectionFired.ShouldBeFalse("OnAuthorizationRejected must not fire when AttemptConnection always returns false");
+            rejectionFired.ShouldBeFalse("OnAuthorizationRejected must not fire when every attempt outcome is Failed (non-auth)");
             cm.AttemptCount.ShouldBeGreaterThan(0, "Should have attempted at least once");
+        }
+
+        // ── C3.4 (oauth-client-error-hygiene 02): StatusCode-based rejection counting where
+        //    observable — an attempt failing with HTTP 401/403 counts toward the SAME 3-strike
+        //    rejection cap as the connected-then-immediately-closed pattern. ──
+
+        [Fact]
+        public async Task Connect_AuthRejectedAttempts_TripCap_AndFireAuthorizationRejected()
+        {
+            // Arrange: every attempt fails with an observable 401/403 (AuthRejected outcome).
+            await using var cm = new AuthRejectedConnectionManager(
+                _logger, _testVersion, _testEndpoint, _mockProvider.Object
+            );
+
+            var rejectionFired = 0;
+            cm.OnAuthorizationRejected.Subscribe(_ => Interlocked.Increment(ref rejectionFired));
+
+            // Act: the loop terminates ON ITS OWN via the rejection cap; the CTS is a pure hang
+            // guard that must NEVER fire (generous for loaded CI runners — see the sibling tests).
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            var result = await cm.Connect(cts.Token);
+
+            // Assert: same terminal consequence as the connected-then-closed rejection pattern.
+            cts.Token.IsCancellationRequested.ShouldBeFalse(
+                "The loop must stop via the rejection cap, not the hang-guard CTS");
+            result.ShouldBeFalse("Connection should fail after repeated 401/403 rejections");
+            cm.KeepConnected.CurrentValue.ShouldBeFalse("KeepConnected should be disabled after the rejection cap");
+            cm.AttemptCount.ShouldBe(3, "Should have attempted exactly MaxConsecutiveRejections times");
+            rejectionFired.ShouldBe(1, "The aggregated 3-strike signal fires exactly once per burst");
+        }
+
+        [Fact]
+        public async Task Connect_AuthRejectedAttempt_ResetsTheFailureCap_NonAuthFailuresResetRejections()
+        {
+            // Both reset directions of the C3.4 branch in one discriminating sequence, with the
+            // opt-in failure cap at 3:
+            //   Failed, Failed, AuthRejected, Failed, Failed, Failed
+            // - The AuthRejected at #3 must RESET consecutiveFailures (a 401/403 response proves
+            //   the endpoint is reachable), so the failure cap must NOT fire at attempt #4
+            //   (which a naive cumulative count would produce) but at attempt #6 — the 3rd
+            //   consecutive non-auth failure AFTER the rejection.
+            // - The Failed at #4 must RESET consecutiveRejections, so the rejection cap (3) never
+            //   fires and OnAuthorizationRejected stays silent.
+            var sequence = new[]
+            {
+                ConnectionManager.ConnectionAttemptResult.Failed, ConnectionManager.ConnectionAttemptResult.Failed,
+                ConnectionManager.ConnectionAttemptResult.AuthRejected,
+                ConnectionManager.ConnectionAttemptResult.Failed, ConnectionManager.ConnectionAttemptResult.Failed,
+                ConnectionManager.ConnectionAttemptResult.Failed,
+            };
+            await using var cm = new SequenceConnectionManager(
+                _logger, _testVersion, _testEndpoint, _mockProvider.Object,
+                attemptResults: sequence, maxConsecutiveConnectionFailures: 3
+            );
+
+            var rejectionFired = false;
+            cm.OnAuthorizationRejected.Subscribe(_ => rejectionFired = true);
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            var result = await cm.Connect(cts.Token);
+
+            cts.Token.IsCancellationRequested.ShouldBeFalse(
+                "The loop must stop via the failure cap, not the hang-guard CTS");
+            result.ShouldBeFalse("Connection should fail");
+            cm.AttemptCount.ShouldBe(6,
+                "The 401/403 at attempt #3 must reset the consecutive-failure count — the failure cap (3) " +
+                "fires only after the 3 consecutive non-auth failures at #4-#6, never at #4 cumulatively");
+            rejectionFired.ShouldBeFalse(
+                "One 401/403 among non-auth failures must never trip the 3-strike rejection cap — " +
+                "the interleaved Failed outcomes reset the rejection counter");
+            cm.KeepConnected.CurrentValue.ShouldBeFalse("The failure cap disables KeepConnected");
         }
 
         [Fact]
@@ -219,7 +297,7 @@ namespace com.IvanMurzak.McpPlugin.Tests.Network.Connection
         }
 
         /// <summary>
-        /// Simulates server rejection: AttemptConnection returns true (handshake succeeds)
+        /// Simulates server rejection: AttemptConnection reports Connected (handshake succeeds)
         /// but connection state stays Disconnected (server closes immediately).
         /// </summary>
         private class RejectingConnectionManager : FastConnectionManager
@@ -233,12 +311,34 @@ namespace com.IvanMurzak.McpPlugin.Tests.Network.Connection
             {
             }
 
-            protected override Task<bool> AttemptConnection(CancellationToken cancellationToken)
+            protected override Task<ConnectionAttemptResult> AttemptConnection(CancellationToken cancellationToken)
             {
                 Interlocked.Increment(ref _attemptCount);
-                // Return true (handshake "succeeded") but don't set _connectionState to Connected.
+                // Report Connected (handshake "succeeded") but don't set _connectionState to Connected.
                 // StartConnectionLoop will see Disconnected after the stability delay → rejection.
-                return Task.FromResult(true);
+                return Task.FromResult(ConnectionAttemptResult.Connected);
+            }
+        }
+
+        /// <summary>
+        /// Simulates an attempt-level auth rejection: every attempt fails with an observable
+        /// HTTP 401/403 (the C3.4 AuthRejected outcome of the failure-reason seam).
+        /// </summary>
+        private class AuthRejectedConnectionManager : FastConnectionManager
+        {
+            private int _attemptCount;
+            public int AttemptCount => _attemptCount;
+
+            public AuthRejectedConnectionManager(
+                ILogger logger, Common.Version version, string endpoint, IHubConnectionProvider provider)
+                : base(logger, version, endpoint, provider)
+            {
+            }
+
+            protected override Task<ConnectionAttemptResult> AttemptConnection(CancellationToken cancellationToken)
+            {
+                Interlocked.Increment(ref _attemptCount);
+                return Task.FromResult(ConnectionAttemptResult.AuthRejected);
             }
         }
 
@@ -247,34 +347,36 @@ namespace com.IvanMurzak.McpPlugin.Tests.Network.Connection
         /// </summary>
         private class SequenceConnectionManager : FastConnectionManager
         {
-            private readonly bool[] _results;
+            private readonly ConnectionAttemptResult[] _results;
             private int _index;
 
             public int AttemptCount => _index;
 
             public SequenceConnectionManager(
                 ILogger logger, Common.Version version, string endpoint,
-                IHubConnectionProvider provider, bool[] attemptResults)
-                : base(logger, version, endpoint, provider)
+                IHubConnectionProvider provider, ConnectionAttemptResult[] attemptResults,
+                int maxConsecutiveConnectionFailures = 0)
+                : base(logger, version, endpoint, provider, maxConsecutiveConnectionFailures)
             {
                 _results = attemptResults;
             }
 
-            protected override Task<bool> AttemptConnection(CancellationToken cancellationToken)
+            protected override Task<ConnectionAttemptResult> AttemptConnection(CancellationToken cancellationToken)
             {
                 var idx = Interlocked.Increment(ref _index) - 1;
                 if (idx >= _results.Length)
                 {
                     _continueToReconnect.Value = false;
-                    return Task.FromResult(false);
+                    return Task.FromResult(ConnectionAttemptResult.Failed);
                 }
                 return Task.FromResult(_results[idx]);
             }
         }
 
         /// <summary>
-        /// Simulates a server that can't be reached: AttemptConnection always returns false.
-        /// The loop is stopped externally via the CancellationToken passed to Connect().
+        /// Simulates a server that can't be reached: AttemptConnection always fails with a
+        /// non-auth outcome. The loop is stopped externally via the CancellationToken passed
+        /// to Connect() (or the opt-in failure cap).
         /// </summary>
         private class NeverConnectsManager : FastConnectionManager
         {
@@ -288,10 +390,10 @@ namespace com.IvanMurzak.McpPlugin.Tests.Network.Connection
             {
             }
 
-            protected override Task<bool> AttemptConnection(CancellationToken cancellationToken)
+            protected override Task<ConnectionAttemptResult> AttemptConnection(CancellationToken cancellationToken)
             {
                 Interlocked.Increment(ref _attemptCount);
-                return Task.FromResult(false);
+                return Task.FromResult(ConnectionAttemptResult.Failed);
             }
         }
 

--- a/McpPlugin.Tests/Network/Connection/ConnectionManagerStatusCodeClassificationTests.cs
+++ b/McpPlugin.Tests/Network/Connection/ConnectionManagerStatusCodeClassificationTests.cs
@@ -1,0 +1,263 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.Tests.Infrastructure;
+using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.Extensions.Logging;
+using Moq;
+using R3;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace com.IvanMurzak.McpPlugin.Tests.Network.Connection
+{
+    /// <summary>
+    /// oauth-client-error-hygiene 02 §C3.4 — the REAL <c>AttemptConnection</c> path (no fake
+    /// override) against a live loopback socket, so the StatusCode classification itself is under
+    /// test, not a test double's word for it:
+    /// <list type="bullet">
+    ///   <item>a server answering the SignalR negotiate with HTTP 401 must produce the
+    ///   AuthRejected outcome, trip the 3-strike rejection cap, and fire
+    ///   <c>OnAuthorizationRejected</c> (this test project runs net8.0/net9.0 — TFMs where
+    ///   <c>HttpRequestException.StatusCode</c> is observable);</item>
+    ///   <item>a connection-refused failure (no listener; the classifier sees an
+    ///   HttpRequestException with a NULL StatusCode) must take the ordinary failure branch —
+    ///   never the rejection path — which is also the behavioural shape the netstandard2.1
+    ///   (Unity) TFM degrades to for EVERY failure, 401 included (its HttpRequestException has
+    ///   no StatusCode property; the fallback there is proven by the netstandard2.1 build).</item>
+    /// </list>
+    /// </summary>
+    public class ConnectionManagerStatusCodeClassificationTests
+    {
+        private readonly ILogger _logger;
+        private readonly Common.Version _testVersion;
+
+        public ConnectionManagerStatusCodeClassificationTests(ITestOutputHelper output)
+        {
+            var loggerFactory = TestLoggerFactory.Create(output, LogLevel.Trace);
+            _logger = loggerFactory.CreateLogger<ConnectionManagerStatusCodeClassificationTests>();
+            _testVersion = new Common.Version { Api = "1.0.0", Plugin = "1.0.0", Environment = "test" };
+        }
+
+        [Fact]
+        public async Task Connect_401AtNegotiate_RealTransport_TripsRejectionCap_FiresAuthorizationRejected()
+        {
+            // Arrange: a real loopback HTTP server that answers EVERY request (the SignalR
+            // negotiate POST) with 401 Unauthorized — the GlitchTip-#17 shape: a dead token
+            // presented at negotiate.
+            using var server = new LoopbackHttpStatusServer(HttpStatusCode.Unauthorized);
+            var provider = new Mock<IHubConnectionProvider>();
+            provider
+                .Setup(x => x.CreateConnectionAsync(It.IsAny<string>()))
+                .ReturnsAsync(() => new HubConnectionBuilder().WithUrl(server.Url).Build());
+
+            await using var cm = new FastRetryConnectionManager(_logger, _testVersion, server.Url, provider.Object);
+
+            var rejectionFired = 0;
+            cm.OnAuthorizationRejected.Subscribe(_ => Interlocked.Increment(ref rejectionFired));
+
+            // Act: the loop must terminate ON ITS OWN via the rejection cap; the CTS is a pure
+            // hang guard that must NEVER fire (generous for loaded CI runners).
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            var result = await cm.Connect(cts.Token);
+
+            // Assert
+            cts.Token.IsCancellationRequested.ShouldBeFalse(
+                "The loop must stop via the rejection cap, not the hang-guard CTS");
+            result.ShouldBeFalse("Connection should fail after repeated 401 negotiates");
+            rejectionFired.ShouldBe(1, "the observable 401s must aggregate into ONE 3-strike rejection signal");
+            cm.KeepConnected.CurrentValue.ShouldBeFalse("KeepConnected must be disabled after the rejection cap");
+            server.ConnectionCount.ShouldBe(3,
+                "exactly MaxConsecutiveRejections (3) negotiate attempts must reach the server — " +
+                "the observable-401 classification counts each toward the rejection cap");
+        }
+
+        [Fact]
+        public async Task Connect_ConnectionRefused_RealTransport_TakesFailureBranch_NeverRejection()
+        {
+            // Arrange: a genuinely closed loopback port (bind, note the port, close). The real
+            // AttemptConnection sees an HttpRequestException WITHOUT a StatusCode (socket-level
+            // refusal) — the classifier must return Failed, so with the opt-in failure cap the
+            // loop stops through the FAILURE branch and the rejection signal stays silent.
+            // Behaviourally this is the same degradation the Unity TFM applies to every failure.
+            var closedPort = LoopbackHttpStatusServer.ReserveClosedPort();
+            var url = $"http://127.0.0.1:{closedPort}";
+            var provider = new Mock<IHubConnectionProvider>();
+            provider
+                .Setup(x => x.CreateConnectionAsync(It.IsAny<string>()))
+                .ReturnsAsync(() => new HubConnectionBuilder().WithUrl(url).Build());
+
+            await using var cm = new FastRetryConnectionManager(_logger, _testVersion, url, provider.Object,
+                maxConsecutiveConnectionFailures: 2);
+
+            var rejectionFired = false;
+            cm.OnAuthorizationRejected.Subscribe(_ => rejectionFired = true);
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            var result = await cm.Connect(cts.Token);
+
+            // Assert: stopped by the failure cap on its own (were these classified AuthRejected,
+            // consecutiveFailures would stay 0, the failure cap could never fire, and the loop
+            // would instead stop via the rejection cap — with the signal fired).
+            cts.Token.IsCancellationRequested.ShouldBeFalse(
+                "The loop must stop via the opt-in failure cap, not the hang-guard CTS");
+            result.ShouldBeFalse("Connection should fail (nothing is listening)");
+            rejectionFired.ShouldBeFalse(
+                "A connection-refused failure has no observable 401/403 — it must never count as an auth rejection");
+            cm.KeepConnected.CurrentValue.ShouldBeFalse("The failure cap disables KeepConnected");
+        }
+
+        [Fact]
+        public async Task Connect_ConnectionRefused_RealTransport_DefaultConfig_RetriesUnbounded()
+        {
+            // Control (binding testing strategy, 02): with DEFAULT config (no failure cap) a
+            // transient connection-refused failure must keep retrying unbounded — only the
+            // external CTS stops the loop, and reconnection intent (KeepConnected) survives.
+            var closedPort = LoopbackHttpStatusServer.ReserveClosedPort();
+            var url = $"http://127.0.0.1:{closedPort}";
+            var provider = new Mock<IHubConnectionProvider>();
+            provider
+                .Setup(x => x.CreateConnectionAsync(It.IsAny<string>()))
+                .ReturnsAsync(() => new HubConnectionBuilder().WithUrl(url).Build());
+
+            await using var cm = new FastRetryConnectionManager(_logger, _testVersion, url, provider.Object);
+
+            var rejectionFired = false;
+            cm.OnAuthorizationRejected.Subscribe(_ => rejectionFired = true);
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(4));
+            var result = await cm.Connect(cts.Token);
+
+            result.ShouldBeFalse("Connection should fail (nothing is listening)");
+            cts.Token.IsCancellationRequested.ShouldBeTrue(
+                "With default (unlimited) config only the external CTS may stop the loop");
+            rejectionFired.ShouldBeFalse("Refused connections must never fire the rejection signal");
+            cm.KeepConnected.CurrentValue.ShouldBeTrue(
+                "Default (unlimited) retry must NOT disable KeepConnected on its own");
+        }
+
+        /// <summary>
+        /// A ConnectionManager with REAL AttemptConnection (the code under test) and only the
+        /// retry pacing accelerated so the tests do not spend 5 s between attempts.
+        /// </summary>
+        private class FastRetryConnectionManager : ConnectionManager
+        {
+            protected override TimeSpan RejectionThreshold { get; } = TimeSpan.FromMilliseconds(50);
+
+            public FastRetryConnectionManager(
+                ILogger logger, Common.Version version, string endpoint, IHubConnectionProvider provider,
+                int maxConsecutiveConnectionFailures = 0)
+                : base(logger, version, endpoint, provider, maxConsecutiveConnectionFailures)
+            {
+            }
+
+            protected override Task WaitBeforeRetry(CancellationToken cancellationToken)
+                => Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Minimal loopback HTTP server (raw TcpListener — no URL ACL, no ASP.NET dependency):
+        /// reads one request's headers and answers with a fixed status code, then closes the
+        /// connection. Enough for the SignalR client's negotiate POST.
+        /// </summary>
+        private sealed class LoopbackHttpStatusServer : IDisposable
+        {
+            readonly TcpListener _listener;
+            readonly HttpStatusCode _status;
+            int _connectionCount;
+            volatile bool _disposed;
+
+            public LoopbackHttpStatusServer(HttpStatusCode status)
+            {
+                _status = status;
+                _listener = new TcpListener(IPAddress.Loopback, 0);
+                _listener.Start();
+                _ = AcceptLoopAsync();
+            }
+
+            public string Url => $"http://127.0.0.1:{((IPEndPoint)_listener.LocalEndpoint).Port}";
+
+            /// <summary>How many TCP connections (≈ HTTP requests, Connection: close) were served.</summary>
+            public int ConnectionCount => _connectionCount;
+
+            /// <summary>Bind an ephemeral loopback port, close it, and return it — a port that refuses connections.</summary>
+            public static int ReserveClosedPort()
+            {
+                var probe = new TcpListener(IPAddress.Loopback, 0);
+                probe.Start();
+                var port = ((IPEndPoint)probe.LocalEndpoint).Port;
+                probe.Stop();
+                return port;
+            }
+
+            async Task AcceptLoopAsync()
+            {
+                try
+                {
+                    while (!_disposed)
+                    {
+                        var client = await _listener.AcceptTcpClientAsync().ConfigureAwait(false);
+                        Interlocked.Increment(ref _connectionCount);
+                        _ = ServeAsync(client);
+                    }
+                }
+                catch (ObjectDisposedException) { }
+                catch (SocketException) { } // listener stopped
+            }
+
+            async Task ServeAsync(TcpClient client)
+            {
+                try
+                {
+                    using (client)
+                    using (var stream = client.GetStream())
+                    {
+                        // Read until the end of the request headers (the negotiate POST has no body).
+                        var buffer = new byte[4096];
+                        var received = new StringBuilder();
+                        while (!received.ToString().Contains("\r\n\r\n"))
+                        {
+                            var read = await stream.ReadAsync(buffer, 0, buffer.Length).ConfigureAwait(false);
+                            if (read <= 0)
+                                break;
+                            received.Append(Encoding.ASCII.GetString(buffer, 0, read));
+                            if (received.Length > 64 * 1024)
+                                break; // defensive bound
+                        }
+
+                        var response = $"HTTP/1.1 {(int)_status} {_status}\r\n" +
+                                       "Content-Length: 0\r\n" +
+                                       "Connection: close\r\n" +
+                                       "\r\n";
+                        var bytes = Encoding.ASCII.GetBytes(response);
+                        await stream.WriteAsync(bytes, 0, bytes.Length).ConfigureAwait(false);
+                        await stream.FlushAsync().ConfigureAwait(false);
+                    }
+                }
+                catch (IOException) { }
+                catch (ObjectDisposedException) { }
+                catch (SocketException) { }
+            }
+
+            public void Dispose()
+            {
+                _disposed = true;
+                try { _listener.Stop(); } catch { }
+            }
+        }
+    }
+}

--- a/McpPlugin.Tests/Network/Connection/Credentials/ConnectionCredentialCoordinatorTests.cs
+++ b/McpPlugin.Tests/Network/Connection/Credentials/ConnectionCredentialCoordinatorTests.cs
@@ -47,7 +47,7 @@ namespace com.IvanMurzak.McpPlugin.Tests.Network.Connection.Credentials
 
         MachineCredentialStore NewStore() => new MachineCredentialStore(_baseDir);
 
-        PluginCredentialProvider SeededProvider(ITokenRefresher refresher)
+        PluginCredentialProvider SeededProvider(ITokenRefresher? refresher)
         {
             NewStore().Write(new MachineCredentials
             {
@@ -127,14 +127,158 @@ namespace com.IvanMurzak.McpPlugin.Tests.Network.Connection.Credentials
             provider.State.CurrentValue.ShouldBe(AuthState.SignedIn);
         }
 
+        // ── C3.1 stop (oauth-client-error-hygiene 02): the dead-family verdict must stop the
+        //    connect loop via the existing stop primitive, exactly once, single-flight. ──
+
+        [Fact]
+        public async Task OnSignInRequired_StopsReconnect_ExactlyOneDisconnect()
+        {
+            var refresher = RefresherReturning(TokenRefreshResult.Failure("refresh token expired", TokenRefreshFailureKind.InvalidGrant));
+            using var provider = SeededProvider(refresher.Object);
+            using var connection = new FakeConnection(keepConnected: true);
+            using var coordinator = new ConnectionCredentialCoordinator(connection, provider);
+
+            // The dead-family verdict (surfaced by the provider) — the coordinator must stop the loop.
+            (await provider.RefreshAsync()).ShouldBeFalse();
+            provider.State.CurrentValue.ShouldBe(AuthState.SignInRequired);
+
+            (await connection.WaitForNextDisconnectAsync(TimeSpan.FromSeconds(5)))
+                .ShouldBeTrue("the sign-in-required verdict must drive Disconnect (the stop primitive)");
+            connection.DisconnectCount.ShouldBe(1);
+            connection.ConnectCount.ShouldBe(0, "stopping must not re-enter any recovery path (P1-26)");
+        }
+
+        [Fact]
+        public async Task OnSignInRequired_FlappingVerdicts_SingleFlight_StillOneDisconnect()
+        {
+            // A provider WITHOUT a refresher surfaces sign-in-required on EVERY RefreshAsync call —
+            // a real (not simulated) flapping OnSignInRequired source. Holding the Disconnect task
+            // pending across all three verdicts proves the stop pass is single-flight: the second
+            // and third signals arrive while the first pass is still in flight and must not stack.
+            using var provider = SeededProvider(refresher: null);
+            using var connection = new FakeConnection(keepConnected: true);
+            connection.HoldDisconnects();
+            using var coordinator = new ConnectionCredentialCoordinator(connection, provider);
+
+            (await provider.RefreshAsync()).ShouldBeFalse();
+            (await provider.RefreshAsync()).ShouldBeFalse();
+            (await provider.RefreshAsync()).ShouldBeFalse();
+
+            (await connection.WaitForNextDisconnectAsync(TimeSpan.FromSeconds(5))).ShouldBeTrue();
+            connection.DisconnectCount.ShouldBe(1, "three verdicts while the stop pass is in flight ⇒ still exactly one Disconnect");
+
+            connection.ReleaseDisconnects();
+            await Task.Delay(100); // let the pass complete — nothing further may run
+            connection.DisconnectCount.ShouldBe(1);
+        }
+
+        // ── C3.2 resume (edge-triggered, intent-gated, never while a loop is live). ──
+
+        [Fact]
+        public async Task SignedInEdge_ResumesConnect_ExactlyOnce_WhenIntentWasOn()
+        {
+            var refresher = RefresherReturning(TokenRefreshResult.Failure("revoked", TokenRefreshFailureKind.InvalidGrant));
+            using var provider = SeededProvider(refresher.Object);
+            using var connection = new FakeConnection(keepConnected: true); // the consumer's loop is live
+            using var coordinator = new ConnectionCredentialCoordinator(connection, provider);
+
+            // Stop: verdict → Disconnect (clears KeepConnected, as the real manager does).
+            (await provider.RefreshAsync()).ShouldBeFalse();
+            (await connection.WaitForNextDisconnectAsync(TimeSpan.FromSeconds(5))).ShouldBeTrue();
+            connection.KeepConnected.CurrentValue.ShouldBeFalse();
+
+            // Resume: authorization returns (a fresh sign-in adoption) ⇒ SignInRequired→SignedIn edge.
+            provider.Adopt(FreshCredentials());
+            provider.State.CurrentValue.ShouldBe(AuthState.SignedIn);
+
+            (await connection.WaitForNextConnectAsync(TimeSpan.FromSeconds(5)))
+                .ShouldBeTrue("the SignedIn edge must resume the connection (intent was on)");
+            connection.ConnectCount.ShouldBe(1, "edge-triggered, single-flight ⇒ exactly one Connect");
+        }
+
+        [Fact]
+        public async Task SignedInEdge_DoesNotConnect_WhenIntentWasOff()
+        {
+            // Identical fixture to SignedInEdge_ResumesConnect... (the same-fixture positive
+            // control) EXCEPT the consumer never had the loop on: resume must not resurrect a
+            // connection the consumer never wanted.
+            var refresher = RefresherReturning(TokenRefreshResult.Failure("revoked", TokenRefreshFailureKind.InvalidGrant));
+            using var provider = SeededProvider(refresher.Object);
+            using var connection = new FakeConnection(keepConnected: false); // intent OFF
+            using var coordinator = new ConnectionCredentialCoordinator(connection, provider);
+
+            (await provider.RefreshAsync()).ShouldBeFalse();
+            provider.State.CurrentValue.ShouldBe(AuthState.SignInRequired);
+
+            provider.Adopt(FreshCredentials());
+            provider.State.CurrentValue.ShouldBe(AuthState.SignedIn);
+
+            (await connection.WaitForNextConnectAsync(TimeSpan.FromMilliseconds(300)))
+                .ShouldBeFalse("with the consumer's KeepConnected intent off, the SignedIn edge must not connect");
+            connection.ConnectCount.ShouldBe(0);
+        }
+
+        [Fact]
+        public async Task SignedInEdge_DoesNotConnect_WhileALoopIsAlreadyLive()
+        {
+            // Identical fixture to SignedInEdge_ResumesConnect... (the same-fixture positive
+            // control) EXCEPT the consumer manually restarted the loop between the stop and the
+            // sign-in: resuming would STACK a second loop (review finding 12).
+            var refresher = RefresherReturning(TokenRefreshResult.Failure("revoked", TokenRefreshFailureKind.InvalidGrant));
+            using var provider = SeededProvider(refresher.Object);
+            using var connection = new FakeConnection(keepConnected: true);
+            using var coordinator = new ConnectionCredentialCoordinator(connection, provider);
+
+            (await provider.RefreshAsync()).ShouldBeFalse();
+            (await connection.WaitForNextDisconnectAsync(TimeSpan.FromSeconds(5))).ShouldBeTrue();
+
+            connection.SetKeepConnected(true); // the consumer manually reconnected — a loop is live
+
+            provider.Adopt(FreshCredentials());
+            provider.State.CurrentValue.ShouldBe(AuthState.SignedIn);
+
+            (await connection.WaitForNextConnectAsync(TimeSpan.FromMilliseconds(300)))
+                .ShouldBeFalse("while a connect loop is already live, the SignedIn edge must be a no-op");
+            connection.ConnectCount.ShouldBe(0);
+        }
+
+        [Fact]
+        public async Task SignedOutToSignedIn_IsNotTheResumeEdge()
+        {
+            // Edge discipline: only the SignInRequired→SignedIn transition resumes. A plain
+            // SignedOut→SignedIn sign-in (no stop happened) must not auto-connect.
+            using var provider = new PluginCredentialProvider(NewStore(), refresher: null); // empty store ⇒ SignedOut
+            provider.State.CurrentValue.ShouldBe(AuthState.SignedOut);
+            using var connection = new FakeConnection(keepConnected: true);
+            using var coordinator = new ConnectionCredentialCoordinator(connection, provider);
+
+            provider.Adopt(FreshCredentials());
+            provider.State.CurrentValue.ShouldBe(AuthState.SignedIn);
+
+            (await connection.WaitForNextConnectAsync(TimeSpan.FromMilliseconds(300)))
+                .ShouldBeFalse("SignedOut→SignedIn is not the resume edge — the engine drives its own first connect");
+            connection.ConnectCount.ShouldBe(0);
+        }
+
+        static MachineCredentials FreshCredentials() => new MachineCredentials
+        {
+            AccessToken = "eyJ.FRESH-LOGIN.zzz",
+            RefreshToken = "RT-FRESH-yyy",
+            ExpiresAt = DateTimeOffset.UtcNow.AddHours(1),
+            ServerTarget = "https://ai-game.dev",
+        };
+
         /// <summary>
         /// A minimal <see cref="IConnection"/> test double: exposes a rejection signal to fire, records
-        /// reconnect attempts, and signals each <see cref="Connect"/> via a task so tests can await the
-        /// fire-and-forget handler deterministically.
+        /// connect/disconnect passes, and signals each via a task so tests can await the fire-and-forget
+        /// handlers deterministically. Mirrors the real manager's KeepConnected semantics —
+        /// <see cref="Connect"/> arms it, <see cref="Disconnect"/> clears it — because the coordinator's
+        /// intent capture and loop-live check read it. <see cref="HoldDisconnects"/> keeps the Disconnect
+        /// task pending so a flapping fixture can prove the stop pass is single-flight.
         /// </summary>
         sealed class FakeConnection : IConnection
         {
-            readonly ReactiveProperty<bool> _keepConnected = new ReactiveProperty<bool>(true);
+            readonly ReactiveProperty<bool> _keepConnected;
             readonly ReactiveProperty<HubConnectionState> _state = new ReactiveProperty<HubConnectionState>(HubConnectionState.Disconnected);
             readonly ReadOnlyReactiveProperty<bool> _keepConnectedRo;
             readonly ReadOnlyReactiveProperty<HubConnectionState> _stateRo;
@@ -143,14 +287,18 @@ namespace com.IvanMurzak.McpPlugin.Tests.Network.Connection.Credentials
             // Single-shot: completes on the FIRST Connect and stays completed, so a waiter registered
             // before OR after the fire-and-forget handler runs observes it (no TCS-replacement race).
             readonly TaskCompletionSource<bool> _firstConnectSignal = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            readonly TaskCompletionSource<bool> _firstDisconnectSignal = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            TaskCompletionSource<bool>? _heldDisconnects;
 
-            public FakeConnection()
+            public FakeConnection(bool keepConnected = true)
             {
+                _keepConnected = new ReactiveProperty<bool>(keepConnected);
                 _keepConnectedRo = _keepConnected.ToReadOnlyReactiveProperty();
                 _stateRo = _state.ToReadOnlyReactiveProperty();
             }
 
             public int ConnectCount { get; private set; }
+            public int DisconnectCount { get; private set; }
 
             public ReadOnlyReactiveProperty<bool> KeepConnected => _keepConnectedRo;
             public ReadOnlyReactiveProperty<HubConnectionState> ConnectionState => _stateRo;
@@ -158,10 +306,37 @@ namespace com.IvanMurzak.McpPlugin.Tests.Network.Connection.Credentials
 
             public void FireAuthorizationRejected() => _authRejected.OnNext(Unit.Default);
 
+            /// <summary>Fixture control: model a consumer manually starting/stopping the loop.</summary>
+            public void SetKeepConnected(bool value) => _keepConnected.Value = value;
+
+            /// <summary>Every Disconnect call from now on returns a task held pending until <see cref="ReleaseDisconnects"/>.</summary>
+            public void HoldDisconnects()
+            {
+                lock (_sync)
+                    _heldDisconnects = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            }
+
+            public void ReleaseDisconnects()
+            {
+                TaskCompletionSource<bool>? held;
+                lock (_sync)
+                {
+                    held = _heldDisconnects;
+                    _heldDisconnects = null;
+                }
+                held?.TrySetResult(true);
+            }
+
             public async Task<bool> WaitForNextConnectAsync(TimeSpan timeout)
             {
                 var completed = await Task.WhenAny(_firstConnectSignal.Task, Task.Delay(timeout)).ConfigureAwait(false);
                 return completed == _firstConnectSignal.Task;
+            }
+
+            public async Task<bool> WaitForNextDisconnectAsync(TimeSpan timeout)
+            {
+                var completed = await Task.WhenAny(_firstDisconnectSignal.Task, Task.Delay(timeout)).ConfigureAwait(false);
+                return completed == _firstDisconnectSignal.Task;
             }
 
             public Task<bool> Connect(CancellationToken cancellationToken = default)
@@ -169,13 +344,27 @@ namespace com.IvanMurzak.McpPlugin.Tests.Network.Connection.Credentials
                 lock (_sync)
                 {
                     ConnectCount++;
+                    _keepConnected.Value = true; // the real manager arms reconnect intent in ConnectCore
                     _state.Value = HubConnectionState.Connected;
                     _firstConnectSignal.TrySetResult(true);
                 }
                 return Task.FromResult(true);
             }
 
-            public Task Disconnect(CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public Task Disconnect(CancellationToken cancellationToken = default)
+            {
+                Task pending;
+                lock (_sync)
+                {
+                    DisconnectCount++;
+                    _keepConnected.Value = false; // the real stop primitive clears _continueToReconnect
+                    _state.Value = HubConnectionState.Disconnected;
+                    _firstDisconnectSignal.TrySetResult(true);
+                    pending = _heldDisconnects?.Task ?? Task.CompletedTask;
+                }
+                return pending;
+            }
+
             public void DisconnectImmediate() { }
             public bool WaitForImmediateTeardown(TimeSpan timeout) => true;
 

--- a/McpPlugin.Tests/Network/Connection/Credentials/CoordinatorStopResumeHarnessTests.cs
+++ b/McpPlugin.Tests/Network/Connection/Credentials/CoordinatorStopResumeHarnessTests.cs
@@ -1,0 +1,277 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.AgentConfig;
+using com.IvanMurzak.McpPlugin.Tests.Infrastructure;
+using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using R3;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.Tests.Network.Connection.Credentials
+{
+    /// <summary>
+    /// End-to-end (harness level) coverage for oauth-client-error-hygiene 02 §C3 stop/resume:
+    /// a REAL <see cref="ConnectionManager"/> retry loop + a REAL
+    /// <see cref="PluginCredentialProvider"/> (temp machine store, scripted refresher, fast peer
+    /// wake-up re-check) wired by the REAL <see cref="ConnectionCredentialCoordinator"/>. Proves
+    /// the loop settles idle-Disconnected after the dead-family verdict (no attempts after it),
+    /// resumes when a peer surface's login lands in the machine store, and — the control — that
+    /// transient failures with default config still retry unbounded with the provider untouched.
+    /// Uses NullLogger: the loops here outlive individual assertions, and a test-output-bound
+    /// logger would race test completion.
+    /// </summary>
+    public sealed class CoordinatorStopResumeHarnessTests : IDisposable
+    {
+        const string SeededAccess = "eyJ.SEEDED.aaa";
+        const string SeededRefresh = "RT-SEEDED-bbb";
+        static readonly TimeSpan ShortRecheckPeriod = TimeSpan.FromMilliseconds(100);
+
+        readonly string _baseDir;
+        readonly Common.Version _testVersion = new Common.Version { Api = "1.0.0", Plugin = "1.0.0", Environment = "test" };
+
+        public CoordinatorStopResumeHarnessTests()
+        {
+            _baseDir = Path.Combine(Path.GetTempPath(), "agd-stopresume-" + Guid.NewGuid().ToString("N"), ".ai-game-dev");
+        }
+
+        public void Dispose()
+        {
+            var parent = Path.GetDirectoryName(_baseDir);
+            if (parent != null && Directory.Exists(parent))
+            {
+                try { Directory.Delete(parent, recursive: true); } catch (IOException) { } catch (UnauthorizedAccessException) { }
+            }
+        }
+
+        MachineCredentialStore NewStore() => new MachineCredentialStore(_baseDir);
+
+        void SeedStore()
+        {
+            // v2 plugin-family shape (a v1-style top-level seed would be adopted as families.legacy,
+            // and the peer-login rewrite below mutates families.plugin explicitly).
+            NewStore().Write(new MachineCredentials
+            {
+                ServerTarget = "https://ai-game.dev",
+                Families = new MachineCredentialFamilies
+                {
+                    Plugin = new MachineCredentialFamily
+                    {
+                        AccessToken = SeededAccess,
+                        RefreshToken = SeededRefresh,
+                        ExpiresAt = DateTimeOffset.UtcNow.AddHours(1),
+                        ClientId = "app-dcr-4f2a9c31",
+                        Scope = "mcp:plugin",
+                    },
+                },
+            });
+        }
+
+        static Mock<IHubConnectionProvider> DummyHubProvider()
+        {
+            var provider = new Mock<IHubConnectionProvider>();
+            provider
+                .Setup(x => x.CreateConnectionAsync(It.IsAny<string>()))
+                .ReturnsAsync(() => new HubConnectionBuilder()
+                    .WithUrl("http://localhost:9999/dummy", options =>
+                    {
+                        options.Transports = Microsoft.AspNetCore.Http.Connections.HttpTransportType.WebSockets;
+                        options.SkipNegotiation = true;
+                    })
+                    .Build());
+            return provider;
+        }
+
+        static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout, string because)
+        {
+            var sw = Stopwatch.StartNew();
+            while (sw.Elapsed < timeout)
+            {
+                if (condition())
+                    return;
+                await Task.Delay(20);
+            }
+            condition().ShouldBeTrue($"{because} (not reached within {timeout.TotalSeconds:0.#}s)");
+        }
+
+        // ── DoD: dead family + running loop ⇒ settles idle-Disconnected; peer login ⇒ resumes. ──
+
+        [Fact]
+        public async Task DeadFamilyVerdict_StopsRunningLoop_PeerLoginResumes()
+        {
+            SeedStore();
+            var next = TokenRefreshResult.Failure("invalid_grant: revoked", TokenRefreshFailureKind.InvalidGrant);
+            var refresher = new FakeTokenRefresher(_ => next);
+            using var provider = new PluginCredentialProvider(
+                NewStore(), refresher, deadFamilyRecheckPeriod: ShortRecheckPeriod);
+            await using var cm = new FailingLoopConnectionManager(_testVersion, DummyHubProvider().Object);
+            using var coordinator = new ConnectionCredentialCoordinator(cm, provider);
+
+            // A live retry loop (default config: unbounded 5 s retry, accelerated here).
+            var connectTask = cm.Connect();
+            await WaitUntilAsync(() => cm.AttemptCount >= 2, TimeSpan.FromSeconds(10), "the retry loop must be live");
+            cm.KeepConnected.CurrentValue.ShouldBeTrue();
+
+            // The dead-family verdict (a2) — in production the proactive refresh path hits this;
+            // the provider surfaces SignInRequired and the coordinator must STOP the loop.
+            (await provider.RefreshAsync()).ShouldBeFalse();
+            provider.State.CurrentValue.ShouldBe(AuthState.SignInRequired);
+
+            // The loop settles idle-Disconnected: Connect() returns, reconnect intent is cleared…
+            (await Task.WhenAny(connectTask, Task.Delay(TimeSpan.FromSeconds(10)))).ShouldBe(connectTask,
+                "the running Connect() must return once the coordinator stops the loop");
+            (await connectTask).ShouldBeFalse();
+            await WaitUntilAsync(() => !cm.KeepConnected.CurrentValue, TimeSpan.FromSeconds(5), "KeepConnected must clear");
+
+            // …and NO attempts run after the verdict (the hammering this task exists to kill).
+            var settledAttempts = cm.AttemptCount;
+            await Task.Delay(500);
+            cm.AttemptCount.ShouldBe(settledAttempts, "an idle-Disconnected loop must make zero further attempts");
+            refresher.Requests.Count.ShouldBe(1, "the dead-family memo blocks every further network refresh");
+
+            // Fake peer login: another surface writes a fresh credential to the machine store.
+            next = TokenRefreshResult.Success("eyJ.PEER.ccc", "RT-PEER-ddd", DateTimeOffset.UtcNow.AddHours(1));
+            var peer = NewStore().Read()!;
+            peer.Families!.Plugin!.RefreshToken = "RT-plugin-peer";
+            NewStore().Write(peer);
+
+            // Wake-up re-check re-arms + refreshes ⇒ SignedIn edge ⇒ the coordinator RESUMES the loop.
+            await WaitUntilAsync(() => provider.State.CurrentValue == AuthState.SignedIn, TimeSpan.FromSeconds(10),
+                "the peer login must wake the parked provider");
+            await WaitUntilAsync(() => cm.AttemptCount > settledAttempts, TimeSpan.FromSeconds(10),
+                "the SignedIn edge must resume the connection loop");
+            cm.KeepConnected.CurrentValue.ShouldBeTrue("the resumed loop re-arms reconnect intent");
+        }
+
+        // ── The 3-strike flavour: rejection cap → coordinator refresh → dead verdict → settle;
+        //    then a peer login resumes (intent captured through the rejection-handling pass). ──
+
+        [Fact]
+        public async Task ThreeStrikeRejection_DeadFamily_SettlesIdle_ThenPeerLoginResumes()
+        {
+            SeedStore();
+            var next = TokenRefreshResult.Failure("invalid_grant: revoked", TokenRefreshFailureKind.InvalidGrant);
+            var refresher = new FakeTokenRefresher(_ => next);
+            using var provider = new PluginCredentialProvider(
+                NewStore(), refresher, deadFamilyRecheckPeriod: ShortRecheckPeriod);
+            await using var cm = new RejectedLoopConnectionManager(_testVersion, DummyHubProvider().Object);
+            using var coordinator = new ConnectionCredentialCoordinator(cm, provider);
+
+            // The loop 3-strikes on server-side rejection, stops itself, and fires the aggregated
+            // signal; the coordinator's refresh then returns the dead-family verdict.
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            var result = await cm.Connect(cts.Token);
+            result.ShouldBeFalse();
+            cm.KeepConnected.CurrentValue.ShouldBeFalse("the rejection cap stops the loop");
+
+            await WaitUntilAsync(() => provider.State.CurrentValue == AuthState.SignInRequired, TimeSpan.FromSeconds(10),
+                "the rejection-driven refresh must surface the dead-family verdict");
+
+            // Settled: no further attempts, exactly one network refresh.
+            var settledAttempts = cm.AttemptCount;
+            await Task.Delay(500);
+            cm.AttemptCount.ShouldBe(settledAttempts, "after the verdict the loop must stay idle-Disconnected");
+            refresher.Requests.Count.ShouldBe(1);
+
+            // Peer login. Intent was captured through the rejection-handling pass (the cap cleared
+            // KeepConnected BEFORE the verdict), so the SignedIn edge must still resume.
+            next = TokenRefreshResult.Success("eyJ.PEER.ccc", "RT-PEER-ddd", DateTimeOffset.UtcNow.AddHours(1));
+            var peer = NewStore().Read()!;
+            peer.Families!.Plugin!.RefreshToken = "RT-plugin-peer";
+            NewStore().Write(peer);
+
+            await WaitUntilAsync(() => provider.State.CurrentValue == AuthState.SignedIn, TimeSpan.FromSeconds(10),
+                "the peer login must wake the parked provider");
+            await WaitUntilAsync(() => cm.AttemptCount > settledAttempts, TimeSpan.FromSeconds(10),
+                "the SignedIn edge must resume the connection loop even though the cap had already cleared KeepConnected");
+        }
+
+        // ── Control (binding testing strategy, 02): transient failures with DEFAULT config keep
+        //    retrying unbounded — no stop, no verdict, provider untouched. ──
+
+        [Fact]
+        public async Task TransientFailures_DefaultConfig_RetryUnbounded_NoStopNoVerdict()
+        {
+            SeedStore();
+            var refresher = new FakeTokenRefresher(
+                TokenRefreshResult.Success("eyJ.WOULD-WORK.eee", "RT-would-work", DateTimeOffset.UtcNow.AddHours(1)));
+            using var provider = new PluginCredentialProvider(
+                NewStore(), refresher, deadFamilyRecheckPeriod: ShortRecheckPeriod);
+            await using var cm = new FailingLoopConnectionManager(_testVersion, DummyHubProvider().Object);
+            using var coordinator = new ConnectionCredentialCoordinator(cm, provider);
+
+            var connectTask = cm.Connect();
+
+            // The loop keeps retrying well past any cap the auth path would impose (3).
+            await WaitUntilAsync(() => cm.AttemptCount > 5, TimeSpan.FromSeconds(10),
+                "transient failures with default config must retry unbounded");
+            cm.KeepConnected.CurrentValue.ShouldBeTrue("nothing may clear the reconnect intent");
+            provider.State.CurrentValue.ShouldBe(AuthState.SignedIn, "no verdict may surface from transient connection failures");
+            refresher.Requests.Count.ShouldBe(0, "no refresh may be driven by transient connection failures");
+
+            await cm.Disconnect();
+            (await Task.WhenAny(connectTask, Task.Delay(TimeSpan.FromSeconds(10)))).ShouldBe(connectTask);
+        }
+
+        /// <summary>Real loop, accelerated pacing, every attempt fails for a NON-AUTH reason (unreachable endpoint).</summary>
+        private class FailingLoopConnectionManager : ConnectionManager
+        {
+            private int _attemptCount;
+            public int AttemptCount => _attemptCount;
+
+            protected override TimeSpan RejectionThreshold { get; } = TimeSpan.FromMilliseconds(50);
+
+            public FailingLoopConnectionManager(Common.Version version, IHubConnectionProvider provider)
+                : base(NullLogger.Instance, version, "http://localhost:9999/dummy", provider)
+            {
+            }
+
+            protected override Task WaitBeforeRetry(CancellationToken cancellationToken)
+                => Task.Delay(TimeSpan.FromMilliseconds(25), CancellationToken.None);
+
+            protected override Task<ConnectionAttemptResult> AttemptConnection(CancellationToken cancellationToken)
+            {
+                Interlocked.Increment(ref _attemptCount);
+                return Task.FromResult(ConnectionAttemptResult.Failed);
+            }
+        }
+
+        /// <summary>Real loop, accelerated pacing, server "accepts the handshake then closes" — the 3-strike rejection pattern.</summary>
+        private class RejectedLoopConnectionManager : ConnectionManager
+        {
+            private int _attemptCount;
+            public int AttemptCount => _attemptCount;
+
+            protected override TimeSpan RejectionThreshold { get; } = TimeSpan.FromMilliseconds(50);
+
+            public RejectedLoopConnectionManager(Common.Version version, IHubConnectionProvider provider)
+                : base(NullLogger.Instance, version, "http://localhost:9999/dummy", provider)
+            {
+            }
+
+            protected override Task WaitBeforeRetry(CancellationToken cancellationToken)
+                => Task.Delay(TimeSpan.FromMilliseconds(25), CancellationToken.None);
+
+            protected override Task<ConnectionAttemptResult> AttemptConnection(CancellationToken cancellationToken)
+            {
+                Interlocked.Increment(ref _attemptCount);
+                // Connected (handshake "succeeds") but the hub state stays Disconnected ⇒ the loop
+                // counts it as a server-side rejection after the stability window.
+                return Task.FromResult(ConnectionAttemptResult.Connected);
+            }
+        }
+    }
+}

--- a/McpPlugin/src/McpPlugin/Network/Connection/ConnectionManager.Connect.cs
+++ b/McpPlugin/src/McpPlugin/Network/Connection/ConnectionManager.Connect.cs
@@ -9,6 +9,8 @@
 */
 
 using System;
+using System.Net;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
@@ -407,8 +409,9 @@ namespace com.IvanMurzak.McpPlugin
 
         /// <summary>
         /// Starts the connection retry loop. Must be called from within a _gate-protected section.
-        /// Detects server-side rejection patterns (immediate disconnect after handshake) and stops
-        /// retrying after <see cref="MaxConsecutiveRejections"/> consecutive rejections.
+        /// Detects server-side rejection patterns (immediate disconnect after handshake, and an
+        /// observable HTTP 401/403 during the attempt itself — <see cref="ConnectionAttemptResult.AuthRejected"/>)
+        /// and stops retrying after <see cref="MaxConsecutiveRejections"/> consecutive rejections.
         /// </summary>
         private async Task<bool> StartConnectionLoop(CancellationToken cancellationToken)
         {
@@ -420,7 +423,8 @@ namespace com.IvanMurzak.McpPlugin
 
             while (!cancellationToken.IsCancellationRequested && _continueToReconnect.CurrentValue)
             {
-                if (await AttemptConnection(cancellationToken))
+                var attempt = await AttemptConnection(cancellationToken);
+                if (attempt == ConnectionAttemptResult.Connected)
                 {
                     consecutiveFailures = 0;
 
@@ -452,17 +456,24 @@ namespace com.IvanMurzak.McpPlugin
                         "This typically indicates authorization failure (invalid or revoked token).",
                         nameof(ConnectionManager), _guid, nameof(StartConnectionLoop), Endpoint, consecutiveRejections, MaxConsecutiveRejections);
 
-                    if (consecutiveRejections >= MaxConsecutiveRejections)
-                    {
-                        _logger.LogError("{class}[{guid}] {method} Connection to {endpoint} rejected {count} times consecutively. " +
-                            "Stopping reconnection attempts. The server is likely rejecting this client due to an authorization issue. " +
-                            "Please check your authorization token and try reconnecting.",
-                            nameof(ConnectionManager), _guid, nameof(StartConnectionLoop), Endpoint, consecutiveRejections);
-                        _continueToReconnect.Value = false;
-                        _connectionState.Value = HubConnectionState.Disconnected;
-                        _authorizationRejected.OnNext(Unit.Default);
+                    if (StopAfterRejectionCap(consecutiveRejections))
                         return false;
-                    }
+                }
+                else if (attempt == ConnectionAttemptResult.AuthRejected)
+                {
+                    // The server ANSWERED the attempt with an observable HTTP 401/403
+                    // (oauth-client-error-hygiene 02 §C3.4): it is reachable but rejecting this
+                    // client, so the failure counts toward the auth-rejection cap — not toward the
+                    // unreachable-endpoint failure cap, which it also resets (a 401/403 response
+                    // proves reachability).
+                    consecutiveFailures = 0;
+                    consecutiveRejections++;
+                    _logger.LogWarning("{class}[{guid}] {method} Connection attempt to {endpoint} was rejected with HTTP 401/403 ({count}/{max}). " +
+                        "This indicates an authorization failure (invalid or revoked token).",
+                        nameof(ConnectionManager), _guid, nameof(StartConnectionLoop), Endpoint, consecutiveRejections, MaxConsecutiveRejections);
+
+                    if (StopAfterRejectionCap(consecutiveRejections))
+                        return false;
                 }
                 else
                 {
@@ -502,17 +513,60 @@ namespace com.IvanMurzak.McpPlugin
         }
 
         /// <summary>
+        /// When the consecutive-rejection cap is reached: stop the reconnect loop, settle
+        /// idle-Disconnected, and fire the aggregated <see cref="OnAuthorizationRejected"/> signal.
+        /// Shared by both rejection flavours (immediate close after handshake, and an observable
+        /// HTTP 401/403 during the attempt — 02 §C3.4). Returns true when the cap fired.
+        /// </summary>
+        private bool StopAfterRejectionCap(int consecutiveRejections)
+        {
+            if (consecutiveRejections < MaxConsecutiveRejections)
+                return false;
+
+            _logger.LogError("{class}[{guid}] {method} Connection to {endpoint} rejected {count} times consecutively. " +
+                "Stopping reconnection attempts. The server is likely rejecting this client due to an authorization issue. " +
+                "Please check your authorization token and try reconnecting.",
+                nameof(ConnectionManager), _guid, nameof(StartConnectionLoop), Endpoint, consecutiveRejections);
+            _continueToReconnect.Value = false;
+            _connectionState.Value = HubConnectionState.Disconnected;
+            _authorizationRejected.OnNext(Unit.Default);
+            return true;
+        }
+
+        /// <summary>
+        /// Outcome of one connection attempt — the failure-reason seam of
+        /// <see cref="AttemptConnection"/> (oauth-client-error-hygiene 02 §C3.4). Public (not
+        /// protected) so test doubles' composers — not only <see cref="ConnectionManager"/>
+        /// subclasses themselves — can build attempt sequences.
+        /// </summary>
+        public enum ConnectionAttemptResult
+        {
+            /// <summary>The transport started (handshake succeeded, or it was already connected/connecting).</summary>
+            Connected,
+
+            /// <summary>The attempt failed for a non-auth (or unclassifiable) reason: unreachable endpoint, timeout, cancellation.</summary>
+            Failed,
+
+            /// <summary>
+            /// The attempt failed with an OBSERVABLE HTTP 401/403 (auth rejection at negotiate/handshake).
+            /// Only produced on TFMs where <c>HttpRequestException.StatusCode</c> exists (.NET 5+); the
+            /// netstandard2.1 (Unity) build never produces it — no message-text matching on any TFM.
+            /// </summary>
+            AuthRejected,
+        }
+
+        /// <summary>
         /// Attempts to start the connection. Must be called from within a _gate-protected section.
         /// Protected virtual to allow test subclasses to simulate server behavior.
         /// </summary>
-        protected virtual async Task<bool> AttemptConnection(CancellationToken cancellationToken)
+        protected virtual async Task<ConnectionAttemptResult> AttemptConnection(CancellationToken cancellationToken)
         {
             var connection = _hubConnection.CurrentValue;
             if (connection == null)
-                return false;
+                return ConnectionAttemptResult.Failed;
 
             if (connection.State is HubConnectionState.Connected or HubConnectionState.Connecting)
-                return true;
+                return ConnectionAttemptResult.Connected;
 
             _logger.LogInformation("{class}[{guid}] {method} Starting connection attempt to: {endpoint}",
                 nameof(ConnectionManager), _guid, nameof(AttemptConnection), Endpoint);
@@ -530,7 +584,7 @@ namespace com.IvanMurzak.McpPlugin
                     // Observe the task to prevent UnobservedTaskException; the exception
                     // (typically OperationCanceledException) is expected and can be ignored.
                     _ = connectionTask.ContinueWith(static t => _ = t.Exception, TaskContinuationOptions.ExecuteSynchronously);
-                    return false;
+                    return ConnectionAttemptResult.Failed;
                 }
 
                 if (connectionTask.IsCompletedSuccessfully)
@@ -538,12 +592,14 @@ namespace com.IvanMurzak.McpPlugin
                     _logger.LogInformation("{class}[{guid}] {method} Connection established successfully to: {endpoint}",
                         nameof(ConnectionManager), _guid, nameof(AttemptConnection), Endpoint);
                     _transportConnected.OnNext(Unit.Default);
-                    return true;
+                    return ConnectionAttemptResult.Connected;
                 }
                 else
                 {
                     _logger.LogWarning("{class}[{guid}] {method} Connection attempt failed for endpoint: {endpoint}. Exception: {exception}",
                         nameof(ConnectionManager), _guid, nameof(AttemptConnection), Endpoint, connectionTask.Exception?.Message);
+                    if (IsObservableAuthRejection(connectionTask.Exception))
+                        return ConnectionAttemptResult.AuthRejected;
                 }
             }
             catch (OperationCanceledException)
@@ -560,9 +616,47 @@ namespace com.IvanMurzak.McpPlugin
             {
                 _logger.LogError(ex, "{class}[{guid}] {method} Connection attempt failed for endpoint: {endpoint}. Error: {error}",
                     nameof(ConnectionManager), _guid, nameof(AttemptConnection), Endpoint, ex.Message);
+                if (IsObservableAuthRejection(ex))
+                    return ConnectionAttemptResult.AuthRejected;
             }
 
+            return ConnectionAttemptResult.Failed;
+        }
+
+        /// <summary>
+        /// True when the attempt's exception tree carries an OBSERVABLE HTTP 401/403 — i.e. an
+        /// <see cref="HttpRequestException"/> whose <c>StatusCode</c> is Unauthorized/Forbidden
+        /// (oauth-client-error-hygiene 02 §C3.4). Best-effort by design: on the netstandard2.1
+        /// (Unity) TFM <see cref="HttpRequestException"/> has no <c>StatusCode</c> property (it was
+        /// added in .NET 5) and message-text matching is FORBIDDEN on every TFM, so this always
+        /// returns false there — an auth failure at negotiate degrades to the ordinary failure
+        /// branch, still bounded by the credential provider's dead-family verdict (C3.1).
+        /// </summary>
+        private static bool IsObservableAuthRejection(Exception? exception)
+        {
+#if NETSTANDARD2_1
+            _ = exception;
             return false;
+#else
+            static bool Walk(Exception? ex, int depth)
+            {
+                if (ex == null || depth > 8)
+                    return false;
+                if (ex is HttpRequestException { StatusCode: HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden })
+                    return true;
+                if (ex is AggregateException aggregate)
+                {
+                    foreach (var inner in aggregate.InnerExceptions)
+                    {
+                        if (Walk(inner, depth + 1))
+                            return true;
+                    }
+                    return false;
+                }
+                return Walk(ex.InnerException, depth + 1);
+            }
+            return Walk(exception, 0);
+#endif
         }
 
         protected virtual async Task WaitBeforeRetry(CancellationToken cancellationToken)

--- a/McpPlugin/src/McpPlugin/Network/Connection/Credentials/ConnectionCredentialCoordinator.cs
+++ b/McpPlugin/src/McpPlugin/Network/Connection/Credentials/ConnectionCredentialCoordinator.cs
@@ -25,6 +25,18 @@ namespace com.IvanMurzak.McpPlugin
     /// surfaced <see cref="AuthState.SignInRequired"/>, so this coordinator simply stops — the editor UI
     /// prompts the user to sign in again.
     /// <para>
+    /// Stop/resume (oauth-client-error-hygiene 02 §C3): a dead credential must not be re-presented
+    /// to the hub every retry period, so <see cref="PluginCredentialProvider.OnSignInRequired"/> —
+    /// the dead-family verdict — drives <c>IConnection.Disconnect</c> (which clears the reconnect
+    /// intent and settles the loop idle-Disconnected). When authorization returns (the
+    /// SignInRequired→SignedIn <b>edge</b> of <see cref="PluginCredentialProvider.State"/>, e.g. a
+    /// fresh sign-in or the provider's peer wake-up re-check) the coordinator resumes with one
+    /// <c>Connect</c> — only when the consumer's KeepConnected intent was on when the stop
+    /// happened, edge-triggered, single-flight, and never while a connect loop is already live
+    /// (review finding 12). The connection's <c>_authorizationRejected</c> signal is deliberately
+    /// NOT reused for the stop: its subscribers all mean "try to recover" (review P1-26).
+    /// </para>
+    /// <para>
     /// This is a small composition seam the engine plugin creates after building the connection; it owns no
     /// UI and no HTTP. It reconnects via <c>IConnection.Connect</c>, which re-invokes the credential-provider
     /// callback and thus presents the freshly refreshed JWT.
@@ -39,6 +51,30 @@ namespace com.IvanMurzak.McpPlugin
         readonly SemaphoreSlim _handleGate = new SemaphoreSlim(1, 1);
         volatile bool _disposed;
 
+        /// <summary>Single-flight guard for the OnSignInRequired→Disconnect pass (a flapping state must not stack Disconnects).</summary>
+        int _stopInFlight;
+
+        /// <summary>Single-flight guard for the SignedIn-edge→Connect pass (a flapping state must not stack connect loops).</summary>
+        int _resumeInFlight;
+
+        /// <summary>
+        /// The consumer's KeepConnected intent, captured when the sign-in-required stop happened —
+        /// armed by the verdict handler, consumed (once) by the SignedIn edge. Without it a
+        /// re-login would resurrect a connection the consumer had deliberately stopped.
+        /// </summary>
+        volatile bool _resumeOnSignedIn;
+
+        /// <summary>
+        /// True while <see cref="HandleRejectionAsync"/> is in flight. The 3-strike signal only
+        /// fires from a live connect loop that has ALREADY stopped itself (the cap clears
+        /// KeepConnected before signalling), so a dead-family verdict surfaced during this pass
+        /// still counts as "the consumer's KeepConnected intent was on".
+        /// </summary>
+        volatile bool _rejectionHandlingInFlight;
+
+        /// <summary>Previous auth state, for edge-triggered resume (only SignInRequired→SignedIn resumes).</summary>
+        AuthState _lastAuthState;
+
         public ConnectionCredentialCoordinator(IConnection connection, PluginCredentialProvider credentials, ILogger? logger = null)
         {
             _connection = connection ?? throw new ArgumentNullException(nameof(connection));
@@ -50,6 +86,19 @@ namespace com.IvanMurzak.McpPlugin
             // any overlap with a non-blocking gate.
             _connection.OnAuthorizationRejected
                 .Subscribe(_ => OnAuthorizationRejected())
+                .AddTo(_disposables);
+
+            // Stop on the dead-family verdict (02 §C3.1): a dead credential must stop the connect
+            // loop instead of hammering the hub with a dead token every retry period.
+            _credentials.OnSignInRequired
+                .Subscribe(_ => OnSignInRequiredVerdict())
+                .AddTo(_disposables);
+
+            // Resume on the SignInRequired→SignedIn EDGE (02 §C3.2). R3 pushes the current value on
+            // subscription; seeding _lastAuthState first makes that initial push a non-edge.
+            _lastAuthState = _credentials.State.CurrentValue;
+            _credentials.State
+                .Subscribe(state => OnAuthStateChanged(state))
                 .AddTo(_disposables);
         }
 
@@ -73,6 +122,7 @@ namespace com.IvanMurzak.McpPlugin
                 return false;
             try
             {
+                _rejectionHandlingInFlight = true;
                 _logger?.LogInformation("Authorization rejected — attempting token refresh + reconnect.");
 
                 var refreshed = await _credentials.RefreshAsync(cancellationToken).ConfigureAwait(false);
@@ -97,7 +147,99 @@ namespace com.IvanMurzak.McpPlugin
             }
             finally
             {
+                _rejectionHandlingInFlight = false;
                 _handleGate.Release();
+            }
+        }
+
+        /// <summary>
+        /// The dead-family verdict (02 §C3.1): capture the consumer's reconnect intent, then stop
+        /// the connect loop via the existing stop primitive (<c>Disconnect</c> clears
+        /// <c>_continueToReconnect</c> and settles idle-Disconnected). Single-flight — a flapping
+        /// state produces exactly one Disconnect pass; and Disconnect itself is idempotent when
+        /// the connection is already down.
+        /// </summary>
+        void OnSignInRequiredVerdict()
+        {
+            if (_disposed)
+                return;
+
+            // Capture intent BEFORE Disconnect clears it. Either the loop is live right now
+            // (KeepConnected), or the verdict surfaced inside a rejection-handling pass — the
+            // 3-strike path, whose cap already cleared KeepConnected before signalling but which
+            // only ever fires from a loop the consumer had running.
+            if (_connection.KeepConnected.CurrentValue || _rejectionHandlingInFlight)
+                _resumeOnSignedIn = true;
+
+            if (Interlocked.CompareExchange(ref _stopInFlight, 1, 0) != 0)
+                return; // a stop pass is already in flight — flapping must not stack Disconnects
+            _ = StopReconnectAsync();
+        }
+
+        // Fire-and-forget body of the stop pass; observes its own faults.
+        async Task StopReconnectAsync()
+        {
+            try
+            {
+                if (_disposed)
+                    return;
+                _logger?.LogInformation("Sign-in required — stopping reconnection so the dead credential is not re-presented (02 §C3.1). Reconnection resumes on the next sign-in.");
+                await _connection.Disconnect().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogError(ex, "Error stopping reconnection after sign-in-required: {message}", ex.Message);
+            }
+            finally
+            {
+                Interlocked.Exchange(ref _stopInFlight, 0);
+            }
+        }
+
+        /// <summary>
+        /// Resume on the SignInRequired→SignedIn edge (02 §C3.2): when authorization returns —
+        /// fresh sign-in, or the provider's peer wake-up re-check adopting another surface's login
+        /// — reconnect, but only when the consumer's KeepConnected intent was on at stop time,
+        /// only on the edge (never level-triggered), and never while a connect loop is already
+        /// live (review finding 12: a flapping state must not stack loops).
+        /// </summary>
+        void OnAuthStateChanged(AuthState state)
+        {
+            var previous = _lastAuthState;
+            _lastAuthState = state;
+
+            if (_disposed || previous != AuthState.SignInRequired || state != AuthState.SignedIn)
+                return; // edge-triggered: only the SignInRequired→SignedIn transition can resume
+
+            if (!_resumeOnSignedIn)
+                return; // the consumer's KeepConnected intent was off — do not resurrect the connection
+            _resumeOnSignedIn = false; // consume: one resume per stop; the next verdict re-arms
+
+            if (_connection.KeepConnected.CurrentValue)
+                return; // a connect loop is already live — resuming would stack loops (finding 12)
+
+            if (Interlocked.CompareExchange(ref _resumeInFlight, 1, 0) != 0)
+                return; // a resume pass is already in flight
+            _ = ResumeAsync();
+        }
+
+        // Fire-and-forget body of the resume pass; observes its own faults.
+        async Task ResumeAsync()
+        {
+            try
+            {
+                if (_disposed)
+                    return;
+                _logger?.LogInformation("Signed in again — resuming the connection (02 §C3.2).");
+                await _connection.Connect().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogError(ex, "Error resuming the connection after sign-in: {message}", ex.Message);
+            }
+            finally
+            {
+                Interlocked.Exchange(ref _resumeInFlight, 0);
             }
         }
 


### PR DESCRIPTION
Implements Taskflow `2026-08-24-oauth-client-error-hygiene` task **a3-coordinator-stop-resume** (02 §C3, rewired per review). Depends on a2 (#212, merged).

## What

**Stop/resume — `ConnectionCredentialCoordinator`** (no `ConnectionConfig` shape change, no ctor/DI change):
- `provider.OnSignInRequired` (the dead-family verdict) → `connection.Disconnect()` — the existing stop primitive (`ConnectionManager.Disconnect.cs` sets `_continueToReconnect=false` and settles idle-Disconnected). Single-flight (`_stopInFlight` CAS); idempotent when already disconnected. `_authorizationRejected` is deliberately **not** fired or subscribed for this (review P1-26: all four existing subscribers treat it as "try to recover"); the existing coordinator 401 handling is unchanged.
- `provider.State` SignInRequired→SignedIn **edge** → `Connect()`, gated on the consumer's KeepConnected intent captured at stop time (read **before** Disconnect clears it; a verdict surfacing inside `HandleRejectionAsync` also counts as intent-on, because the 3-strike cap clears KeepConnected before signalling but only ever fires from a loop the consumer had running). Edge-triggered, single-flight (`_resumeInFlight` CAS), and a no-op while a connect loop is already live (review finding 12).

**StatusCode-based rejection counting — best-effort (02 §C3.4)**:
- New failure-reason seam: `AttemptConnection` returns `ConnectionAttemptResult` (`Connected` / `Failed` / `AuthRejected`) instead of bare `bool`.
- Where an `HttpRequestException.StatusCode` of **401/403** is observable (net8.0/net9.0), the failed attempt counts toward the `consecutiveRejections` 3-strike cap — same terminal consequence (stop + `_authorizationRejected`) — and **resets** the unreachable-failure cap (a 401/403 response proves reachability). Non-auth failures still reset the rejection counter.
- **netstandard2.1 (Unity)**: `HttpRequestException` has no `StatusCode` (added in .NET 5), so `IsObservableAuthRejection` is `#if`-compiled to return false — the same fixture falls back to the ordinary failure branch. **No message-text matching on any TFM.** C3.1 still bounds the dead-credential loop via the provider verdict.
- Transient-failure behavior unchanged: unbounded 5 s retry stays the Unity/Unreal default.

## Pinned tests — protective intent kept (DoD)

- `Connect_FailedAttemptsResetRejectionCounter` (was :76-107): kept for **non-auth** failures — interleaved `Failed` outcomes still reset the rejection counter (an `AuthRejected` outcome deliberately does not; it feeds the cap).
- `Connect_DoesNotTriggerRejection_WhenConnectionStaysAlive` (was :110-134): kept for **non-auth** failed attempts — `Failed` outcomes never fire `OnAuthorizationRejected`.
- The three `AttemptConnection` fakes (was :236/:263/:291) moved to the new seam; `SequenceConnectionManager` now plays `ConnectionAttemptResult[]`.

## DoD evidence

- Coordinator tests: verdict ⇒ exactly one `Disconnect` (`OnSignInRequired_StopsReconnect_ExactlyOneDisconnect`); **flapping fixture ⇒ still one** — a real flapping source (refresher-less provider surfaces the verdict on every `RefreshAsync`) with the Disconnect task held pending across three verdicts (`OnSignInRequired_FlappingVerdicts_SingleFlight_StillOneDisconnect`); SignedIn edge ⇒ exactly one `Connect` (`SignedInEdge_ResumesConnect_ExactlyOnce_WhenIntentWasOn`); no `Connect` while a loop is live / intent off / SignedOut→SignedIn — each negative has the resume test as its same-fixture positive control.
- End-to-end harness (`CoordinatorStopResumeHarnessTests`, real loop + real provider + real coordinator): dead family + running loop ⇒ settles idle-Disconnected with **zero attempts after the verdict** and one network refresh (memo); fake peer login (store rewrite) ⇒ wake-up re-check ⇒ SignedIn edge ⇒ loop resumes — in both the proactive-verdict flavour and the 3-strike flavour. Control: transient failures with default config retry unbounded, provider untouched.
- StatusCode TFM split: real-transport loopback fixture (`ConnectionManagerStatusCodeClassificationTests`) — a server answering the SignalR negotiate with **401** trips the 3-strike cap through the *real* `AttemptConnection` and fires `OnAuthorizationRejected` exactly once (exactly 3 negotiates reach the server); connection-refused (StatusCode-less) goes to the failure branch and never fires the rejection signal; default config retries unbounded. The Unity fallback is proven by the green `netstandard2.1` build of the `#if` branch (tests run net8/net9 only).
- **Plant round (all applied via tracked edits, run, then reverted):**
  1. Stop subscription deleted ⇒ 6 RED (both stop tests, both harness flows, resume, loop-live fixture).
  2. Resume (`State`) subscription deleted ⇒ 3 RED (exactly the resume claims; stop tests stayed green).
  3. Intent gate removed (always resume) ⇒ `SignedInEdge_DoesNotConnect_WhenIntentWasOff` RED — the negative half can fail.
  4. Loop-live guard removed ⇒ `SignedInEdge_DoesNotConnect_WhileALoopIsAlreadyLive` RED.
  5. Stop single-flight CAS removed ⇒ flapping test RED (3 Disconnects).
  6. StatusCode classifier deleted ⇒ real-transport 401 test RED (loop no longer self-caps).
  7. AuthRejected branch mis-counted as ordinary failure ⇒ both AuthRejected counting tests RED (`AttemptCount 3 ≠ 6` discriminates the reset direction).
- `dotnet test` green across the solution: McpPlugin.Tests **969/969** on net8.0 and net9.0; McpPlugin.Server.Tests 745/745 both TFMs. `McpPlugin` builds clean on netstandard2.1/net8.0/net9.0. No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVipj7Xi4HouAmmdCYSdmz