### PR TITLE
feat: emit SkillDescription/SkillBody into tools/list _meta

### DIFF
--- a/McpPlugin.Common/src/Data/Response/Tool/List/ResponseListTool.cs
+++ b/McpPlugin.Common/src/Data/Response/Tool/List/ResponseListTool.cs
@@ -25,6 +25,29 @@ namespace com.IvanMurzak.McpPlugin.Common.Model
         public bool? IdempotentHint { get; set; }
         public bool? OpenWorldHint { get; set; }
 
+        /// <summary>
+        /// Optional concise blurb sourced from the tool's <c>AiSkillDescription</c> attribute.
+        /// Surfaced on the wire so the MCP server can emit it as a <c>tools/list</c>
+        /// <c>_meta.skillDescription</c> key. <see langword="null"/> when the tool declares none.
+        /// </summary>
+        /// <remarks>
+        /// MUST stay a property: the SignalR payload serializer is configured by
+        /// <see cref="SignalR_JsonConfiguration"/>, which does NOT propagate
+        /// <c>JsonSerializerOptions.IncludeFields</c> — a field would compile and pass
+        /// in-process tests while silently vanishing on the wire.
+        /// </remarks>
+        public string? SkillDescription { get; set; }
+
+        /// <summary>
+        /// Optional long-form markdown sourced from the tool's <c>AiSkillBody</c> attribute.
+        /// Surfaced on the wire so the MCP server can emit it as a <c>tools/list</c>
+        /// <c>_meta.skillBody</c> key. <see langword="null"/> when the tool declares none.
+        /// </summary>
+        /// <remarks>
+        /// MUST stay a property, for the same reason as <see cref="SkillDescription"/>.
+        /// </remarks>
+        public string? SkillBody { get; set; }
+
         public ResponseListTool() { }
     }
 }

--- a/McpPlugin.Common/src/Utils/Consts.MCP.cs
+++ b/McpPlugin.Common/src/Utils/Consts.MCP.cs
@@ -263,8 +263,11 @@ namespace com.IvanMurzak.McpPlugin.Common
                     /// — and disabled entries are tagged with
                     /// <c>_meta.enabled = false</c> so the trusted client can tell
                     /// them apart. Any client that does NOT send this header keeps
-                    /// the pre-existing behaviour: disabled entries are filtered
-                    /// out, and no <c>_meta</c> is emitted by this server.
+                    /// the pre-existing filtering: disabled entries are filtered
+                    /// out, so <c>_meta.enabled</c> never reaches it.
+                    /// <c>_meta</c> itself is NOT trusted-client-only: a
+                    /// <c>tools/list</c> entry also carries the skill keys for every
+                    /// caller, so its presence does not imply this mode.
                     ///
                     /// This is a UX gate, NOT a security boundary — the header is
                     /// trivially spoofable. Pair it with bearer-token auth when

--- a/McpPlugin.Server.Tests/ToolListSkillMetaTests.cs
+++ b/McpPlugin.Server.Tests/ToolListSkillMetaTests.cs
@@ -1,0 +1,147 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+using System.Linq;
+using com.IvanMurzak.McpPlugin.Common;
+using com.IvanMurzak.McpPlugin.Common.Model;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.Server.Tests
+{
+    /// <summary>
+    /// <c>tools/list</c> surfaces a tool's skill metadata as the <c>_meta</c> keys
+    /// <c>skillDescription</c> / <c>skillBody</c>. The projection under test is
+    /// <c>ExtensionsTool.ToTool()</c> — the exact expression
+    /// <c>ToolRouter.ListAll</c> maps every plugin tool through.
+    /// <para>
+    /// The composition is deliberately tools-only:
+    /// <c>ExtensionsListMeta.BuildEnabledMeta</c> keeps its null-when-enabled contract
+    /// because prompts, resources and resource templates assign its result wholesale.
+    /// </para>
+    /// </summary>
+    public class ToolListSkillMetaTests
+    {
+        const string SkillDescriptionText = "Creates a primitive object in the scene";
+        const string SkillBodyText = "# GameObject create\n\nUse `path` to nest the new object.";
+
+        static ResponseListTool Tool(
+            bool enabled = true,
+            string? skillDescription = null,
+            string? skillBody = null)
+            => new ResponseListTool
+            {
+                Name = "gameobject-create",
+                Enabled = enabled,
+                InputSchema = Consts.MCP.EmptyInputSchema,
+                SkillDescription = skillDescription,
+                SkillBody = skillBody
+            };
+
+        [Fact]
+        public void ToTool_EmitsBothSkillKeys_WhenBothPresent()
+        {
+            var meta = Tool(skillDescription: SkillDescriptionText, skillBody: SkillBodyText).ToTool().Meta;
+
+            meta.ShouldNotBeNull();
+            meta![ExtensionsListMeta.SkillDescriptionKey]!.GetValue<string>().ShouldBe(SkillDescriptionText);
+            meta[ExtensionsListMeta.SkillBodyKey]!.GetValue<string>().ShouldBe(SkillBodyText);
+
+            // An ENABLED tool must not gain an `enabled` key: the two assertions above are
+            // the positive control proving the object was built, so this absence is a
+            // statement about `enabled` alone.
+            meta.ContainsKey(ExtensionsListMeta.EnabledKey).ShouldBeFalse();
+            meta.Count.ShouldBe(2);
+        }
+
+        [Fact]
+        public void ToTool_EmitsOnlySkillDescription_WhenBodyAbsent()
+        {
+            var meta = Tool(skillDescription: SkillDescriptionText).ToTool().Meta;
+
+            meta.ShouldNotBeNull();
+            meta![ExtensionsListMeta.SkillDescriptionKey]!.GetValue<string>().ShouldBe(SkillDescriptionText);
+            meta.Select(kv => kv.Key).ShouldBe(new[] { ExtensionsListMeta.SkillDescriptionKey });
+        }
+
+        [Fact]
+        public void ToTool_EmitsOnlySkillBody_WhenDescriptionAbsent()
+        {
+            var meta = Tool(skillBody: SkillBodyText).ToTool().Meta;
+
+            meta.ShouldNotBeNull();
+            meta![ExtensionsListMeta.SkillBodyKey]!.GetValue<string>().ShouldBe(SkillBodyText);
+            meta.Select(kv => kv.Key).ShouldBe(new[] { ExtensionsListMeta.SkillBodyKey });
+        }
+
+        [Fact]
+        public void ToTool_CombinesEnabledFalseWithSkillKeys_WhenDisabledAndAttributed()
+        {
+            var meta = Tool(enabled: false, skillDescription: SkillDescriptionText, skillBody: SkillBodyText)
+                .ToTool()
+                .Meta;
+
+            meta.ShouldNotBeNull();
+            meta![ExtensionsListMeta.EnabledKey]!.GetValue<bool>().ShouldBeFalse();
+            meta[ExtensionsListMeta.SkillDescriptionKey]!.GetValue<string>().ShouldBe(SkillDescriptionText);
+            meta[ExtensionsListMeta.SkillBodyKey]!.GetValue<string>().ShouldBe(SkillBodyText);
+            meta.Count.ShouldBe(3);
+        }
+
+        [Fact]
+        public void ToTool_OmitsMetaEntirely_WhenEnabledAndNoSkillMetadata()
+        {
+            // The unchanged default wire shape: this is what every third-party client sees
+            // today, and the whole point of composing instead of always emitting an object.
+            Tool().ToTool().Meta.ShouldBeNull();
+        }
+
+        [Fact]
+        public void ToTool_EmitsOnlyEnabledKey_WhenDisabledAndNoSkillMetadata()
+        {
+            var meta = Tool(enabled: false).ToTool().Meta;
+
+            meta.ShouldNotBeNull();
+            meta![ExtensionsListMeta.EnabledKey]!.GetValue<bool>().ShouldBeFalse();
+            meta.Select(kv => kv.Key).ShouldBe(new[] { ExtensionsListMeta.EnabledKey });
+        }
+
+        [Fact]
+        public void ToTool_TreatsBlankSkillMetadataAsAbsent()
+        {
+            // A tool whose attribute carried an empty string must not push an empty key onto
+            // the wire — clients render the catalog line from it.
+            Tool(skillDescription: string.Empty, skillBody: string.Empty).ToTool().Meta.ShouldBeNull();
+        }
+
+        [Fact]
+        public void BuildToolMeta_MatchesToTool_ForTheAttributedCase()
+        {
+            // Pins the helper itself, so a future call site gets the same composition.
+            var meta = ExtensionsListMeta.BuildToolMeta(Tool(skillDescription: SkillDescriptionText));
+
+            meta.ShouldNotBeNull();
+            meta![ExtensionsListMeta.SkillDescriptionKey]!.GetValue<string>().ShouldBe(SkillDescriptionText);
+        }
+
+        [Fact]
+        public void BuildEnabledMeta_StillEmitsExactlyTheEnabledKey()
+        {
+            // The three non-tool call sites (prompts / resources / resource templates) assign
+            // BuildEnabledMeta's result WHOLESALE, so teaching it the skill keys would leak
+            // them onto primitives that have no such metadata. This reddens if the skill keys
+            // are folded into the shared helper instead of composed on top of it.
+            var meta = ExtensionsListMeta.BuildEnabledMeta(enabled: false);
+
+            meta.ShouldNotBeNull();
+            meta!.Select(kv => kv.Key).ShouldBe(new[] { ExtensionsListMeta.EnabledKey });
+        }
+    }
+}

--- a/McpPlugin.Server.Tests/ToolListSkillMetaTests.cs
+++ b/McpPlugin.Server.Tests/ToolListSkillMetaTests.cs
@@ -21,11 +21,8 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
     /// <c>skillDescription</c> / <c>skillBody</c>. The projection under test is
     /// <c>ExtensionsTool.ToTool()</c> — the exact expression
     /// <c>ToolRouter.ListAll</c> maps every plugin tool through.
-    /// <para>
-    /// The composition is deliberately tools-only:
-    /// <c>ExtensionsListMeta.BuildEnabledMeta</c> keeps its null-when-enabled contract
-    /// because prompts, resources and resource templates assign its result wholesale.
-    /// </para>
+    /// The composition is deliberately tools-only — see the <c>remarks</c> on
+    /// <c>ExtensionsListMeta.BuildToolMeta</c> for why the shared helper stays untouched.
     /// </summary>
     public class ToolListSkillMetaTests
     {
@@ -54,11 +51,11 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
             meta![ExtensionsListMeta.SkillDescriptionKey]!.GetValue<string>().ShouldBe(SkillDescriptionText);
             meta[ExtensionsListMeta.SkillBodyKey]!.GetValue<string>().ShouldBe(SkillBodyText);
 
-            // An ENABLED tool must not gain an `enabled` key: the two assertions above are
-            // the positive control proving the object was built, so this absence is a
-            // statement about `enabled` alone.
-            meta.ContainsKey(ExtensionsListMeta.EnabledKey).ShouldBeFalse();
-            meta.Count.ShouldBe(2);
+            // An ENABLED tool must not gain an `enabled` key. The exact key SET says that in
+            // one assertion and pins emission ORDER too; the value assertions above are the
+            // positive control proving the object was built at all.
+            meta.Select(kv => kv.Key).ShouldBe(
+                new[] { ExtensionsListMeta.SkillDescriptionKey, ExtensionsListMeta.SkillBodyKey });
         }
 
         [Fact]
@@ -92,7 +89,14 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
             meta![ExtensionsListMeta.EnabledKey]!.GetValue<bool>().ShouldBeFalse();
             meta[ExtensionsListMeta.SkillDescriptionKey]!.GetValue<string>().ShouldBe(SkillDescriptionText);
             meta[ExtensionsListMeta.SkillBodyKey]!.GetValue<string>().ShouldBe(SkillBodyText);
-            meta.Count.ShouldBe(3);
+            // Same key-SET form as the two-key case above: this is the only test exercising
+            // all three keys, so it is the only one that can pin their emission order.
+            meta.Select(kv => kv.Key).ShouldBe(new[]
+            {
+                ExtensionsListMeta.EnabledKey,
+                ExtensionsListMeta.SkillDescriptionKey,
+                ExtensionsListMeta.SkillBodyKey
+            });
         }
 
         [Fact]
@@ -122,13 +126,33 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
         }
 
         [Fact]
-        public void BuildToolMeta_MatchesToTool_ForTheAttributedCase()
+        public void ToTool_RelaysWhitespaceOnlySkillBody_BecauseTheGuardIsIsNullOrEmpty()
         {
-            // Pins the helper itself, so a future call site gets the same composition.
+            // BuildToolMeta guards with IsNullOrEmpty, NOT IsNullOrWhiteSpace, so a
+            // whitespace-only value is relayed verbatim; SkillFileGenerator drops it from
+            // SKILL.md. That divergence is deliberate and was prose-only until this test:
+            // swapping the guard to IsNullOrWhiteSpace reddened NOTHING and would have
+            // silently turned the comment at the guard into a false claim.
+            var meta = Tool(skillBody: "   ").ToTool().Meta;
+
+            meta.ShouldNotBeNull();
+            meta![ExtensionsListMeta.SkillBodyKey]!.GetValue<string>().ShouldBe("   ");
+            meta.Select(kv => kv.Key).ShouldBe(new[] { ExtensionsListMeta.SkillBodyKey });
+        }
+
+        [Fact]
+        public void BuildToolMeta_EmitsExactlyTheSkillKeys_WhenCalledDirectly()
+        {
+            // Pins the PUBLIC helper directly. ToTool() assigns BuildToolMeta(response)
+            // verbatim today, so this deliberately overlaps
+            // ToTool_EmitsOnlySkillDescription_WhenBodyAbsent above; it earns its place only
+            // because BuildToolMeta ships as public API of com.IvanMurzak.McpPlugin.Server and
+            // a second call site could use it without going through ToTool().
             var meta = ExtensionsListMeta.BuildToolMeta(Tool(skillDescription: SkillDescriptionText));
 
             meta.ShouldNotBeNull();
             meta![ExtensionsListMeta.SkillDescriptionKey]!.GetValue<string>().ShouldBe(SkillDescriptionText);
+            meta.Select(kv => kv.Key).ShouldBe(new[] { ExtensionsListMeta.SkillDescriptionKey });
         }
 
         [Fact]
@@ -142,6 +166,16 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
 
             meta.ShouldNotBeNull();
             meta!.Select(kv => kv.Key).ShouldBe(new[] { ExtensionsListMeta.EnabledKey });
+        }
+
+        [Fact]
+        public void SkillMetaKeys_AreTheLiteralWireNames()
+        {
+            // Every other assertion in this file reads the keys THROUGH these constants, so
+            // changing a constant's VALUE would rename the key for every MCP client while
+            // reddening nothing. These two strings ARE the wire contract; pin them literally.
+            ExtensionsListMeta.SkillDescriptionKey.ShouldBe("skillDescription");
+            ExtensionsListMeta.SkillBodyKey.ShouldBe("skillBody");
         }
     }
 }

--- a/McpPlugin.Server.Tests/TrustedInternalClientTests.cs
+++ b/McpPlugin.Server.Tests/TrustedInternalClientTests.cs
@@ -123,6 +123,10 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
         {
             // Default-case wire shape MUST be unchanged for enabled primitives —
             // a non-null Meta would surface to every existing third-party client.
+            // Prompts, resources and resource templates assign this result WHOLESALE,
+            // so the null is load-bearing for them; the tools call site layers its
+            // skillDescription/skillBody keys on top via BuildToolMeta instead of
+            // changing this helper. (Tool-side composition: ToolListSkillMetaTests.)
             ExtensionsListMeta.BuildEnabledMeta(enabled: true).ShouldBeNull();
         }
 
@@ -134,6 +138,9 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
             meta.ShouldNotBeNull();
             meta!.ContainsKey(ExtensionsListMeta.EnabledKey).ShouldBeTrue();
             meta[ExtensionsListMeta.EnabledKey]!.GetValue<bool>().ShouldBeFalse();
+            // ...and nothing else: the shared helper stays a pure enabled-annotation for
+            // its three non-tool call sites.
+            meta.Count.ShouldBe(1);
         }
 
         // ─────────────────────────────────────────────────────────────────────
@@ -143,6 +150,9 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
         [Fact]
         public void ToTool_OmitsMeta_WhenEnabled()
         {
+            // ToTool() now composes through BuildToolMeta, which may also add
+            // skillDescription/skillBody. With neither set — the case here — the result
+            // must still be the pre-existing null.
             new ResponseListTool { Name = "ping", Enabled = true, InputSchema = Consts.MCP.EmptyInputSchema }
                 .ToTool()
                 .Meta
@@ -156,6 +166,9 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
 
             meta.ShouldNotBeNull();
             meta![ExtensionsListMeta.EnabledKey]!.GetValue<bool>().ShouldBeFalse();
+            // A tool with no skill metadata carries the enabled annotation ALONE, so the
+            // additive change leaves this payload byte-identical to what shipped before.
+            meta.Count.ShouldBe(1);
         }
 
         [Fact]

--- a/McpPlugin.Server/src/Extension/ExtensionsListMeta.cs
+++ b/McpPlugin.Server/src/Extension/ExtensionsListMeta.cs
@@ -52,6 +52,41 @@ namespace com.IvanMurzak.McpPlugin.Server
         public static JsonObject? BuildEnabledMeta(bool enabled)
             => enabled ? null : new JsonObject { [EnabledKey] = false };
 
+        /// <summary>Property name carrying a tool's short skill blurb on the <c>_meta</c> object.</summary>
+        public const string SkillDescriptionKey = "skillDescription";
+
+        /// <summary>Property name carrying a tool's long-form skill markdown on the <c>_meta</c> object.</summary>
+        public const string SkillBodyKey = "skillBody";
+
+        /// <summary>
+        /// Builds the <c>_meta</c> object for a <c>tools/list</c> entry: the
+        /// <see cref="BuildEnabledMeta"/> annotation, plus <c>skillDescription</c> /
+        /// <c>skillBody</c> whenever the tool carries them. Returns
+        /// <see langword="null"/> when there is nothing at all to emit, so an enabled
+        /// tool with no skill metadata keeps today's exact wire shape.
+        /// </summary>
+        /// <remarks>
+        /// Tools-only on purpose. <see cref="BuildEnabledMeta"/> stays untouched because
+        /// prompts / resources / resource-templates share it and rely on its
+        /// null-when-enabled contract; composing here instead of mutating it keeps those
+        /// three call sites byte-identical.
+        /// </remarks>
+        public static JsonObject? BuildToolMeta(Common.Model.ResponseListTool response)
+        {
+            if (response == null)
+                throw new ArgumentNullException(nameof(response));
+
+            var meta = BuildEnabledMeta(response.Enabled);
+
+            if (!string.IsNullOrEmpty(response.SkillDescription))
+                (meta ??= new JsonObject())[SkillDescriptionKey] = response.SkillDescription;
+
+            if (!string.IsNullOrEmpty(response.SkillBody))
+                (meta ??= new JsonObject())[SkillBodyKey] = response.SkillBody;
+
+            return meta;
+        }
+
         /// <summary>
         /// Filters a list-router's source primitives to the set the current
         /// caller is allowed to see, then projects each survivor through

--- a/McpPlugin.Server/src/Extension/ExtensionsListMeta.cs
+++ b/McpPlugin.Server/src/Extension/ExtensionsListMeta.cs
@@ -28,15 +28,18 @@ namespace com.IvanMurzak.McpPlugin.Server
     ///   <see cref="ModelContextProtocol.Protocol.Prompt"/>,
     ///   <see cref="ModelContextProtocol.Protocol.Resource"/>,
     ///   <see cref="ModelContextProtocol.Protocol.ResourceTemplate"/> primitives
-    ///   (<see cref="BuildEnabledMeta"/>).</description></item>
+    ///   (<see cref="BuildEnabledMeta"/> for prompts / resources / resource
+    ///   templates; tools compose through <see cref="BuildToolMeta"/>, which
+    ///   adds the skill keys on top of it).</description></item>
     /// </list>
     /// </summary>
     /// <remarks>
     /// MCP's <c>_meta</c> field is reserved for protocol-level metadata that
-    /// servers may emit and clients may ignore (per spec). We use it to surface
-    /// the plugin-side <c>Enabled</c> flag to trusted internal clients that
-    /// have opted in to the unfiltered catalog — see
-    /// <see cref="com.IvanMurzak.McpPlugin.Common.Consts.MCP.Server.Headers.TrustedInternalClient"/>.
+    /// servers may emit and clients may ignore (per spec). We use it for two
+    /// things: the plugin-side <c>Enabled</c> flag, surfaced ONLY to trusted
+    /// internal clients that have opted in to the unfiltered catalog — see
+    /// <see cref="com.IvanMurzak.McpPlugin.Common.Consts.MCP.Server.Headers.TrustedInternalClient"/>
+    /// — and, on tools only, the skill blurb / body, which reach EVERY caller.
     /// </remarks>
     public static class ExtensionsListMeta
     {
@@ -78,6 +81,11 @@ namespace com.IvanMurzak.McpPlugin.Server
 
             var meta = BuildEnabledMeta(response.Enabled);
 
+            // IsNullOrEmpty, not IsNullOrWhiteSpace: the guard drops an attribute that
+            // carried an empty string, and nothing more. SkillFileGenerator uses
+            // IsNullOrWhiteSpace for the SKILL.md body, so a whitespace-only SkillBody is
+            // dropped there and relayed here. That is deliberate: these keys are a verbatim
+            // relay of the attribute text, whereas SKILL.md is rendered markdown.
             if (!string.IsNullOrEmpty(response.SkillDescription))
                 (meta ??= new JsonObject())[SkillDescriptionKey] = response.SkillDescription;
 

--- a/McpPlugin.Server/src/Extension/ExtensionsTool.cs
+++ b/McpPlugin.Server/src/Extension/ExtensionsTool.cs
@@ -79,7 +79,10 @@ namespace com.IvanMurzak.McpPlugin.Server
                 // internal clients (which receive the unfiltered list) can tell which
                 // entries the user has turned off plugin-side. Untrusted clients never
                 // receive disabled tools so the field never reaches them.
-                Meta = ExtensionsListMeta.BuildEnabledMeta(response.Enabled)
+                // Tools additionally carry `skillDescription` / `skillBody` when the tool
+                // declares them, so MCP clients can build a tool catalog without calling
+                // every tool's schema. Still null when there is nothing to emit.
+                Meta = ExtensionsListMeta.BuildToolMeta(response)
             };
         }
 

--- a/McpPlugin.Server/src/Extension/ExtensionsTool.cs
+++ b/McpPlugin.Server/src/Extension/ExtensionsTool.cs
@@ -81,7 +81,7 @@ namespace com.IvanMurzak.McpPlugin.Server
                 // receive disabled tools so the field never reaches them.
                 // Tools additionally carry `skillDescription` / `skillBody` when the tool
                 // declares them, so MCP clients can build a tool catalog without calling
-                // every tool's schema. Still null when there is nothing to emit.
+                // every tool's schema.
                 Meta = ExtensionsListMeta.BuildToolMeta(response)
             };
         }

--- a/McpPlugin.Tests/Data/Annotations/SkillAnnotatedToolClass.cs
+++ b/McpPlugin.Tests/Data/Annotations/SkillAnnotatedToolClass.cs
@@ -1,0 +1,41 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+namespace com.IvanMurzak.McpPlugin.Tests.Data.Annotations
+{
+    /// <summary>
+    /// Tools carrying the optional skill metadata attributes, so a test can observe
+    /// what <c>tools/list</c> reports for each combination of present / absent.
+    /// </summary>
+    [AiToolType]
+    public static class SkillAnnotatedToolClass
+    {
+        public const string BothDescription = "Short blurb for the both-attributes tool";
+        public const string BothBody = "# Both\n\nLong-form markdown body with a `code` sample.";
+        public const string DescriptionOnlyDescription = "Short blurb, no body";
+        public const string BodyOnlyBody = "# Body only\n\nNo short blurb on this one.";
+
+        [AiTool("skill-tool-both", "Tool With Both Skill Attributes")]
+        [AiSkillDescription(BothDescription)]
+        [AiSkillBody(BothBody)]
+        public static void Both() { }
+
+        [AiTool("skill-tool-description-only", "Tool With Only A Skill Description")]
+        [AiSkillDescription(DescriptionOnlyDescription)]
+        public static void DescriptionOnly() { }
+
+        [AiTool("skill-tool-body-only", "Tool With Only A Skill Body")]
+        [AiSkillBody(BodyOnlyBody)]
+        public static void BodyOnly() { }
+
+        [AiTool("skill-tool-none", "Tool With No Skill Attributes")]
+        public static void None() { }
+    }
+}

--- a/McpPlugin.Tests/Mcp/McpBuilderTests_ToolSkillMetadata.cs
+++ b/McpPlugin.Tests/Mcp/McpBuilderTests_ToolSkillMetadata.cs
@@ -1,0 +1,113 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.Common.Model;
+using com.IvanMurzak.McpPlugin.Tests.Data.Annotations;
+using com.IvanMurzak.McpPlugin.Tests.Infrastructure;
+using com.IvanMurzak.ReflectorNet;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+using Version = com.IvanMurzak.McpPlugin.Common.Version;
+
+namespace com.IvanMurzak.McpPlugin.Tests.Mcp
+{
+    /// <summary>
+    /// <c>tools/list</c> must carry each tool's optional skill metadata
+    /// (<c>[AiSkillDescription]</c> / <c>[AiSkillBody]</c>) so the MCP server can
+    /// re-emit it as <c>_meta.skillDescription</c> / <c>_meta.skillBody</c>. The
+    /// accessors already existed on <c>IRunTool</c>; what is under test here is that
+    /// <c>McpToolManager.RunListTool</c> actually COPIES them into the response DTO.
+    /// </summary>
+    [Collection("McpPlugin")]
+    public class McpBuilderTests_ToolSkillMetadata
+    {
+        private readonly ITestOutputHelper _output;
+        private readonly XunitTestOutputLoggerProvider _loggerProvider;
+        private readonly Version version = new Version();
+
+        public McpBuilderTests_ToolSkillMetadata(ITestOutputHelper output)
+        {
+            _output = output;
+            _loggerProvider = new XunitTestOutputLoggerProvider(output);
+        }
+
+        private async Task<ResponseListTool> GetTool(string toolName)
+        {
+            var reflector = new Reflector();
+            var mcpPluginBuilder = new McpPluginBuilder(version, _loggerProvider)
+                .AddLogging(b => b.AddXunitTestOutput(_output))
+                .WithTools(typeof(SkillAnnotatedToolClass));
+
+            var mcpPlugin = mcpPluginBuilder.Build(reflector);
+            var response = await mcpPlugin.McpManager.ToolManager!.RunListTool(new RequestListTool());
+
+            response.ShouldNotBeNull();
+            response.Status.ShouldBe(ResponseStatus.Success);
+            response.Value.ShouldNotBeNull();
+
+            var tool = System.Linq.Enumerable.FirstOrDefault(response.Value!, t => t.Name == toolName);
+            tool.ShouldNotBeNull($"Tool '{toolName}' should be registered");
+            return tool!;
+        }
+
+        [Fact]
+        public async Task ListTool_CopiesSkillDescription_WhenAttributePresent()
+        {
+            var tool = await GetTool("skill-tool-both");
+
+            tool.SkillDescription.ShouldBe(SkillAnnotatedToolClass.BothDescription);
+        }
+
+        [Fact]
+        public async Task ListTool_CopiesSkillBody_WhenAttributePresent()
+        {
+            var tool = await GetTool("skill-tool-both");
+
+            tool.SkillBody.ShouldBe(SkillAnnotatedToolClass.BothBody);
+        }
+
+        [Fact]
+        public async Task ListTool_CopiesSkillDescription_IndependentlyOfSkillBody()
+        {
+            // Independent halves: a tool that declares only ONE of the two attributes must
+            // carry exactly that one. Asserting the exact value (not "not null") so a copy
+            // wired to the wrong accessor cannot satisfy it.
+            var tool = await GetTool("skill-tool-description-only");
+
+            tool.SkillDescription.ShouldBe(SkillAnnotatedToolClass.DescriptionOnlyDescription);
+            tool.SkillBody.ShouldBeNull();
+        }
+
+        [Fact]
+        public async Task ListTool_CopiesSkillBody_IndependentlyOfSkillDescription()
+        {
+            var tool = await GetTool("skill-tool-body-only");
+
+            tool.SkillBody.ShouldBe(SkillAnnotatedToolClass.BodyOnlyBody);
+            tool.SkillDescription.ShouldBeNull();
+        }
+
+        [Fact]
+        public async Task ListTool_LeavesSkillMetadataNull_WhenNoAttributes()
+        {
+            // The "nothing happened" half. Its same-fixture positive control is
+            // ListTool_CopiesSkill*_WhenAttributePresent above, which proves the copy path
+            // is live for this very builder — so a null here means "no attribute", not
+            // "the projection never ran".
+            var tool = await GetTool("skill-tool-none");
+
+            tool.Name.ShouldBe("skill-tool-none");   // positive artifact: the tool WAS projected
+            tool.Title.ShouldBe("Tool With No Skill Attributes");
+            tool.SkillDescription.ShouldBeNull();
+            tool.SkillBody.ShouldBeNull();
+        }
+    }
+}

--- a/McpPlugin.Tests/Serialization/ResponseListToolSkillWireTests.cs
+++ b/McpPlugin.Tests/Serialization/ResponseListToolSkillWireTests.cs
@@ -1,0 +1,175 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+using System.Text.Json;
+using com.IvanMurzak.McpPlugin.Common;
+using com.IvanMurzak.McpPlugin.Common.Model;
+using com.IvanMurzak.ReflectorNet;
+using Microsoft.AspNetCore.SignalR;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.Tests.Serialization
+{
+    /// <summary>
+    /// <c>ResponseListTool</c> travels plugin → server over the SignalR hub, so its new
+    /// skill members are only useful if they survive THAT serializer — not the ambient
+    /// <c>JsonSerializerOptions</c> a hand-rolled test would reach for.
+    /// <para>
+    /// The options here are built by the production
+    /// <see cref="SignalR_JsonConfiguration.ConfigureJsonSerializer"/> exactly as
+    /// <c>HubConnectionProvider</c> (plugin side) and <c>ExtensionsMcpServerBuilder</c>
+    /// (server side) build them. That configuration copies
+    /// <c>DefaultIgnoreCondition</c> / <c>PropertyNamingPolicy</c> / <c>WriteIndented</c>
+    /// / converters — but NOT <c>IncludeFields</c>, which is why the DTO members must be
+    /// PROPERTIES. A field compiles, satisfies every in-process assertion, and then
+    /// silently vanishes on the wire; the transport tests below are what catch that.
+    /// </para>
+    /// </summary>
+    public class ResponseListToolSkillWireTests
+    {
+        const string SkillDescriptionText = "Creates a primitive object in the scene";
+        const string SkillBodyText = "# GameObject create\n\nUse `path` to nest the new object.";
+
+        static JsonSerializerOptions HubPayloadOptions()
+        {
+            var options = new JsonHubProtocolOptions();
+            SignalR_JsonConfiguration.ConfigureJsonSerializer(new Reflector(), options);
+            return options.PayloadSerializerOptions;
+        }
+
+        /// <summary>Resolves the on-the-wire member name under the hub's naming policy.</summary>
+        static string WireName(JsonSerializerOptions options, string clrName)
+            => options.PropertyNamingPolicy?.ConvertName(clrName) ?? clrName;
+
+        [Fact]
+        public void HubSerializer_TransportsSkillDescription()
+        {
+            var options = HubPayloadOptions();
+            var source = new ResponseListTool
+            {
+                Name = "gameobject-create",
+                InputSchema = Consts.MCP.EmptyInputSchema,
+                SkillDescription = SkillDescriptionText
+            };
+
+            var json = JsonSerializer.Serialize(source, options);
+
+            // Positive artifact on the WIRE, not merely on the round-tripped object: a
+            // field-instead-of-property member is absent here even though the CLR object
+            // that produced it held the value.
+            using (var doc = JsonDocument.Parse(json))
+            {
+                doc.RootElement
+                    .TryGetProperty(WireName(options, nameof(ResponseListTool.SkillDescription)), out var emitted)
+                    .ShouldBeTrue($"skill description must be emitted on the hub payload. Payload was: {json}");
+                emitted.GetString().ShouldBe(SkillDescriptionText);
+            }
+
+            var roundTripped = JsonSerializer.Deserialize<ResponseListTool>(json, options);
+            roundTripped.ShouldNotBeNull();
+            roundTripped!.SkillDescription.ShouldBe(SkillDescriptionText);
+        }
+
+        [Fact]
+        public void HubSerializer_TransportsSkillBody()
+        {
+            var options = HubPayloadOptions();
+            var source = new ResponseListTool
+            {
+                Name = "gameobject-create",
+                InputSchema = Consts.MCP.EmptyInputSchema,
+                SkillBody = SkillBodyText
+            };
+
+            var json = JsonSerializer.Serialize(source, options);
+
+            using (var doc = JsonDocument.Parse(json))
+            {
+                doc.RootElement
+                    .TryGetProperty(WireName(options, nameof(ResponseListTool.SkillBody)), out var emitted)
+                    .ShouldBeTrue($"skill body must be emitted on the hub payload. Payload was: {json}");
+                emitted.GetString().ShouldBe(SkillBodyText);
+            }
+
+            var roundTripped = JsonSerializer.Deserialize<ResponseListTool>(json, options);
+            roundTripped.ShouldNotBeNull();
+            roundTripped!.SkillBody.ShouldBe(SkillBodyText);
+        }
+
+        [Fact]
+        public void HubSerializer_OmitsSkillMembers_WhenAbsent()
+        {
+            var options = HubPayloadOptions();
+            var source = new ResponseListTool
+            {
+                Name = "gameobject-create",
+                InputSchema = Consts.MCP.EmptyInputSchema
+            };
+
+            var json = JsonSerializer.Serialize(source, options);
+
+            using var doc = JsonDocument.Parse(json);
+
+            // Control: this payload really was produced (so the two absences below are a
+            // statement about the skill members, not about an empty document).
+            doc.RootElement
+                .TryGetProperty(WireName(options, nameof(ResponseListTool.Name)), out var name)
+                .ShouldBeTrue($"the payload must carry the tool name. Payload was: {json}");
+            name.GetString().ShouldBe("gameobject-create");
+
+            // OMITTED, not emitted-as-null: a `"SkillDescription": null` member would make
+            // TryGetProperty succeed with JsonValueKind.Null, so this distinguishes the two.
+            doc.RootElement
+                .TryGetProperty(WireName(options, nameof(ResponseListTool.SkillDescription)), out _)
+                .ShouldBeFalse($"absent skill description must not reach the wire at all. Payload was: {json}");
+            doc.RootElement
+                .TryGetProperty(WireName(options, nameof(ResponseListTool.SkillBody)), out _)
+                .ShouldBeFalse($"absent skill body must not reach the wire at all. Payload was: {json}");
+        }
+
+        [Fact]
+        public void HubSerializer_ReadsOldShapePayload_WithoutSkillMembers()
+        {
+            // Backward tolerance: a plugin built before this change sends a payload with
+            // neither member. The server must still materialise the tool.
+            var options = HubPayloadOptions();
+            var oldShape =
+                "{\"" + WireName(options, nameof(ResponseListTool.Name)) + "\":\"gameobject-create\"," +
+                "\"" + WireName(options, nameof(ResponseListTool.Enabled)) + "\":true," +
+                "\"" + WireName(options, nameof(ResponseListTool.Description)) + "\":\"legacy\"}";
+
+            var parsed = JsonSerializer.Deserialize<ResponseListTool>(oldShape, options);
+
+            parsed.ShouldNotBeNull();
+            parsed!.Name.ShouldBe("gameobject-create");
+            parsed.Description.ShouldBe("legacy");
+            parsed.Enabled.ShouldBeTrue();
+            parsed.SkillDescription.ShouldBeNull();
+            parsed.SkillBody.ShouldBeNull();
+        }
+
+        [Fact]
+        public void HubSerializer_IgnoresUnknownMembers_SoNewKeysAreForwardTolerant()
+        {
+            // Forward tolerance: the mirror of the case above. An OLDER peer deserializing a
+            // payload that carries members it does not know must not throw — which is what
+            // makes adding the two skill members a non-breaking wire change.
+            var options = HubPayloadOptions();
+            var newerShape =
+                "{\"" + WireName(options, nameof(ResponseListTool.Name)) + "\":\"gameobject-create\"," +
+                "\"someMemberFromAFuturePeer\":\"value\"}";
+
+            var parsed = JsonSerializer.Deserialize<ResponseListTool>(newerShape, options);
+
+            parsed.ShouldNotBeNull();
+            parsed!.Name.ShouldBe("gameobject-create");
+        }
+    }
+}

--- a/McpPlugin.Tests/Serialization/ResponseListToolSkillWireTests.cs
+++ b/McpPlugin.Tests/Serialization/ResponseListToolSkillWireTests.cs
@@ -61,9 +61,8 @@ namespace com.IvanMurzak.McpPlugin.Tests.Serialization
 
             var json = JsonSerializer.Serialize(source, options);
 
-            // Positive artifact on the WIRE, not merely on the round-tripped object: a
-            // field-instead-of-property member is absent here even though the CLR object
-            // that produced it held the value.
+            // Positive artifact on the WIRE, not merely on the round-tripped object (the
+            // class summary above states why that distinction is the point of this file).
             using (var doc = JsonDocument.Parse(json))
             {
                 doc.RootElement
@@ -140,9 +139,13 @@ namespace com.IvanMurzak.McpPlugin.Tests.Serialization
             // Backward tolerance: a plugin built before this change sends a payload with
             // neither member. The server must still materialise the tool.
             var options = HubPayloadOptions();
+            // `Enabled` is carried as FALSE on purpose. The member defaults to `true`, so
+            // asserting it deserializes to `true` is satisfied by the initializer and holds
+            // under every mutation, including one that stops binding the member at all.
+            // `false` is the only value in the domain that distinguishes a real bind.
             var oldShape =
                 "{\"" + WireName(options, nameof(ResponseListTool.Name)) + "\":\"gameobject-create\"," +
-                "\"" + WireName(options, nameof(ResponseListTool.Enabled)) + "\":true," +
+                "\"" + WireName(options, nameof(ResponseListTool.Enabled)) + "\":false," +
                 "\"" + WireName(options, nameof(ResponseListTool.Description)) + "\":\"legacy\"}";
 
             var parsed = JsonSerializer.Deserialize<ResponseListTool>(oldShape, options);
@@ -150,7 +153,7 @@ namespace com.IvanMurzak.McpPlugin.Tests.Serialization
             parsed.ShouldNotBeNull();
             parsed!.Name.ShouldBe("gameobject-create");
             parsed.Description.ShouldBe("legacy");
-            parsed.Enabled.ShouldBeTrue();
+            parsed.Enabled.ShouldBeFalse();
             parsed.SkillDescription.ShouldBeNull();
             parsed.SkillBody.ShouldBeNull();
         }

--- a/McpPlugin/src/Mcp/McpSystemToolManager.cs
+++ b/McpPlugin/src/Mcp/McpSystemToolManager.cs
@@ -116,6 +116,11 @@ namespace com.IvanMurzak.McpPlugin
                 var result = _tools
                     .Select(kvp =>
                     {
+                        // SkillDescription / SkillBody are deliberately NOT copied here,
+                        // unlike McpToolManager.RunListTool: system tools are projected only
+                        // by the hand-built REST handler in SystemToolEndpoints, which emits a
+                        // fixed key set and never reaches ExtensionsTool.ToTool(). Copy them
+                        // if a system tool ever has to appear in an MCP tools/list response.
                         var response = new ResponseListTool()
                         {
                             Name = kvp.Value.Name,

--- a/McpPlugin/src/Mcp/McpToolManager.cs
+++ b/McpPlugin/src/Mcp/McpToolManager.cs
@@ -191,6 +191,8 @@ namespace com.IvanMurzak.McpPlugin
                             Enabled = kvp.Value.Enabled,
                             Title = kvp.Value.Title,
                             Description = kvp.Value.Description,
+                            SkillDescription = kvp.Value.SkillDescription,
+                            SkillBody = kvp.Value.SkillBody,
                             InputSchema = kvp.Value.InputSchema.ToJsonElement() ?? Common.Consts.MCP.EmptyInputSchema,
                             ReadOnlyHint = kvp.Value.ReadOnlyHint,
                             DestructiveHint = kvp.Value.DestructiveHint,

--- a/McpPlugin/src/Mcp/Tool/IRunTool.cs
+++ b/McpPlugin/src/Mcp/Tool/IRunTool.cs
@@ -28,6 +28,10 @@ namespace com.IvanMurzak.McpPlugin
         /// When <see langword="null"/>, <see cref="Skills.SkillFileGenerator"/> falls back to <see cref="Description"/>
         /// (truncated to fit the YAML cap).
         /// Sourced from <see cref="AiSkillDescriptionAttribute"/> on the underlying method by default.
+        /// <para>
+        /// PUBLISHED: this value is also copied onto the MCP <c>tools/list</c> entry as the
+        /// <c>_meta.skillDescription</c> key, for every caller — it is not SKILL.md-only.
+        /// </para>
         /// </summary>
         string? SkillDescription { get; }
 
@@ -36,6 +40,12 @@ namespace com.IvanMurzak.McpPlugin
         /// and the <c>## How to Call</c> section. Lets tools ship rich content (code samples, notes) that
         /// would otherwise overflow the YAML <c>description:</c> cap.
         /// Sourced from <see cref="AiSkillBodyAttribute"/> on the underlying method by default.
+        /// <para>
+        /// PUBLISHED: this value is also copied onto the MCP <c>tools/list</c> entry as the
+        /// <c>_meta.skillBody</c> key, for every caller — it is not SKILL.md-only. It is
+        /// uncapped on that path, so keep it to content that is safe and sensible to send to
+        /// every connected MCP client.
+        /// </para>
         /// </summary>
         string? SkillBody { get; }
 

--- a/McpPlugin/src/Mcp/Tool/ProxyTool.cs
+++ b/McpPlugin/src/Mcp/Tool/ProxyTool.cs
@@ -100,8 +100,12 @@ namespace com.IvanMurzak.McpPlugin
         /// <param name="name">Unique tool name. Required.</param>
         /// <param name="title">Human-readable title. Optional.</param>
         /// <param name="description">Tool description shown to the AI client. Optional.</param>
-        /// <param name="skillDescription">Optional concise SKILL.md description override.</param>
-        /// <param name="skillBody">Optional long-form SKILL.md body.</param>
+        /// <param name="skillDescription">Optional concise skill blurb. Feeds the SKILL.md YAML
+        /// <c>description:</c> field AND the <c>tools/list</c> <c>_meta.skillDescription</c> key,
+        /// which reaches every MCP client. Optional.</param>
+        /// <param name="skillBody">Optional long-form skill markdown. Feeds the SKILL.md body AND
+        /// the <c>tools/list</c> <c>_meta.skillBody</c> key, which reaches every MCP client — so
+        /// keep it to content that is safe to publish. Optional.</param>
         /// <param name="inputSchema">JSON Schema for the tool inputs, supplied externally. Optional.</param>
         /// <param name="outputSchema">JSON Schema for the tool output, supplied externally. Optional.</param>
         /// <param name="readOnlyHint">MCP read-only behavior hint. Optional.</param>

--- a/McpPlugin/src/Mcp/Tool/RunTool.cs
+++ b/McpPlugin/src/Mcp/Tool/RunTool.cs
@@ -40,7 +40,8 @@ namespace com.IvanMurzak.McpPlugin
         /// <summary>
         /// Reads <see cref="AiSkillDescriptionAttribute"/> from the underlying method, if present.
         /// Used by <see cref="Skills.SkillFileGenerator"/> in place of <see cref="MethodWrapper.Description"/>
-        /// when building the SKILL.md YAML <c>description:</c> field.
+        /// when building the SKILL.md YAML <c>description:</c> field, AND copied onto the MCP
+        /// <c>tools/list</c> entry as <c>_meta.skillDescription</c> — see <see cref="IRunTool.SkillDescription"/>.
         /// </summary>
         /// <remarks>
         /// Uses the plural <c>GetCustomAttributes</c> overload so that a method carrying BOTH
@@ -56,7 +57,8 @@ namespace com.IvanMurzak.McpPlugin
         /// <summary>
         /// Reads <see cref="AiSkillBodyAttribute"/> from the underlying method, if present.
         /// Used by <see cref="Skills.SkillFileGenerator"/> to inject long-form markdown into the SKILL.md body
-        /// between the description paragraph and the <c>## How to Call</c> section.
+        /// between the description paragraph and the <c>## How to Call</c> section, AND copied onto the
+        /// MCP <c>tools/list</c> entry as <c>_meta.skillBody</c> — see <see cref="IRunTool.SkillBody"/>.
         /// </summary>
         /// <remarks>
         /// Uses the plural <c>GetCustomAttributes</c> overload so that a method carrying BOTH

--- a/McpPlugin/src/McpPlugin/Attribute/Tool/AiSkillBodyAttribute.cs
+++ b/McpPlugin/src/McpPlugin/Attribute/Tool/AiSkillBodyAttribute.cs
@@ -18,8 +18,10 @@ namespace com.IvanMurzak.McpPlugin
     /// usage notes, suggestions) that would otherwise blow past the 1024-character cap on the YAML
     /// <c>description:</c> field.
     /// <para>
-    /// This text is <b>not</b> written into the YAML front-matter and does <b>not</b> affect the MCP
-    /// <c>tools/list</c> payload — it only enriches the generated SKILL.md.
+    /// This text is <b>not</b> written into the YAML front-matter, but it DOES reach the MCP
+    /// <c>tools/list</c> payload: the server emits it as the <c>_meta.skillBody</c> key on the
+    /// tool's list entry, for every caller — see <c>ExtensionsListMeta.BuildToolMeta</c>.
+    /// Keep it to content that is safe to publish to any connected MCP client.
     /// </para>
     /// </summary>
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false, Inherited = true)]

--- a/McpPlugin/src/McpPlugin/Attribute/Tool/AiSkillDescriptionAttribute.cs
+++ b/McpPlugin/src/McpPlugin/Attribute/Tool/AiSkillDescriptionAttribute.cs
@@ -19,7 +19,10 @@ namespace com.IvanMurzak.McpPlugin
     /// front-matter, decorate the same tool method with this attribute to provide a short summary.
     /// <para>
     /// The original <see cref="System.ComponentModel.DescriptionAttribute"/> remains the source of truth
-    /// for the MCP <c>tools/list</c> payload that AI agents see; this attribute only controls the YAML field.
+    /// for the tool's <c>description</c> in the MCP <c>tools/list</c> payload. This attribute controls the
+    /// YAML field AND is surfaced beside it as the <c>_meta.skillDescription</c> key on the tool's
+    /// <c>tools/list</c> entry, for every caller — see <c>ExtensionsListMeta.BuildToolMeta</c>,
+    /// so keep it to content that is safe to publish to any connected MCP client.
     /// </para>
     /// </summary>
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false, Inherited = true)]


### PR DESCRIPTION
Implements Taskflow `2026-08-28-tool-catalog` task **a1-wire-meta** (02 §T1 — wire bridge).
Tracked on the Taskflow board, not on a GitHub issue (matching PRs #211/#212/#213).

## Summary

- **`tools/list` now carries each tool's skill metadata as `_meta.skillDescription` / `_meta.skillBody`** (plain, un-namespaced keys, matching the existing `_meta.enabled` precedent), sourced from the already-existing `IRunTool.SkillDescription` / `IRunTool.SkillBody` accessors. No attribute work — `[AiSkillDescription]` / `[AiSkillBody]` already existed; they simply never reached the wire.
- **`ResponseListTool` gains two optional members — declared as PROPERTIES, deliberately not fields.** `SignalR_JsonConfiguration` copies `DefaultIgnoreCondition` / `PropertyNamingPolicy` / `WriteIndented` / converters but **not `IncludeFields`**, so a field would compile, satisfy every in-process assertion, and silently vanish on the hub payload. There is a dedicated plant for exactly that mutation (A3/A4 below).
- **`ExtensionsListMeta.BuildToolMeta(ResponseListTool)` composes on top of `BuildEnabledMeta` rather than changing it.** `BuildEnabledMeta` returns `null` for enabled primitives and its result is assigned wholesale by four call sites; the three non-tool ones (`ExtensionsPrompt`, `ExtensionsListResources`, `ExtensionsListResourceTemplates`) are untouched and stay byte-identical. Only `ExtensionsTool.ToTool()` uses the composing helper.
- **Additive and `ApiVersion`-neutral.** `Consts.ApiVersion` stays `"2.0.0"` (unchanged — it is a hard equality gate that disconnects mismatched pairs). Absent values are *omitted*, not null-emitted; unknown members are tolerated in both directions. No `<Version>` bump, no ReflectorNet pin change, no change to `ProxyTool`'s public ctor.

An enabled tool with no skill attributes still produces `Meta == null` — today's exact wire shape for every existing third-party client.

## Test plan

- [x] Target-specific local tests passed (see profile test.md) — Suite 1, solution-level, Release: **4/4 test hosts `Test Run Successful.`, 0 `Test Run Failed.`**, 979 + 979 (`McpPlugin.Tests`, net8.0/net9.0) and 754 + 754 (`McpPlugin.Server.Tests`, net8.0/net9.0) = **3,466 passed, 0 failed**. The known machine-load flake (`ConnectionManagerTests.Connect_ThreadSafety_NoRaceConditionsUnderLoad`) did not fire.
- [x] `dotnet restore` → `dotnet build --no-restore --configuration Release`: 0 errors, 8 warnings (all pre-existing `CS8604` in `McpPlugin.Tests`, unchanged count vs. the base tree).

### New coverage

| Where | What it pins |
|---|---|
| `McpPlugin.Tests/Serialization/ResponseListToolSkillWireTests.cs` | Round-trip through the **real** hub payload options (built by `SignalR_JsonConfiguration.ConfigureJsonSerializer`, exactly as `HubConnectionProvider` / `ExtensionsMcpServerBuilder` build them): both values transported, both **omitted** (not null-emitted) when absent, an old-shape payload without them deserializes cleanly, and unknown members stay ignored. |
| `McpPlugin.Tests/Mcp/McpBuilderTests_ToolSkillMetadata.cs` | `McpToolManager.RunListTool` copies each accessor into the DTO — one test per independent half, plus the both-absent case whose same-fixture positive control is the copy tests above it. |
| `McpPlugin.Server.Tests/ToolListSkillMetaTests.cs` | `ToTool()` `_meta` composition across all four combinations of enabled × attributed, blank-string treated as absent, and `BuildEnabledMeta` still emitting exactly the `enabled` key. |
| `McpPlugin.Server.Tests/TrustedInternalClientTests.cs` (updated) | The two pinned `BuildEnabledMeta` / `ToTool` tests keep the null-when-enabled contract, now each asserting the key **count** so a leak of skill keys into the shared helper reddens them. |

### Plant round — 18/18 RED, 0 GREEN, restore-failures 0

*(Re-run against the final tree by `03-refine`, extended 13 → 18. Collected count
constant per surface — 10 client / 28 server — so no RED came from an import break.)*

Two surfaces (they take different verify commands), every RED attributed from its own per-plant log; all thirteen failure **sets** are distinct, and the collected-test count was constant within each surface (10 client / 26 server) so no RED came from an import break.

`--verify-cmd`: `dotnet build --no-restore --configuration Release && dotnet test <project> --no-build --configuration Release --filter "…"` — the build is inside the `&&` chain, so no plant scored against the previous plant's assemblies.

| # | Mutation | Reddened (exactly) |
|---|---|---|
| A1 | `McpToolManager` stops copying `SkillDescription` | `ListTool_CopiesSkillDescription_WhenAttributePresent`, `…_IndependentlyOfSkillBody` |
| A2 | `McpToolManager` stops copying `SkillBody` | `ListTool_CopiesSkillBody_WhenAttributePresent`, `…_IndependentlyOfSkillDescription` |
| A3 | `SkillDescription` property → **field** | `HubSerializer_TransportsSkillDescription` |
| A4 | `SkillBody` property → **field** | `HubSerializer_TransportsSkillBody` |
| A5 | Hub serializer stops copying `DefaultIgnoreCondition` | `HubSerializer_OmitsSkillMembers_WhenAbsent` |
| A6 | `SkillDescription` defaults to `""` instead of `null` | `HubSerializer_ReadsOldShapePayload_WithoutSkillMembers`, `…_OmitsSkillMembers_WhenAbsent` |
| A7 | Hub serializer set to `UnmappedMemberHandling.Disallow` | `HubSerializer_IgnoresUnknownMembers_SoNewKeysAreForwardTolerant` |
| B1 | `BuildToolMeta` drops the `skillDescription` block | 4 tests incl. `ToTool_EmitsOnlySkillDescription_WhenBodyAbsent` |
| B2 | `BuildToolMeta` drops the `skillBody` block | 3 tests incl. `ToTool_EmitsOnlySkillBody_WhenDescriptionAbsent` |
| B3 | `BuildToolMeta` always returns an object | `ToTool_OmitsMetaEntirely_…`, `ToTool_TreatsBlankSkillMetadataAsAbsent`, `TrustedInternalClientTests.ToTool_OmitsMeta_WhenEnabled` |
| B4 | `ToTool` reverts to `BuildEnabledMeta(response.Enabled)` | all 4 skill-emission tests |
| B5 | `BuildEnabledMeta` gains a skill key (the forbidden edit) | `BuildEnabledMeta_StillEmitsExactlyTheEnabledKey` + 3 pinned tests |
| B6 | `BuildToolMeta` treats blank as present (`!= null`) | `ToTool_TreatsBlankSkillMetadataAsAbsent` |

| N1 | `SkillDescriptionKey`'s VALUE renamed | `SkillMetaKeys_AreTheLiteralWireNames` |
| N2 | `SkillBodyKey`'s VALUE renamed | `SkillMetaKeys_AreTheLiteralWireNames` |
| N3 | `skillBody` guard harmonized to `IsNullOrWhiteSpace` | `ToTool_RelaysWhitespaceOnlySkillBody_…` |
| N4 | `Enabled` stops deserializing (`[JsonIgnore]`) | `HubSerializer_ReadsOldShapePayload_WithoutSkillMembers` |
| N5 | `BuildToolMeta` emits the two keys in reverse order | `ToTool_EmitsBothSkillKeys_…`, `ToTool_CombinesEnabledFalseWithSkillKeys_…` |

A3/A4 are the trap the DoD names: they leave every in-process test green and redden **only** the hub-serializer test.
N1/N2 share one marker test but fail on **different assertion halves** (confirmed from each
per-plant log), which is why they are two plants and not one.


## Recorded caveats (found by review, deliberately NOT changed here)

Each of these is real and verified; none is in this task's ruled scope, so they are
recorded rather than fixed. The first two are the ones worth an owner decision.

- **`_meta` is no longer trusted-client-only, and `skillBody` is uncapped.** Any client
  now receives `_meta.skillDescription` / `_meta.skillBody` for attributed tools. Measured
  against the largest real consumer (Unity-MCP, ~115 `[AiTool]`): **+62,535 characters per
  `tools/list`** (48,122 of bodies + 14,413 of blurbs), roughly **+65%** on the catalogue's
  human-readable text, crossing two hops and re-paid per session and per `list_changed`.
  Nothing truncates it (`SkillFileGenerator.MaxSkillDescriptionLength` bounds SKILL.md only);
  the transport tolerates it (`MaximumReceiveMessageSize` = 128 MB). If that is not wanted,
  the natural gate already exists one function away — `McpSessionTokenContext.IsTrustedInternalClient`
  — but gating would contradict the DoD, so it is not done here.
- **`ToolTokenCount.Calculate` does not see the new members**, so `EnabledToolsTokenCount`
  — this repo's own measure of catalogue weight — now under-reports the transferred catalogue
  by ~15.6k tokens for Unity-MCP. It is the one metric that would have bounded the growth above.
- **Three shipped docs asserted the opposite of this change** and are corrected in this PR:
  both skill attributes, `IRunTool`/`RunTool`/`ProxyTool`'s member docs, and
  `Consts.MCP.Server.Headers.TrustedInternalClient` (which promised untrusted callers that
  "no `_meta` is emitted by this server").
- **`McpSystemToolManager.RunListSystemTool`** is a verbatim twin of `McpToolManager.RunListTool`
  and deliberately does *not* copy the two members — system tools are projected only by the
  hand-built REST handler. Now recorded in a comment at the omission site. Extracting the shared
  projection is the real fix and is out of scope.
- **The REST list handlers** (`DirectToolCallEndpoints`, `SystemToolEndpoints`) build a fixed key
  set and do not surface the skill members, so `GET /tools` and MCP `tools/list` now describe the
  same tool differently. Pre-existing pattern (they also drop `ReadOnlyHint` / `OutputSchema`).
- **`RunTool.SkillDescription` / `SkillBody` do an uncached `GetCustomAttributes` on every get**,
  and this change puts them on the per-`tools/list` path (~230 lookups per list for Unity-MCP).
  In-repo precedent for caching exists (`_cachedTokenCount`, `_paramNameLookup`); deferred because
  it is outside the named seams and deserves its own measurement.
- **`ToolListSkillMetaTests` overlaps three tests in `TrustedInternalClientTests`.** Reviewers
  flagged the duplication; kept deliberately, because those three are the enabled x attributed
  truth table's baseline rows — deleting them would leave the new file's coverage matrix
  incomplete — and two of them are plant markers.
- **`skillDescription` / `skillBody` carry no vendor prefix.** Checked against the MCP spec
  (2025-06-18 and 2025-11-25): un-prefixed names are legal, only `mcp`/`modelcontextprotocol`
  prefixes are reserved. Matches the existing `enabled` precedent, which the DoD fixes.

## Notes for the reviewer

- All `file:line` citations from the plan were re-verified against **`origin/main` = tag `8.3.0` = `ebafe1e`** (planning was done at 8.2.0). `McpToolManager.cs:188-198`, `ExtensionsTool.cs:82`, `ExtensionsListMeta.cs:52-53` and `Consts.cs:14` all still hold.
- `docs/` needs no update: there is no `architecture-protocol.md` in this repo and no `docs/` or `specs/` file mentions `_meta` (grep: 0 hits). The downstream app-side ingestion of these keys is Taskflow task T3, in a different repo.

