### PR TITLE
a2: provenance marker in generated SKILL.md front matter

### DIFF
--- a/McpPlugin.Tests/Mcp/McpPluginSkillContentTests.cs
+++ b/McpPlugin.Tests/Mcp/McpPluginSkillContentTests.cs
@@ -205,6 +205,10 @@ namespace com.IvanMurzak.McpPlugin.Tests.Mcp
             // The provenance marker is part of the front-matter block, so it sits BEFORE the
             // closing '---'. Asserted un-trimmed on the nested key to pin its two-space indent,
             // which is what makes it a YAML mapping rather than a sibling scalar.
+            // These are LITERALS on purpose, not SkillFileGenerator's own constants: the on-disk
+            // bytes are the contract a front-matter reader parses, so a changed constant must
+            // redden this rather than move with it. SkillFileGeneratorProvenanceTests spells the
+            // same two literals for the same reason — a marker-format change touches both.
             lines[3].ShouldBe("metadata:");
             lines[4].ShouldBe("  generated-by: mcp-plugin-dotnet");
             lines[5].ShouldBe("---");

--- a/McpPlugin.Tests/Mcp/McpPluginSkillContentTests.cs
+++ b/McpPlugin.Tests/Mcp/McpPluginSkillContentTests.cs
@@ -197,11 +197,17 @@ namespace com.IvanMurzak.McpPlugin.Tests.Mcp
             generator.Generate(skills, _tempDir);
 
             var content = File.ReadAllText(Path.Combine(_tempDir, "test-skill", "SKILL.md"));
-            var lines = content.Split('\n');
-            lines[0].Trim().ShouldBe("---");
-            lines[1].Trim().ShouldBe("name: test-skill");
-            lines[2].Trim().ShouldBe("description: Test description");
-            lines[3].Trim().ShouldBe("---");
+            // Normalize CRLF so the indent assertions below compare content, not line endings.
+            var lines = content.Replace("\r\n", "\n").Split('\n');
+            lines[0].ShouldBe("---");
+            lines[1].ShouldBe("name: test-skill");
+            lines[2].ShouldBe("description: Test description");
+            // The provenance marker is part of the front-matter block, so it sits BEFORE the
+            // closing '---'. Asserted un-trimmed on the nested key to pin its two-space indent,
+            // which is what makes it a YAML mapping rather than a sibling scalar.
+            lines[3].ShouldBe("metadata:");
+            lines[4].ShouldBe("  generated-by: mcp-plugin-dotnet");
+            lines[5].ShouldBe("---");
         }
 
         // ── Deletion ────────────────────────────────────────────────────────

--- a/McpPlugin.Tests/Skills/SkillFileGeneratorProvenanceTests.cs
+++ b/McpPlugin.Tests/Skills/SkillFileGeneratorProvenanceTests.cs
@@ -1,0 +1,300 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.Common.Model;
+using com.IvanMurzak.McpPlugin.Skills;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.Tests.Skills
+{
+    /// <summary>
+    /// Pins the provenance marker stamped into every generated SKILL.md front-matter, in BOTH
+    /// emission paths (tool skills and custom skill-content skills), plus the two properties a
+    /// consumer relies on when it uses the marker to de-duplicate generated skills: regeneration
+    /// is byte-stable, and a skill file the generator does not own is never rewritten.
+    /// </summary>
+    public class SkillFileGeneratorProvenanceTests : IDisposable
+    {
+        // Literal expectations, deliberately NOT built from SkillFileGenerator's own constants:
+        // this is the on-disk contract a front-matter reader parses, so a changed constant must
+        // redden these tests rather than move with them.
+        const string MarkerBlockLine = "metadata:";
+        const string MarkerEntryLine = "  generated-by: mcp-plugin-dotnet";
+
+        const string Host = "http://localhost:8080";
+
+        readonly string _tempDir;
+
+        public SkillFileGeneratorProvenanceTests()
+        {
+            _tempDir = Path.Combine(Path.GetTempPath(), $"SkillFileGeneratorProvenanceTests_{Guid.NewGuid():N}");
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(_tempDir))
+                Directory.Delete(_tempDir, recursive: true);
+        }
+
+        // ── Marker present, in the front matter, in BOTH emission paths ──────────
+
+        [Fact]
+        public void Generate_Tool_StampsMarkerInsideFrontMatter()
+        {
+            var generator = new SkillFileGenerator();
+            var tool = new MockRunTool { Name = "marked-tool", Description = "A tool." };
+
+            generator.Generate(new[] { tool }, _tempDir, Host).ShouldBeTrue();
+
+            var lines = ReadLines(Path.Combine(_tempDir, "marked-tool", "SKILL.md"));
+            var frontMatter = FrontMatter(lines);
+
+            frontMatter.ShouldContain(MarkerBlockLine);
+            frontMatter.ShouldContain(MarkerEntryLine);
+            // Order matters for YAML: the nested entry must directly follow its block key.
+            frontMatter.IndexOf(MarkerEntryLine).ShouldBe(frontMatter.IndexOf(MarkerBlockLine) + 1);
+        }
+
+        [Fact]
+        public void Generate_SkillContent_StampsMarkerInsideFrontMatter()
+        {
+            var generator = new SkillFileGenerator();
+            var skill = new SkillContent("marked-skill", "A skill.", "# Marked\n\nBody.\n");
+
+            generator.Generate(new[] { skill }, _tempDir).ShouldBeTrue();
+
+            var lines = ReadLines(Path.Combine(_tempDir, "marked-skill", "SKILL.md"));
+            var frontMatter = FrontMatter(lines);
+
+            frontMatter.ShouldContain(MarkerBlockLine);
+            frontMatter.ShouldContain(MarkerEntryLine);
+            frontMatter.IndexOf(MarkerEntryLine).ShouldBe(frontMatter.IndexOf(MarkerBlockLine) + 1);
+        }
+
+        [Fact]
+        public void Generate_Tool_StampsMarkerExactlyOnce()
+        {
+            var generator = new SkillFileGenerator();
+            var tool = new MockRunTool { Name = "once-tool" };
+
+            generator.Generate(new[] { tool }, _tempDir, Host).ShouldBeTrue();
+
+            var lines = ReadLines(Path.Combine(_tempDir, "once-tool", "SKILL.md"));
+            CountOf(lines, MarkerEntryLine).ShouldBe(1);
+        }
+
+        [Fact]
+        public void Generate_SkillContent_StampsMarkerExactlyOnce()
+        {
+            var generator = new SkillFileGenerator();
+            var skill = new SkillContent("once-skill", "A skill.", "Body");
+
+            generator.Generate(new[] { skill }, _tempDir).ShouldBeTrue();
+
+            var lines = ReadLines(Path.Combine(_tempDir, "once-skill", "SKILL.md"));
+            CountOf(lines, MarkerEntryLine).ShouldBe(1);
+        }
+
+        /// <summary>
+        /// A multi-line description is emitted as a YAML literal block scalar (<c>|-</c>) whose body
+        /// lines are indented by two spaces — the same indent the marker's nested entry uses. The
+        /// marker must therefore stay a TOP-LEVEL front-matter key: its block line at column 0 is
+        /// what terminates the block scalar. Without that, a reader parses the marker as description
+        /// text and the skill reads as user-authored.
+        /// </summary>
+        [Fact]
+        public void Generate_Tool_MarkerIsTopLevelEvenAfterABlockScalarDescription()
+        {
+            var generator = new SkillFileGenerator();
+            var tool = new MockRunTool
+            {
+                Name = "multiline-tool",
+                Description = "First line of the description.\nSecond line.\nThird line."
+            };
+
+            generator.Generate(new[] { tool }, _tempDir, Host).ShouldBeTrue();
+
+            var lines = ReadLines(Path.Combine(_tempDir, "multiline-tool", "SKILL.md"));
+            var frontMatter = FrontMatter(lines);
+
+            // Positive control: the fixture really did produce a block scalar, so the block-scalar
+            // hazard this test exists for is actually present.
+            frontMatter.ShouldContain("description: |-");
+            frontMatter.ShouldContain("  Second line.");
+
+            // The marker's block key sits at column 0 (closing the block scalar) and its entry
+            // directly follows.
+            frontMatter.ShouldContain(MarkerBlockLine);
+            frontMatter.IndexOf(MarkerEntryLine).ShouldBe(frontMatter.IndexOf(MarkerBlockLine) + 1);
+        }
+
+        // ── Idempotence ──────────────────────────────────────────────────────────
+
+        [Fact]
+        public void Generate_Tool_RegeneratingOverAnExistingDirectoryIsByteStable()
+        {
+            var generator = new SkillFileGenerator();
+            var tool = new MockRunTool { Name = "stable-tool", Description = "A tool." };
+            var filePath = Path.Combine(_tempDir, "stable-tool", "SKILL.md");
+
+            generator.Generate(new[] { tool }, _tempDir, Host).ShouldBeTrue();
+            var first = File.ReadAllBytes(filePath);
+
+            generator.Generate(new[] { tool }, _tempDir, Host).ShouldBeTrue();
+            var second = File.ReadAllBytes(filePath);
+
+            second.ShouldBe(first);
+            // Positive control: the bytes that stayed equal are bytes that carry the marker — an
+            // equality over two empty/marker-free files would prove nothing about this task.
+            CountOf(ReadLines(filePath), MarkerEntryLine).ShouldBe(1);
+        }
+
+        [Fact]
+        public void Generate_SkillContent_RegeneratingOverAnExistingDirectoryIsByteStable()
+        {
+            var generator = new SkillFileGenerator();
+            var skill = new SkillContent("stable-skill", "A skill.", "# Stable\n\nBody.\n");
+            var filePath = Path.Combine(_tempDir, "stable-skill", "SKILL.md");
+
+            generator.Generate(new[] { skill }, _tempDir).ShouldBeTrue();
+            var first = File.ReadAllBytes(filePath);
+
+            generator.Generate(new[] { skill }, _tempDir).ShouldBeTrue();
+            var second = File.ReadAllBytes(filePath);
+
+            second.ShouldBe(first);
+            CountOf(ReadLines(filePath), MarkerEntryLine).ShouldBe(1);
+        }
+
+        // ── Foreign skill files are left alone ───────────────────────────────────
+
+        [Fact]
+        public void Generate_Tool_LeavesAHandCraftedSkillOfAnotherToolByteIntact()
+        {
+            const string handCrafted =
+                "---\n" +
+                "name: hand-written\n" +
+                "description: Authored by a human, not by this generator.\n" +
+                "---\n" +
+                "\n" +
+                "# Hand Written\n";
+
+            var handCraftedPath = Path.Combine(_tempDir, "hand-written", "SKILL.md");
+            Directory.CreateDirectory(Path.Combine(_tempDir, "hand-written"));
+            File.WriteAllText(handCraftedPath, handCrafted);
+            var before = File.ReadAllBytes(handCraftedPath);
+
+            var generator = new SkillFileGenerator();
+            generator.Generate(new[] { new MockRunTool { Name = "other-tool" } }, _tempDir, Host).ShouldBeTrue();
+
+            // Positive control FIRST: the generation pass really did run and really did write a
+            // marked file, so the untouched assertion below cannot pass by nothing happening.
+            CountOf(ReadLines(Path.Combine(_tempDir, "other-tool", "SKILL.md")), MarkerEntryLine).ShouldBe(1);
+
+            File.ReadAllBytes(handCraftedPath).ShouldBe(before);
+            CountOf(ReadLines(handCraftedPath), MarkerEntryLine).ShouldBe(0);
+            CountOf(ReadLines(handCraftedPath), MarkerBlockLine).ShouldBe(0);
+        }
+
+        [Fact]
+        public void Generate_SkillContent_LeavesAHandCraftedSkillOfAnotherSkillByteIntact()
+        {
+            const string handCrafted =
+                "---\n" +
+                "name: hand-written-skill\n" +
+                "description: Authored by a human, not by this generator.\n" +
+                "---\n" +
+                "\n" +
+                "# Hand Written Skill\n";
+
+            var handCraftedPath = Path.Combine(_tempDir, "hand-written-skill", "SKILL.md");
+            Directory.CreateDirectory(Path.Combine(_tempDir, "hand-written-skill"));
+            File.WriteAllText(handCraftedPath, handCrafted);
+            var before = File.ReadAllBytes(handCraftedPath);
+
+            var generator = new SkillFileGenerator();
+            generator.Generate(new[] { new SkillContent("other-skill", "A skill.", "Body") }, _tempDir).ShouldBeTrue();
+
+            CountOf(ReadLines(Path.Combine(_tempDir, "other-skill", "SKILL.md")), MarkerEntryLine).ShouldBe(1);
+
+            File.ReadAllBytes(handCraftedPath).ShouldBe(before);
+            CountOf(ReadLines(handCraftedPath), MarkerEntryLine).ShouldBe(0);
+        }
+
+        // ── The published constants describe the bytes actually written ──────────
+
+        [Fact]
+        public void ProvenanceConstants_MatchTheBytesWrittenToDisk()
+        {
+            SkillFileGenerator.ProvenanceBlockKey.ShouldBe("metadata");
+            SkillFileGenerator.ProvenanceKey.ShouldBe("generated-by");
+            SkillFileGenerator.ProvenanceValue.ShouldBe("mcp-plugin-dotnet");
+        }
+
+        // ── helpers ──────────────────────────────────────────────────────────────
+
+        static string[] ReadLines(string path)
+            => File.ReadAllText(path).Replace("\r\n", "\n").Split('\n');
+
+        /// <summary>Returns the lines strictly between the opening and closing <c>---</c>.</summary>
+        static List<string> FrontMatter(string[] lines)
+        {
+            lines.Length.ShouldBeGreaterThan(0);
+            lines[0].ShouldBe("---");
+
+            var result = new List<string>();
+            for (var i = 1; i < lines.Length; i++)
+            {
+                if (lines[i] == "---")
+                    return result;
+                result.Add(lines[i]);
+            }
+
+            throw new InvalidOperationException("SKILL.md front-matter block was never closed by a '---' line.");
+        }
+
+        static int CountOf(string[] lines, string line)
+        {
+            var count = 0;
+            foreach (var candidate in lines)
+                if (candidate == line)
+                    count++;
+            return count;
+        }
+
+        class MockRunTool : IRunTool
+        {
+            public string Name { get; init; } = "mock-tool";
+            public string? Title { get; init; } = "Mock Tool";
+            public string? Description { get; init; } = "A mock tool for testing.";
+            public string? SkillDescription { get; init; }
+            public string? SkillBody { get; init; }
+            public JsonNode? InputSchema { get; init; }
+            public JsonNode? OutputSchema { get; init; }
+            public bool Enabled { get; set; } = true;
+            public bool? ReadOnlyHint => null;
+            public bool? DestructiveHint => null;
+            public bool? IdempotentHint => null;
+            public bool? OpenWorldHint => null;
+            public int TokenCount => 0;
+
+            public Task<ResponseCallTool> Run(string requestId, IReadOnlyDictionary<string, JsonElement>? namedParameters, CancellationToken cancellationToken = default)
+                => throw new NotImplementedException();
+        }
+    }
+}

--- a/McpPlugin.Tests/Skills/SkillFileGeneratorProvenanceTests.cs
+++ b/McpPlugin.Tests/Skills/SkillFileGeneratorProvenanceTests.cs
@@ -23,10 +23,13 @@ using Xunit;
 namespace com.IvanMurzak.McpPlugin.Tests.Skills
 {
     /// <summary>
-    /// Pins the provenance marker stamped into every generated SKILL.md front-matter, in BOTH
-    /// emission paths (tool skills and custom skill-content skills), plus the two properties a
-    /// consumer relies on when it uses the marker to de-duplicate generated skills: regeneration
-    /// is byte-stable, and a skill file the generator does not own is never rewritten.
+    /// Pins the provenance marker the DEFAULT <see cref="SkillFileGenerator"/> stamps into a
+    /// generated SKILL.md front-matter, in BOTH emission paths (tool skills and custom
+    /// skill-content skills), plus the two properties a consumer relies on when it uses the marker
+    /// to de-duplicate generated skills: regeneration is byte-stable, and a skill file the
+    /// generator does not own is never rewritten. A subclass that replaces <c>BuildMarkdown</c> or
+    /// <c>BuildSkillContentMarkdown</c> wholesale is outside this contract — see those methods'
+    /// own documentation.
     /// </summary>
     public class SkillFileGeneratorProvenanceTests : IDisposable
     {
@@ -64,10 +67,7 @@ namespace com.IvanMurzak.McpPlugin.Tests.Skills
             var lines = ReadLines(Path.Combine(_tempDir, "marked-tool", "SKILL.md"));
             var frontMatter = FrontMatter(lines);
 
-            frontMatter.ShouldContain(MarkerBlockLine);
-            frontMatter.ShouldContain(MarkerEntryLine);
-            // Order matters for YAML: the nested entry must directly follow its block key.
-            frontMatter.IndexOf(MarkerEntryLine).ShouldBe(frontMatter.IndexOf(MarkerBlockLine) + 1);
+            MarkerBlockIsExactlyTheProvenanceEntry(frontMatter);
         }
 
         [Fact]
@@ -81,9 +81,7 @@ namespace com.IvanMurzak.McpPlugin.Tests.Skills
             var lines = ReadLines(Path.Combine(_tempDir, "marked-skill", "SKILL.md"));
             var frontMatter = FrontMatter(lines);
 
-            frontMatter.ShouldContain(MarkerBlockLine);
-            frontMatter.ShouldContain(MarkerEntryLine);
-            frontMatter.IndexOf(MarkerEntryLine).ShouldBe(frontMatter.IndexOf(MarkerBlockLine) + 1);
+            MarkerBlockIsExactlyTheProvenanceEntry(frontMatter);
         }
 
         [Fact]
@@ -95,7 +93,7 @@ namespace com.IvanMurzak.McpPlugin.Tests.Skills
             generator.Generate(new[] { tool }, _tempDir, Host).ShouldBeTrue();
 
             var lines = ReadLines(Path.Combine(_tempDir, "once-tool", "SKILL.md"));
-            CountOf(lines, MarkerEntryLine).ShouldBe(1);
+            CountOf(lines, MarkerEntryLine).ShouldBe(1, WholeFile("tool path: provenance entry line", lines));
         }
 
         [Fact]
@@ -107,7 +105,7 @@ namespace com.IvanMurzak.McpPlugin.Tests.Skills
             generator.Generate(new[] { skill }, _tempDir).ShouldBeTrue();
 
             var lines = ReadLines(Path.Combine(_tempDir, "once-skill", "SKILL.md"));
-            CountOf(lines, MarkerEntryLine).ShouldBe(1);
+            CountOf(lines, MarkerEntryLine).ShouldBe(1, WholeFile("skill-content path: provenance entry line", lines));
         }
 
         /// <summary>
@@ -139,8 +137,7 @@ namespace com.IvanMurzak.McpPlugin.Tests.Skills
 
             // The marker's block key sits at column 0 (closing the block scalar) and its entry
             // directly follows.
-            frontMatter.ShouldContain(MarkerBlockLine);
-            frontMatter.IndexOf(MarkerEntryLine).ShouldBe(frontMatter.IndexOf(MarkerBlockLine) + 1);
+            MarkerBlockIsExactlyTheProvenanceEntry(frontMatter);
         }
 
         // ── Idempotence ──────────────────────────────────────────────────────────
@@ -148,40 +145,61 @@ namespace com.IvanMurzak.McpPlugin.Tests.Skills
         [Fact]
         public void Generate_Tool_RegeneratingOverAnExistingDirectoryIsByteStable()
         {
-            var generator = new SkillFileGenerator();
-            var tool = new MockRunTool { Name = "stable-tool", Description = "A tool." };
             var filePath = Path.Combine(_tempDir, "stable-tool", "SKILL.md");
 
-            generator.Generate(new[] { tool }, _tempDir, Host).ShouldBeTrue();
+            // Regeneration in production is a NEW process: a fresh generator over freshly
+            // constructed, equal-valued tool objects. Reusing one generator and one tool instance
+            // would let any per-instance or identity-derived content pass as byte-stable here and
+            // be unstable in the real world.
+            new SkillFileGenerator()
+                .Generate(new[] { new MockRunTool { Name = "stable-tool", Description = "A tool." } }, _tempDir, Host)
+                .ShouldBeTrue();
             var first = File.ReadAllBytes(filePath);
 
-            generator.Generate(new[] { tool }, _tempDir, Host).ShouldBeTrue();
+            new SkillFileGenerator()
+                .Generate(new[] { new MockRunTool { Name = "stable-tool", Description = "A tool." } }, _tempDir, Host)
+                .ShouldBeTrue();
             var second = File.ReadAllBytes(filePath);
 
             second.ShouldBe(first);
             // Positive control: the bytes that stayed equal are bytes that carry the marker — an
             // equality over two empty/marker-free files would prove nothing about this task.
-            CountOf(ReadLines(filePath), MarkerEntryLine).ShouldBe(1);
+            var lines = ReadLines(filePath);
+            CountOf(lines, MarkerEntryLine)
+                .ShouldBe(1, WholeFile("byte-stability control, tool path: provenance entry line", lines));
         }
 
         [Fact]
         public void Generate_SkillContent_RegeneratingOverAnExistingDirectoryIsByteStable()
         {
-            var generator = new SkillFileGenerator();
-            var skill = new SkillContent("stable-skill", "A skill.", "# Stable\n\nBody.\n");
             var filePath = Path.Combine(_tempDir, "stable-skill", "SKILL.md");
 
-            generator.Generate(new[] { skill }, _tempDir).ShouldBeTrue();
+            // Fresh generator + freshly constructed, equal-valued skill on each pass — see the
+            // tool-path twin above for why reusing one instance would weaken this.
+            new SkillFileGenerator()
+                .Generate(new[] { new SkillContent("stable-skill", "A skill.", "# Stable\n\nBody.\n") }, _tempDir)
+                .ShouldBeTrue();
             var first = File.ReadAllBytes(filePath);
 
-            generator.Generate(new[] { skill }, _tempDir).ShouldBeTrue();
+            new SkillFileGenerator()
+                .Generate(new[] { new SkillContent("stable-skill", "A skill.", "# Stable\n\nBody.\n") }, _tempDir)
+                .ShouldBeTrue();
             var second = File.ReadAllBytes(filePath);
 
             second.ShouldBe(first);
-            CountOf(ReadLines(filePath), MarkerEntryLine).ShouldBe(1);
+            var lines = ReadLines(filePath);
+            CountOf(lines, MarkerEntryLine)
+                .ShouldBe(1, WholeFile("byte-stability control, skill-content path: provenance entry line", lines));
         }
 
         // ── Foreign skill files are left alone ───────────────────────────────────
+        //
+        // Scope, so a later reader does not over-read these: the generator writes only into the
+        // directory named for the tool/skill it is generating, so what is pinned is that
+        // regenerating a DIFFERENT tool does not disturb an unrelated skill's file. The marker is
+        // WRITE-ONLY today — nothing in the generator reads it back — so these do NOT establish
+        // that a hand-authored file at a COLLIDING name would be spared. Reading the marker to
+        // decide ownership is a consumer-side concern and is deliberately not implemented here.
 
         [Fact]
         public void Generate_Tool_LeavesAHandCraftedSkillOfAnotherToolByteIntact()
@@ -204,11 +222,15 @@ namespace com.IvanMurzak.McpPlugin.Tests.Skills
 
             // Positive control FIRST: the generation pass really did run and really did write a
             // marked file, so the untouched assertion below cannot pass by nothing happening.
-            CountOf(ReadLines(Path.Combine(_tempDir, "other-tool", "SKILL.md")), MarkerEntryLine).ShouldBe(1);
+            var generated = ReadLines(Path.Combine(_tempDir, "other-tool", "SKILL.md"));
+            CountOf(generated, MarkerEntryLine)
+                .ShouldBe(1, WholeFile("foreign-file control, tool path: the generator's OWN file", generated));
 
-            File.ReadAllBytes(handCraftedPath).ShouldBe(before);
-            CountOf(ReadLines(handCraftedPath), MarkerEntryLine).ShouldBe(0);
-            CountOf(ReadLines(handCraftedPath), MarkerBlockLine).ShouldBe(0);
+            // Byte equality against a literal carrying no marker, so it ALREADY establishes that
+            // neither the block key nor the entry was stamped here — asserting either separately
+            // would add no independently breakable half.
+            File.ReadAllBytes(handCraftedPath)
+                .ShouldBe(before, $"the hand-crafted SKILL.md at '{handCraftedPath}' was rewritten by a tool that does not own it");
         }
 
         [Fact]
@@ -230,10 +252,12 @@ namespace com.IvanMurzak.McpPlugin.Tests.Skills
             var generator = new SkillFileGenerator();
             generator.Generate(new[] { new SkillContent("other-skill", "A skill.", "Body") }, _tempDir).ShouldBeTrue();
 
-            CountOf(ReadLines(Path.Combine(_tempDir, "other-skill", "SKILL.md")), MarkerEntryLine).ShouldBe(1);
+            var generated = ReadLines(Path.Combine(_tempDir, "other-skill", "SKILL.md"));
+            CountOf(generated, MarkerEntryLine)
+                .ShouldBe(1, WholeFile("foreign-file control, skill-content path: the generator's OWN file", generated));
 
-            File.ReadAllBytes(handCraftedPath).ShouldBe(before);
-            CountOf(ReadLines(handCraftedPath), MarkerEntryLine).ShouldBe(0);
+            File.ReadAllBytes(handCraftedPath)
+                .ShouldBe(before, $"the hand-crafted SKILL.md at '{handCraftedPath}' was rewritten by a skill that does not own it");
         }
 
         // ── The published constants describe the bytes actually written ──────────
@@ -241,12 +265,56 @@ namespace com.IvanMurzak.McpPlugin.Tests.Skills
         [Fact]
         public void ProvenanceConstants_MatchTheBytesWrittenToDisk()
         {
-            SkillFileGenerator.ProvenanceBlockKey.ShouldBe("metadata");
-            SkillFileGenerator.ProvenanceKey.ShouldBe("generated-by");
-            SkillFileGenerator.ProvenanceValue.ShouldBe("mcp-plugin-dotnet");
+            // Half 1 — the published contract values have not drifted from what downstream readers
+            // were told to expect. These are `public const`, so a consumer inlines them at ITS
+            // compile time; changing one is a contract change, not a refactor.
+            SkillFileGenerator.ProvenanceBlockKey.ShouldBe("metadata", "published constant: block key");
+            SkillFileGenerator.ProvenanceKey.ShouldBe("generated-by", "published constant: entry key");
+            SkillFileGenerator.ProvenanceValue.ShouldBe("mcp-plugin-dotnet", "published constant: entry value");
+
+            // Half 2 — INDEPENDENT of half 1: the emission still DERIVES from those constants. If
+            // the writer stopped using them (a hardcoded literal drifting away from the published
+            // value), every literal pin above still passes while the contract is silently broken.
+            // Composed from the constants and compared for whole-LINE equality, never containment:
+            // a longer on-disk value would satisfy a substring check.
+            new SkillFileGenerator()
+                .Generate(new[] { new MockRunTool { Name = "contract-tool" } }, _tempDir, Host)
+                .ShouldBeTrue();
+
+            var lines = ReadLines(Path.Combine(_tempDir, "contract-tool", "SKILL.md"));
+            lines.ShouldContain(
+                SkillFileGenerator.ProvenanceBlockKey + ":",
+                "the block key on disk is not the one the published constant names");
+            lines.ShouldContain(
+                "  " + SkillFileGenerator.ProvenanceKey + ": " + SkillFileGenerator.ProvenanceValue,
+                "the provenance entry on disk is not the one the published constants compose");
         }
 
         // ── helpers ──────────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Asserts the front matter carries a top-level <c>metadata:</c> block whose contents are
+        /// EXACTLY the provenance entry. Pinning the whole block — not just "the entry is present
+        /// and directly follows its key" — is what makes a SECOND nested entry (a version, a
+        /// timestamp) visible: such an entry keeps every containment and adjacency check passing
+        /// while destroying the byte-stability the constant marker value exists to guarantee.
+        /// The block is emitted immediately before the closing <c>---</c> on both paths, so this
+        /// also pins that it is the last front-matter block.
+        /// </summary>
+        static void MarkerBlockIsExactlyTheProvenanceEntry(List<string> frontMatter)
+        {
+            var blockIdx = frontMatter.IndexOf(MarkerBlockLine);
+            blockIdx.ShouldBeGreaterThanOrEqualTo(
+                0,
+                $"the front matter carries no top-level '{MarkerBlockLine}' line; it was:\n{string.Join("\n", frontMatter)}");
+
+            frontMatter.GetRange(blockIdx, frontMatter.Count - blockIdx).ToArray().ShouldBe(
+                new[] { MarkerBlockLine, MarkerEntryLine },
+                "the metadata block must hold the provenance entry and nothing else");
+        }
+
+        static string WholeFile(string what, string[] lines)
+            => $"{what}: expected exactly one matching line; the file was:\n{string.Join("\n", lines)}";
 
         static string[] ReadLines(string path)
             => File.ReadAllText(path).Replace("\r\n", "\n").Split('\n');
@@ -277,7 +345,7 @@ namespace com.IvanMurzak.McpPlugin.Tests.Skills
             return count;
         }
 
-        class MockRunTool : IRunTool
+        private class MockRunTool : IRunTool
         {
             public string Name { get; init; } = "mock-tool";
             public string? Title { get; init; } = "Mock Tool";

--- a/McpPlugin/src/McpPlugin/Skills/SkillFileGenerator.cs
+++ b/McpPlugin/src/McpPlugin/Skills/SkillFileGenerator.cs
@@ -49,6 +49,48 @@ namespace com.IvanMurzak.McpPlugin.Skills
             _logger = logger;
         }
 
+        // ── Provenance marker ────────────────────────────────────────────────
+
+        /// <summary>
+        /// YAML front-matter key holding the provenance block. <c>metadata</c> is a first-class
+        /// SKILL.md front-matter field: hosts read it as a free-form mapping of extra keys.
+        /// </summary>
+        public const string ProvenanceBlockKey = "metadata";
+
+        /// <summary>
+        /// Key, nested under <see cref="ProvenanceBlockKey"/>, that marks a SKILL.md as written by
+        /// this generator rather than hand-authored by a user.
+        /// </summary>
+        public const string ProvenanceKey = "generated-by";
+
+        /// <summary>
+        /// Value written for <see cref="ProvenanceKey"/>. Deliberately a constant carrying no
+        /// version and no timestamp, so regenerating an unchanged tool rewrites a byte-identical file.
+        /// </summary>
+        public const string ProvenanceValue = "mcp-plugin-dotnet";
+
+        /// <summary>
+        /// Appends the provenance marker as raw YAML lines. Callers must invoke it INSIDE the
+        /// front-matter block — before the closing <c>---</c> — because a consumer that identifies
+        /// generated skills parses the front-matter only:
+        /// <code>
+        /// ---
+        /// name: tool-name
+        /// description: ...
+        /// metadata:
+        ///   generated-by: mcp-plugin-dotnet
+        /// ---
+        /// </code>
+        /// Written literally rather than through <see cref="EscapeYaml"/>, which escapes a single
+        /// scalar and would collapse the nested mapping into a quoted string.
+        /// </summary>
+        /// <param name="sb">The <see cref="StringBuilder"/> that accumulates the skill file content.</param>
+        protected static void AppendProvenanceMetadata(StringBuilder sb)
+        {
+            sb.AppendLine(ProvenanceBlockKey + ":");
+            sb.AppendLine("  " + ProvenanceKey + ": " + ProvenanceValue);
+        }
+
         // ── Customization properties ─────────────────────────────────────────
 
         /// <summary>
@@ -331,7 +373,8 @@ namespace com.IvanMurzak.McpPlugin.Skills
 
         /// <summary>
         /// Builds the full markdown content for a custom skill's SKILL.md.
-        /// Contains YAML frontmatter (name, description) followed by the verbatim content body.
+        /// Contains YAML frontmatter (name, description, and the
+        /// <see cref="AppendProvenanceMetadata"/> marker) followed by the verbatim content body.
         /// </summary>
         protected virtual string BuildSkillContentMarkdown(ISkillContent skill, string skillName)
         {
@@ -343,6 +386,7 @@ namespace com.IvanMurzak.McpPlugin.Skills
             sb.AppendLine("---");
             sb.AppendLine($"name: {EscapeYaml(skillName)}");
             sb.AppendLine($"description: {EscapeYaml(yamlDescription)}");
+            AppendProvenanceMetadata(sb);
             sb.AppendLine("---");
 
             // Verbatim content body
@@ -478,6 +522,7 @@ namespace com.IvanMurzak.McpPlugin.Skills
             sb.AppendLine("---");
             sb.AppendLine($"name: {EscapeYaml(skillName)}");
             sb.AppendLine($"description: {EscapeYaml(yamlDescription)}");
+            AppendProvenanceMetadata(sb);
             sb.AppendLine("---");
             sb.AppendLine();
             BuildFrontMatterNotes(sb);
@@ -562,6 +607,8 @@ namespace com.IvanMurzak.McpPlugin.Skills
         /// ---
         /// name: tool-name
         /// description: ...
+        /// metadata:
+        ///   generated-by: mcp-plugin-dotnet
         /// ---
         ///                          ← content appended HERE
         /// # Tool Title

--- a/McpPlugin/src/McpPlugin/Skills/SkillFileGenerator.cs
+++ b/McpPlugin/src/McpPlugin/Skills/SkillFileGenerator.cs
@@ -52,8 +52,10 @@ namespace com.IvanMurzak.McpPlugin.Skills
         // ── Provenance marker ────────────────────────────────────────────────
 
         /// <summary>
-        /// YAML front-matter key holding the provenance block. <c>metadata</c> is a first-class
-        /// SKILL.md front-matter field: hosts read it as a free-form mapping of extra keys.
+        /// YAML front-matter key holding the provenance block. In the Skills file format used by
+        /// Codex (and Anthropic Agent Skills), <c>metadata</c> is a declared front-matter field
+        /// carrying a free-form mapping of extra keys — which is why the marker is nested under it
+        /// rather than written as a bare top-level key a host would simply ignore.
         /// </summary>
         public const string ProvenanceBlockKey = "metadata";
 
@@ -83,6 +85,13 @@ namespace com.IvanMurzak.McpPlugin.Skills
         /// </code>
         /// Written literally rather than through <see cref="EscapeYaml"/>, which escapes a single
         /// scalar and would collapse the nested mapping into a quoted string.
+        /// <para>
+        /// The default <see cref="BuildMarkdown"/> and <see cref="BuildSkillContentMarkdown"/>
+        /// implementations call this, so the marker is emitted for every file THEY write. It is a
+        /// convention, not an invariant the type can enforce: a subclass that replaces either of
+        /// those wholesale — which their own documentation permits — must call this itself, or the
+        /// files it writes carry no marker and read as hand-authored to any consumer.
+        /// </para>
         /// </summary>
         /// <param name="sb">The <see cref="StringBuilder"/> that accumulates the skill file content.</param>
         protected static void AppendProvenanceMetadata(StringBuilder sb)
@@ -375,6 +384,8 @@ namespace com.IvanMurzak.McpPlugin.Skills
         /// Builds the full markdown content for a custom skill's SKILL.md.
         /// Contains YAML frontmatter (name, description, and the
         /// <see cref="AppendProvenanceMetadata"/> marker) followed by the verbatim content body.
+        /// An override that rebuilds the front matter must still call
+        /// <see cref="AppendProvenanceMetadata"/> before the closing <c>---</c>.
         /// </summary>
         protected virtual string BuildSkillContentMarkdown(ISkillContent skill, string skillName)
         {
@@ -508,6 +519,8 @@ namespace com.IvanMurzak.McpPlugin.Skills
         /// Override to replace or extend the entire document structure.
         /// For targeted changes, prefer overriding individual section helpers or the
         /// customization properties/methods instead.
+        /// An override that rebuilds the front matter must still call
+        /// <see cref="AppendProvenanceMetadata"/> before the closing <c>---</c>.
         /// </summary>
         protected virtual string BuildMarkdown(IRunTool tool, string skillName, string host)
         {


### PR DESCRIPTION
Implements Taskflow `2026-08-28-tool-catalog` task **a2-skill-marker** (02 §T2 — generator
provenance marker). Tracked on the Taskflow board, not on a GitHub issue (matching PRs
#211/#212/#213/#216).

## Summary

- **Every SKILL.md the generator writes now carries a provenance marker inside its YAML
  front-matter** — a `metadata:` block holding `generated-by: mcp-plugin-dotnet` — so a consumer can
  tell a generated skill from a hand-authored one and de-duplicate only its own (design 02 §T6/D5).
- **Stamped in BOTH emission paths**, via one shared `AppendProvenanceMetadata(StringBuilder)`
  helper: `BuildMarkdown` (tool skills) and `BuildSkillContentMarkdown` (custom
  `ISkillContent` skills). `BuildFrontMatterNotes` was deliberately NOT used — it appends *below*
  the closing `---`, so anything it writes is invisible to a front-matter reader.
- **Emitted as raw literal YAML lines, not through `EscapeYaml`.** `EscapeYaml` escapes a single
  scalar; routing a nested mapping through it would quote the block into a string.
- **The marker carries no version and no timestamp**, which is what keeps regeneration
  byte-identical. The two `public const` values (`ProvenanceBlockKey` / `ProvenanceKey` /
  `ProvenanceValue`) publish the on-disk contract for downstream readers.
- Untouched, per the task's scope fence: `SanitizeSkillName`, `BuildNameMap`, `BuildSkillNameMap`,
  and all description/body resolution (`ResolveYamlDescription` / `TruncateForYaml`). No `<Version>`
  bump, no ReflectorNet pin change.

Generated front-matter (real generator output):

```yaml
---
name: probe-tool
description: Adds two numbers and returns the sum.
metadata:
  generated-by: mcp-plugin-dotnet
---
```

A **multi-line** description is emitted as a YAML literal block scalar (`|-`) whose body lines are
indented two spaces — the same indent the marker's nested entry uses. The marker's block key sits at
column 0, which is precisely what terminates that scalar, so the marker stays a top-level key:

```yaml
---
name: probe-multiline
description: |-
  First line of the description.
  Second line.
  Third line.
metadata:
  generated-by: mcp-plugin-dotnet
---
```

## Marker tolerance — VERIFIED, no `.generated-by` fallback needed

The task required proving Claude Code accepts the extra front-matter key before shipping this
variant. It does, and `metadata` is not merely *tolerated* — it is a first-class, type-checked
SKILL.md front-matter field.

**Runtime evidence** (Claude Code 2.1.251, `claude plugin validate`, which validates "the skills,
agents, and commands in a directory"; `--strict` "treat[s] warnings as errors … to fail on
unrecognized fields … that the runtime tolerates"):

| Tree under validation | `--strict` result |
|---|---|
| **Real generator output** — all 3 skills above, produced by this branch's `SkillFileGenerator` | **exit 0, `✔ Validation passed`** |
| Same tree, generator's `metadata:` block hand-corrupted to a YAML *array* | exit 1 — `❯ metadata: 'metadata' must be a mapping (key: value pairs); got array. It is dropped at load time.` |
| A skill with no `description:` | exit 1 (control: the validator does reject) |

The middle row is the positive control that matters: the validator names the exact generated file and
inspects the exact key this PR adds, so the green in row 1 is a real verdict on this marker rather
than a validator that looked at nothing.

**Static evidence** from the same binary: the skill front-matter loader's field triple is
`["name","description","metadata"]`, and the loaded skill object freezes `metadata` into place; the
validator has a dedicated `s === "skill" || s === "command"` branch asserting `metadata` is a
mapping. So the key is read at load time, not discarded.

Shipping variant: **front-matter `metadata:` block.** The sibling `.generated-by` file fallback was
not needed and was not implemented.

## Test plan

- [x] Target-specific local tests passed (see profile `test.md`) — Suite 1, solution-level, Release:
      **4/4 test hosts `Test Run Successful.`, 0 `Test Run Failed.`** — 989 + 989
      (`McpPlugin.Tests`, net8.0/net9.0) and 756 + 756 (`McpPlugin.Server.Tests`, net8.0/net9.0) =
      **3,490 passed, 0 failed**. The known machine-load flake
      (`ConnectionManagerTests.Connect_ThreadSafety_NoRaceConditionsUnderLoad`) did not fire.
- [x] `dotnet restore` -> `dotnet build --no-restore --configuration Release --no-incremental`:
      **0 errors, 8 warnings** (all pre-existing `CS8604` in `McpPlugin.Tests`, unchanged count vs.
      the base tree).

### New / updated coverage

| Where | What it pins |
|---|---|
| `McpPlugin.Tests/Skills/SkillFileGeneratorProvenanceTests.cs` (new, 10 tests) | Marker present, correctly ordered and **inside** the front-matter block, in both emission paths; stamped exactly once; still top-level after a block-scalar description; regeneration byte-stable on both paths; a hand-crafted skill of another tool/skill left byte-intact; the published constants match the bytes on disk. |
| `McpPlugin.Tests/Mcp/McpPluginSkillContentTests.cs` (updated) | `Generate_SkillContent_YamlFrontmatterIsCorrect` now pins the full 6-line front-matter layout, un-trimmed on the nested entry so the two-space indent — what makes it a mapping rather than a sibling scalar — is part of the assertion. |

Expectations are written as **literals**, deliberately not built from `SkillFileGenerator`'s own
constants: the on-disk bytes are the contract a front-matter reader parses, so a changed constant
must redden the tests rather than move with them.

### Plant round — 12/12 RED, 0 GREEN, restore-failures 0

> Re-run and **extended** by the refine pass, which rewrote several assertions in these tests. The
> round below supersedes the original 10-plant one: 02's ten plants all still redden, two plants
> were added for claims the refine pass authored, and **all ten inherited plants gained an
> `expect_red_marker`** — 02's table carried none, so every one of its reds was reported
> UNATTRIBUTED by the harness and attributed only by hand.

Run through `plant_and_revert.py` with the profile's verify command
(`dotnet build --no-restore --configuration Release && dotnet test McpPlugin.Tests/... --no-build
--configuration Release --filter ...`) — the build is **inside** the `&&` chain, so no plant
scored against the previous plant's assemblies. Every plant's log carries a real `Failed!` line and
the **collected count was a constant `Total: 27` across all twelve**, so no RED came from a build or
collection break. Baseline before the round: 27/27 green. Restore verified byte-exact
(`restore-failures 0`) plus a residue grep for every planted string.

| # | Mutation | Marker test it is attributed to |
|---|---|---|
| P1 | tool path: marker call dropped | `Generate_Tool_StampsMarkerInsideFrontMatter` |
| P2 | skill-content path: marker call dropped | `Generate_SkillContent_StampsMarkerInsideFrontMatter` |
| P3 | tool path: marker emitted **below** the closing `---` | `Generate_Tool_MarkerIsTopLevelEvenAfterABlockScalarDescription` |
| P4 | skill-content path: marker below the closing `---` | `Generate_SkillContent_YamlFrontmatterIsCorrect` |
| P5 | `ProvenanceValue` -> `"mcp-plugin"` | `ProvenanceConstants_MatchTheBytesWrittenToDisk` |
| P6 | `ProvenanceBlockKey` -> `"meta"` | `ProvenanceConstants_MatchTheBytesWrittenToDisk` |
| P7 | nested entry's two-space indent dropped | `Generate_Tool_StampsMarkerExactlyOnce` |
| P8 | marker value made to vary per call | `Generate_Tool_RegeneratingOverAnExistingDirectoryIsByteStable` |
| P9 | tool `Generate` rewrites skill dirs it does not own | `Generate_Tool_LeavesAHandCraftedSkillOfAnotherToolByteIntact` |
| P10 | skill-content `Generate` rewrites dirs it does not own | `Generate_SkillContent_LeavesAHandCraftedSkillOfAnotherSkillByteIntact` |
| **P11** *(new)* | a **second, constant-valued entry** added to the metadata block (`generated-at: <fixed>`) | `Generate_Tool_StampsMarkerInsideFrontMatter` |
| **P12** *(new)* | emission stops **deriving** from the published constant (hardcoded literal, consts untouched) | `ProvenanceConstants_MatchTheBytesWrittenToDisk` |

**Why P11 and P12 exist.** Both name claims that nothing in the original round could reach:

- **P11.** A constant-valued extra line in the metadata block keeps every containment, adjacency,
  `CountOf == 1` and byte-stability assertion passing — while destroying exactly the
  byte-stability the constant marker value exists to guarantee. It is caught only by the exact-slice
  assertion this pass added ("the metadata block must hold the provenance entry and nothing else").
- **P12.** With the published constants left at their contract values and only the emission
  hardcoded, every literal pin still passes; only the composed-from-constants disk check sees it.
  That is the half that makes `ProvenanceConstants_MatchTheBytesWrittenToDisk` live up to its name.

**Two plants share a marker in each of two groups, and the harness could not compare them** (its
assertion-text extraction is pytest-shaped; this is an xunit runner — it reports
`could NOT be compared`, which is *not* a pass). Verified by hand from the per-plant logs; all five
fail their marker test with distinct text:

- `Generate_Tool_StampsMarkerInsideFrontMatter` — **P1**: `blockIdx should be greater than or
  equal to 0 but was -1` / "the front matter carries no top-level `metadata:` line". **P11**:
  `... should be ["metadata:", "  generated-by: mcp-plugin-dotnet"] but was [..., "  generated-at:
  2026-08-29T00:00:00Z"]` / "the metadata block must hold the provenance entry and nothing else".
- `ProvenanceConstants_MatchTheBytesWrittenToDisk` — **P5**: `ProvenanceValue should be
  "mcp-plugin-dotnet" but was "mcp-plugin"`. **P6**: `ProvenanceBlockKey should be "metadata" but
  was "meta"`. **P12**: `lines should contain "  generated-by: mcp-plugin-dotnet"` / "the provenance
  entry on disk is not the one the published constants compose" — with both literal pins
  passing, which is what shows the two halves are independent.

P7/P8 and P9/P10 are separated by test identity and by assertion line, as before.

### Reviewed and deliberately NOT changed

Recorded here rather than actioned, so a reader can see they were weighed:

- **`EscapeYaml` does not escape backslashes** (`SkillFileGenerator.cs`, pre-existing on `main`).
  A description containing both a colon and a backslash — any Windows path, many
  regex-documenting descriptions — takes the double-quoted branch and emits invalid YAML
  escapes (`\U` requires 8 hex digits), so the front matter does not parse. This PR raises the
  stakes (an unparseable document reads as "not generated by us"), but the task's scope item 3
  fences off the description/body resolution logic, and a fix changes output for existing users'
  skills. **Read from source, not executed.** Worth its own task.
- **`public const` vs `static readonly`** for the three published values. `const` is inlined into a
  consumer's IL at *its* compile time, so a later value change would not reach a consumer that
  upgrades the package without recompiling. Left as `const`: it is this repo's consistent
  convention for public string contract constants (`AiAgentConfig.DefaultMcpServerName`,
  `MachineCredentialStore.DirectoryName`/`CredentialsFileName`, `ProjectMarker.DirectoryName`,
  `ServerTargetResolver.HostedTarget`, `TokenExchangeClient.GrantType`/`PluginScope`), every one
  carrying the same property; changing only these three would be the inconsistency.
- **A subclass can drop the marker.** `AppendProvenanceMetadata` is called from two
  `protected virtual` methods whose own docs invite wholesale override, and this repo's suite
  already contains such a subclass (`SkillFileGeneratorTests.CustomMarkdownGenerator`). Making the
  emission unskippable would restructure seams the task does not authorize touching, so the fix was
  to stop implying a guarantee the type cannot enforce: it is documented as a convention on the
  helper, with a pointer on each `Build*` method, and the test docstring is scoped to the default
  generator.
- **`DemoConsoleApp/SKILLS/console-log/SKILL.md`** is a tracked sample of generator output and is
  now stale by two lines. Not patched: it was *already* stale independently — it carries a
  UTF-8 BOM while the generator writes through `_utf8NoBom` — so hand-inserting the marker
  would make it look current when it demonstrably was not generated by this code. It should be
  regenerated (or untracked) in a follow-up. Nothing reads it: no test, no workflow, no README link.
- **`MockRunTool` is a 5th private copy** of the same `IRunTool` fake. Per-file duplication is this
  repo's established pattern (4 pre-existing copies, no shared fake in `Infrastructure/`);
  extracting one is a refactor beyond this PR's surface.
