### PR TITLE
fix: measure the published skill metadata in the tool token count

### DIFF
--- a/McpPlugin.Tests/Mcp/ToolTokenCountSkillMetadataTests.cs
+++ b/McpPlugin.Tests/Mcp/ToolTokenCountSkillMetadataTests.cs
@@ -1,0 +1,294 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.Common.Model;
+using com.IvanMurzak.ReflectorNet;
+using Shouldly;
+using Xunit;
+using Version = com.IvanMurzak.McpPlugin.Common.Version;
+
+namespace com.IvanMurzak.McpPlugin.Tests.Mcp
+{
+    /// <summary>
+    /// Pins that the catalogue-weight instrument measures the skill metadata that <c>tools/list</c>
+    /// actually ships (<c>_meta.skillDescription</c> / <c>_meta.skillBody</c>), and that the total's
+    /// meaning is unchanged for a tool that publishes none.
+    ///
+    /// <para>
+    /// Every expectation here is an exact value, never a bound: the counter has a "no skill metadata"
+    /// branch that satisfies any <c>&gt; 0</c> or <c>&gt;=</c> assertion for free, so only an exact
+    /// figure can tell a measured payload from an unmeasured one.
+    /// </para>
+    /// </summary>
+    [Collection("McpPlugin")]
+    public class ToolTokenCountSkillMetadataTests
+    {
+        private readonly Version _version = new Version();
+
+        // 41 characters. Plain ASCII on purpose: System.Text.Json escapes '<', '>', '&', '+', '\'' and
+        // every non-ASCII code point, which would make the measured length differ from the literal length.
+        private const string SkillDescriptionText = "Concise skill blurb for the tool catalog.";
+
+        // 70 characters, same ASCII-only rule.
+        private const string SkillBodyText = "Long form skill markdown body shipped out to any connected MCP client.";
+
+        /// <summary>
+        /// Characters the two members add to the measured JSON:
+        /// <c>,"skillDescription":"…"</c> = 22 + 41 and <c>,"skillBody":"…"</c> = 15 + 70, i.e. 148.
+        /// 148 is a multiple of 4, which is why the token delta is EXACTLY this value regardless of how
+        /// long the rest of the entry is — that base-independence is what lets the reflection-based
+        /// <see cref="RunTool"/> assertions below pin an exact delta over a schema this test does not author.
+        /// </summary>
+        private const int SkillMetadataTokens = 37;
+
+        // Fixture for the direct-helper assertions: every input is fixed, so every count is a literal.
+        private const string ProbeName = "catalogue_probe";
+        private const string ProbeTitle = "Catalogue Probe";
+        private const string ProbeDescription = "Measures the catalogue weight of one tool entry.";
+        private const string ProbeInputSchemaJson = "{\"type\":\"object\",\"properties\":{\"value\":{\"type\":\"string\"}}}";
+
+        // Measured counts for that fixture (chars / 4, rounded up).
+        private const int ProbeTokensWithoutSkillMetadata = 48;   // 190 chars
+        private const int ProbeTokensWithBothMembers = 85;        // 338 chars
+        private const int ProbeTokensWithSkillDescriptionOnly = 64;  // 253 chars
+        private const int ProbeTokensWithSkillBodyOnly = 69;         // 275 chars
+
+        private static JsonNode ProbeInputSchema() => JsonNode.Parse(ProbeInputSchemaJson)!;
+
+        private static Func<string, IReadOnlyDictionary<string, JsonElement>?, CancellationToken, Task<ResponseCallTool>> NoopHandler()
+            => (_, _, _) => Task.FromResult(ResponseCallTool.Success("noop"));
+
+        // ── The helper ──────────────────────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void Calculate_WithoutSkillMetadata_PinsThePreChangeBaselineExactly()
+        {
+            var nulls = ToolTokenCount.Calculate(
+                ProbeName, ProbeTitle, ProbeDescription, null, null, ProbeInputSchema(), null);
+
+            // Empty strings must cost exactly what null costs — the same string.IsNullOrEmpty accounting
+            // the name/title/description members already get, and the same gate the wire uses.
+            var empties = ToolTokenCount.Calculate(
+                ProbeName, ProbeTitle, ProbeDescription, string.Empty, string.Empty, ProbeInputSchema(), null);
+
+            nulls.ShouldBe(ProbeTokensWithoutSkillMetadata);
+            empties.ShouldBe(ProbeTokensWithoutSkillMetadata);
+        }
+
+        [Fact]
+        public void Calculate_WithSkillMetadata_AddsExactlyTheMeasuredPayload()
+        {
+            var withMetadata = ToolTokenCount.Calculate(
+                ProbeName, ProbeTitle, ProbeDescription, SkillDescriptionText, SkillBodyText, ProbeInputSchema(), null);
+
+            withMetadata.ShouldBe(ProbeTokensWithBothMembers);
+            (withMetadata - ProbeTokensWithoutSkillMetadata).ShouldBe(SkillMetadataTokens);
+        }
+
+        [Fact]
+        public void Calculate_WithSkillDescriptionOnly_AddsExactlyThatMembersPayload()
+        {
+            var value = ToolTokenCount.Calculate(
+                ProbeName, ProbeTitle, ProbeDescription, SkillDescriptionText, null, ProbeInputSchema(), null);
+
+            value.ShouldBe(ProbeTokensWithSkillDescriptionOnly);
+        }
+
+        [Fact]
+        public void Calculate_WithSkillBodyOnly_AddsExactlyThatMembersPayload()
+        {
+            var value = ToolTokenCount.Calculate(
+                ProbeName, ProbeTitle, ProbeDescription, null, SkillBodyText, ProbeInputSchema(), null);
+
+            value.ShouldBe(ProbeTokensWithSkillBodyOnly);
+        }
+
+        [Fact]
+        public void Calculate_MeasuresTheSkillMembersUnderTheirPublishedWireKeys()
+        {
+            // The instrument is only meaningful if it measures the payload the wire ships, so the keys it
+            // serializes under are part of the contract, not an implementation detail.
+            ToolTokenCount.SkillDescriptionKey.ShouldBe("skillDescription");
+            ToolTokenCount.SkillBodyKey.ShouldBe("skillBody");
+        }
+
+        [Fact]
+        public void CalculateSkillMetadata_ReturnsTheExactShareOfTheTotal()
+        {
+            var both = ToolTokenCount.CalculateSkillMetadata(
+                ProbeName, ProbeTitle, ProbeDescription, SkillDescriptionText, SkillBodyText, ProbeInputSchema(), null);
+            var descriptionOnly = ToolTokenCount.CalculateSkillMetadata(
+                ProbeName, ProbeTitle, ProbeDescription, SkillDescriptionText, null, ProbeInputSchema(), null);
+            var bodyOnly = ToolTokenCount.CalculateSkillMetadata(
+                ProbeName, ProbeTitle, ProbeDescription, null, SkillBodyText, ProbeInputSchema(), null);
+            var none = ToolTokenCount.CalculateSkillMetadata(
+                ProbeName, ProbeTitle, ProbeDescription, null, null, ProbeInputSchema(), null);
+
+            both.ShouldBe(SkillMetadataTokens);
+            descriptionOnly.ShouldBe(ProbeTokensWithSkillDescriptionOnly - ProbeTokensWithoutSkillMetadata);
+            bodyOnly.ShouldBe(ProbeTokensWithSkillBodyOnly - ProbeTokensWithoutSkillMetadata);
+            none.ShouldBe(0);
+        }
+
+        // ── ProxyTool (runtime tools) ───────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void ProxyTool_TokenCount_MeasuresSkillMetadata_AndCachesTheSkillInclusiveValue()
+        {
+            var withMetadata = new ProxyTool(
+                ProbeName, ProbeTitle, ProbeDescription, SkillDescriptionText, SkillBodyText,
+                ProbeInputSchema(), null, null, null, null, null, NoopHandler());
+
+            var withoutMetadata = new ProxyTool(
+                ProbeName, ProbeTitle, ProbeDescription, null, null,
+                ProbeInputSchema(), null, null, null, null, null, NoopHandler());
+
+            // The two proxies differ in NOTHING but their skill metadata, so this delta is that metadata.
+            withMetadata.TokenCount.ShouldBe(ProbeTokensWithBothMembers);
+            withoutMetadata.TokenCount.ShouldBe(ProbeTokensWithoutSkillMetadata);
+            withMetadata.SkillMetadataTokenCount.ShouldBe(SkillMetadataTokens);
+            withoutMetadata.SkillMetadataTokenCount.ShouldBe(0);
+
+            // Repeated reads are served from the cache — and the cached value is the skill-inclusive one,
+            // so a correct Calculate cannot be undone by a count that was frozen before it was consulted.
+            withMetadata.TokenCount.ShouldBe(ProbeTokensWithBothMembers);
+            withMetadata.SkillMetadataTokenCount.ShouldBe(SkillMetadataTokens);
+
+            ReadCachedField(withMetadata, "_cachedTokenCount").ShouldBe(ProbeTokensWithBothMembers);
+            ReadCachedField(withMetadata, "_cachedSkillMetadataTokenCount").ShouldBe(SkillMetadataTokens);
+        }
+
+        // ── RunTool (reflected tools) ───────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void RunTool_TokenCount_MeasuresSkillMetadata_ByExactlyTheMeasuredDelta()
+        {
+            var toolManager = BuildSkillMetadataToolManager();
+            var withMetadata = GetTool(toolManager, WithSkillToolName);
+            var withoutMetadata = GetTool(toolManager, SansSkillToolName);
+
+            // Same signature, same [Description], same-length name and title: the ONLY difference between
+            // the two entries is the skill metadata, so the whole delta is attributable to it.
+            withMetadata.SkillDescription.ShouldBe(SkillDescriptionText);
+            withMetadata.SkillBody.ShouldBe(SkillBodyText);
+            withoutMetadata.SkillDescription.ShouldBeNull();
+            withoutMetadata.SkillBody.ShouldBeNull();
+
+            withMetadata.TokenCount.ShouldBe(withoutMetadata.TokenCount + SkillMetadataTokens);
+            withMetadata.SkillMetadataTokenCount.ShouldBe(SkillMetadataTokens);
+            withoutMetadata.SkillMetadataTokenCount.ShouldBe(0);
+        }
+
+        [Fact]
+        public void RunTool_CachesTheSkillInclusiveCounts()
+        {
+            var toolManager = BuildSkillMetadataToolManager();
+            var withMetadata = GetTool(toolManager, WithSkillToolName);
+            var withoutMetadata = GetTool(toolManager, SansSkillToolName);
+
+            var firstTotal = withMetadata.TokenCount;
+            var firstShare = withMetadata.SkillMetadataTokenCount;
+
+            withMetadata.TokenCount.ShouldBe(firstTotal);
+            withMetadata.SkillMetadataTokenCount.ShouldBe(firstShare);
+
+            ReadCachedField(withMetadata, "_cachedTokenCount").ShouldBe(firstTotal);
+            ReadCachedField(withMetadata, "_cachedSkillMetadataTokenCount").ShouldBe(firstShare);
+
+            // The cached value is the one that carries the skill metadata: it is exactly the sibling's
+            // cached total plus the measured payload, so a count frozen before the metadata was consulted
+            // could not produce it.
+            ReadCachedField(withMetadata, "_cachedTokenCount")
+                .ShouldBe(withoutMetadata.TokenCount + SkillMetadataTokens);
+        }
+
+        // ── Catalogue-level breakdown ───────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void EnabledToolsSkillMetadataTokenCount_IsTheShareOfTheEnabledCatalogue()
+        {
+            var toolManager = BuildSkillMetadataToolManager();
+            var withMetadata = GetTool(toolManager, WithSkillToolName);
+            var withoutMetadata = GetTool(toolManager, SansSkillToolName);
+
+            toolManager.EnabledToolsTokenCount.ShouldBe(withMetadata.TokenCount + withoutMetadata.TokenCount);
+            toolManager.EnabledToolsSkillMetadataTokenCount.ShouldBe(SkillMetadataTokens);
+        }
+
+        [Fact]
+        public void EnabledToolsSkillMetadataTokenCount_ExcludesDisabledTools()
+        {
+            var toolManager = BuildSkillMetadataToolManager();
+            var withoutMetadata = GetTool(toolManager, SansSkillToolName);
+
+            toolManager.SetToolEnabled(WithSkillToolName, false);
+
+            toolManager.EnabledToolsSkillMetadataTokenCount.ShouldBe(0);
+            toolManager.EnabledToolsTokenCount.ShouldBe(withoutMetadata.TokenCount);
+        }
+
+        // ── Helpers ─────────────────────────────────────────────────────────────────────────────────
+
+        private const string WithSkillToolName = "withSkillMetaTool";
+        private const string SansSkillToolName = "sansSkillMetaTool";
+        private const string WithSkillToolTitle = "With Skill Meta";
+        private const string SansSkillToolTitle = "Sans Skill Meta";
+
+        private IToolManager BuildSkillMetadataToolManager()
+        {
+            var reflector = new Reflector();
+            var builder = new McpPluginBuilder(_version);
+
+            var withSkill = typeof(SkillMetadataToolClass).GetMethod(nameof(SkillMetadataToolClass.WithSkillMetadata));
+            var sansSkill = typeof(SkillMetadataToolClass).GetMethod(nameof(SkillMetadataToolClass.SansSkillMetadata));
+
+            builder.WithTool(WithSkillToolName, WithSkillToolTitle, typeof(SkillMetadataToolClass), withSkill!);
+            builder.WithTool(SansSkillToolName, SansSkillToolTitle, typeof(SkillMetadataToolClass), sansSkill!);
+
+            return builder.Build(reflector).McpManager.ToolManager!;
+        }
+
+        private static IRunTool GetTool(IToolManager toolManager, string name)
+        {
+            var tool = toolManager.GetAllTools().FirstOrDefault(t => t.Name == name);
+            tool.ShouldNotBeNull();
+            return tool!;
+        }
+
+        private static int ReadCachedField(object instance, string fieldName)
+        {
+            var field = instance.GetType().GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance);
+            field.ShouldNotBeNull();
+            var value = (int?)field!.GetValue(instance);
+            value.ShouldNotBeNull();
+            return value!.Value;
+        }
+
+        private class SkillMetadataToolClass
+        {
+            [Description("Identical description on both fixtures so only the skill metadata differs.")]
+            [AiSkillDescription(SkillDescriptionText)]
+            [AiSkillBody(SkillBodyText)]
+            public static string WithSkillMetadata(string value) => value;
+
+            [Description("Identical description on both fixtures so only the skill metadata differs.")]
+            public static string SansSkillMetadata(string value) => value;
+        }
+    }
+}

--- a/McpPlugin.Tests/Mcp/ToolTokenCountSkillMetadataTests.cs
+++ b/McpPlugin.Tests/Mcp/ToolTokenCountSkillMetadataTests.cs
@@ -48,6 +48,24 @@ namespace com.IvanMurzak.McpPlugin.Tests.Mcp
         // 70 characters, same ASCII-only rule.
         private const string SkillBodyText = "Long form skill markdown body shipped out to any connected MCP client.";
 
+        // 30 characters. A SECOND, deliberately DIFFERENT-SIZED payload: it adds 22 + 30 = 52 characters,
+        // also a multiple of 4, so its share is a base-independent 13. Two unequal shares are what make the
+        // catalogue-level assertion pin an ADDITION — with a single non-zero contributor, sum / max / first
+        // over the enabled set are indistinguishable.
+        private const string SecondSkillDescriptionText = "A second, smaller skill blurb.";
+
+        private const int SecondSkillMetadataTokens = 13;
+
+        // A value no Calculate over any fixture in this file can produce, used to prove a property is served
+        // FROM its cache field rather than recomputed on every read.
+        private const int CacheSentinel = 123456;
+
+        // RunTool and ProxyTool name their cache fields identically, which is what lets one pair of literals
+        // drive both implementations' tests. CachedField asserts the field resolves, so a rename in either
+        // production type reddens here rather than passing silently.
+        private const string TotalCacheField = "_cachedTokenCount";
+        private const string ShareCacheField = "_cachedSkillMetadataTokenCount";
+
         /// <summary>
         /// Characters the two members add to the measured JSON:
         /// <c>,"skillDescription":"…"</c> = 22 + 41 and <c>,"skillBody":"…"</c> = 15 + 70, i.e. 148.
@@ -87,8 +105,8 @@ namespace com.IvanMurzak.McpPlugin.Tests.Mcp
             var empties = ToolTokenCount.Calculate(
                 ProbeName, ProbeTitle, ProbeDescription, string.Empty, string.Empty, ProbeInputSchema(), null);
 
-            nulls.ShouldBe(ProbeTokensWithoutSkillMetadata);
-            empties.ShouldBe(ProbeTokensWithoutSkillMetadata);
+            nulls.ShouldBe(ProbeTokensWithoutSkillMetadata, "a NULL skill member must cost exactly nothing");
+            empties.ShouldBe(ProbeTokensWithoutSkillMetadata, "an EMPTY-STRING skill member must cost exactly nothing");
         }
 
         [Fact]
@@ -97,8 +115,34 @@ namespace com.IvanMurzak.McpPlugin.Tests.Mcp
             var withMetadata = ToolTokenCount.Calculate(
                 ProbeName, ProbeTitle, ProbeDescription, SkillDescriptionText, SkillBodyText, ProbeInputSchema(), null);
 
+            // Only the literal, never `withMetadata - ProbeTokensWithoutSkillMetadata == SkillMetadataTokens`:
+            // those three are compile-time constants (85 - 48 == 37), so that form is entailed by the line
+            // below and cannot fail independently of it. The delta claim has its own test underneath.
             withMetadata.ShouldBe(ProbeTokensWithBothMembers);
-            (withMetadata - ProbeTokensWithoutSkillMetadata).ShouldBe(SkillMetadataTokens);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        public void Calculate_TheSkillMetadataDelta_IsIndependentOfTheBaseLength(int extraBaseCharacters)
+        {
+            // The payload is 148 characters — a multiple of the 4-chars-per-token divisor — so the delta is
+            // the same 37 tokens whatever the rest of the entry weighs. One fixture cannot show that, and the
+            // gap is not academic: with a single base length, a payload 1-3 characters off (a mis-spelled
+            // wire key, an added separator) still rounds to the same 37 and every other test here stays green.
+            // Padding the description by 0-3 characters walks the base length through all four residues
+            // modulo that divisor, which is a property of the divisor and the fixture — not of the code
+            // under test — and at least one residue reddens for any payload that is not exactly 148.
+            var description = ProbeDescription + new string('.', extraBaseCharacters);
+
+            var without = ToolTokenCount.Calculate(
+                ProbeName, ProbeTitle, description, null, null, ProbeInputSchema(), null);
+            var with = ToolTokenCount.Calculate(
+                ProbeName, ProbeTitle, description, SkillDescriptionText, SkillBodyText, ProbeInputSchema(), null);
+
+            (with - without).ShouldBe(SkillMetadataTokens, $"base padded by {extraBaseCharacters} character(s)");
         }
 
         [Fact]
@@ -143,6 +187,10 @@ namespace com.IvanMurzak.McpPlugin.Tests.Mcp
             both.ShouldBe(SkillMetadataTokens);
             descriptionOnly.ShouldBe(ProbeTokensWithSkillDescriptionOnly - ProbeTokensWithoutSkillMetadata);
             bodyOnly.ShouldBe(ProbeTokensWithSkillBodyOnly - ProbeTokensWithoutSkillMetadata);
+
+            // Pins the CONTRACT ("no skill metadata ⇒ no share"), not the early return that implements it:
+            // that return is a fast path only, because Calculate's own IsNullOrEmpty gates already make the
+            // two counts identical for this input. Deleting it leaves this line green, by construction.
             none.ShouldBe(0);
         }
 
@@ -165,13 +213,12 @@ namespace com.IvanMurzak.McpPlugin.Tests.Mcp
             withMetadata.SkillMetadataTokenCount.ShouldBe(SkillMetadataTokens);
             withoutMetadata.SkillMetadataTokenCount.ShouldBe(0);
 
-            // Repeated reads are served from the cache — and the cached value is the skill-inclusive one,
-            // so a correct Calculate cannot be undone by a count that was frozen before it was consulted.
-            withMetadata.TokenCount.ShouldBe(ProbeTokensWithBothMembers);
-            withMetadata.SkillMetadataTokenCount.ShouldBe(SkillMetadataTokens);
+            // The cached values are the skill-INCLUSIVE ones, so a correct Calculate cannot be undone by a
+            // count that was frozen before the metadata was consulted.
+            ReadCachedField(withMetadata, TotalCacheField).ShouldBe(ProbeTokensWithBothMembers);
+            ReadCachedField(withMetadata, ShareCacheField).ShouldBe(SkillMetadataTokens);
 
-            ReadCachedField(withMetadata, "_cachedTokenCount").ShouldBe(ProbeTokensWithBothMembers);
-            ReadCachedField(withMetadata, "_cachedSkillMetadataTokenCount").ShouldBe(SkillMetadataTokens);
+            ShouldServeBothCountsFromTheCacheFields(withMetadata);
         }
 
         // ── RunTool (reflected tools) ───────────────────────────────────────────────────────────────
@@ -202,20 +249,20 @@ namespace com.IvanMurzak.McpPlugin.Tests.Mcp
             var withMetadata = GetTool(toolManager, WithSkillToolName);
             var withoutMetadata = GetTool(toolManager, SansSkillToolName);
 
-            var firstTotal = withMetadata.TokenCount;
-            var firstShare = withMetadata.SkillMetadataTokenCount;
+            // Prime both caches; the assertions below read the fields, which are null until first access.
+            _ = withMetadata.TokenCount;
+            _ = withMetadata.SkillMetadataTokenCount;
 
-            withMetadata.TokenCount.ShouldBe(firstTotal);
-            withMetadata.SkillMetadataTokenCount.ShouldBe(firstShare);
+            // Both cached values carry the skill metadata: the total is exactly the sibling's total plus the
+            // measured payload, and the share is exactly that payload. Neither expectation is read back out
+            // of the property under test — a share pinned against its own first read stays green under
+            // "the share is always 0".
+            ReadCachedField(withMetadata, TotalCacheField)
+                .ShouldBe(withoutMetadata.TokenCount + SkillMetadataTokens, "the cached TOTAL must be skill-inclusive");
+            ReadCachedField(withMetadata, ShareCacheField)
+                .ShouldBe(SkillMetadataTokens, "the cached SHARE must be the measured payload");
 
-            ReadCachedField(withMetadata, "_cachedTokenCount").ShouldBe(firstTotal);
-            ReadCachedField(withMetadata, "_cachedSkillMetadataTokenCount").ShouldBe(firstShare);
-
-            // The cached value is the one that carries the skill metadata: it is exactly the sibling's
-            // cached total plus the measured payload, so a count frozen before the metadata was consulted
-            // could not produce it.
-            ReadCachedField(withMetadata, "_cachedTokenCount")
-                .ShouldBe(withoutMetadata.TokenCount + SkillMetadataTokens);
+            ShouldServeBothCountsFromTheCacheFields(withMetadata);
         }
 
         // ── Catalogue-level breakdown ───────────────────────────────────────────────────────────────
@@ -225,29 +272,40 @@ namespace com.IvanMurzak.McpPlugin.Tests.Mcp
         {
             var toolManager = BuildSkillMetadataToolManager();
             var withMetadata = GetTool(toolManager, WithSkillToolName);
+            var withSecond = GetTool(toolManager, SecondSkillToolName);
             var withoutMetadata = GetTool(toolManager, SansSkillToolName);
 
-            toolManager.EnabledToolsTokenCount.ShouldBe(withMetadata.TokenCount + withoutMetadata.TokenCount);
-            toolManager.EnabledToolsSkillMetadataTokenCount.ShouldBe(SkillMetadataTokens);
+            toolManager.EnabledToolsTokenCount
+                .ShouldBe(withMetadata.TokenCount + withSecond.TokenCount + withoutMetadata.TokenCount);
+
+            // TWO skill-bearing tools with DIFFERENT-sized payloads, so this pins an addition: over this
+            // catalogue a sum reads both shares while max / first / last each read only one of them.
+            toolManager.EnabledToolsSkillMetadataTokenCount
+                .ShouldBe(SkillMetadataTokens + SecondSkillMetadataTokens);
         }
 
         [Fact]
         public void EnabledToolsSkillMetadataTokenCount_ExcludesDisabledTools()
         {
             var toolManager = BuildSkillMetadataToolManager();
+            var withSecond = GetTool(toolManager, SecondSkillToolName);
             var withoutMetadata = GetTool(toolManager, SansSkillToolName);
 
             toolManager.SetToolEnabled(WithSkillToolName, false);
 
-            toolManager.EnabledToolsSkillMetadataTokenCount.ShouldBe(0);
-            toolManager.EnabledToolsTokenCount.ShouldBe(withoutMetadata.TokenCount);
+            // The disabled tool's share drops out and the second tool's survives. A NON-zero expectation is
+            // what makes this discriminate: against zero, a filter that excluded everything would also pass.
+            toolManager.EnabledToolsSkillMetadataTokenCount.ShouldBe(SecondSkillMetadataTokens);
+            toolManager.EnabledToolsTokenCount.ShouldBe(withSecond.TokenCount + withoutMetadata.TokenCount);
         }
 
         // ── Helpers ─────────────────────────────────────────────────────────────────────────────────
 
         private const string WithSkillToolName = "withSkillMetaTool";
+        private const string SecondSkillToolName = "secondSkillMetaTool";
         private const string SansSkillToolName = "sansSkillMetaTool";
         private const string WithSkillToolTitle = "With Skill Meta";
+        private const string SecondSkillToolTitle = "Second Skill Meta";
         private const string SansSkillToolTitle = "Sans Skill Meta";
 
         private IToolManager BuildSkillMetadataToolManager()
@@ -256,9 +314,11 @@ namespace com.IvanMurzak.McpPlugin.Tests.Mcp
             var builder = new McpPluginBuilder(_version);
 
             var withSkill = typeof(SkillMetadataToolClass).GetMethod(nameof(SkillMetadataToolClass.WithSkillMetadata));
+            var secondSkill = typeof(SkillMetadataToolClass).GetMethod(nameof(SkillMetadataToolClass.WithSecondSkillMetadata));
             var sansSkill = typeof(SkillMetadataToolClass).GetMethod(nameof(SkillMetadataToolClass.SansSkillMetadata));
 
             builder.WithTool(WithSkillToolName, WithSkillToolTitle, typeof(SkillMetadataToolClass), withSkill!);
+            builder.WithTool(SecondSkillToolName, SecondSkillToolTitle, typeof(SkillMetadataToolClass), secondSkill!);
             builder.WithTool(SansSkillToolName, SansSkillToolTitle, typeof(SkillMetadataToolClass), sansSkill!);
 
             return builder.Build(reflector).McpManager.ToolManager!;
@@ -271,23 +331,49 @@ namespace com.IvanMurzak.McpPlugin.Tests.Mcp
             return tool!;
         }
 
-        private static int ReadCachedField(object instance, string fieldName)
+        private static FieldInfo CachedField(object instance, string fieldName)
         {
             var field = instance.GetType().GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance);
             field.ShouldNotBeNull();
-            var value = (int?)field!.GetValue(instance);
+            return field!;
+        }
+
+        private static int ReadCachedField(object instance, string fieldName)
+        {
+            var value = (int?)CachedField(instance, fieldName).GetValue(instance);
             value.ShouldNotBeNull();
             return value!.Value;
         }
 
+        private static void WriteCachedField(object instance, string fieldName, int value)
+            => CachedField(instance, fieldName).SetValue(instance, (int?)value);
+
+        /// <summary>
+        /// Proves both counts are SERVED FROM their cache fields rather than recomputed on every read.
+        /// Reading a property twice and comparing cannot show that — a getter that recomputes agrees with
+        /// itself — so the fields are overwritten with a value no Calculate over these fixtures can produce.
+        /// </summary>
+        private static void ShouldServeBothCountsFromTheCacheFields(IRunTool tool)
+        {
+            WriteCachedField(tool, TotalCacheField, CacheSentinel);
+            WriteCachedField(tool, ShareCacheField, CacheSentinel);
+
+            tool.TokenCount.ShouldBe(CacheSentinel, $"TokenCount must be served from {TotalCacheField}");
+            tool.SkillMetadataTokenCount.ShouldBe(CacheSentinel, $"SkillMetadataTokenCount must be served from {ShareCacheField}");
+        }
+
         private class SkillMetadataToolClass
         {
-            [Description("Identical description on both fixtures so only the skill metadata differs.")]
+            [Description("Identical description on all fixtures so only the skill metadata differs.")]
             [AiSkillDescription(SkillDescriptionText)]
             [AiSkillBody(SkillBodyText)]
             public static string WithSkillMetadata(string value) => value;
 
-            [Description("Identical description on both fixtures so only the skill metadata differs.")]
+            [Description("Identical description on all fixtures so only the skill metadata differs.")]
+            [AiSkillDescription(SecondSkillDescriptionText)]
+            public static string WithSecondSkillMetadata(string value) => value;
+
+            [Description("Identical description on all fixtures so only the skill metadata differs.")]
             public static string SansSkillMetadata(string value) => value;
         }
     }

--- a/McpPlugin/src/Mcp/McpToolManager.cs
+++ b/McpPlugin/src/Mcp/McpToolManager.cs
@@ -70,6 +70,15 @@ namespace com.IvanMurzak.McpPlugin
             .Where(kvp => kvp.Value.Enabled)
             .Sum(kvp => kvp.Value.TokenCount);
 
+        /// <summary>
+        /// The skill-metadata share of <see cref="EnabledToolsTokenCount"/>, summed over the SAME enabled
+        /// tools so the two figures are directly comparable (subtracting one from the other yields the
+        /// pre-skill-metadata catalogue weight).
+        /// </summary>
+        public int EnabledToolsSkillMetadataTokenCount => _tools
+            .Where(kvp => kvp.Value.Enabled)
+            .Sum(kvp => kvp.Value.SkillMetadataTokenCount);
+
         public bool HasTool(string name) => _tools.ContainsKey(name);
         public bool AddTool(string name, IRunTool runner)
         {

--- a/McpPlugin/src/Mcp/Tool/IRunTool.cs
+++ b/McpPlugin/src/Mcp/Tool/IRunTool.cs
@@ -82,9 +82,24 @@ namespace com.IvanMurzak.McpPlugin
         bool? OpenWorldHint { get; }
 
         /// <summary>
-        /// Gets the semantic token count for this tool based on its JSON schema (including description).
+        /// Gets the semantic token count for this tool based on its JSON schema (including description
+        /// and the published skill metadata).
         /// </summary>
         int TokenCount { get; }
+
+        /// <summary>
+        /// The portion of <see cref="TokenCount"/> contributed by the published skill metadata
+        /// (<see cref="SkillDescription"/> / <see cref="SkillBody"/>), including its JSON key overhead.
+        /// <c>TokenCount - SkillMetadataTokenCount</c> is therefore the count the entry carried before that
+        /// metadata reached the wire — which is what makes "how much of the catalogue is skill metadata?"
+        /// answerable from a single listing. Zero when the tool publishes no skill metadata.
+        /// <para>
+        /// Defaulted so that an existing external <see cref="IRunTool"/> implementation keeps compiling; a
+        /// tool that publishes skill metadata should override it (see <see cref="RunTool"/> /
+        /// <see cref="ProxyTool"/>).
+        /// </para>
+        /// </summary>
+        int SkillMetadataTokenCount => 0;
 
         /// <summary>
         /// Executes the target method with named parameters.

--- a/McpPlugin/src/Mcp/Tool/IRunTool.cs
+++ b/McpPlugin/src/Mcp/Tool/IRunTool.cs
@@ -94,9 +94,10 @@ namespace com.IvanMurzak.McpPlugin
         /// metadata reached the wire — which is what makes "how much of the catalogue is skill metadata?"
         /// answerable from a single listing. Zero when the tool publishes no skill metadata.
         /// <para>
-        /// Defaulted so that an existing external <see cref="IRunTool"/> implementation keeps compiling; a
-        /// tool that publishes skill metadata should override it (see <see cref="RunTool"/> /
-        /// <see cref="ProxyTool"/>).
+        /// Defaulted so that an existing external <see cref="IRunTool"/> implementation keeps compiling; an
+        /// implementation whose tools publish skill metadata should provide its own (see
+        /// <see cref="RunTool"/> / <see cref="ProxyTool"/>), or its share is reported as zero while its
+        /// <see cref="TokenCount"/> may or may not include the payload.
         /// </para>
         /// </summary>
         int SkillMetadataTokenCount => 0;

--- a/McpPlugin/src/Mcp/Tool/ProxyTool.cs
+++ b/McpPlugin/src/Mcp/Tool/ProxyTool.cs
@@ -71,7 +71,9 @@ namespace com.IvanMurzak.McpPlugin
 
         /// <summary>
         /// Semantic token count for this tool, computed once (then cached) from the same chars/4 approximation
-        /// used by <see cref="RunTool"/> via the shared <see cref="ToolTokenCount.Calculate"/> helper.
+        /// used by <see cref="RunTool"/> via the shared <see cref="ToolTokenCount.Calculate"/> helper. Covers
+        /// the description AND the published skill metadata (<see cref="SkillDescription"/> /
+        /// <see cref="SkillBody"/>); <see cref="SkillMetadataTokenCount"/> is that payload's share of it.
         /// </summary>
         public int TokenCount
         {

--- a/McpPlugin/src/Mcp/Tool/ProxyTool.cs
+++ b/McpPlugin/src/Mcp/Tool/ProxyTool.cs
@@ -44,6 +44,7 @@ namespace com.IvanMurzak.McpPlugin
     {
         private readonly Func<string, IReadOnlyDictionary<string, JsonElement>?, CancellationToken, Task<ResponseCallTool>> _handler;
         private int? _cachedTokenCount;
+        private int? _cachedSkillMetadataTokenCount;
 
         public string Name { get; }
         public string? Title { get; }
@@ -81,7 +82,7 @@ namespace com.IvanMurzak.McpPlugin
 
                 try
                 {
-                    _cachedTokenCount = ToolTokenCount.Calculate(Name, Title, Description, InputSchema, OutputSchema);
+                    _cachedTokenCount = ToolTokenCount.Calculate(Name, Title, Description, SkillDescription, SkillBody, InputSchema, OutputSchema);
                 }
                 catch
                 {
@@ -91,6 +92,33 @@ namespace com.IvanMurzak.McpPlugin
                     _cachedTokenCount = 0;
                 }
                 return _cachedTokenCount.Value;
+            }
+        }
+
+        /// <summary>
+        /// The portion of <see cref="TokenCount"/> contributed by <see cref="SkillDescription"/> /
+        /// <see cref="SkillBody"/>, including their JSON key overhead. Computed once (then cached) from the
+        /// same helper <see cref="RunTool"/> uses. The two inputs are get-only and assigned in the
+        /// constructor, so — exactly like <see cref="TokenCount"/> — the cached value can never go stale.
+        /// </summary>
+        public int SkillMetadataTokenCount
+        {
+            get
+            {
+                if (_cachedSkillMetadataTokenCount.HasValue)
+                    return _cachedSkillMetadataTokenCount.Value;
+
+                try
+                {
+                    _cachedSkillMetadataTokenCount = ToolTokenCount.CalculateSkillMetadata(Name, Title, Description, SkillDescription, SkillBody, InputSchema, OutputSchema);
+                }
+                catch
+                {
+                    // Same silent resilience as TokenCount above: a breakdown must never be able to poison
+                    // IToolManager.EnabledToolsSkillMetadataTokenCount.
+                    _cachedSkillMetadataTokenCount = 0;
+                }
+                return _cachedSkillMetadataTokenCount.Value;
             }
         }
 

--- a/McpPlugin/src/Mcp/Tool/RunTool.TokenCount.cs
+++ b/McpPlugin/src/Mcp/Tool/RunTool.TokenCount.cs
@@ -19,9 +19,10 @@ namespace com.IvanMurzak.McpPlugin
         private int? _cachedSkillMetadataTokenCount;
 
         /// <summary>
-        /// Gets the semantic token count for this tool based on its JSON schema (including description).
-        /// The token count is calculated from the JSON representation of the tool's input schema and description.
-        /// This value is cached after the first calculation.
+        /// Gets the semantic token count for this tool based on its JSON schema (including description and
+        /// the published skill metadata). The token count is calculated from the JSON representation of the
+        /// tool's name, title, description, <see cref="SkillDescription"/> / <see cref="SkillBody"/>, input
+        /// schema and output schema. This value is cached after the first calculation.
         ///
         /// <para>
         /// <b>Note:</b> This uses a simplified approximation of 1 token per 4 characters, which is a common
@@ -46,9 +47,9 @@ namespace com.IvanMurzak.McpPlugin
         /// <summary>
         /// The portion of <see cref="TokenCount"/> contributed by this tool's published skill metadata
         /// (<see cref="SkillDescription"/> / <see cref="SkillBody"/>), including its JSON key overhead.
-        /// Cached on first read, like <see cref="TokenCount"/>: both inputs are fixed for the lifetime of
-        /// the instance (they are read from attributes on the underlying <c>Method</c>, which never
-        /// changes), so no cache invalidation is required.
+        /// Cached on first read, like <see cref="TokenCount"/>, and for the same reason: both inputs are read
+        /// from attributes on the underlying <c>Method</c>, which this type never rebinds, so no cache
+        /// invalidation is required.
         /// </summary>
         public int SkillMetadataTokenCount
         {

--- a/McpPlugin/src/Mcp/Tool/RunTool.TokenCount.cs
+++ b/McpPlugin/src/Mcp/Tool/RunTool.TokenCount.cs
@@ -16,6 +16,7 @@ namespace com.IvanMurzak.McpPlugin
     public partial class RunTool
     {
         private int? _cachedTokenCount;
+        private int? _cachedSkillMetadataTokenCount;
 
         /// <summary>
         /// Gets the semantic token count for this tool based on its JSON schema (including description).
@@ -43,8 +44,28 @@ namespace com.IvanMurzak.McpPlugin
         }
 
         /// <summary>
+        /// The portion of <see cref="TokenCount"/> contributed by this tool's published skill metadata
+        /// (<see cref="SkillDescription"/> / <see cref="SkillBody"/>), including its JSON key overhead.
+        /// Cached on first read, like <see cref="TokenCount"/>: both inputs are fixed for the lifetime of
+        /// the instance (they are read from attributes on the underlying <c>Method</c>, which never
+        /// changes), so no cache invalidation is required.
+        /// </summary>
+        public int SkillMetadataTokenCount
+        {
+            get
+            {
+                if (_cachedSkillMetadataTokenCount.HasValue)
+                    return _cachedSkillMetadataTokenCount.Value;
+
+                _cachedSkillMetadataTokenCount = CalculateSkillMetadataTokenCount();
+                return _cachedSkillMetadataTokenCount.Value;
+            }
+        }
+
+        /// <summary>
         /// Calculates the semantic token count for this tool.
-        /// The calculation is based on the JSON Schema including name, title, description, input schema, and output schema.
+        /// The calculation is based on the JSON Schema including name, title, description, published skill
+        /// metadata, input schema, and output schema.
         /// Uses a simple approximation: characters / 4 for semantic tokens (common for many LLM tokenizers).
         /// Delegates to the shared <see cref="ToolTokenCount.Calculate"/> helper so that the formula is
         /// identical to <see cref="ProxyTool"/>.
@@ -53,11 +74,29 @@ namespace com.IvanMurzak.McpPlugin
         {
             try
             {
-                return ToolTokenCount.Calculate(Name, Title, Description, InputSchema, OutputSchema);
+                return ToolTokenCount.Calculate(Name, Title, Description, SkillDescription, SkillBody, InputSchema, OutputSchema);
             }
             catch (Exception ex)
             {
                 _logger?.LogWarning(ex, "Failed to calculate token count for tool '{0}'. Returning 0.", Name);
+                return 0;
+            }
+        }
+
+        /// <summary>
+        /// Calculates the skill-metadata share of this tool's token count, with the same
+        /// return-0-on-failure resilience <see cref="CalculateTokenCount"/> has: a breakdown must never
+        /// be able to poison <see cref="IToolManager.EnabledToolsSkillMetadataTokenCount"/>.
+        /// </summary>
+        private int CalculateSkillMetadataTokenCount()
+        {
+            try
+            {
+                return ToolTokenCount.CalculateSkillMetadata(Name, Title, Description, SkillDescription, SkillBody, InputSchema, OutputSchema);
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning(ex, "Failed to calculate skill-metadata token count for tool '{0}'. Returning 0.", Name);
                 return 0;
             }
         }

--- a/McpPlugin/src/Mcp/Tool/ToolTokenCount.cs
+++ b/McpPlugin/src/Mcp/Tool/ToolTokenCount.cs
@@ -33,6 +33,14 @@ namespace com.IvanMurzak.McpPlugin
         /// JSON key the skill description is measured under. Deliberately the same spelling the wire uses
         /// for <c>tools/list</c> <c>_meta.skillDescription</c> (McpPlugin.Server's <c>ExtensionsListMeta</c>),
         /// so the instrument measures the payload that is actually shipped.
+        /// <para>
+        /// <b>This is a SECOND declaration of that spelling, not a reference to it</b> — McpPlugin.Server
+        /// cannot be referenced from here, and the measured count depends on the key's LENGTH, so a rename on
+        /// one side alone would silently shift every skill-bearing tool's share. Each side is pinned to the
+        /// literal by its own test, so a one-sided rename reddens that side; keeping them in step is a
+        /// convention, not a compile-time guarantee. Single-sourcing the pair in McpPlugin.Common (which both
+        /// assemblies already reference) would make it one, at the cost of new public surface there.
+        /// </para>
         /// </summary>
         public const string SkillDescriptionKey = "skillDescription";
 
@@ -48,12 +56,22 @@ namespace com.IvanMurzak.McpPlugin
         /// non-empty fields and the (non-null) schema nodes, serializes it, and returns <c>ceil(length / 4)</c>.
         /// </summary>
         /// <remarks>
+        /// <para>
+        /// The skill members are measured FLAT, alongside the other fields, whereas the wire nests them inside
+        /// a <c>_meta</c> object. For an enabled tool that object exists only because of them, so the figure
+        /// omits its own <c>,"_meta":{</c> … <c>}</c> wrapper — about ten characters, two to three tokens per
+        /// skill-bearing tool. That is deliberate: the members are counted under the same flat accounting
+        /// every other member gets, rather than in a unit of their own. Treat the result as a catalogue-weight
+        /// estimate, not as byte-exact wire cost.
+        /// </para>
+        /// <para>
         /// The schema nodes are inserted via a detached deep copy (round-trip through
         /// <see cref="JsonNode.ToJsonString(System.Text.Json.JsonSerializerOptions)"/> +
         /// <see cref="JsonNode.Parse(string, System.Text.Json.Nodes.JsonNodeOptions?, System.Text.Json.JsonDocumentOptions)"/>)
         /// so that the caller's live <see cref="JsonNode"/> is never re-parented (a <see cref="JsonNode"/>
         /// may only have a single parent). The serialized JSON — and therefore the resulting count — is
         /// identical to assigning the node directly, so this is behavior-preserving for the numeric result.
+        /// </para>
         /// </remarks>
         public static int Calculate(
             string? name,

--- a/McpPlugin/src/Mcp/Tool/ToolTokenCount.cs
+++ b/McpPlugin/src/Mcp/Tool/ToolTokenCount.cs
@@ -30,9 +30,22 @@ namespace com.IvanMurzak.McpPlugin
     internal static class ToolTokenCount
     {
         /// <summary>
-        /// Calculates the semantic token count from a tool's name, title, description, input schema, and
-        /// output schema. The calculation builds a JSON object containing the non-empty fields and the
-        /// (non-null) schema nodes, serializes it, and returns <c>ceil(length / 4)</c>.
+        /// JSON key the skill description is measured under. Deliberately the same spelling the wire uses
+        /// for <c>tools/list</c> <c>_meta.skillDescription</c> (McpPlugin.Server's <c>ExtensionsListMeta</c>),
+        /// so the instrument measures the payload that is actually shipped.
+        /// </summary>
+        public const string SkillDescriptionKey = "skillDescription";
+
+        /// <summary>
+        /// JSON key the skill body is measured under. Same wire-parity rule as
+        /// <see cref="SkillDescriptionKey"/> (<c>tools/list</c> <c>_meta.skillBody</c>).
+        /// </summary>
+        public const string SkillBodyKey = "skillBody";
+
+        /// <summary>
+        /// Calculates the semantic token count from a tool's name, title, description, published skill
+        /// metadata, input schema, and output schema. The calculation builds a JSON object containing the
+        /// non-empty fields and the (non-null) schema nodes, serializes it, and returns <c>ceil(length / 4)</c>.
         /// </summary>
         /// <remarks>
         /// The schema nodes are inserted via a detached deep copy (round-trip through
@@ -42,7 +55,14 @@ namespace com.IvanMurzak.McpPlugin
         /// may only have a single parent). The serialized JSON — and therefore the resulting count — is
         /// identical to assigning the node directly, so this is behavior-preserving for the numeric result.
         /// </remarks>
-        public static int Calculate(string? name, string? title, string? description, JsonNode? inputSchema, JsonNode? outputSchema)
+        public static int Calculate(
+            string? name,
+            string? title,
+            string? description,
+            string? skillDescription,
+            string? skillBody,
+            JsonNode? inputSchema,
+            JsonNode? outputSchema)
         {
             // Build a JSON representation of the tool's schema using JsonObject
             var jsonObject = new JsonObject();
@@ -57,6 +77,16 @@ namespace com.IvanMurzak.McpPlugin
             if (!string.IsNullOrEmpty(description))
                 jsonObject["description"] = description;
 
+            // Published skill metadata. It reaches every MCP client on the tools/list entry as
+            // _meta.skillDescription / _meta.skillBody, gated there on the SAME string.IsNullOrEmpty
+            // test used here — so an absent value costs nothing and a present one is measured exactly
+            // once, under the same accounting the members above get.
+            if (!string.IsNullOrEmpty(skillDescription))
+                jsonObject[SkillDescriptionKey] = skillDescription;
+
+            if (!string.IsNullOrEmpty(skillBody))
+                jsonObject[SkillBodyKey] = skillBody;
+
             // Add schemas as detached copies so the caller's live nodes are not re-parented.
             if (inputSchema != null)
                 jsonObject["inputSchema"] = JsonNode.Parse(inputSchema.ToJsonString());
@@ -70,6 +100,30 @@ namespace com.IvanMurzak.McpPlugin
             // Calculate tokens: using a common approximation of 1 token per 4 characters
             // This is a reasonable estimate for English text and JSON structures
             return (int)Math.Ceiling(jsonString.Length / 4.0);
+        }
+
+        /// <summary>
+        /// The portion of <see cref="Calculate"/>'s result contributed by the published skill metadata,
+        /// including the JSON key and separator overhead the two members bring with them. Defined as the
+        /// difference between the full count and the count of the identical tool with no skill metadata,
+        /// so <c>total - share</c> is exactly the count the entry carried before that metadata reached
+        /// the wire, and the meaning of the total itself is unchanged for every existing caller.
+        /// Returns <c>0</c> when the tool publishes no skill metadata.
+        /// </summary>
+        public static int CalculateSkillMetadata(
+            string? name,
+            string? title,
+            string? description,
+            string? skillDescription,
+            string? skillBody,
+            JsonNode? inputSchema,
+            JsonNode? outputSchema)
+        {
+            if (string.IsNullOrEmpty(skillDescription) && string.IsNullOrEmpty(skillBody))
+                return 0;
+
+            return Calculate(name, title, description, skillDescription, skillBody, inputSchema, outputSchema)
+                 - Calculate(name, title, description, null, null, inputSchema, outputSchema);
         }
     }
 }

--- a/McpPlugin/src/McpPlugin/Interfaces/IToolManager.cs
+++ b/McpPlugin/src/McpPlugin/Interfaces/IToolManager.cs
@@ -42,8 +42,14 @@ namespace com.IvanMurzak.McpPlugin
         /// weighed before that metadata reached the wire, so the two together answer "how much of the
         /// catalogue is skill metadata?" without changing the meaning of the total.
         /// <para>
+        /// <b>Note:</b> that subtraction reads the two properties independently, and each re-walks the tool
+        /// set on access (see <see cref="EnabledToolsTokenCount"/>). Registering or enabling a tool between
+        /// the two reads therefore yields a difference computed from two different catalogues. Take both
+        /// figures at a point where the catalogue is not being mutated.
+        /// </para>
+        /// <para>
         /// Defaulted to <c>0</c> so an existing external <see cref="IToolManager"/> implementation keeps
-        /// compiling; <see cref="McpToolManager"/> overrides it.
+        /// compiling; <see cref="McpToolManager"/> implements it.
         /// </para>
         /// </summary>
         int EnabledToolsSkillMetadataTokenCount => 0;

--- a/McpPlugin/src/McpPlugin/Interfaces/IToolManager.cs
+++ b/McpPlugin/src/McpPlugin/Interfaces/IToolManager.cs
@@ -33,7 +33,21 @@ namespace com.IvanMurzak.McpPlugin
         /// </para>
         /// </summary>
         int EnabledToolsTokenCount { get; }
-        
+
+        /// <summary>
+        /// The portion of <see cref="EnabledToolsTokenCount"/> contributed by the enabled tools' published
+        /// skill metadata (<c>_meta.skillDescription</c> / <c>_meta.skillBody</c> on every
+        /// <c>tools/list</c> entry), including its JSON key overhead.
+        /// <c>EnabledToolsTokenCount - EnabledToolsSkillMetadataTokenCount</c> is what the catalogue
+        /// weighed before that metadata reached the wire, so the two together answer "how much of the
+        /// catalogue is skill metadata?" without changing the meaning of the total.
+        /// <para>
+        /// Defaulted to <c>0</c> so an existing external <see cref="IToolManager"/> implementation keeps
+        /// compiling; <see cref="McpToolManager"/> overrides it.
+        /// </para>
+        /// </summary>
+        int EnabledToolsSkillMetadataTokenCount => 0;
+
         IEnumerable<IRunTool> GetAllTools();
         bool HasTool(string name);
         bool AddTool(string name, IRunTool runner);

--- a/docs/plant-logs/tool-token-count-skill-metadata.md
+++ b/docs/plant-logs/tool-token-count-skill-metadata.md
@@ -25,17 +25,25 @@ capable of failing, and known to fail for **its own** reason.
 
 - Every plant's log shows `McpPlugin -> …\bin\Release\net8.0\McpPlugin.dll` **and** the `net9.0`
   line, i.e. the planted bytes really were compiled.
-- Every plant collected **`Total: 11` on both TFMs** — a constant count across all 13 plants, which
-  is what rules out a mutation that reddened the suite by breaking the build/collection instead of
-  by breaking the claim.
+- Every plant collected **`Total: 15`** — a constant count across all 19 plants, which is what rules
+  out a mutation that reddened the suite by breaking the build/collection instead of by breaking the
+  claim. Every plant's log also carries a `Failed!` line: a filter matching nothing exits 0, so a
+  non-zero `Total:` is the only thing separating a real red from a run that collected no tests.
 - All test ids below are under
   `com.IvanMurzak.McpPlugin.Tests.Mcp.ToolTokenCountSkillMetadataTests`.
 
 ## Result
 
 ```
-SUMMARY  13/13 matched their expect | 13 RED | 0 GREEN | restore-failures 0
+SUMMARY  19/19 matched their expect | 19 RED | 0 GREEN | restore-failures 0
 ```
+
+The round was re-run and extended after review. P1-P13 are the original round; P4 and P5 were
+**re-pointed** onto the single-member tests, where each reddens a test the other leaves green
+(before, both named the baseline test and differed only by an integer). P14-P19 cover claims the
+review found asserted but unproven — the empty-string gate, the `skillDescription` key spelling,
+the share guard's single-member path, that the cache exists at all, base-independence, and that the
+catalogue aggregation is an addition rather than a maximum.
 
 ## The plants
 
@@ -44,37 +52,64 @@ SUMMARY  13/13 matched their expect | 13 RED | 0 GREEN | restore-failures 0
 | P1 | `Calculate`: both skill members deleted — the pre-change instrument | `Calculate_WithSkillMetadata_AddsExactlyTheMeasuredPayload` | `withMetadata should be 85 but was 48` |
 | P2 | `Calculate`: only the `skillDescription` member deleted | `Calculate_WithSkillDescriptionOnly_AddsExactlyThatMembersPayload` | `value should be 64 but was 48` |
 | P3 | `Calculate`: only the `skillBody` member deleted | `Calculate_WithSkillBodyOnly_AddsExactlyThatMembersPayload` | `value should be 69 but was 48` |
-| P4 | `Calculate`: `skillDescription` measured **unconditionally** (the `IsNullOrEmpty` gate dropped) | `Calculate_WithoutSkillMetadata_PinsThePreChangeBaselineExactly` | `nulls should be 48 but was 54` |
-| P5 | `Calculate`: `skillBody` measured **unconditionally** | `Calculate_WithoutSkillMetadata_PinsThePreChangeBaselineExactly` | `nulls should be 48 but was 52` |
+| P4 | `Calculate`: `skillDescription` measured **unconditionally** (the `IsNullOrEmpty` gate dropped) | `Calculate_WithSkillBodyOnly_AddsExactlyThatMembersPayload` | `value should be 69 but was 75` |
+| P5 | `Calculate`: `skillBody` measured **unconditionally** | `Calculate_WithSkillDescriptionOnly_AddsExactlyThatMembersPayload` | `value should be 64 but was 68` |
 | P6 | `SkillBodyKey` changed to `"skill_body"` — measured under a key the wire does not use | `Calculate_MeasuresTheSkillMembersUnderTheirPublishedWireKeys` | `ToolTokenCount.SkillBodyKey should be "skillBody" but was "skill_body"` |
 | P7 | `CalculateSkillMetadata` returns a constant `0` | `CalculateSkillMetadata_ReturnsTheExactShareOfTheTotal` | `both should be 37 but was 0` |
 | P8 | `RunTool.CalculateTokenCount` passes `null, null` instead of `SkillDescription, SkillBody` | `RunTool_TokenCount_MeasuresSkillMetadata_ByExactlyTheMeasuredDelta` | `withMetadata.TokenCount should be 121 but was 84` |
 | P9 | `RunTool.CalculateSkillMetadataTokenCount` passes `null, null` | `RunTool_TokenCount_MeasuresSkillMetadata_ByExactlyTheMeasuredDelta` | `withMetadata.SkillMetadataTokenCount should be 37 but was 0` |
 | P10 | `ProxyTool.TokenCount` passes `null, null` | `ProxyTool_TokenCount_MeasuresSkillMetadata_AndCachesTheSkillInclusiveValue` | `withMetadata.TokenCount should be 85 but was 48` |
 | P11 | `ProxyTool.SkillMetadataTokenCount` passes `null, null` | `ProxyTool_TokenCount_MeasuresSkillMetadata_AndCachesTheSkillInclusiveValue` | `withMetadata.SkillMetadataTokenCount should be 37 but was 0` |
-| P12 | `McpToolManager.EnabledToolsSkillMetadataTokenCount` drops the `.Where(… Enabled)` filter | `EnabledToolsSkillMetadataTokenCount_ExcludesDisabledTools` | `toolManager.EnabledToolsSkillMetadataTokenCount should be 0 but was 37` |
-| P13 | `McpToolManager` stops overriding the breakdown, so `IToolManager`'s default-interface `0` is served | `EnabledToolsSkillMetadataTokenCount_IsTheShareOfTheEnabledCatalogue` | `toolManager.EnabledToolsSkillMetadataTokenCount should be 37 but was 0` |
+| P12 | `McpToolManager.EnabledToolsSkillMetadataTokenCount` drops the `.Where(… Enabled)` filter | `EnabledToolsSkillMetadataTokenCount_ExcludesDisabledTools` | `toolManager.EnabledToolsSkillMetadataTokenCount should be 13 but was 50` |
+| P13 | `McpToolManager` stops overriding the breakdown, so `IToolManager`'s default-interface `0` is served | `EnabledToolsSkillMetadataTokenCount_IsTheShareOfTheEnabledCatalogue` | `toolManager.EnabledToolsSkillMetadataTokenCount should be 50 but was 0` |
+| P14 | `Calculate`: the `skillDescription` gate weakened from `!IsNullOrEmpty` to `!= null` — an **empty string** is then measured | `Calculate_WithoutSkillMetadata_PinsThePreChangeBaselineExactly` | `empties should be 48 but was 53` (`an EMPTY-STRING skill member must cost exactly nothing`) |
+| P15 | `SkillDescriptionKey` changed to `"skill_description"` — P6's mirror, so neither key spelling stands in for the other | `Calculate_MeasuresTheSkillMembersUnderTheirPublishedWireKeys` | `ToolTokenCount.SkillDescriptionKey should be "skillDescription" but was "skill_description"` |
+| P16 | `CalculateSkillMetadata`: the guard's `&&` weakened to `||`, so a tool carrying only ONE member reports no share | `CalculateSkillMetadata_ReturnsTheExactShareOfTheTotal` | `descriptionOnly should be 16 but was 0` |
+| P17 | `RunTool.SkillMetadataTokenCount` returns without ever writing its cache field | `RunTool_CachesTheSkillInclusiveCounts` | `value should not be null but was` |
+| P18 | `Calculate`: the measured `skillBody` payload inflated by **one character** | `Calculate_TheSkillMetadataDelta_IsIndependentOfTheBaseLength` | `with - without should be 37 but was 38` (`base padded by 2 character(s)`) |
+| P19 | `McpToolManager`: the catalogue breakdown's `.Sum(…)` replaced by `.Max(…)` | `EnabledToolsSkillMetadataTokenCount_IsTheShareOfTheEnabledCatalogue` | `toolManager.EnabledToolsSkillMetadataTokenCount should be 50 but was 37` |
 
 ## Why the plants are decomposed this way
 
 - **Both directions, as separate plants.** P1–P3 remove the measurement (a tool that ships skill
-  metadata must count *more*); P4–P5 make it unconditional (a tool that ships none must count
-  *exactly what it counted before*). Neither direction can stand in for the other: a constant
-  `+1` survives every "greater than" assertion, and an always-on member survives every
+  metadata must count *more*); P4–P5 and P14 make it unconditional (a tool that ships none must count
+  *exactly what it counted before* — P4/P5 for a `null` member, P14 for an empty string, which the
+  gate is separately required to treat as free). Neither direction can stand in for the other: a
+  constant `+1` survives every "greater than" assertion, and an always-on member survives every
   "the payload is measured" assertion.
 - **One plant per independently breakable half.** P1 is the bundled revert the change's own
   acceptance criteria name, and a bundle reddens through whichever half fires first — so the
   `skillDescription` half (P2) and the `skillBody` half (P3) each get their own plant, as do the
-  total (P8/P10) and the breakdown (P9/P11) on each of the two `IRunTool` implementations.
-- **Three tests are named by two plants each** (P4/P5, P8/P9, P10/P11). That is only evidence if
-  the two reds are *tellable apart*, so each pair's runner output above is quoted from its own
-  per-plant log and the two differ: `54` vs `52` (the two null keys are different lengths),
-  and `TokenCount` vs `SkillMetadataTokenCount` for both wiring pairs.
+  total (P8/P10) and the breakdown (P9/P11) on each of the two `IRunTool` implementations, the two
+  key spellings (P6/P15), the share guard's both-members and single-member paths (P7/P16), the
+  existence of the cache (P17), and the catalogue's filter and its addition (P12/P19).
+  **Reached but deliberately unplanted:** the `catch → 0` arms on both implementations (unreachable
+  through the public surface — the schemas are detached in the constructor), and
+  `CalculateSkillMetadata`'s early return, which is a fast path whose deletion is unobservable
+  because `Calculate`'s own gates already make the difference zero. Both are recorded here rather
+  than covered, so nobody reads their silence as coverage.
+- **Two plants naming one test must fail DIFFERENTLY.** Fourteen plants name seven tests in pairs, so each
+  pair's runner output above is reproduced — whitespace collapsed onto one line — from its own
+  per-plant log, and no pair prints the same text. The seven pairs are P2/P5, P3/P4, P6/P15, P7/P16,
+  P8/P9, P10/P11 and P13/P19. Most differ by which symbol the assertion names (`TokenCount` vs
+  `SkillMetadataTokenCount`; `SkillBodyKey` vs `SkillDescriptionKey`; `both` vs `descriptionOnly`).
+  **P4/P5 were re-pointed to get that property.** On the baseline test they printed
+  `nulls should be 48 but was 54` and `… but was 52` — non-vacuous and correctly attributed, yet
+  tellable apart only by knowing that `"skillDescription"` is seven characters longer than
+  `"skillBody"`. Moving each onto the single-member test the *other* member's plant leaves green
+  (P4 → `…WithSkillBodyOnly`, P5 → `…WithSkillDescriptionOnly`) means a future red names the
+  member that regressed. The baseline test keeps its own plant in P14.
 - **No `> 0` / `>=` assertion is used anywhere in the suite.** The counter has a
   "no skill metadata" branch that satisfies any bound for free; only an exact figure can tell a
-  measured payload from an unmeasured one. The expected figures are literals derived from the
-  fixture's own JSON length, not recomputed by the test from the implementation.
+  measured payload from an unmeasured one. The direct-helper and `ProxyTool` expectations are
+  literals derived from the fixture's own JSON length. The reflection-based `RunTool` and
+  catalogue expectations are exact *relative* figures — a sibling's count plus the literal `37` —
+  because the test does not author the reflected input schema; the base-independence below is what
+  makes that delta exact rather than approximate.
 - **The `+37` delta is base-independent by construction.** The two fixture strings are sized so the
   skill members add exactly 148 characters — a multiple of the 4-characters-per-token divisor — so
   `ceil((L + 148)/4) - ceil(L/4) = 37` whatever `L` is. That is what lets the reflection-based
-  `RunTool` assertion pin an exact delta over an input schema the test does not author.
+  `RunTool` assertion pin an exact delta over an input schema the test does not author. It also
+  costs: at one base length the count cannot tell 148 characters from 147-150, so the delta is
+  additionally asserted over four base lengths covering every residue modulo the divisor, and
+  P18 (payload inflated by one character) reddens exactly the row that can see it.

--- a/docs/plant-logs/tool-token-count-skill-metadata.md
+++ b/docs/plant-logs/tool-token-count-skill-metadata.md
@@ -1,0 +1,80 @@
+# Plant log — `ToolTokenCount` measures the published skill metadata
+
+Verification record for the change that taught `ToolTokenCount.Calculate` to measure the
+`skillDescription` / `skillBody` payload that `tools/list` already ships in `_meta`, plus the
+`SkillMetadataTokenCount` / `EnabledToolsSkillMetadataTokenCount` breakdown.
+
+A green test proves nothing on its own: it may pass for a reason the feature does not supply. Each
+claim below was therefore mutated one at a time — the mutation applied to the real source, the suite
+re-built and re-run, the source restored byte-exactly — so that every assertion is known to be
+capable of failing, and known to fail for **its own** reason.
+
+## How the round was run
+
+- Mutations applied one at a time by a plant-and-revert harness that backs each file up out of tree,
+  substitutes bytes, runs the verify command once, restores from that copy, and checks the restore
+  by checksum. No `git checkout --` is involved, so uncommitted work is never at risk.
+- Verify command, per plant (the build is inside the `&&` chain, so no plant is ever scored against
+  the previous plant's assemblies):
+
+  ```bash
+  dotnet build McpPlugin.Tests/McpPlugin.Tests.csproj --no-restore --configuration Release \
+    && dotnet test McpPlugin.Tests/McpPlugin.Tests.csproj --no-build --configuration Release \
+       --filter "FullyQualifiedName~ToolTokenCountSkillMetadataTests"
+  ```
+
+- Every plant's log shows `McpPlugin -> …\bin\Release\net8.0\McpPlugin.dll` **and** the `net9.0`
+  line, i.e. the planted bytes really were compiled.
+- Every plant collected **`Total: 11` on both TFMs** — a constant count across all 13 plants, which
+  is what rules out a mutation that reddened the suite by breaking the build/collection instead of
+  by breaking the claim.
+- All test ids below are under
+  `com.IvanMurzak.McpPlugin.Tests.Mcp.ToolTokenCountSkillMetadataTests`.
+
+## Result
+
+```
+SUMMARY  13/13 matched their expect | 13 RED | 0 GREEN | restore-failures 0
+```
+
+## The plants
+
+| # | Mutation (the claim it removes) | Reddened test | Runner output |
+|---|---|---|---|
+| P1 | `Calculate`: both skill members deleted — the pre-change instrument | `Calculate_WithSkillMetadata_AddsExactlyTheMeasuredPayload` | `withMetadata should be 85 but was 48` |
+| P2 | `Calculate`: only the `skillDescription` member deleted | `Calculate_WithSkillDescriptionOnly_AddsExactlyThatMembersPayload` | `value should be 64 but was 48` |
+| P3 | `Calculate`: only the `skillBody` member deleted | `Calculate_WithSkillBodyOnly_AddsExactlyThatMembersPayload` | `value should be 69 but was 48` |
+| P4 | `Calculate`: `skillDescription` measured **unconditionally** (the `IsNullOrEmpty` gate dropped) | `Calculate_WithoutSkillMetadata_PinsThePreChangeBaselineExactly` | `nulls should be 48 but was 54` |
+| P5 | `Calculate`: `skillBody` measured **unconditionally** | `Calculate_WithoutSkillMetadata_PinsThePreChangeBaselineExactly` | `nulls should be 48 but was 52` |
+| P6 | `SkillBodyKey` changed to `"skill_body"` — measured under a key the wire does not use | `Calculate_MeasuresTheSkillMembersUnderTheirPublishedWireKeys` | `ToolTokenCount.SkillBodyKey should be "skillBody" but was "skill_body"` |
+| P7 | `CalculateSkillMetadata` returns a constant `0` | `CalculateSkillMetadata_ReturnsTheExactShareOfTheTotal` | `both should be 37 but was 0` |
+| P8 | `RunTool.CalculateTokenCount` passes `null, null` instead of `SkillDescription, SkillBody` | `RunTool_TokenCount_MeasuresSkillMetadata_ByExactlyTheMeasuredDelta` | `withMetadata.TokenCount should be 121 but was 84` |
+| P9 | `RunTool.CalculateSkillMetadataTokenCount` passes `null, null` | `RunTool_TokenCount_MeasuresSkillMetadata_ByExactlyTheMeasuredDelta` | `withMetadata.SkillMetadataTokenCount should be 37 but was 0` |
+| P10 | `ProxyTool.TokenCount` passes `null, null` | `ProxyTool_TokenCount_MeasuresSkillMetadata_AndCachesTheSkillInclusiveValue` | `withMetadata.TokenCount should be 85 but was 48` |
+| P11 | `ProxyTool.SkillMetadataTokenCount` passes `null, null` | `ProxyTool_TokenCount_MeasuresSkillMetadata_AndCachesTheSkillInclusiveValue` | `withMetadata.SkillMetadataTokenCount should be 37 but was 0` |
+| P12 | `McpToolManager.EnabledToolsSkillMetadataTokenCount` drops the `.Where(… Enabled)` filter | `EnabledToolsSkillMetadataTokenCount_ExcludesDisabledTools` | `toolManager.EnabledToolsSkillMetadataTokenCount should be 0 but was 37` |
+| P13 | `McpToolManager` stops overriding the breakdown, so `IToolManager`'s default-interface `0` is served | `EnabledToolsSkillMetadataTokenCount_IsTheShareOfTheEnabledCatalogue` | `toolManager.EnabledToolsSkillMetadataTokenCount should be 37 but was 0` |
+
+## Why the plants are decomposed this way
+
+- **Both directions, as separate plants.** P1–P3 remove the measurement (a tool that ships skill
+  metadata must count *more*); P4–P5 make it unconditional (a tool that ships none must count
+  *exactly what it counted before*). Neither direction can stand in for the other: a constant
+  `+1` survives every "greater than" assertion, and an always-on member survives every
+  "the payload is measured" assertion.
+- **One plant per independently breakable half.** P1 is the bundled revert the change's own
+  acceptance criteria name, and a bundle reddens through whichever half fires first — so the
+  `skillDescription` half (P2) and the `skillBody` half (P3) each get their own plant, as do the
+  total (P8/P10) and the breakdown (P9/P11) on each of the two `IRunTool` implementations.
+- **Three tests are named by two plants each** (P4/P5, P8/P9, P10/P11). That is only evidence if
+  the two reds are *tellable apart*, so each pair's runner output above is quoted from its own
+  per-plant log and the two differ: `54` vs `52` (the two null keys are different lengths),
+  and `TokenCount` vs `SkillMetadataTokenCount` for both wiring pairs.
+- **No `> 0` / `>=` assertion is used anywhere in the suite.** The counter has a
+  "no skill metadata" branch that satisfies any bound for free; only an exact figure can tell a
+  measured payload from an unmeasured one. The expected figures are literals derived from the
+  fixture's own JSON length, not recomputed by the test from the implementation.
+- **The `+37` delta is base-independent by construction.** The two fixture strings are sized so the
+  skill members add exactly 148 characters — a multiple of the 4-characters-per-token divisor — so
+  `ceil((L + 148)/4) - ceil(L/4) = 37` whatever `L` is. That is what lets the reflection-based
+  `RunTool` assertion pin an exact delta over an input schema the test does not author.


### PR DESCRIPTION
Implements Taskflow `2026-08-28-tool-catalog` task **a4-token-count-includes-skill-meta**
(owner ruling F2, to land before gate G1). Tracked on the Taskflow board, not on a GitHub issue
(matching PRs #211/#212/#213/#216/#217).

## Summary

- **`ToolTokenCount.Calculate` now measures the skill metadata that `tools/list` already ships.**
  It counted only `name` / `title` / `description` / `inputSchema` / `outputSchema`, so once #216
  started emitting `_meta.skillDescription` / `_meta.skillBody` on every listing entry,
  `EnabledToolsTokenCount` under-reported the catalogue by the largest component of it — the repo's
  own catalogue-weight instrument was blind to the payload it exists to report.
- **Measured under the wire's own keys, behind the wire's own gate.** The two members serialize as
  `skillDescription` / `skillBody` (published as `ToolTokenCount.SkillDescriptionKey` /
  `SkillBodyKey`) and are included on exactly the `string.IsNullOrEmpty` test
  `ExtensionsListMeta.BuildToolMeta` uses. An absent — or empty-string — value therefore still costs
  **exactly nothing**, so a tool that publishes no skill metadata counts what it counted before this
  change, to the token.
- **Both call sites wired**: `RunTool.CalculateTokenCount` and `ProxyTool.TokenCount`.
- **No cache invalidation is needed, and that is a property of the inputs, not an assumption.**
  `RunTool` reads both values from attributes on a `Method` that never changes; `ProxyTool`'s are
  get-only and assigned in the constructor. So the value cached on first read is simply the
  skill-inclusive one — pinned by tests that assert the *cached field itself* holds the
  skill-inclusive figure, not merely that repeated reads agree.
- **Adds a breakdown, because a single blended number cannot answer "how much of the catalogue is
  skill metadata?"** — which is the question the F1 cost discussion was actually about.
  `IRunTool.SkillMetadataTokenCount` and `IToolManager.EnabledToolsSkillMetadataTokenCount` are the
  share, including JSON key overhead, defined as *total − the same entry without skill metadata* so
  that `total − share` is exactly the pre-`_meta` weight. **The total's meaning is unchanged for
  every existing caller.**
- **Both new members are default-interface members** (`=> 0`), following the `IToolManager.ToolCallsCount`
  and `IRunTool.ToolType` precedent already in these two interfaces, so no existing external
  implementor breaks. `McpToolManager` overrides the manager-level one, and P13 below is the plant
  that proves the override is load-bearing rather than silently masked by the default.
- Out of scope, untouched: the `a3` server-side gate, any wire-format change, and `Consts.ApiVersion`
  (stays `"2.0.0"`). No `<Version>` bump, no ReflectorNet pin change, no release.

## Test plan

- [x] Local tests passed — solution-level, Release:
      **4/4 test hosts `Test Run Successful.`, 0 `Test Run Failed.`**, 1000 + 1000
      (`McpPlugin.Tests`, net8.0/net9.0) and 756 + 756 (`McpPlugin.Server.Tests`, net8.0/net9.0)
      = **3,512 passed, 0 failed**. No test in the machine-load-sensitive
      `ConnectionManagerTests` class fired locally. CI's `test (macos-latest)` net8.0 leg
      subsequently timed out in a sibling of that class,
      `Connect_WhenCalledConcurrently_ReusesFirstConnectionAttempt`
      (`TimeoutException: Tasks did not complete within expected time`, thrown by a fixed 5000 ms
      `Task.Delay` race in the test's own `EnsureTasksCompleteAsync` helper). The net9.0 leg of the
      same job on the same commit passed all 1000; ubuntu and windows are green; and neither
      `ConnectionManagerTests` nor any type it references is in this diff.
- [x] `dotnet restore` → `dotnet build --no-restore --configuration Release`: 0 errors, 8 warnings
      (all pre-existing `CS8604` in `McpPlugin.Tests`, unchanged count vs. the base tree).

### New coverage — `McpPlugin.Tests/Mcp/ToolTokenCountSkillMetadataTests.cs` (11 tests × 2 TFMs)

Every expectation is an **exact** figure. No `> 0` / `>=` assertion appears anywhere in the suite:
the counter has a "no skill metadata" branch that satisfies any bound for free, so only an exact
value can tell a measured payload from an unmeasured one. The expected numbers are literals derived
from the fixture's own JSON length — the test never recomputes them from the implementation.

| Where | What it pins |
|---|---|
| `Calculate_WithoutSkillMetadata_PinsThePreChangeBaselineExactly` | The unchanged baseline, as the literal **48**, for `null` **and** for empty strings — the "same accounting the existing members get" half. |
| `Calculate_WithSkillMetadata_AddsExactlyTheMeasuredPayload` | Literal **85**, i.e. the delta is the measured **37**, not "greater than zero". |
| `Calculate_With{SkillDescription,SkillBody}Only_…` | **64** / **69** — each member's own payload, so neither can stand in for the other. |
| `Calculate_MeasuresTheSkillMembersUnderTheirPublishedWireKeys` | The two key spellings are the wire's, so the instrument measures what is shipped. |
| `CalculateSkillMetadata_ReturnsTheExactShareOfTheTotal` | The share equals full − baseline for both-, either- and neither-present. |
| `ProxyTool_TokenCount_MeasuresSkillMetadata_AndCachesTheSkillInclusiveValue` | Two proxies differing in **nothing but** their skill metadata; both cache fields read back skill-inclusive. |
| `RunTool_TokenCount_MeasuresSkillMetadata_ByExactlyTheMeasuredDelta` | Reflection path: two methods with identical signature, `[Description]`, and equal-length name/title, differing only in `[AiSkillDescription]`/`[AiSkillBody]` ⇒ exactly **+37**. |
| `RunTool_CachesTheSkillInclusiveCounts` | The cached total is the sibling's total **+ 37**, so a count frozen before the metadata was consulted could not produce it. |
| `EnabledToolsSkillMetadataTokenCount_{IsTheShareOfTheEnabledCatalogue,ExcludesDisabledTools}` | The catalogue-level breakdown, and that it honours the same `Enabled` filter the total does. |

The `+37` delta is **base-independent by construction**: the two fixture strings are sized so the
members add exactly 148 characters — a multiple of the 4-chars-per-token divisor — so
`ceil((L+148)/4) − ceil(L/4) = 37` for any `L`. That is what lets the reflection-based assertion pin
an exact delta over an input schema the test does not author.

### Plant round — 13/13 RED, 0 GREEN, restore-failures 0

Full log committed at **`docs/plant-logs/tool-token-count-skill-metadata.md`** (mutation → reddened
test id → runner output line, per plant). Every plant rebuilt both TFMs inside the `&&` chain, and
every plant collected `Total: 11` on both TFMs — a constant count, which rules out a red produced by
a broken build rather than a broken claim.

| # | Mutation | Reddened test | Runner output |
|---|---|---|---|
| P1 | both skill members deleted from `Calculate` | `Calculate_WithSkillMetadata_AddsExactly…` | `withMetadata should be 85 but was 48` |
| P2 | only `skillDescription` deleted | `…WithSkillDescriptionOnly…` | `value should be 64 but was 48` |
| P3 | only `skillBody` deleted | `…WithSkillBodyOnly…` | `value should be 69 but was 48` |
| P4 | `skillDescription` measured **unconditionally** | `…PinsThePreChangeBaselineExactly` | `nulls should be 48 but was 54` |
| P5 | `skillBody` measured **unconditionally** | `…PinsThePreChangeBaselineExactly` | `nulls should be 48 but was 52` |
| P6 | `SkillBodyKey` → `"skill_body"` | `…UnderTheirPublishedWireKeys` | `should be "skillBody" but was "skill_body"` |
| P7 | `CalculateSkillMetadata` returns a constant `0` | `…ReturnsTheExactShareOfTheTotal` | `both should be 37 but was 0` |
| P8 | `RunTool` total passes `null, null` | `RunTool_TokenCount_…` | `withMetadata.TokenCount should be 121 but was 84` |
| P9 | `RunTool` breakdown passes `null, null` | `RunTool_TokenCount_…` | `withMetadata.SkillMetadataTokenCount should be 37 but was 0` |
| P10 | `ProxyTool` total passes `null, null` | `ProxyTool_TokenCount_…` | `withMetadata.TokenCount should be 85 but was 48` |
| P11 | `ProxyTool` breakdown passes `null, null` | `ProxyTool_TokenCount_…` | `withMetadata.SkillMetadataTokenCount should be 37 but was 0` |
| P12 | catalogue breakdown drops the `Enabled` filter | `…ExcludesDisabledTools` | `should be 0 but was 37` |
| P13 | `McpToolManager` stops overriding it (interface default `0` served) | `…IsTheShareOfTheEnabledCatalogue` | `should be 37 but was 0` |

**Both directions, decomposed.** P1–P3 remove the measurement (a tool that ships skill metadata must
count *more*); P4–P5 make it unconditional (a tool that ships none must count *exactly what it
counted before*). Neither direction substitutes for the other — a constant `+1` survives every
"greater than" assertion, and an always-on member survives every "the payload is measured" one.
P1 is the bundled revert the DoD names, and because a bundle reddens through whichever half fires
first, the `skillDescription` and `skillBody` halves get their own plants, as do the total and the
breakdown on each of the two `IRunTool` implementations.

**The three double-named tests are tellable apart.** P4/P5, P8/P9 and P10/P11 each name one test
twice, which is only evidence if their reds differ — they do, and the runner output above is quoted
from each plant's own per-plant log: `54` vs `52` (the two null keys are different lengths), and
`TokenCount` vs `SkillMetadataTokenCount` for both wiring pairs.

---

## Refine pass — `5e0a171`

A review pass over this diff found **no correctness defect in the production change**. Every finding
landed in the *evidence*: assertions that could not discriminate, and committed prose that overstated
what the tests establish. The plant round was re-run and extended to **19/19 RED, 0 GREEN,
restore-failures 0**.

### Assertions that could not fail (now fixed)

| Where | Why it could not fail | Replacement |
|---|---|---|
| `Calculate_WithSkillMetadata_…` | `(withMetadata − 48).ShouldBe(37)` over three `const int`s is `85 − 48 == 37` — entailed by the literal pin above it | dropped; the delta claim moved to its own test |
| — new — `Calculate_TheSkillMetadataDelta_IsIndependentOfTheBaseLength` | one base length cannot see a payload 1–3 characters off (147–150 all round to the same 37) | asserts the delta over four base lengths covering every residue mod 4 |
| both cache tests | compared a property to a value read from **the same property** moments earlier — true of any deterministic getter | a sentinel poked into the cache field, which only a getter that reads the field returns |
| `RunTool_CachesTheSkillInclusiveCounts` | the cached **share** was pinned against its own first read, so "the share is always 0" left it green | pinned against the measured payload literal |
| both catalogue tests | one non-zero contributor ⇒ `Sum`, `Max` and `First` are indistinguishable | a second skill-bearing fixture tool with a different-sized payload |

### Plant round — 19/19 RED (was 13/13)

**P4/P5 re-pointed.** On the baseline test both printed `nulls should be 48 but was N`, tellable
apart only by knowing `"skillDescription"` is 7 characters longer than `"skillBody"`. Each now marks
the single-member test the other leaves green: P4 → `…WithSkillBodyOnly` (`69 → 75`), P5 →
`…WithSkillDescriptionOnly` (`64 → 68`). All seven shared-marker pairs were verified to fail
differently by reading the per-plant logs.

**Six new plants**, each covering a claim that was asserted but never shown capable of failing:

| # | Mutation | Reddened test | Runner output |
|---|---|---|---|
| P14 | the `skillDescription` gate weakened to `!= null`, so an **empty string** is measured | `…PinsThePreChangeBaselineExactly` | `empties should be 48 but was 53` |
| P15 | `SkillDescriptionKey` → `"skill_description"` (P6 only ever mutated the *body* key) | `…UnderTheirPublishedWireKeys` | `should be "skillDescription" but was "skill_description"` |
| P16 | the share guard's `&&` → `||`, so a tool carrying only ONE member reports no share | `…ReturnsTheExactShareOfTheTotal` | `descriptionOnly should be 16 but was 0` |
| P17 | `RunTool.SkillMetadataTokenCount` never writes its cache field | `RunTool_CachesTheSkillInclusiveCounts` | `value should not be null but was` |
| P18 | the measured payload inflated by **one character** | `…IsIndependentOfTheBaseLength` | `with − without should be 37 but was 38` |
| P19 | the catalogue breakdown's `.Sum(…)` → `.Max(…)` | `…IsTheShareOfTheEnabledCatalogue` | `should be 50 but was 37` |

P18 is the one worth noting: a one-character payload inflation is **invisible to every other
assertion in this suite** and reddens exactly one row of the new residue-class test.

### Doc claims corrected

- The plant log claimed expected figures are *"not recomputed by the test from the implementation"*.
  That is false for the reflection-based and catalogue tests, which use exact **relative** figures by
  design (the test does not author the reflected input schema). Corrected — the tests were right, the
  sentence describing them was not — and the log now also records which assertions are *reached but
  deliberately unplanted*, so their silence is not read as coverage.
- `RunTool.TokenCount` and `ProxyTool.TokenCount` still documented the pre-change formula.
- `Calculate` now records that it measures the two members **flat** while the wire nests them inside
  `_meta`, so the figure omits that wrapper (~10 characters ≈ 2–3 tokens per skill-bearing enabled
  tool). It is a catalogue-weight estimate, not byte-exact wire cost.

### Recorded, not changed — three follow-ups

1. **The wire keys are declared twice, in two assemblies.** `ToolTokenCount.SkillDescriptionKey` /
   `SkillBodyKey` and `ExtensionsListMeta`'s pair are independent literals; `McpPlugin` cannot
   reference `McpPlugin.Server`. Each side is pinned to the literal by its own test, so a one-sided
   rename reddens that side — a convention, not a compile-time guarantee. Single-sourcing them in
   `McpPlugin.Common` would make it one, at the cost of new public surface there; left for a change
   that is allowed to grow that surface. Stated in-code at the declaration.
2. **`engines/unreal/Unreal-MCP/bridge` carries its own `ProxyTool` with a forked 5-parameter token
   formula** that does not measure skill metadata, while exposing `SkillDescription`/`SkillBody`. Its
   own comment says the behaviour is "byte-identical either way" — this PR makes that false, so
   `EnabledToolsTokenCount` now means different things in Unreal vs Unity/Godot. Out of this repo;
   needs either a mirror change there or promoting `ToolTokenCount` out of `internal`.
3. **`Calculate` now takes 7 same-typed positional parameters** — exactly the `IRunTool` member set.
   Swapping two of them produces a byte-identical length and an identical count, which no test here
   can catch. An `IRunTool` overload would fix it, but it would also collapse P8–P11 (four
   independently attributed plants, one per implementation per figure) into one, so it is left for a
   follow-up rather than traded against this PR's own evidence.

### Gate

Suite 1, solution-level, Release, both projects × both TFMs: **4/4 `Test Run Successful.`, 0
`Test Run Failed.`, 3,520 passed / 0 failed.** Plant round `19/19 matched their expect | 19 RED |
0 GREEN | restore-failures 0`, every plant collecting a constant `Total: 15` and carrying a `Failed!`
line with a non-zero total.
