### PR TITLE
feat(auth): gate tools/list skill metadata behind X-McpPlugin-Skill-Meta

### DIFF
--- a/McpPlugin.Common/src/Utils/Consts.MCP.cs
+++ b/McpPlugin.Common/src/Utils/Consts.MCP.cs
@@ -266,8 +266,11 @@ namespace com.IvanMurzak.McpPlugin.Common
                     /// the pre-existing filtering: disabled entries are filtered
                     /// out, so <c>_meta.enabled</c> never reaches it.
                     /// <c>_meta</c> itself is NOT trusted-client-only: a
-                    /// <c>tools/list</c> entry also carries the skill keys for every
-                    /// caller, so its presence does not imply this mode.
+                    /// <c>tools/list</c> entry may also carry the skill keys, but those
+                    /// have their OWN opt-in header (<see cref="SkillMetaClient"/>) and
+                    /// this one neither grants nor implies them. Neither header implies
+                    /// the other — see <see cref="SkillMetaClient"/> for why the two
+                    /// axes are deliberately separate.
                     ///
                     /// This is a UX gate, NOT a security boundary — the header is
                     /// trivially spoofable. Pair it with bearer-token auth when
@@ -277,6 +280,37 @@ namespace com.IvanMurzak.McpPlugin.Common
 
                     /// <summary>Value the trusted-client header must carry to opt in.</summary>
                     public const string TrustedInternalClientOptInValue = "1";
+
+                    /// <summary>
+                    /// Marks the caller as a skill-metadata consumer. When the request
+                    /// carries this header set to <c>"1"</c>, each <c>tools/list</c>
+                    /// entry additionally carries <c>_meta.skillDescription</c> /
+                    /// <c>_meta.skillBody</c> for every tool that declares them (see
+                    /// <c>ExtensionsListMeta.BuildToolMeta</c>). A caller that does NOT
+                    /// send it receives neither key, i.e. exactly the <c>_meta</c> shape
+                    /// the server produced before those keys existed.
+                    ///
+                    /// <para><b>Opt-in because the payload is large, not because it is
+                    /// secret.</b> The skill blurb and body are re-sent in full on EVERY
+                    /// <c>tools/list</c>; across a real engine catalog that is hundreds of
+                    /// kilobytes per listing, per session. Clients that never read the
+                    /// keys should not pay for them.</para>
+                    ///
+                    /// <para><b>A separate axis from <see cref="TrustedInternalClient"/>
+                    /// on purpose.</b> That header ALSO unlocks the disabled-tool catalog,
+                    /// so reusing it here would start shipping <c>Enabled = false</c>
+                    /// tools to every skill-metadata consumer. The two flags are
+                    /// independent: sending one never sets the other.</para>
+                    ///
+                    /// <para>This is a payload gate, NOT a security boundary — the header
+                    /// is trivially spoofable, exactly like
+                    /// <see cref="TrustedInternalClient"/>. Keep skill text to content
+                    /// that is safe to publish to any connected MCP client.</para>
+                    /// </summary>
+                    public const string SkillMetaClient = "X-McpPlugin-Skill-Meta";
+
+                    /// <summary>Value the skill-metadata header must carry to opt in.</summary>
+                    public const string SkillMetaClientOptInValue = "1";
 
                     /// <summary>
                     /// Per-installation MCP instance identity (design 07 §2.3, D10.2). The value is

--- a/McpPlugin.Common/src/Utils/Consts.MCP.cs
+++ b/McpPlugin.Common/src/Utils/Consts.MCP.cs
@@ -292,9 +292,9 @@ namespace com.IvanMurzak.McpPlugin.Common
                     ///
                     /// <para><b>Opt-in because the payload is large, not because it is
                     /// secret.</b> The skill blurb and body are re-sent in full on EVERY
-                    /// <c>tools/list</c>; across a real engine catalog that is hundreds of
-                    /// kilobytes per listing, per session. Clients that never read the
-                    /// keys should not pay for them.</para>
+                    /// <c>tools/list</c>; at the measured 216-tool engine catalog that is
+                    /// roughly 205,000 characters (~200 KB) per listing, per session.
+                    /// Clients that never read the keys should not pay for them.</para>
                     ///
                     /// <para><b>A separate axis from <see cref="TrustedInternalClient"/>
                     /// on purpose.</b> That header ALSO unlocks the disabled-tool catalog,

--- a/McpPlugin.Server.Tests/Infrastructure/SkillMetaClientScope.cs
+++ b/McpPlugin.Server.Tests/Infrastructure/SkillMetaClientScope.cs
@@ -1,0 +1,52 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+using com.IvanMurzak.McpPlugin.Server.Auth;
+
+namespace com.IvanMurzak.McpPlugin.Server.Tests.Infrastructure
+{
+    /// <summary>
+    /// Opts the current async flow in to skill metadata for the lifetime of the scope, then
+    /// restores whatever <see cref="McpSessionTokenContext.IsSkillMetaClient"/> held before.
+    ///
+    /// <para>Exists so a unit test that exercises the <c>_meta</c> skill keys WITHOUT running the
+    /// HTTP middleware can still reach the gate. The restore is what keeps the ambient
+    /// <c>AsyncLocal</c> from bleeding into a later test on the same flow — the same discipline the
+    /// production middleware applies in its own <c>finally</c>.</para>
+    ///
+    /// <para>It deliberately touches ONLY the skill-metadata slot. A helper that also flipped
+    /// <see cref="McpSessionTokenContext.IsTrustedInternalClient"/> would make every test using it
+    /// blind to the two axes being conflated, which is precisely the regression the split exists to
+    /// prevent.</para>
+    /// </summary>
+    public sealed class SkillMetaClientScope : IDisposable
+    {
+        readonly bool _previous;
+
+        SkillMetaClientScope(bool previous)
+        {
+            _previous = previous;
+        }
+
+        /// <summary>Sets the skill-metadata flag for this flow; dispose to restore the prior value.</summary>
+        public static SkillMetaClientScope OptIn()
+        {
+            var previous = McpSessionTokenContext.IsSkillMetaClient;
+            McpSessionTokenContext.IsSkillMetaClient = true;
+            return new SkillMetaClientScope(previous);
+        }
+
+        public void Dispose()
+        {
+            McpSessionTokenContext.IsSkillMetaClient = _previous;
+        }
+    }
+}

--- a/McpPlugin.Server.Tests/SkillMetaClientGateTests.cs
+++ b/McpPlugin.Server.Tests/SkillMetaClientGateTests.cs
@@ -12,6 +12,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 using com.IvanMurzak.McpPlugin.Common;
 using com.IvanMurzak.McpPlugin.Common.Model;
@@ -93,7 +94,7 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
             McpSessionTokenContext.IsSkillMetaClient.ShouldBeFalse();
 
             var capturedFlag = false;
-            System.Text.Json.Nodes.JsonObject? capturedMeta = null;
+            JsonObject? capturedMeta = null;
 
             await InvokeMiddlewareAsync(
                 headers: new() { [Consts.MCP.Server.Headers.SkillMetaClient] = "1" },
@@ -112,7 +113,10 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
             capturedMeta.Select(kv => kv.Key).ShouldBe(
                 new[] { ExtensionsListMeta.SkillDescriptionKey, ExtensionsListMeta.SkillBodyKey });
 
-            // Cleared in the middleware's `finally`, exactly like the trusted flag.
+            // The caller's flow never observes the middleware's write: AsyncTaskMethodBuilder
+            // restores the ExecutionContext around an async method, so this holds whether or not
+            // the `finally` reset exists. It is NOT evidence about that reset — see the block
+            // above `Middleware_SkillMetaFlag_DoesNotLeakIntoTheNextRequest` for what is.
             McpSessionTokenContext.IsSkillMetaClient.ShouldBeFalse();
         }
 
@@ -126,7 +130,7 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
             // An ENABLED tool's pre-skill-metadata `_meta` was `null` — BuildEnabledMeta's own
             // contract, assigned wholesale. Asserting the WHOLE payload rather than "the skill keys
             // are missing": a null cannot be satisfied by a partially-built object.
-            System.Text.Json.Nodes.JsonObject? gated = null;
+            JsonObject? gated = null;
             await InvokeMiddlewareAsync(
                 headers: new(),
                 next: () => { gated = AttributedTool().ToTool().Meta; return Task.CompletedTask; });
@@ -136,7 +140,7 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
             // Positive control, SAME fixture: with the header the very same tool emits both keys.
             // Without this, `gated == null` would be equally satisfied by a fixture that carried no
             // skill metadata in the first place, and the assertion above would prove nothing.
-            System.Text.Json.Nodes.JsonObject? optedIn = null;
+            JsonObject? optedIn = null;
             await InvokeMiddlewareAsync(
                 headers: new() { [Consts.MCP.Server.Headers.SkillMetaClient] = "1" },
                 next: () => { optedIn = AttributedTool().ToTool().Meta; return Task.CompletedTask; });
@@ -152,7 +156,7 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
             // A DISABLED tool's pre-skill-metadata `_meta` was exactly `{"enabled":false}`. The
             // serialized text is the whole-payload artifact: it pins the key set, the value, AND
             // that nothing else rode along.
-            System.Text.Json.Nodes.JsonObject? gated = null;
+            JsonObject? gated = null;
             await InvokeMiddlewareAsync(
                 headers: new(),
                 next: () => { gated = AttributedTool(enabled: false).ToTool().Meta; return Task.CompletedTask; });
@@ -162,7 +166,7 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
 
             // Positive control, SAME fixture: with the header all three keys appear, so the payload
             // above is short because of the gate and not because the tool had nothing to publish.
-            System.Text.Json.Nodes.JsonObject? optedIn = null;
+            JsonObject? optedIn = null;
             await InvokeMiddlewareAsync(
                 headers: new() { [Consts.MCP.Server.Headers.SkillMetaClient] = "1" },
                 next: () => { optedIn = AttributedTool(enabled: false).ToTool().Meta; return Task.CompletedTask; });
@@ -194,7 +198,7 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
             McpSessionTokenContext.IsSkillMetaClient.ShouldBeFalse();
 
             var capturedFlag = true;
-            System.Text.Json.Nodes.JsonObject? capturedMeta = null;
+            JsonObject? capturedMeta = null;
 
             await InvokeMiddlewareAsync(
                 headers: new() { [Consts.MCP.Server.Headers.SkillMetaClient] = headerValue },
@@ -268,8 +272,8 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
             // IsTrustedInternalClient instead of IsSkillMetaClient, the skill keys below would
             // appear for a caller that only ever asked for the unfiltered catalog.
             var visibleNames = new List<string>();
-            System.Text.Json.Nodes.JsonObject? disabledMeta = null;
-            System.Text.Json.Nodes.JsonObject? enabledMeta = null;
+            JsonObject? disabledMeta = null;
+            JsonObject? enabledMeta = null;
 
             await InvokeMiddlewareAsync(
                 headers: new() { [Consts.MCP.Server.Headers.TrustedInternalClient] = "1" },
@@ -296,7 +300,7 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
             // The mirror: opting in to skill metadata must not widen catalog visibility. A single
             // shared flag — or SelectVisible learning to read the skill flag — reddens here.
             var visibleNames = new List<string>();
-            System.Text.Json.Nodes.JsonObject? enabledMeta = null;
+            JsonObject? enabledMeta = null;
 
             await InvokeMiddlewareAsync(
                 headers: new() { [Consts.MCP.Server.Headers.SkillMetaClient] = "1" },
@@ -349,7 +353,7 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
             // `finally` reset of request 1 is the only thing standing between the two, which is
             // exactly the pooled-request hazard this asserts against.
             var secondFlag = true;
-            System.Text.Json.Nodes.JsonObject? secondMeta = null;
+            JsonObject? secondMeta = null;
             await InvokeMiddlewareAsync(
                 headers: new(),
                 next: () =>

--- a/McpPlugin.Server.Tests/SkillMetaClientGateTests.cs
+++ b/McpPlugin.Server.Tests/SkillMetaClientGateTests.cs
@@ -1,0 +1,401 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.Common;
+using com.IvanMurzak.McpPlugin.Common.Model;
+using com.IvanMurzak.McpPlugin.Server.Auth;
+using Microsoft.AspNetCore.Http;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.Server.Tests
+{
+    /// <summary>
+    /// Covers the skill-metadata opt-in gate: the <c>X-McpPlugin-Skill-Meta</c> request header
+    /// flips <see cref="McpSessionTokenContext.IsSkillMetaClient"/>, which
+    /// <c>ExtensionsListMeta.BuildToolMeta</c> consumes to decide whether a <c>tools/list</c>
+    /// entry carries <c>_meta.skillDescription</c> / <c>_meta.skillBody</c>.
+    ///
+    /// <para>Every fixture here is a tool that DOES declare both skill values, so a "no skill key
+    /// was emitted" outcome can only come from the gate — never from an empty fixture. Each such
+    /// case is paired with a positive control on the SAME fixture, run with the header, which is
+    /// what proves the tool's metadata was reachable at all.</para>
+    ///
+    /// <para>The second thing under test is that this is a genuinely SEPARATE axis from
+    /// <see cref="McpSessionTokenContext.IsTrustedInternalClient"/>. That is asserted twice over:
+    /// on the flags themselves (neither setter moves the other slot) and on OBSERVABLE behaviour
+    /// (each header alone unlocks its own payload and nothing else) — the flag-level pair catches a
+    /// conflated backing field, the behaviour-level pair catches the gate being wired to the wrong
+    /// flag, and neither substitutes for the other.</para>
+    ///
+    /// <para><see cref="McpSessionTokenContext"/> values are <c>AsyncLocal</c>; these tests either
+    /// let the middleware's own <c>finally</c> clean up or restore the slot themselves, so state
+    /// never leaks between cases.</para>
+    /// </summary>
+    public class SkillMetaClientGateTests
+    {
+        const string SkillDescriptionText = "Creates a primitive object in the scene";
+        const string SkillBodyText = "# GameObject create\n\nUse `path` to nest the new object.";
+
+        /// <summary>The exact <c>_meta</c> payload a pre-skill-metadata server produced for a DISABLED tool.</summary>
+        const string PreSkillMetadataDisabledPayload = "{\"enabled\":false}";
+
+        /// <summary>A tool that declares BOTH skill values — the fixture every gate assertion runs on.</summary>
+        static ResponseListTool AttributedTool(bool enabled = true)
+            => new ResponseListTool
+            {
+                Name = "gameobject-create",
+                Enabled = enabled,
+                InputSchema = Consts.MCP.EmptyInputSchema,
+                SkillDescription = SkillDescriptionText,
+                SkillBody = SkillBodyText
+            };
+
+        // ─────────────────────────────────────────────────────────────────────
+        // Wire contract — the header name/value are shared with the app client
+        // ─────────────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void SkillMetaHeader_ConstantsAreTheLiteralWireContract()
+        {
+            // Every other assertion in this file sends the header THROUGH these constants, so a
+            // changed value would rename the header for every client while reddening nothing.
+            // The app's own `SKILL_META_HEADER` / `SKILL_META_HEADER_VALUE` carry these exact
+            // strings; the two halves only meet on the wire, so each side must pin them literally.
+            Consts.MCP.Server.Headers.SkillMetaClient.ShouldBe("X-McpPlugin-Skill-Meta");
+            Consts.MCP.Server.Headers.SkillMetaClientOptInValue.ShouldBe("1");
+
+            // ...and it is its OWN header. Reaching for the trusted-client constant by copy-paste
+            // is the single likeliest way to silently re-merge the two axes at the wire level.
+            Consts.MCP.Server.Headers.SkillMetaClient
+                .ShouldNotBe(Consts.MCP.Server.Headers.TrustedInternalClient);
+        }
+
+        // ─────────────────────────────────────────────────────────────────────
+        // Header present → the skill keys are emitted
+        // ─────────────────────────────────────────────────────────────────────
+
+        [Fact]
+        public async Task Middleware_SkillMetaHeader_EmitsBothSkillKeys()
+        {
+            McpSessionTokenContext.IsSkillMetaClient.ShouldBeFalse();
+
+            var capturedFlag = false;
+            System.Text.Json.Nodes.JsonObject? capturedMeta = null;
+
+            await InvokeMiddlewareAsync(
+                headers: new() { [Consts.MCP.Server.Headers.SkillMetaClient] = "1" },
+                next: () =>
+                {
+                    capturedFlag = McpSessionTokenContext.IsSkillMetaClient;
+                    capturedMeta = AttributedTool().ToTool().Meta;
+                    return Task.CompletedTask;
+                });
+
+            capturedFlag.ShouldBeTrue();
+            capturedMeta.ShouldNotBeNull();
+            capturedMeta![ExtensionsListMeta.SkillDescriptionKey]!.GetValue<string>().ShouldBe(SkillDescriptionText);
+            capturedMeta[ExtensionsListMeta.SkillBodyKey]!.GetValue<string>().ShouldBe(SkillBodyText);
+            // The exact key SET, so an ENABLED tool is also proven not to gain an `enabled` key.
+            capturedMeta.Select(kv => kv.Key).ShouldBe(
+                new[] { ExtensionsListMeta.SkillDescriptionKey, ExtensionsListMeta.SkillBodyKey });
+
+            // Cleared in the middleware's `finally`, exactly like the trusted flag.
+            McpSessionTokenContext.IsSkillMetaClient.ShouldBeFalse();
+        }
+
+        // ─────────────────────────────────────────────────────────────────────
+        // Header absent → the payload is byte-identical to the pre-skill-metadata server's
+        // ─────────────────────────────────────────────────────────────────────
+
+        [Fact]
+        public async Task Middleware_NoSkillMetaHeader_EnabledTool_ProducesTheExactPreSkillMetadataPayload()
+        {
+            // An ENABLED tool's pre-skill-metadata `_meta` was `null` — BuildEnabledMeta's own
+            // contract, assigned wholesale. Asserting the WHOLE payload rather than "the skill keys
+            // are missing": a null cannot be satisfied by a partially-built object.
+            System.Text.Json.Nodes.JsonObject? gated = null;
+            await InvokeMiddlewareAsync(
+                headers: new(),
+                next: () => { gated = AttributedTool().ToTool().Meta; return Task.CompletedTask; });
+
+            gated.ShouldBeNull();
+
+            // Positive control, SAME fixture: with the header the very same tool emits both keys.
+            // Without this, `gated == null` would be equally satisfied by a fixture that carried no
+            // skill metadata in the first place, and the assertion above would prove nothing.
+            System.Text.Json.Nodes.JsonObject? optedIn = null;
+            await InvokeMiddlewareAsync(
+                headers: new() { [Consts.MCP.Server.Headers.SkillMetaClient] = "1" },
+                next: () => { optedIn = AttributedTool().ToTool().Meta; return Task.CompletedTask; });
+
+            optedIn.ShouldNotBeNull();
+            optedIn!.Select(kv => kv.Key).ShouldBe(
+                new[] { ExtensionsListMeta.SkillDescriptionKey, ExtensionsListMeta.SkillBodyKey });
+        }
+
+        [Fact]
+        public async Task Middleware_NoSkillMetaHeader_DisabledTool_ProducesTheExactPreSkillMetadataPayload()
+        {
+            // A DISABLED tool's pre-skill-metadata `_meta` was exactly `{"enabled":false}`. The
+            // serialized text is the whole-payload artifact: it pins the key set, the value, AND
+            // that nothing else rode along.
+            System.Text.Json.Nodes.JsonObject? gated = null;
+            await InvokeMiddlewareAsync(
+                headers: new(),
+                next: () => { gated = AttributedTool(enabled: false).ToTool().Meta; return Task.CompletedTask; });
+
+            gated.ShouldNotBeNull();
+            gated!.ToJsonString().ShouldBe(PreSkillMetadataDisabledPayload);
+
+            // Positive control, SAME fixture: with the header all three keys appear, so the payload
+            // above is short because of the gate and not because the tool had nothing to publish.
+            System.Text.Json.Nodes.JsonObject? optedIn = null;
+            await InvokeMiddlewareAsync(
+                headers: new() { [Consts.MCP.Server.Headers.SkillMetaClient] = "1" },
+                next: () => { optedIn = AttributedTool(enabled: false).ToTool().Meta; return Task.CompletedTask; });
+
+            optedIn.ShouldNotBeNull();
+            optedIn!.Select(kv => kv.Key).ShouldBe(new[]
+            {
+                ExtensionsListMeta.EnabledKey,
+                ExtensionsListMeta.SkillDescriptionKey,
+                ExtensionsListMeta.SkillBodyKey
+            });
+        }
+
+        // ─────────────────────────────────────────────────────────────────────
+        // Wrong header value → treated as absent (ordinal compare, not truthiness)
+        // ─────────────────────────────────────────────────────────────────────
+
+        [Theory]
+        [InlineData("0")]
+        [InlineData("true")]
+        [InlineData("yes")]
+        [InlineData("TRUE")]
+        [InlineData("01")]
+        [InlineData("1 ")]
+        [InlineData(" 1")]
+        [InlineData("")]
+        public async Task Middleware_SkillMetaHeader_WithAnyOtherValue_IsTreatedAsAbsent(string headerValue)
+        {
+            McpSessionTokenContext.IsSkillMetaClient.ShouldBeFalse();
+
+            var capturedFlag = true;
+            System.Text.Json.Nodes.JsonObject? capturedMeta = null;
+
+            await InvokeMiddlewareAsync(
+                headers: new() { [Consts.MCP.Server.Headers.SkillMetaClient] = headerValue },
+                next: () =>
+                {
+                    capturedFlag = McpSessionTokenContext.IsSkillMetaClient;
+                    capturedMeta = AttributedTool().ToTool().Meta;
+                    return Task.CompletedTask;
+                });
+
+            // Only the exact opt-in value opts in. An ordinal comparison is what makes "TRUE",
+            // "01" and a value with stray whitespace all fail; a truthiness or case-insensitive
+            // test would let several of these through.
+            capturedFlag.ShouldBeFalse();
+            capturedMeta.ShouldBeNull();
+        }
+
+        // ─────────────────────────────────────────────────────────────────────
+        // Independence of the two axes — at the FLAG level, both directions
+        // ─────────────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void Context_SettingSkillMetaFlag_LeavesTheTrustedFlagUntouched()
+        {
+            McpSessionTokenContext.IsSkillMetaClient.ShouldBeFalse();
+            McpSessionTokenContext.IsTrustedInternalClient.ShouldBeFalse();
+
+            try
+            {
+                McpSessionTokenContext.IsSkillMetaClient = true;
+
+                McpSessionTokenContext.IsSkillMetaClient.ShouldBeTrue();
+                // One backing slot for both properties would make this read `true`.
+                McpSessionTokenContext.IsTrustedInternalClient.ShouldBeFalse();
+            }
+            finally
+            {
+                McpSessionTokenContext.IsSkillMetaClient = false;
+            }
+        }
+
+        [Fact]
+        public void Context_SettingTrustedFlag_LeavesTheSkillMetaFlagUntouched()
+        {
+            McpSessionTokenContext.IsSkillMetaClient.ShouldBeFalse();
+            McpSessionTokenContext.IsTrustedInternalClient.ShouldBeFalse();
+
+            try
+            {
+                McpSessionTokenContext.IsTrustedInternalClient = true;
+
+                McpSessionTokenContext.IsTrustedInternalClient.ShouldBeTrue();
+                // The mirror of the case above. Asserting only ONE direction cannot distinguish a
+                // shared slot from a one-way alias, so both directions are required.
+                McpSessionTokenContext.IsSkillMetaClient.ShouldBeFalse();
+            }
+            finally
+            {
+                McpSessionTokenContext.IsTrustedInternalClient = false;
+            }
+        }
+
+        // ─────────────────────────────────────────────────────────────────────
+        // Independence of the two axes — at the BEHAVIOUR level, both directions
+        // ─────────────────────────────────────────────────────────────────────
+
+        [Fact]
+        public async Task Middleware_TrustedInternalClientHeaderAlone_UnlocksDisabledTools_ButNotSkillMetadata()
+        {
+            // The load-bearing case for keeping the axes split. If BuildToolMeta read
+            // IsTrustedInternalClient instead of IsSkillMetaClient, the skill keys below would
+            // appear for a caller that only ever asked for the unfiltered catalog.
+            var visibleNames = new List<string>();
+            System.Text.Json.Nodes.JsonObject? disabledMeta = null;
+            System.Text.Json.Nodes.JsonObject? enabledMeta = null;
+
+            await InvokeMiddlewareAsync(
+                headers: new() { [Consts.MCP.Server.Headers.TrustedInternalClient] = "1" },
+                next: () =>
+                {
+                    visibleNames.AddRange(Catalog().SelectVisible(x => x.Enabled, x => x.Name!));
+                    disabledMeta = AttributedTool(enabled: false).ToTool().Meta;
+                    enabledMeta = AttributedTool().ToTool().Meta;
+                    return Task.CompletedTask;
+                });
+
+            // The trusted axis IS on — a positive artifact, so this cannot pass by nothing happening.
+            visibleNames.ShouldBe(new[] { "enabled-tool", "disabled-tool" });
+
+            // ...and the skill axis is NOT: both payloads are exactly the pre-skill-metadata shapes.
+            disabledMeta.ShouldNotBeNull();
+            disabledMeta!.ToJsonString().ShouldBe(PreSkillMetadataDisabledPayload);
+            enabledMeta.ShouldBeNull();
+        }
+
+        [Fact]
+        public async Task Middleware_SkillMetaHeaderAlone_EmitsSkillMetadata_ButKeepsDisabledToolsHidden()
+        {
+            // The mirror: opting in to skill metadata must not widen catalog visibility. A single
+            // shared flag — or SelectVisible learning to read the skill flag — reddens here.
+            var visibleNames = new List<string>();
+            System.Text.Json.Nodes.JsonObject? enabledMeta = null;
+
+            await InvokeMiddlewareAsync(
+                headers: new() { [Consts.MCP.Server.Headers.SkillMetaClient] = "1" },
+                next: () =>
+                {
+                    visibleNames.AddRange(Catalog().SelectVisible(x => x.Enabled, x => x.Name!));
+                    enabledMeta = AttributedTool().ToTool().Meta;
+                    return Task.CompletedTask;
+                });
+
+            // Exactly the enabled tool survives — named, not merely counted.
+            visibleNames.ShouldBe(new[] { "enabled-tool" });
+
+            // ...while the skill keys DO reach this caller (the positive half of the same claim).
+            enabledMeta.ShouldNotBeNull();
+            enabledMeta!.Select(kv => kv.Key).ShouldBe(
+                new[] { ExtensionsListMeta.SkillDescriptionKey, ExtensionsListMeta.SkillBodyKey });
+        }
+
+        // ─────────────────────────────────────────────────────────────────────
+        // The flag must not survive its request
+        //
+        // Both cases below are guarded by TWO INDEPENDENT mechanisms, and that is worth stating
+        // because it changes how they must be verified. (1) The flag's storage is per-flow: an
+        // AsyncLocal write inside the middleware is not observable by an awaiting caller at all,
+        // because AsyncTaskMethodBuilder.Start restores the ExecutionContext around the
+        // synchronous part of an async method. (2) The middleware clears the slot in its own
+        // `finally`. Either mechanism alone satisfies these assertions, so a plant that neuters
+        // just ONE of them scores GREEN *correctly* — measured: deleting the `finally` reset left
+        // all 46 tests passing. That is not a vacuous test, it is defence in depth, and the honest
+        // proof is the simultaneous pair: make the storage process-global AND drop the reset, and
+        // both cases below redden. Do not "fix" a single-site GREEN here by weakening the test.
+        // ─────────────────────────────────────────────────────────────────────
+
+        [Fact]
+        public async Task Middleware_SkillMetaFlag_DoesNotLeakIntoTheNextRequest()
+        {
+            McpSessionTokenContext.IsSkillMetaClient.ShouldBeFalse();
+
+            // Request 1 opts in.
+            var firstFlag = false;
+            await InvokeMiddlewareAsync(
+                headers: new() { [Consts.MCP.Server.Headers.SkillMetaClient] = "1" },
+                next: () => { firstFlag = McpSessionTokenContext.IsSkillMetaClient; return Task.CompletedTask; });
+
+            firstFlag.ShouldBeTrue();
+
+            // Request 2, on the SAME execution context, sends no header. The middleware only WRITES
+            // the flag when the header is present, so nothing here overwrites a stale `true` — the
+            // `finally` reset of request 1 is the only thing standing between the two, which is
+            // exactly the pooled-request hazard this asserts against.
+            var secondFlag = true;
+            System.Text.Json.Nodes.JsonObject? secondMeta = null;
+            await InvokeMiddlewareAsync(
+                headers: new(),
+                next: () =>
+                {
+                    secondFlag = McpSessionTokenContext.IsSkillMetaClient;
+                    secondMeta = AttributedTool().ToTool().Meta;
+                    return Task.CompletedTask;
+                });
+
+            secondFlag.ShouldBeFalse();
+            // Asserted on the OBSERVABLE payload too: the bool is the mechanism, the withheld
+            // skill metadata is the consequence a client would actually see.
+            secondMeta.ShouldBeNull();
+        }
+
+        [Fact]
+        public async Task Middleware_ClearsSkillMetaFlag_EvenIfNextThrows()
+        {
+            McpSessionTokenContext.IsSkillMetaClient.ShouldBeFalse();
+
+            await Should.ThrowAsync<InvalidDataException>(() => InvokeMiddlewareAsync(
+                headers: new() { [Consts.MCP.Server.Headers.SkillMetaClient] = "1" },
+                next: () => throw new InvalidDataException("boom")));
+
+            McpSessionTokenContext.IsSkillMetaClient.ShouldBeFalse();
+        }
+
+        // ─────────────────────────────────────────────────────────────────────
+        // helpers
+        // ─────────────────────────────────────────────────────────────────────
+
+        /// <summary>One enabled and one disabled tool — the input <c>SelectVisible</c> filters.</summary>
+        static List<ResponseListTool?> Catalog() => new()
+        {
+            new ResponseListTool { Name = "enabled-tool", Enabled = true, InputSchema = Consts.MCP.EmptyInputSchema },
+            new ResponseListTool { Name = "disabled-tool", Enabled = false, InputSchema = Consts.MCP.EmptyInputSchema }
+        };
+
+        static async Task InvokeMiddlewareAsync(Dictionary<string, string> headers, Func<Task> next)
+        {
+            var ctx = new DefaultHttpContext();
+            foreach (var (k, v) in headers)
+                ctx.Request.Headers[k] = v;
+
+            var middleware = new McpSessionTokenMiddleware(_ => next());
+            await middleware.InvokeAsync(ctx);
+        }
+    }
+}

--- a/McpPlugin.Server.Tests/ToolListSkillMetaTests.cs
+++ b/McpPlugin.Server.Tests/ToolListSkillMetaTests.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
 ┌────────────────────────────────────────────────────────────────────────┐
 │  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
 │  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
@@ -11,6 +11,7 @@
 using System.Linq;
 using com.IvanMurzak.McpPlugin.Common;
 using com.IvanMurzak.McpPlugin.Common.Model;
+using com.IvanMurzak.McpPlugin.Server.Tests.Infrastructure;
 using Shouldly;
 using Xunit;
 
@@ -23,6 +24,13 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
     /// <c>ToolRouter.ListAll</c> maps every plugin tool through.
     /// The composition is deliberately tools-only — see the <c>remarks</c> on
     /// <c>ExtensionsListMeta.BuildToolMeta</c> for why the shared helper stays untouched.
+    ///
+    /// <para>Every case here runs INSIDE <see cref="SkillMetaClientScope"/>, i.e. as a caller that
+    /// sent <c>X-McpPlugin-Skill-Meta: 1</c>. That is load-bearing rather than incidental: the keys
+    /// are now gated, so without the opt-in the "no key is emitted" cases below would hold for the
+    /// gate's reason instead of their own and could no longer tell the composition apart from a
+    /// server that never learned to emit skill metadata at all. What the gate itself does to a
+    /// caller that did NOT opt in is pinned separately, in <c>SkillMetaClientGateTests</c>.</para>
     /// </summary>
     public class ToolListSkillMetaTests
     {
@@ -45,6 +53,8 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
         [Fact]
         public void ToTool_EmitsBothSkillKeys_WhenBothPresent()
         {
+            using var optIn = SkillMetaClientScope.OptIn();
+
             var meta = Tool(skillDescription: SkillDescriptionText, skillBody: SkillBodyText).ToTool().Meta;
 
             meta.ShouldNotBeNull();
@@ -61,6 +71,8 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
         [Fact]
         public void ToTool_EmitsOnlySkillDescription_WhenBodyAbsent()
         {
+            using var optIn = SkillMetaClientScope.OptIn();
+
             var meta = Tool(skillDescription: SkillDescriptionText).ToTool().Meta;
 
             meta.ShouldNotBeNull();
@@ -71,6 +83,8 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
         [Fact]
         public void ToTool_EmitsOnlySkillBody_WhenDescriptionAbsent()
         {
+            using var optIn = SkillMetaClientScope.OptIn();
+
             var meta = Tool(skillBody: SkillBodyText).ToTool().Meta;
 
             meta.ShouldNotBeNull();
@@ -81,6 +95,8 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
         [Fact]
         public void ToTool_CombinesEnabledFalseWithSkillKeys_WhenDisabledAndAttributed()
         {
+            using var optIn = SkillMetaClientScope.OptIn();
+
             var meta = Tool(enabled: false, skillDescription: SkillDescriptionText, skillBody: SkillBodyText)
                 .ToTool()
                 .Meta;
@@ -102,6 +118,8 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
         [Fact]
         public void ToTool_OmitsMetaEntirely_WhenEnabledAndNoSkillMetadata()
         {
+            using var optIn = SkillMetaClientScope.OptIn();
+
             // The unchanged default wire shape: this is what every third-party client sees
             // today, and the whole point of composing instead of always emitting an object.
             Tool().ToTool().Meta.ShouldBeNull();
@@ -110,6 +128,8 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
         [Fact]
         public void ToTool_EmitsOnlyEnabledKey_WhenDisabledAndNoSkillMetadata()
         {
+            using var optIn = SkillMetaClientScope.OptIn();
+
             var meta = Tool(enabled: false).ToTool().Meta;
 
             meta.ShouldNotBeNull();
@@ -120,6 +140,8 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
         [Fact]
         public void ToTool_TreatsBlankSkillMetadataAsAbsent()
         {
+            using var optIn = SkillMetaClientScope.OptIn();
+
             // A tool whose attribute carried an empty string must not push an empty key onto
             // the wire — clients render the catalog line from it.
             Tool(skillDescription: string.Empty, skillBody: string.Empty).ToTool().Meta.ShouldBeNull();
@@ -128,6 +150,8 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
         [Fact]
         public void ToTool_RelaysWhitespaceOnlySkillBody_BecauseTheGuardIsIsNullOrEmpty()
         {
+            using var optIn = SkillMetaClientScope.OptIn();
+
             // BuildToolMeta guards with IsNullOrEmpty, NOT IsNullOrWhiteSpace, so a
             // whitespace-only value is relayed verbatim; SkillFileGenerator drops it from
             // SKILL.md. That divergence is deliberate and was prose-only until this test:
@@ -143,6 +167,8 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
         [Fact]
         public void BuildToolMeta_EmitsExactlyTheSkillKeys_WhenCalledDirectly()
         {
+            using var optIn = SkillMetaClientScope.OptIn();
+
             // Pins the PUBLIC helper directly. ToTool() assigns BuildToolMeta(response)
             // verbatim today, so this deliberately overlaps
             // ToTool_EmitsOnlySkillDescription_WhenBodyAbsent above; it earns its place only
@@ -158,6 +184,8 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
         [Fact]
         public void BuildEnabledMeta_StillEmitsExactlyTheEnabledKey()
         {
+            using var optIn = SkillMetaClientScope.OptIn();
+
             // The three non-tool call sites (prompts / resources / resource templates) assign
             // BuildEnabledMeta's result WHOLESALE, so teaching it the skill keys would leak
             // them onto primitives that have no such metadata. This reddens if the skill keys

--- a/McpPlugin.Server.Tests/ToolListSkillMetaTests.cs
+++ b/McpPlugin.Server.Tests/ToolListSkillMetaTests.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 ┌────────────────────────────────────────────────────────────────────────┐
 │  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
 │  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │

--- a/McpPlugin.Server/src/Auth/McpSessionTokenContext.cs
+++ b/McpPlugin.Server/src/Auth/McpSessionTokenContext.cs
@@ -22,6 +22,7 @@ namespace com.IvanMurzak.McpPlugin.Server.Auth
         static readonly AsyncLocal<string?> _currentClientIp = new();
         static readonly AsyncLocal<string?> _currentUserAgent = new();
         static readonly AsyncLocal<bool> _isTrustedInternalClient = new();
+        static readonly AsyncLocal<bool> _isSkillMetaClient = new();
         static readonly AsyncLocal<ConnectionIdentity?> _currentIdentity = new();
         static readonly AsyncLocal<string?> _currentProjectPin = new();
         static readonly AsyncLocal<string?> _currentSelectedInstanceId = new();
@@ -117,6 +118,26 @@ namespace com.IvanMurzak.McpPlugin.Server.Auth
         {
             get => _isTrustedInternalClient.Value;
             set => _isTrustedInternalClient.Value = value;
+        }
+
+        /// <summary>
+        /// True when the in-flight request opted in to skill metadata. Set by
+        /// <see cref="McpSessionTokenMiddleware"/> from the
+        /// <c>X-McpPlugin-Skill-Meta</c> header (see
+        /// <c>Consts.MCP.Server.Headers.SkillMetaClient</c>) and consumed by
+        /// <c>ExtensionsListMeta.BuildToolMeta</c> to decide whether a
+        /// <c>tools/list</c> entry carries <c>_meta.skillDescription</c> /
+        /// <c>_meta.skillBody</c>. Cleared in the middleware's <c>finally</c>,
+        /// so values never leak across requests.
+        /// <para>A SEPARATE flag from <see cref="IsTrustedInternalClient"/> on
+        /// purpose: that one also unlocks the <c>Enabled = false</c> catalog, so
+        /// a client asking only for skill metadata must not acquire it. Neither
+        /// property reads or writes the other's slot.</para>
+        /// </summary>
+        public static bool IsSkillMetaClient
+        {
+            get => _isSkillMetaClient.Value;
+            set => _isSkillMetaClient.Value = value;
         }
     }
 }

--- a/McpPlugin.Server/src/Auth/McpSessionTokenMiddleware.cs
+++ b/McpPlugin.Server/src/Auth/McpSessionTokenMiddleware.cs
@@ -153,6 +153,20 @@ namespace com.IvanMurzak.McpPlugin.Server.Auth
                     StringComparison.Ordinal);
             }
 
+            // Skill-metadata opt-in — a SEPARATE axis from the trusted-client header above,
+            // never a second reader of it. Sharing that flag would hand every skill-metadata
+            // consumer the `Enabled = false` catalog too (SelectVisible reads the same
+            // predicate), which is a visibility change nobody asked for by sending this
+            // header. Ordinal compare against the exact opt-in value, exactly like the
+            // block above: "true" / "yes" / "0" are NOT interchangeable with "1".
+            if (context.Request.Headers.TryGetValue(Consts.MCP.Server.Headers.SkillMetaClient, out var skillMetaHeader))
+            {
+                McpSessionTokenContext.IsSkillMetaClient = string.Equals(
+                    skillMetaHeader.ToString(),
+                    Consts.MCP.Server.Headers.SkillMetaClientOptInValue,
+                    StringComparison.Ordinal);
+            }
+
             try
             {
                 await _next(context);
@@ -163,6 +177,7 @@ namespace com.IvanMurzak.McpPlugin.Server.Auth
                 McpSessionTokenContext.CurrentClientIp = null;
                 McpSessionTokenContext.CurrentUserAgent = null;
                 McpSessionTokenContext.IsTrustedInternalClient = false;
+                McpSessionTokenContext.IsSkillMetaClient = false;
                 McpSessionTokenContext.CurrentIdentity = null;
                 McpSessionTokenContext.CurrentProjectPin = null;
                 McpSessionTokenContext.CurrentSelectedInstanceId = null;

--- a/McpPlugin.Server/src/Extension/ExtensionsListMeta.cs
+++ b/McpPlugin.Server/src/Extension/ExtensionsListMeta.cs
@@ -94,12 +94,11 @@ namespace com.IvanMurzak.McpPlugin.Server
 
             var meta = BuildEnabledMeta(response.Enabled);
 
-            // Opt-in gate: the skill blurb and body are re-sent in full on every
-            // tools/list, which across a real engine catalog is hundreds of kilobytes per
-            // listing. Only a caller that asked for them pays for them; everyone else gets
-            // exactly the pre-skill-metadata _meta shape (null when enabled, {enabled:false}
-            // when disabled). Checked BEFORE the per-key guards so neither key can be
-            // reached without the opt-in.
+            // Opt-in gate. Checked BEFORE the per-key guards, so neither skill key can be
+            // reached without the opt-in and a caller that did not opt in gets the
+            // pre-skill-metadata _meta shape (null when enabled, {enabled:false} when
+            // disabled) by construction rather than by two guards agreeing. Why it is
+            // opt-in, and the measured payload size: Consts.MCP.Server.Headers.SkillMetaClient.
             if (!McpSessionTokenContext.IsSkillMetaClient)
                 return meta;
 

--- a/McpPlugin.Server/src/Extension/ExtensionsListMeta.cs
+++ b/McpPlugin.Server/src/Extension/ExtensionsListMeta.cs
@@ -36,10 +36,14 @@ namespace com.IvanMurzak.McpPlugin.Server
     /// <remarks>
     /// MCP's <c>_meta</c> field is reserved for protocol-level metadata that
     /// servers may emit and clients may ignore (per spec). We use it for two
-    /// things: the plugin-side <c>Enabled</c> flag, surfaced ONLY to trusted
-    /// internal clients that have opted in to the unfiltered catalog — see
+    /// things, each behind its OWN opt-in header: the plugin-side <c>Enabled</c>
+    /// flag, surfaced only to trusted internal clients that have opted in to the
+    /// unfiltered catalog — see
     /// <see cref="com.IvanMurzak.McpPlugin.Common.Consts.MCP.Server.Headers.TrustedInternalClient"/>
-    /// — and, on tools only, the skill blurb / body, which reach EVERY caller.
+    /// — and, on tools only, the skill blurb / body, surfaced only to callers
+    /// that sent
+    /// <see cref="com.IvanMurzak.McpPlugin.Common.Consts.MCP.Server.Headers.SkillMetaClient"/>.
+    /// The two headers are independent; neither grants the other's payload.
     /// </remarks>
     public static class ExtensionsListMeta
     {
@@ -64,15 +68,24 @@ namespace com.IvanMurzak.McpPlugin.Server
         /// <summary>
         /// Builds the <c>_meta</c> object for a <c>tools/list</c> entry: the
         /// <see cref="BuildEnabledMeta"/> annotation, plus <c>skillDescription</c> /
-        /// <c>skillBody</c> whenever the tool carries them. Returns
+        /// <c>skillBody</c> whenever the tool carries them AND the caller opted in to
+        /// skill metadata with <c>X-McpPlugin-Skill-Meta: 1</c> (see
+        /// <see cref="McpSessionTokenContext.IsSkillMetaClient"/>). Returns
         /// <see langword="null"/> when there is nothing at all to emit, so an enabled
         /// tool with no skill metadata keeps today's exact wire shape.
         /// </summary>
         /// <remarks>
-        /// Tools-only on purpose. <see cref="BuildEnabledMeta"/> stays untouched because
+        /// <para>Tools-only on purpose. <see cref="BuildEnabledMeta"/> stays untouched because
         /// prompts / resources / resource-templates share it and rely on its
         /// null-when-enabled contract; composing here instead of mutating it keeps those
-        /// three call sites byte-identical.
+        /// three call sites byte-identical.</para>
+        /// <para>The skill gate reads
+        /// <see cref="McpSessionTokenContext.IsSkillMetaClient"/> and DELIBERATELY not
+        /// <see cref="McpSessionTokenContext.IsTrustedInternalClient"/>: the latter also
+        /// drives <see cref="SelectVisible{TIn, TOut}"/>, so keying skill metadata off it
+        /// would hand every skill-metadata consumer the disabled-tool catalog as well.
+        /// For a caller that did not opt in, this method's output is byte-identical to
+        /// <see cref="BuildEnabledMeta"/>'s.</para>
         /// </remarks>
         public static JsonObject? BuildToolMeta(Common.Model.ResponseListTool response)
         {
@@ -80,6 +93,15 @@ namespace com.IvanMurzak.McpPlugin.Server
                 throw new ArgumentNullException(nameof(response));
 
             var meta = BuildEnabledMeta(response.Enabled);
+
+            // Opt-in gate: the skill blurb and body are re-sent in full on every
+            // tools/list, which across a real engine catalog is hundreds of kilobytes per
+            // listing. Only a caller that asked for them pays for them; everyone else gets
+            // exactly the pre-skill-metadata _meta shape (null when enabled, {enabled:false}
+            // when disabled). Checked BEFORE the per-key guards so neither key can be
+            // reached without the opt-in.
+            if (!McpSessionTokenContext.IsSkillMetaClient)
+                return meta;
 
             // IsNullOrEmpty, not IsNullOrWhiteSpace: the guard drops an attribute that
             // carried an empty string, and nothing more. SkillFileGenerator uses

--- a/McpPlugin.Server/src/Extension/ExtensionsTool.cs
+++ b/McpPlugin.Server/src/Extension/ExtensionsTool.cs
@@ -80,10 +80,10 @@ namespace com.IvanMurzak.McpPlugin.Server
                 // entries the user has turned off plugin-side. Untrusted clients never
                 // receive disabled tools so the field never reaches them.
                 // Tools additionally carry `skillDescription` / `skillBody` when the tool
-                // declares them AND the caller opted in with `X-McpPlugin-Skill-Meta: 1`,
-                // so an MCP client that wants a tool catalog can build one without calling
-                // every tool's schema, while callers that never read those keys are not
-                // charged the payload.
+                // declares them AND the caller opted in to skill metadata, so such a client
+                // can build a tool catalog without calling every tool's schema while callers
+                // that never read those keys are not charged the payload — see
+                // ExtensionsListMeta.BuildToolMeta.
                 Meta = ExtensionsListMeta.BuildToolMeta(response)
             };
         }

--- a/McpPlugin.Server/src/Extension/ExtensionsTool.cs
+++ b/McpPlugin.Server/src/Extension/ExtensionsTool.cs
@@ -80,8 +80,10 @@ namespace com.IvanMurzak.McpPlugin.Server
                 // entries the user has turned off plugin-side. Untrusted clients never
                 // receive disabled tools so the field never reaches them.
                 // Tools additionally carry `skillDescription` / `skillBody` when the tool
-                // declares them, so MCP clients can build a tool catalog without calling
-                // every tool's schema.
+                // declares them AND the caller opted in with `X-McpPlugin-Skill-Meta: 1`,
+                // so an MCP client that wants a tool catalog can build one without calling
+                // every tool's schema, while callers that never read those keys are not
+                // charged the payload.
                 Meta = ExtensionsListMeta.BuildToolMeta(response)
             };
         }

--- a/McpPlugin/src/Mcp/Tool/IRunTool.cs
+++ b/McpPlugin/src/Mcp/Tool/IRunTool.cs
@@ -30,7 +30,8 @@ namespace com.IvanMurzak.McpPlugin
         /// Sourced from <see cref="AiSkillDescriptionAttribute"/> on the underlying method by default.
         /// <para>
         /// PUBLISHED: this value is also copied onto the MCP <c>tools/list</c> entry as the
-        /// <c>_meta.skillDescription</c> key, for every caller — it is not SKILL.md-only.
+        /// <c>_meta.skillDescription</c> key for callers that opted in with the
+        /// <c>X-McpPlugin-Skill-Meta: 1</c> request header — it is not SKILL.md-only.
         /// </para>
         /// </summary>
         string? SkillDescription { get; }
@@ -42,9 +43,11 @@ namespace com.IvanMurzak.McpPlugin
         /// Sourced from <see cref="AiSkillBodyAttribute"/> on the underlying method by default.
         /// <para>
         /// PUBLISHED: this value is also copied onto the MCP <c>tools/list</c> entry as the
-        /// <c>_meta.skillBody</c> key, for every caller — it is not SKILL.md-only. It is
-        /// uncapped on that path, so keep it to content that is safe and sensible to send to
-        /// every connected MCP client.
+        /// <c>_meta.skillBody</c> key for callers that opted in with the
+        /// <c>X-McpPlugin-Skill-Meta: 1</c> request header — it is not SKILL.md-only. It is
+        /// uncapped on that path, and that header is a payload gate rather than a security
+        /// boundary (any client may send it), so keep it to content that is safe and sensible
+        /// to send to any connected MCP client.
         /// </para>
         /// </summary>
         string? SkillBody { get; }

--- a/McpPlugin/src/Mcp/Tool/ProxyTool.cs
+++ b/McpPlugin/src/Mcp/Tool/ProxyTool.cs
@@ -132,9 +132,10 @@ namespace com.IvanMurzak.McpPlugin
         /// <param name="description">Tool description shown to the AI client. Optional.</param>
         /// <param name="skillDescription">Optional concise skill blurb. Feeds the SKILL.md YAML
         /// <c>description:</c> field AND the <c>tools/list</c> <c>_meta.skillDescription</c> key,
-        /// which reaches every MCP client. Optional.</param>
+        /// which reaches callers that opted in with <c>X-McpPlugin-Skill-Meta: 1</c>. Optional.</param>
         /// <param name="skillBody">Optional long-form skill markdown. Feeds the SKILL.md body AND
-        /// the <c>tools/list</c> <c>_meta.skillBody</c> key, which reaches every MCP client — so
+        /// the <c>tools/list</c> <c>_meta.skillBody</c> key, which reaches callers that opted in
+        /// with <c>X-McpPlugin-Skill-Meta: 1</c> — a payload gate, not a security boundary, so
         /// keep it to content that is safe to publish. Optional.</param>
         /// <param name="inputSchema">JSON Schema for the tool inputs, supplied externally. Optional.</param>
         /// <param name="outputSchema">JSON Schema for the tool output, supplied externally. Optional.</param>

--- a/McpPlugin/src/Mcp/Tool/ToolTokenCount.cs
+++ b/McpPlugin/src/Mcp/Tool/ToolTokenCount.cs
@@ -95,10 +95,13 @@ namespace com.IvanMurzak.McpPlugin
             if (!string.IsNullOrEmpty(description))
                 jsonObject["description"] = description;
 
-            // Published skill metadata. It reaches every MCP client on the tools/list entry as
-            // _meta.skillDescription / _meta.skillBody, gated there on the SAME string.IsNullOrEmpty
-            // test used here — so an absent value costs nothing and a present one is measured exactly
-            // once, under the same accounting the members above get.
+            // Published skill metadata. It reaches the tools/list entry as _meta.skillDescription
+            // / _meta.skillBody only for callers that opted in with X-McpPlugin-Skill-Meta: 1, and
+            // this count deliberately ignores that opt-in: it answers "what does this catalogue cost
+            // a client that reads the skill metadata?", which is the same number whoever asks. The
+            // PER-KEY emptiness guard on the wire is the SAME string.IsNullOrEmpty test used here
+            // (the opt-in gate sits BEFORE it), so an absent value costs nothing and a present one is
+            // measured exactly once, under the same accounting the members above get.
             if (!string.IsNullOrEmpty(skillDescription))
                 jsonObject[SkillDescriptionKey] = skillDescription;
 

--- a/McpPlugin/src/McpPlugin/Attribute/Tool/AiSkillBodyAttribute.cs
+++ b/McpPlugin/src/McpPlugin/Attribute/Tool/AiSkillBodyAttribute.cs
@@ -18,10 +18,12 @@ namespace com.IvanMurzak.McpPlugin
     /// usage notes, suggestions) that would otherwise blow past the 1024-character cap on the YAML
     /// <c>description:</c> field.
     /// <para>
-    /// This text is <b>not</b> written into the YAML front-matter, but it DOES reach the MCP
+    /// This text is <b>not</b> written into the YAML front-matter, but it CAN reach the MCP
     /// <c>tools/list</c> payload: the server emits it as the <c>_meta.skillBody</c> key on the
-    /// tool's list entry, for every caller — see <c>ExtensionsListMeta.BuildToolMeta</c>.
-    /// Keep it to content that is safe to publish to any connected MCP client.
+    /// tool's list entry for callers that opted in with the <c>X-McpPlugin-Skill-Meta: 1</c>
+    /// request header — see <c>ExtensionsListMeta.BuildToolMeta</c>. That header is a payload gate,
+    /// not a security boundary (any client may send it), so keep this text to content that is safe
+    /// to publish to any connected MCP client.
     /// </para>
     /// </summary>
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false, Inherited = true)]

--- a/McpPlugin/src/McpPlugin/Attribute/Tool/AiSkillDescriptionAttribute.cs
+++ b/McpPlugin/src/McpPlugin/Attribute/Tool/AiSkillDescriptionAttribute.cs
@@ -21,8 +21,10 @@ namespace com.IvanMurzak.McpPlugin
     /// The original <see cref="System.ComponentModel.DescriptionAttribute"/> remains the source of truth
     /// for the tool's <c>description</c> in the MCP <c>tools/list</c> payload. This attribute controls the
     /// YAML field AND is surfaced beside it as the <c>_meta.skillDescription</c> key on the tool's
-    /// <c>tools/list</c> entry, for every caller — see <c>ExtensionsListMeta.BuildToolMeta</c>,
-    /// so keep it to content that is safe to publish to any connected MCP client.
+    /// <c>tools/list</c> entry — but only for callers that opted in with the
+    /// <c>X-McpPlugin-Skill-Meta: 1</c> request header, see <c>ExtensionsListMeta.BuildToolMeta</c>.
+    /// That header is a payload gate, not a security boundary (any client may send it), so keep this
+    /// text to content that is safe to publish to any connected MCP client.
     /// </para>
     /// </summary>
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false, Inherited = true)]

--- a/docs/plant-logs/server-skill-meta-gate.md
+++ b/docs/plant-logs/server-skill-meta-gate.md
@@ -2,7 +2,8 @@
 
 Verification record for the change that stopped `tools/list` from shipping
 `_meta.skillDescription` / `_meta.skillBody` to every caller, and emits them only to clients
-presenting `X-McpPlugin-Skill-Meta: 1` (owner ruling F1). The gate reads a NEW
+presenting `X-McpPlugin-Skill-Meta: 1` — a payload gate, not a secrecy one: the blurb and body
+are re-sent in full on every `tools/list`. The gate reads a NEW
 `McpSessionTokenContext.IsSkillMetaClient` axis, deliberately not the pre-existing
 `IsTrustedInternalClient`.
 
@@ -37,6 +38,10 @@ Each row names the mutation, the test it reddened, and that test's own runner li
 reddened several tests, the row names the one the plant was aimed at; the rest are listed under
 *Collateral* below.
 
+The numbering is non-contiguous: the ids `P7` and `P15` appear nowhere in this file. The 14 rows
+below are the round in full — their count matches the `14/14` summary above — so no executed plant
+is missing from the table; only the id sequence has gaps.
+
 | # | Mutation | Reddened test | Runner output |
 |---|---|---|---|
 | P1 | `BuildToolMeta`: the opt-in gate deleted entirely | `Middleware_NoSkillMetaHeader_EnabledTool_ProducesTheExactPreSkillMetadataPayload` | `Shouldly.ShouldAssertException : capturedMeta` (a non-opting caller received `_meta`) |
@@ -50,9 +55,9 @@ reddened several tests, the row names the one the plant was aimed at; the rest a
 | P10 | `Consts`: header renamed to `X-McpPlugin-SkillMeta` | `SkillMetaHeader_ConstantsAreTheLiteralWireContract` | `Shouldly.ShouldAssertException : Consts.MCP.Server.Headers.SkillMetaClient should be` |
 | P11 | `Consts`: opt-in value changed `"1"` → `"true"` | `SkillMetaHeader_ConstantsAreTheLiteralWireContract` | same assertion on the value constant |
 | P12 | `SkillMetaClientScope.OptIn()` made a no-op (`= false`) | `ToTool_EmitsBothSkillKeys_WhenBothPresent` | `Shouldly.ShouldAssertException : meta should not be null but was` |
-| P13 | **Pair**: per-flow storage made process-global (`AsyncLocal<bool>` → `StrongBox<bool>`) **and** the `finally` reset removed | `Middleware_SkillMetaFlag_DoesNotLeakIntoTheNextRequest` | `Shouldly.ShouldAssertException : gated!.ToJsonString()` — request 2 inherited request 1's opt-in |
+| P13 | **Pair**: per-flow storage made process-global (`AsyncLocal<bool>` → `StrongBox<bool>`) **and** the `finally` reset removed | `Middleware_SkillMetaFlag_DoesNotLeakIntoTheNextRequest` | `Shouldly.ShouldAssertException : secondFlag should be False but was True` — request 2 inherited request 1's opt-in. Measured **with that test collected alone**; see § *Attributing P13 and P16* |
 | P14 | **Half, `expect: green`**: the `finally` reset removed *alone* | *(none — GREEN by design)* | `Passed! - Failed: 0, Passed: 46` on both TFMs |
-| P16 | **Pair**: storage made process-global **and** the reset moved out of `finally` into the happy path | `Middleware_ClearsSkillMetaFlag_EvenIfNextThrows` | `Shouldly.ShouldAssertException` — a throwing request left the flag set |
+| P16 | **Pair**: storage made process-global **and** the reset moved out of `finally` into the happy path | `Middleware_ClearsSkillMetaFlag_EvenIfNextThrows` | `Shouldly.ShouldAssertException : McpSessionTokenContext.IsSkillMetaClient should be False but was True` — a throwing request left the flag set. Also measured with that test collected alone |
 
 ## Why P14 is GREEN, and why that is not a weak test
 
@@ -90,6 +95,30 @@ The observation is worth keeping: it means the two mechanisms above are *not* sy
 `AsyncLocal` storage is load-bearing — replacing it with any process-global store makes the server
 test suite non-deterministic.
 
+## Attributing P13 and P16 — why these two need the test collected alone
+
+Both plants make the flag's storage process-global. Run inside the full filtered suite, that
+contaminates every LATER test in the class, so `Middleware_SkillMetaFlag_DoesNotLeakIntoTheNextRequest`
+fails at its OPENING guard — `McpSessionTokenContext.IsSkillMetaClient should be False but was True`,
+before its own two-request sequence runs. The test reddens, and the RED is real, but it is charged to
+contamination from an earlier test rather than to the leak assertion the plant exists to prove. An
+earlier revision of this log recorded a runner line for P13 that belonged to a collateral test
+(`gated!.ToJsonString()`, from `Middleware_NoSkillMetaHeader_DisabledTool_...`) for the same reason.
+
+Collecting the aimed test alone removes the contaminating predecessors, so the opening guard cannot
+fire and the assertion under test has to carry the RED:
+
+```bash
+dotnet build --no-restore --configuration Release && dotnet test McpPlugin.Server.Tests/McpPlugin.Server.Tests.csproj --no-build --configuration Release   --filter "FullyQualifiedName~Middleware_SkillMetaFlag_DoesNotLeakIntoTheNextRequest"
+```
+
+Measured that way, `Total: 1` on both TFMs (so the filter matched, and the run is not a zero-match
+false green), and the failure is `Shouldly.ShouldAssertException : secondFlag should be False but was
+True` — the leak assertion itself. P16 isolated the same way fails on
+`McpSessionTokenContext.IsSkillMetaClient`, which in a single-test run can only be its post-throw
+assertion. Both claims are therefore non-vacuous; the wider failing sets in the table's own round are
+collateral, not the attribution.
+
 ## Collateral reddening (not the aimed-at test, listed for completeness)
 
 - **P4** also reddened the pre-existing `TrustedInternalClientTests.ToTool_AttachesEnabledFalseMeta_WhenDisabled`
@@ -101,6 +130,10 @@ test suite non-deterministic.
   the skill keys, so every "this caller must not" case fails together.
 - **P3 / P12** additionally reddened the `ToolListSkillMetaTests` cases, which now run under the
   opt-in scope — the intended coupling, since those tests exist to pin the composition itself.
+  P3's blast radius is wider than that line alone suggests, and worth stating because P3 is the plant
+  the Definition of Done singles out: it also reddens `Middleware_SkillMetaHeader_EmitsBothSkillKeys`
+  and `Middleware_SkillMetaHeaderAlone_EmitsSkillMetadata_ButKeepsDisabledToolsHidden` — with the gate
+  keyed off the trusted flag, a caller that sends ONLY the skill-meta header gets no keys at all.
 - **P16** additionally reddened two tests via the process-global-storage half it shares with P13
   (see the withdrawn plant above); its aimed-at test failed deterministically on both TFMs.
 
@@ -111,3 +144,24 @@ test suite non-deterministic.
 - The `enabled` contract, `BuildEnabledMeta`, and `SelectVisible`'s own behaviour are out of this
   task's scope. `TrustedInternalClientTests.cs` is byte-identical (`git diff` on it is empty) and is
   the regression fence for them; P4 and P9 above show that fence is live.
+- **No test drives the gate over the real Streamable HTTP transport.** Every case here reaches the
+  middleware directly through a `DefaultHttpContext`, so the assertion and the middleware's
+  `AsyncLocal` write share one execution flow. Production does not: `StreamableHttpTransportLayer`
+  sets `PerSessionExecutionContext = true`, so a session's request handlers run on the
+  `ExecutionContext` captured inside `RunSessionHandler` during `initialize` (that is the documented
+  reason `CurrentSessionId` has to be published from there — see `AmbientSessionIdOverHttpTests`).
+  Which request's header therefore decides `IsSkillMetaClient` for a `tools/list` handler is NOT
+  established by anything in this round, and no assertion here would notice if the answer were
+  "none of them". The asymmetry worth checking first: `McpSessionTokenContext.CurrentToken` is
+  published from BOTH the middleware and `RunSessionHandler`, and `CurrentSessionId` only from
+  `RunSessionHandler` — while both boolean flags are published only from the middleware. The pre-existing `IsTrustedInternalClient` axis has the identical test shape and is
+  shipping, so this is not a gap this change introduces — but it is not a gap this change closes
+  either, and it is recorded rather than left to be inferred from a green suite. Closing it means an
+  over-HTTP case built on the `*OverHttpTests` harness, driving a real `initialize` + `tools/list`
+  with and without the header.
+- **P1 and P2 are one equivalence class, jointly rather than independently attributed.** Deleting the
+  gate and hard-wiring it open are behaviourally identical mutations, so no test can tell them apart
+  and they print the same failure line. Measured: their failing sets are identical, test for test, and
+  both print `Shouldly.ShouldAssertException : gated should be null but was [...]` on the aimed test.
+  Both are kept because the task's Definition of Done names both; the table should not be read as two
+  independent proofs.

--- a/docs/plant-logs/server-skill-meta-gate.md
+++ b/docs/plant-logs/server-skill-meta-gate.md
@@ -1,0 +1,113 @@
+# Plant log — the `X-McpPlugin-Skill-Meta` opt-in gate
+
+Verification record for the change that stopped `tools/list` from shipping
+`_meta.skillDescription` / `_meta.skillBody` to every caller, and emits them only to clients
+presenting `X-McpPlugin-Skill-Meta: 1` (owner ruling F1). The gate reads a NEW
+`McpSessionTokenContext.IsSkillMetaClient` axis, deliberately not the pre-existing
+`IsTrustedInternalClient`.
+
+A green test proves nothing on its own: it may pass for a reason the feature does not supply. Each
+claim below was therefore mutated one at a time — the mutation applied to the real source, the
+suite re-built and re-run, the source restored byte-exactly — so that every assertion is known to be
+capable of failing, and known to fail for **its own** reason.
+
+## How the round was run
+
+- Mutations applied one at a time by a plant-and-revert harness that backs each file up out of tree,
+  substitutes bytes, runs the verify command once, restores from that copy, and checks the restore
+  by checksum. No `git checkout --` is involved, so uncommitted work is never at risk.
+- Verify command, per plant (the build is **inside** the `&&` chain, so no plant is ever scored
+  against the previous plant's assemblies):
+
+  ```bash
+  dotnet build --no-restore --configuration Release && \
+  dotnet test McpPlugin.Server.Tests/McpPlugin.Server.Tests.csproj --no-build --configuration Release \
+    --filter "FullyQualifiedName~SkillMetaClientGateTests|FullyQualifiedName~ToolListSkillMetaTests|FullyQualifiedName~TrustedInternalClientTests"
+  ```
+
+- Every per-plant log carries a `Passed!`/`Failed!` line with `Total: 46` on both `net8.0` and
+  `net9.0`. That the collected count is **46 on all 14 plants** is the check that no RED came from
+  an import or compile break rather than from the planted violation.
+- Final round: `SUMMARY 14/14 matched their expect | 13 RED | 1 GREEN | restore-failures 0`,
+  harness exit `0`.
+
+## The round
+
+Each row names the mutation, the test it reddened, and that test's own runner line. Where a plant
+reddened several tests, the row names the one the plant was aimed at; the rest are listed under
+*Collateral* below.
+
+| # | Mutation | Reddened test | Runner output |
+|---|---|---|---|
+| P1 | `BuildToolMeta`: the opt-in gate deleted entirely | `Middleware_NoSkillMetaHeader_EnabledTool_ProducesTheExactPreSkillMetadataPayload` | `Shouldly.ShouldAssertException : capturedMeta` (a non-opting caller received `_meta`) |
+| P2 | `BuildToolMeta`: gate hard-wired open — `if (!McpSessionTokenContext.IsSkillMetaClient)` → `if (!true)` | `Middleware_NoSkillMetaHeader_EnabledTool_ProducesTheExactPreSkillMetadataPayload` | same assertion; the payload is emitted regardless of the header |
+| P3 | `BuildToolMeta`: gate reads `IsTrustedInternalClient` instead of the new flag | `Middleware_TrustedInternalClientHeaderAlone_UnlocksDisabledTools_ButNotSkillMetadata` | `Shouldly.ShouldAssertException : disabledMeta!.ToJsonString() should be` — a trusted-client caller started receiving skill metadata |
+| P4 | `BuildToolMeta`: the gate returns `null` instead of the pre-existing `_meta` | `Middleware_NoSkillMetaHeader_DisabledTool_ProducesTheExactPreSkillMetadataPayload` | `Shouldly.ShouldAssertException : disabledMeta` — `{"enabled":false}` was dropped for non-opting callers |
+| P5 | Middleware: the skill-meta header block deleted, so the flag is never set | `Middleware_SkillMetaHeader_EmitsBothSkillKeys` | `Shouldly.ShouldAssertException : optedIn should not be null but was` |
+| P6 | Middleware: ordinal compare replaced by a truthiness test (`!string.IsNullOrEmpty(...)`) | `Middleware_SkillMetaHeader_WithAnyOtherValue_IsTreatedAsAbsent` — 7 of 8 rows | `Shouldly.ShouldAssertException : capturedFlag should be` for `"0"`, `"true"`, `"yes"`, `"TRUE"`, `"01"`, `"1 "`, `" 1"` |
+| P8 | `McpSessionTokenContext`: `IsSkillMetaClient` re-pointed at the trusted flag's backing slot | `Context_SettingSkillMetaFlag_LeavesTheTrustedFlagUntouched` | `Shouldly.ShouldAssertException : McpSessionTokenContext.IsSkillMetaClient` — one slot serving both properties |
+| P9 | `SelectVisible`: visibility filter re-pointed at the skill flag | `Middleware_SkillMetaHeaderAlone_EmitsSkillMetadata_ButKeepsDisabledToolsHidden` | `Shouldly.ShouldAssertException : visibleNames should be` — opting in to skill metadata also revealed disabled tools |
+| P10 | `Consts`: header renamed to `X-McpPlugin-SkillMeta` | `SkillMetaHeader_ConstantsAreTheLiteralWireContract` | `Shouldly.ShouldAssertException : Consts.MCP.Server.Headers.SkillMetaClient should be` |
+| P11 | `Consts`: opt-in value changed `"1"` → `"true"` | `SkillMetaHeader_ConstantsAreTheLiteralWireContract` | same assertion on the value constant |
+| P12 | `SkillMetaClientScope.OptIn()` made a no-op (`= false`) | `ToTool_EmitsBothSkillKeys_WhenBothPresent` | `Shouldly.ShouldAssertException : meta should not be null but was` |
+| P13 | **Pair**: per-flow storage made process-global (`AsyncLocal<bool>` → `StrongBox<bool>`) **and** the `finally` reset removed | `Middleware_SkillMetaFlag_DoesNotLeakIntoTheNextRequest` | `Shouldly.ShouldAssertException : gated!.ToJsonString()` — request 2 inherited request 1's opt-in |
+| P14 | **Half, `expect: green`**: the `finally` reset removed *alone* | *(none — GREEN by design)* | `Passed! - Failed: 0, Passed: 46` on both TFMs |
+| P16 | **Pair**: storage made process-global **and** the reset moved out of `finally` into the happy path | `Middleware_ClearsSkillMetaFlag_EvenIfNextThrows` | `Shouldly.ShouldAssertException` — a throwing request left the flag set |
+
+## Why P14 is GREEN, and why that is not a weak test
+
+The first round ran P14's mutation with `expect: red` and it came back **GREEN: 46/46 passing with
+the `finally` reset deleted**. That is a finding about the test, so it was diagnosed rather than
+accepted or papered over.
+
+The two leak assertions are guarded by **two independent mechanisms**:
+
+1. **Per-flow storage.** `AsyncLocal<bool>` writes made inside `McpSessionTokenMiddleware.InvokeAsync`
+   are not observable by an awaiting caller at all: `AsyncTaskMethodBuilder.Start` saves the
+   `ExecutionContext` around the synchronous portion of an async method and restores it on return.
+   Two sequential `await`ed middleware invocations are therefore already isolated from each other.
+2. **The `finally` reset**, which clears the slot explicitly.
+
+Either mechanism alone satisfies the assertions, so a plant that neuters just one scores GREEN
+**correctly**. Deleting the test would have dropped a correct assertion at the moment the system was
+shown to be doubly safe. The honest instrument is the simultaneous pair — P13 — which neuters both
+at once and reddens the leak test with the exact symptom the reset exists to prevent. P14 is
+retained in the table, with `expect: green`, as the recorded proof that the redundancy is real
+rather than a rationalisation.
+
+## A withdrawn plant, and why
+
+A third variant — *process-global storage alone*, predicted GREEN as P13's other half — measured
+**RED**, and not for the predicted reason. It reddens through **cross-test pollution**: with
+process-global storage a write from one test class bleeds into a sibling class running in parallel.
+Its failing set was not stable (`net8.0` failed 2 tests, `net9.0` failed 1, different sets), so it is
+a race, and a race can carry no reliable `expect_red_marker`. Rather than ship it as an
+unattributable RED — or leave a wrong `expect: green` in the table — it was **withdrawn from the
+plant table and recorded here as an observation**.
+
+The observation is worth keeping: it means the two mechanisms above are *not* symmetric. The
+`finally` reset is genuine defence in depth (removing it alone changes nothing observable), whereas
+`AsyncLocal` storage is load-bearing — replacing it with any process-global store makes the server
+test suite non-deterministic.
+
+## Collateral reddening (not the aimed-at test, listed for completeness)
+
+- **P4** also reddened the pre-existing `TrustedInternalClientTests.ToTool_AttachesEnabledFalseMeta_WhenDisabled`
+  (`meta should not be null but was`). That is the `enabled`-contract regression fence firing exactly
+  as intended: it proves the untouched a1-era tests really do guard `_meta.enabled` against this
+  change, which is the single most important property of a subtractive gate.
+- **P1 / P2** additionally reddened several `Middleware_SkillMetaHeader_WithAnyOtherValue_IsTreatedAsAbsent`
+  rows and `Middleware_TrustedInternalClientHeaderAlone_...`: with the gate open, every caller sees
+  the skill keys, so every "this caller must not" case fails together.
+- **P3 / P12** additionally reddened the `ToolListSkillMetaTests` cases, which now run under the
+  opt-in scope — the intended coupling, since those tests exist to pin the composition itself.
+- **P16** additionally reddened two tests via the process-global-storage half it shares with P13
+  (see the withdrawn plant above); its aimed-at test failed deterministically on both TFMs.
+
+## What is NOT covered here
+
+- `Consts.ApiVersion` stays `"2.0.0"`. It is unchanged in the diff, which `git diff` shows directly;
+  no plant is needed for a constant this change does not touch.
+- The `enabled` contract, `BuildEnabledMeta`, and `SelectVisible`'s own behaviour are out of this
+  task's scope. `TrustedInternalClientTests.cs` is byte-identical (`git diff` on it is empty) and is
+  the regression fence for them; P4 and P9 above show that fence is live.


### PR DESCRIPTION
Implements Taskflow `2026-08-28-tool-catalog` task **a3-server-skill-meta-gate** (owner ruling F1).
Tracked on the Taskflow board, not on a GitHub issue (matching PRs #211/#212/#213/#216/#217/#218).

**Ordering check — `b5-app-skill-meta-header` is already merged**: `IvanMurzak/AI-Game-Dev-App`
PR #454 → `734a2469`, merged 2026-08-30T08:36:24Z. That is safety-critical here. `b1-meta-catalog`
is merged and shipping, and drives the app's instructions catalog and every `searchHint` from
`skillDescription`, treating absence as "this engine publishes none" — so this gate landing *before*
b5 would have silently emptied the shipped catalog with no error and no failing test. The app now
sends the header, so this gate is a no-op for it.

## Summary

- **`tools/list` no longer ships `_meta.skillDescription` / `_meta.skillBody` to every caller.**
  Both keys are emitted only to clients presenting `X-McpPlugin-Skill-Meta: 1`. Motivation is
  payload, not secrecy: at the real 216-tool Unity fleet the skill payload is ≈205,000 characters
  (~51k tokens) per `tools/list`, re-paid per session, and it currently reaches every third-party
  client.
- **A caller that does not opt in gets the pre-`a1` wire shape exactly** — `null` when the tool is
  enabled, exactly `{"enabled":false}` when disabled. The gate returns `BuildEnabledMeta`'s result
  untouched, so `_meta.enabled` is unaffected; there is a dedicated plant (P4) for a gate that
  returns `null` instead, and it reddens the pre-existing `enabled`-contract test too.
- **A NEW axis, deliberately not `IsTrustedInternalClient`.** That predicate also unlocks the
  disabled-tool catalog at `ExtensionsListMeta.SelectVisible`, so reusing it would mean any client
  opting into skill metadata also starts receiving `Enabled = false` tools — which the app would
  register with the SDK as live, since it never reads `_meta.enabled`. `IsSkillMetaClient` is a
  second `AsyncLocal<bool>` mirroring the existing property, set in its own block beside the
  trusted-client block and cleared in the same `finally`.
- **Ordinal comparison against the exact opt-in value**, matching the trusted-client block: `"true"`,
  `"yes"`, `"TRUE"`, `"01"` and values with stray whitespace are all treated as absent.
- **Header name and value are a wire contract shared with the app** and are pinned literally on both
  sides — `X-McpPlugin-Skill-Meta` / `"1"` here, `SKILL_META_HEADER` / `SKILL_META_HEADER_VALUE` in
  `packages/core/src/engine-connect/skill-meta-header.ts` there. They only ever meet on the wire, so
  each side asserts its own spelling.
- **`Consts.ApiVersion` stays `"2.0.0"`** — stated explicitly rather than left implicit, since it is
  a hard equality gate that disconnects mismatched pairs. The change is *subtractive* for non-opting
  clients and restores the older documented `_meta` shape, so there is no new capability for a peer
  to negotiate and no bump is warranted. The constant is untouched in the diff.
- **Stale prose corrected where this change falsifies it**: `Consts.MCP.cs`'s claim that `_meta`
  "also carries the skill keys for every caller", the `ExtensionsListMeta` class remarks, the
  `ExtensionsTool.ToTool()` call-site comment, and both `[AiSkillDescription]` / `[AiSkillBody]`
  attribute docblocks (which told authors the text reaches every caller). The refine commit
  closes that sweep: `IRunTool.SkillDescription` / `SkillBody` and `ProxyTool`'s two `<param>`
  docs carried the same "for every caller" / "reaches every MCP client" claim, and
  `ToolTokenCount`'s comment additionally asserted the wire emission is gated on the *same*
  `string.IsNullOrEmpty` test it uses -- an equivalence this change breaks by placing the
  opt-in gate before those guards. All doc-only; no behaviour, tests or assertions changed.

## Test plan

- [x] Target-specific local tests passed (see profile test.md) — Suite 1, solution-level, Release:
  **4/4 test hosts `Test Run Successful.`, 0 `Test Run Failed.`**, 774 + 774 (`McpPlugin.Server.Tests`,
  net8.0/net9.0) and 1004 + 1004 (`McpPlugin.Tests`, net8.0/net9.0) = **3,556 passed, 0 failed**. The
  known machine-load flake (`ConnectionManagerTests.Connect_ThreadSafety_NoRaceConditionsUnderLoad`)
  did not fire.
- [x] `dotnet restore` → `dotnet build --no-restore --configuration Release`: 0 errors, 8 warnings
  (all pre-existing `CS8604` in `McpPlugin.Tests`, unchanged count vs. the base tree).

### The primary regression fence

`McpPlugin.Server.Tests/TrustedInternalClientTests.cs` is **byte-identical** — `git diff` on it is
empty. Its `enabled`-contract cases are what guarantee this subtractive change did not disturb the
`_meta.enabled` behaviour that prompts, resources and resource templates share. Plant P4 shows that
fence is live rather than merely present: a gate that returns `null` instead of the pre-existing
`_meta` reddens `ToTool_AttachesEnabledFalseMeta_WhenDisabled` in that untouched file.

### New coverage

| Where | What it pins |
|---|---|
| `McpPlugin.Server.Tests/SkillMetaClientGateTests.cs` (new, 18 cases) | The gate end-to-end through the real middleware: header present → both keys; header absent → the byte-exact pre-`a1` payload for enabled *and* disabled tools, each with a same-fixture positive control; 8 wrong header values treated as absent; the two axes independent at the flag level *and* the behaviour level, both directions; no leak across sequential requests; cleared on the exception path; the header constants pinned literally. |
| `McpPlugin.Server.Tests/Infrastructure/SkillMetaClientScope.cs` (new) | An opt-in scope that restores the prior value on dispose, so a unit test can reach the gate without running the middleware. Touches only the skill slot — a helper that also flipped the trusted flag would blind every consumer to the axes being conflated. |
| `McpPlugin.Server.Tests/ToolListSkillMetaTests.cs` (updated) | Every a1 case that reaches `BuildToolMeta` -- 10 of the 11 -- now runs *inside* the opt-in scope. The eleventh, `SkillMetaKeys_AreTheLiteralWireNames`, only asserts the two key constants and never calls `ToTool()`, so the gate cannot affect it. This is load-bearing, not cosmetic: without it the "no key is emitted" cases would hold for the gate's reason instead of their own and could no longer tell the composition apart from a server that never learned to emit skill metadata. Plant P12 (scope made a no-op) proves the opt-in is real. |

Every "no skill key was emitted" assertion runs on a fixture that **does** declare both skill values,
paired with a positive control on that same fixture — so an absence can only come from the gate,
never from an empty fixture.

### Plant round — 14/14 matched expect, 13 RED / 1 GREEN, restore-failures 0

Committed as a written artifact at **`docs/plant-logs/server-skill-meta-gate.md`** (per-plant
mutation, reddened test id, and that test's own runner line), following the `a4` precedent. The
three plants the task's DoD names verbatim are P1 (gate removed), P2 (gate hard-wired to true) and
P3 (gate wired to `IsTrustedInternalClient`) — P3 being the one that proves the axes were actually
split. Collected count was **46 on all 14 plants**, so no RED came from an import or compile break.

Two results in that log are worth reading rather than skimming:

- **P14 is GREEN by design.** Deleting the `finally` reset alone left all 46 tests passing, because
  the leak assertions are guarded by *two* independent mechanisms — `AsyncLocal` per-flow storage
  (an async method's `ExecutionContext` is restored on return, so the write is never observable by
  the caller) *and* the explicit reset. The honest instrument is the simultaneous pair, P13, which
  neuters both and reddens the leak test. The test was kept and the redundancy documented, rather
  than weakened to make a single-site plant red.
- **One plant was withdrawn, and the log says why.** "Process-global storage alone", predicted GREEN,
  measured RED — via cross-test pollution whose failing set differed per TFM. A race cannot carry a
  stable marker, so it was removed from the table and recorded as an observation instead of shipped
  as an unattributable RED. It yields a real finding: the `finally` reset is defence in depth, but
  `AsyncLocal` storage is load-bearing.

## Scope

Untouched, per the task's fence: `BuildEnabledMeta`, `SelectVisible`, the `enabled` contract and its
tests, and the three non-tool `_meta` call sites (`ExtensionsPrompt.cs`,
`ExtensionsListResources.cs`, `ExtensionsListResourceTemplates.cs`). No `<Version>` bump, no
ReflectorNet pin change, no release.

## Operator follow-up

Nothing in this PR reaches production on merge. `GameDev-MCP-Server` pins
`com.IvanMurzak.McpPlugin.Server` **8.2.0**, and `a1` is not in the `8.3.0` tag, so the gate cannot
ship until gate **G1** publishes a new McpPlugin release and bumps that pin. G1 is owner-gated and
outside this pipeline's remit.

