### PR TITLE
feat(tests): McpPlugin.NullEngine headless host + the first real-transport test

### DIFF
--- a/McpPlugin.NullEngine/McpPlugin.NullEngine.csproj
+++ b/McpPlugin.NullEngine/McpPlugin.NullEngine.csproj
@@ -1,0 +1,37 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!-- The "null engine": a REAL headless McpPlugin host - real McpPluginBuilder, real SignalR
+       transport, no editor. Spawned as an actual OS process by McpPlugin.Server.Tests
+       (NullEngineRealTransportTests) so this repo has at least one test that drives a real plugin
+       against the real server host over the real transport, and by out-of-repo consumers that need
+       one deterministic, scriptable engine process to point a server at.
+
+       Test / fixture infrastructure only - never packed, never published (IsPackable=false, and it
+       is absent from deploy.yml / release.yml on purpose).
+
+       Two TFMs, mirroring McpPlugin.Tests.LockHarness: McpPlugin.Server.Tests runs on net8.0 AND
+       net9.0, and each test leg locates the exe built for its OWN TFM. -->
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>11.0</LangVersion>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>com.IvanMurzak.McpPlugin.NullEngine</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- McpPlugin ONLY. No reference to McpPlugin.Server: this process is a plugin CLIENT, and the
+         two pin different SignalR major versions (client 8.0.15, server 10.0.3). -->
+    <ProjectReference Include="../McpPlugin/McpPlugin.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Same console-logging provider and version DemoConsoleApp uses. The 'fail:'/'info:' line
+         prefixes this host's contract is asserted on are this formatter's. -->
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.3" />
+  </ItemGroup>
+
+</Project>

--- a/McpPlugin.NullEngine/README.md
+++ b/McpPlugin.NullEngine/README.md
@@ -38,11 +38,11 @@ dotnet McpPlugin.NullEngine.dll --help
 
 | Flag | Meaning | Default |
 |---|---|---|
-| `--mcp-server-endpoint=<url>` | MCP server base URL. The existing `ConnectionConfig` key; env `MCP_SERVER_ENDPOINT` also works. | `http://localhost:8080` |
+| `--mcp-server-endpoint=<url>` | MCP server base URL. The existing `ConnectionConfig` key; env `MCP_SERVER_ENDPOINT` also works. | `Consts.Hub.DefaultHost` (`http://localhost:8080` today) |
 | `--project-root=<dir>` | Host project root. Sets `ConnectionConfig.ProjectRootPath`, which anchors the relative `SkillsPath` (`SKILLS`). | a fresh temp directory |
 | `--ready-file=<path>` | Write `{pid, tools, prompts, resources, plugin_version}` as JSON once the handshake succeeded. Written via temp-file + rename, so a reader never sees a partial document. | not written |
 | `--exit-after-ms=<n>` | Exit `0` this many milliseconds after becoming ready. | run until Ctrl-C |
-| `--mcp-server-timeout=<ms>` | Handshake timeout; env `MCP_SERVER_TIMEOUT`. | `10000` |
+| `--mcp-server-timeout=<ms>` | Handshake timeout; env `MCP_SERVER_TIMEOUT`. | `Consts.Hub.DefaultTimeoutMs` (`10000` today) |
 | `--help` | Print the contract and exit `0` **without connecting**. | — |
 
 `--project-root` is not cosmetic. Without it the plugin cannot resolve the relative default

--- a/McpPlugin.NullEngine/README.md
+++ b/McpPlugin.NullEngine/README.md
@@ -1,0 +1,146 @@
+# McpPlugin.NullEngine
+
+A **real headless McpPlugin host**: real `McpPluginBuilder`, real SignalR transport, real
+attribute-scanned tool / prompt / resource registration — and no editor behind it.
+
+It exists so a test (or an out-of-repo consumer) has ONE deterministic, scriptable engine process to
+point an MCP server at. Every tool response is a pure function of its arguments — no clock, no
+randomness, no ambient state — so the same call sequence replayed later produces byte-identical
+results.
+
+It is **test / fixture infrastructure**: `IsPackable=false`, never packed, never published, and
+absent from `deploy.yml` / `release.yml` on purpose.
+
+- Source: `src/Program.cs`, `src/Tools/`, `src/Prompts/`, `src/Resources/`
+- In-repo consumer: `McpPlugin.Server.Tests/NullEngineRealTransportTests.cs`
+
+## Build
+
+The project is part of `McpPlugin.sln`, so the repo-root build produces it:
+
+```bash
+dotnet build McpPlugin.sln -c Release
+```
+
+Output: `McpPlugin.NullEngine/bin/<Configuration>/<tfm>/McpPlugin.NullEngine.dll`
+for `<tfm>` in `net8.0`, `net9.0`.
+
+## CLI contract
+
+```
+dotnet McpPlugin.NullEngine.dll --mcp-server-endpoint=<url> \
+                                [--project-root=<dir>] \
+                                [--ready-file=<path>] \
+                                [--exit-after-ms=<n>] \
+                                [--mcp-server-timeout=<ms>]
+dotnet McpPlugin.NullEngine.dll --help
+```
+
+| Flag | Meaning | Default |
+|---|---|---|
+| `--mcp-server-endpoint=<url>` | MCP server base URL. The existing `ConnectionConfig` key; env `MCP_SERVER_ENDPOINT` also works. | `http://localhost:8080` |
+| `--project-root=<dir>` | Host project root. Sets `ConnectionConfig.ProjectRootPath`, which anchors the relative `SkillsPath` (`SKILLS`). | a fresh temp directory |
+| `--ready-file=<path>` | Write `{pid, tools, prompts, resources, plugin_version}` as JSON once the handshake succeeded. Written via temp-file + rename, so a reader never sees a partial document. | not written |
+| `--exit-after-ms=<n>` | Exit `0` this many milliseconds after becoming ready. | run until Ctrl-C |
+| `--mcp-server-timeout=<ms>` | Handshake timeout; env `MCP_SERVER_TIMEOUT`. | `10000` |
+| `--help` | Print the contract and exit `0` **without connecting**. | — |
+
+`--project-root` is not cosmetic. Without it the plugin cannot resolve the relative default
+`SkillsPath` and logs an error during construction (`Cannot resolve relative SkillsPath 'SKILLS'
+… ProjectRootPath is not set`, `McpPlugin/src/McpPlugin/McpPlugin.cs`), which the console formatter
+writes as a `fail:` line. This host always sets it — that is why a clean startup emits no `fail:`
+line at all, and it is the property `NullEngineRealTransportTests` asserts.
+
+> `dotnet run --project McpPlugin.NullEngine` needs an explicit `-f`, because the project multi-targets
+> `net8.0;net9.0` (both are needed: `McpPlugin.Server.Tests` runs on both, and each leg locates the
+> engine built for its own TFM):
+>
+> ```bash
+> dotnet run --project McpPlugin.NullEngine -f net9.0 -c Release -- --help
+> ```
+
+### Ready line
+
+On a successful version handshake the host prints exactly one line to **stdout**:
+
+```
+NULL-ENGINE READY tools=12 prompts=2 resources=1 plugin=8.3.0+<commit sha>
+```
+
+`plugin=` is the **McpPlugin assembly's** `AssemblyInformationalVersion`, read at runtime from
+`typeof(McpPlugin).Assembly` — never the `Consts.PluginVersion` compile-time constant, which cannot
+tell a locally built assembly from a released one.
+
+### Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Clean shutdown: Ctrl-C, `--exit-after-ms` elapsed, or `--help`. |
+| `3` | The version handshake did not complete within `--mcp-server-timeout`. A `NULL-ENGINE HANDSHAKE-FAILED …` line is written to stderr. |
+
+### Logging
+
+Console logging is deliberately configured at `Trace`, so the `Microsoft.Extensions.Logging` console
+formatter's level prefixes (`trce:` / `dbug:` / `info:` / `warn:` / `fail:` / `crit:`) are observable
+by a consumer that captures stdout. Two tools (`fail`, `throw`) are REQUIRED to produce errors, so
+they DO emit `fail:` blocks when called; the startup / handshake window is the part that must be
+free of them.
+
+## Tools
+
+All names are prefixed `null-engine/`. Arguments below are the JSON `arguments` object of a
+`tools/call`. "Response" is the text of the first content block.
+
+| Tool | Arguments | Response | `isError` |
+|---|---|---|---|
+| `ping` | — | `{"result":"pong"}` | `false` |
+| `echo` | `payload: {text: string, number: int, flag: bool}` | `{"result":{"Text":…,"Number":…,"Flag":…}}` — the payload unchanged | `false` |
+| `large-payload` | `kb: int` (0..1024, default 1) | `{"result":{"kb":…,"length":…,"payload":"xxx…"}}` | `false` (out of range ⇒ `true`) |
+| `fail` | — | `null-engine: deliberate tool failure (fixed message).` | **`true`** |
+| `throw` | — | `Tool execution failed for 'Throw': null-engine: deliberate unhandled exception (fixed message).` | **`true`** — and the process stays alive |
+| `slow` | `ms: int` (0..10000, default 0) | `{"result":{"slept_ms":…,"status":"slept"}}` | `false` (out of range ⇒ `true`) |
+| `progress` | `steps: int` (0..100, default 3) | `{"result":{"emitted":…}}`, plus one `info:` log line per step | `false` (out of range ⇒ `true`) |
+| `unicode` | `text: string` (default: a mixed non-ASCII sample) | `{"result":{"text":…}}` — the text unchanged | `false` |
+| `nested` | — | `{"result":{"level":1,…{"level":5,…,"child":null}}}` — five levels | `false` |
+| `enum-arg` | `color: Red \| Green \| Blue` (default `Red`) | `{"result":{"color":"Green"}}` | `false`; anything else ⇒ `true` |
+| `optional-args` | `name: string` (default `world`), `count: int` (default `1`) | `{"result":{"name":"world","count":1}}` | `false` |
+| `list-self` | — | `{"result":{"tools":[…]}}` — the names the plugin actually registered, ordered ordinally | `false` |
+
+`progress` reports through log lines rather than MCP progress notifications: the plugin exposes no
+progress API on the tool seam today. That is the fallback the contract allows, and it keeps the tool
+response itself deterministic.
+
+## Prompts
+
+| Prompt | Arguments | Body |
+|---|---|---|
+| `null-engine/greeting` | `name: string` (default `world`) | `null-engine: hello, <name>.` |
+| `null-engine/static` | — | `null-engine: a fixed prompt body with no arguments.` |
+
+## Resources
+
+| URI | MIME type | Body |
+|---|---|---|
+| `null-engine://config` | `application/json` | `{"endpoint":…,"project_root":…,"tools":…,"prompts":…,"resources":…,"plugin_version":…}` — the host's own resolved configuration |
+
+## Running it by hand against a local server
+
+`DemoWebApp` is the in-repo `auth=none` Streamable-HTTP server:
+
+```bash
+dotnet build McpPlugin.sln -c Release
+
+# terminal 1 - the server. `auth=none` is load-bearing: DataArguments also reads the environment,
+# and a worktree's .worktree.env sets MCP_AUTHORIZATION=required.
+dotnet DemoWebApp/bin/Release/net9.0/DemoWebApp.dll \
+  port=18099 client-transport=streamableHttp auth=none plugin-timeout=10000
+
+# terminal 2 - the engine, once GET http://127.0.0.1:18099/help answers 200
+dotnet McpPlugin.NullEngine/bin/Release/net9.0/McpPlugin.NullEngine.dll \
+  --mcp-server-endpoint=http://127.0.0.1:18099 \
+  --ready-file=/tmp/null-engine-ready.json
+```
+
+Then drive a real MCP session against `http://127.0.0.1:18099/mcp`:
+`initialize` → capture the `Mcp-Session-Id` response header → `notifications/initialized` →
+`tools/list` → `tools/call`. Replies are SSE frames; the JSON is on the `data:` lines.

--- a/McpPlugin.NullEngine/src/NullEngineHost.cs
+++ b/McpPlugin.NullEngine/src/NullEngineHost.cs
@@ -9,7 +9,6 @@
 */
 #nullable enable
 using System;
-using System.Text.Json;
 using System.Text.Json.Nodes;
 using Microsoft.Extensions.Logging;
 
@@ -34,10 +33,10 @@ namespace com.IvanMurzak.McpPlugin.NullEngine
         public static ILogger? Logger { get; set; }
 
         /// <summary>Resolved host project root (<c>--project-root</c>, else a fresh temp directory).</summary>
-        public static string ProjectRoot { get; set; } = string.Empty;
+        public static string ProjectRoot { get; private set; } = string.Empty;
 
         /// <summary>Resolved MCP server base URL (<c>--mcp-server-endpoint</c>).</summary>
-        public static string Endpoint { get; set; } = string.Empty;
+        public static string Endpoint { get; private set; } = string.Empty;
 
         /// <summary>
         /// The registered tool names, ordered ordinally. Serving these from the plugin's own tool
@@ -63,26 +62,45 @@ namespace com.IvanMurzak.McpPlugin.NullEngine
             }
         }
 
-        public static void SetToolNames(string[] names)
+        /// <summary>
+        /// Publishes the whole catalog in ONE call, made once by <c>Program</c> before it prints the
+        /// ready line.
+        ///
+        /// <para>One call rather than several setters is deliberate. The endpoint and project root
+        /// are ARGUMENTS here instead of properties read back out of this class, so there is no
+        /// order in which a caller can get this wrong: reading them as properties meant an
+        /// initialisation sequence spread across three statements, and a caller that published the
+        /// catalog before assigning them shipped <c>"endpoint": ""</c> in the config resource -
+        /// silently, since every count would still be right. The tool COUNT is likewise derived from
+        /// the names array rather than passed alongside it, so the two cannot disagree.</para>
+        /// </summary>
+        public static void SetCatalog(
+            string[] toolNames,
+            int prompts,
+            int resources,
+            string pluginVersion,
+            string endpoint,
+            string projectRoot)
         {
-            lock (_gate)
-                _toolNames = names ?? Array.Empty<string>();
-        }
-
-        public static void SetCounts(int tools, int prompts, int resources, string pluginVersion)
-        {
+            var names = toolNames ?? Array.Empty<string>();
             var payload = new JsonObject
             {
-                ["endpoint"] = Endpoint,
-                ["project_root"] = ProjectRoot,
-                ["tools"] = tools,
+                ["endpoint"] = endpoint,
+                ["project_root"] = projectRoot,
+                ["tools"] = names.Length,
                 ["prompts"] = prompts,
                 ["resources"] = resources,
                 ["plugin_version"] = pluginVersion
             };
 
+            Endpoint = endpoint;
+            ProjectRoot = projectRoot;
+
             lock (_gate)
-                _configJson = payload.ToJsonString(new JsonSerializerOptions { WriteIndented = false });
+            {
+                _toolNames = names;
+                _configJson = payload.ToJsonString();
+            }
         }
     }
 }

--- a/McpPlugin.NullEngine/src/NullEngineHost.cs
+++ b/McpPlugin.NullEngine/src/NullEngineHost.cs
@@ -1,0 +1,88 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.Logging;
+
+namespace com.IvanMurzak.McpPlugin.NullEngine
+{
+    /// <summary>
+    /// The small amount of state the attribute-scanned tool / prompt / resource classes need from
+    /// the running host. They are STATIC classes (that is what <c>[AiToolType]</c> scanning
+    /// registers), so there is no constructor to inject through; <c>Program</c> populates this once,
+    /// before it prints the ready line.
+    /// </summary>
+    public static class NullEngineHost
+    {
+        static readonly object _gate = new object();
+        static string[] _toolNames = Array.Empty<string>();
+        static string _configJson = "{}";
+
+        /// <summary>
+        /// The plugin's own logger, so a tool never has to call <c>Console.WriteLine</c>.
+        /// Null until <c>Program</c> has built the plugin.
+        /// </summary>
+        public static ILogger? Logger { get; set; }
+
+        /// <summary>Resolved host project root (<c>--project-root</c>, else a fresh temp directory).</summary>
+        public static string ProjectRoot { get; set; } = string.Empty;
+
+        /// <summary>Resolved MCP server base URL (<c>--mcp-server-endpoint</c>).</summary>
+        public static string Endpoint { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The registered tool names, ordered ordinally. Serving these from the plugin's own tool
+        /// manager (rather than re-reflecting over the assembly) is what makes <c>list-self</c>
+        /// report what the plugin ACTUALLY registered.
+        /// </summary>
+        public static string[] ToolNames
+        {
+            get
+            {
+                lock (_gate)
+                    return (string[])_toolNames.Clone();
+            }
+        }
+
+        /// <summary>The <c>null-engine://config</c> resource body: the resolved host configuration.</summary>
+        public static string ConfigJson
+        {
+            get
+            {
+                lock (_gate)
+                    return _configJson;
+            }
+        }
+
+        public static void SetToolNames(string[] names)
+        {
+            lock (_gate)
+                _toolNames = names ?? Array.Empty<string>();
+        }
+
+        public static void SetCounts(int tools, int prompts, int resources, string pluginVersion)
+        {
+            var payload = new JsonObject
+            {
+                ["endpoint"] = Endpoint,
+                ["project_root"] = ProjectRoot,
+                ["tools"] = tools,
+                ["prompts"] = prompts,
+                ["resources"] = resources,
+                ["plugin_version"] = pluginVersion
+            };
+
+            lock (_gate)
+                _configJson = payload.ToJsonString(new JsonSerializerOptions { WriteIndented = false });
+        }
+    }
+}

--- a/McpPlugin.NullEngine/src/Program.cs
+++ b/McpPlugin.NullEngine/src/Program.cs
@@ -61,6 +61,11 @@ namespace com.IvanMurzak.McpPlugin.NullEngine
         public static async Task<int> Main(string[] args)
         {
             args ??= Array.Empty<string>();
+            // ArgsUtils directly, not DataArguments: DataArguments models the SERVER's argument
+            // surface (port, authorization, webhooks, bind), and this process is a plugin CLIENT
+            // that does not reference McpPlugin.Server. ConnectionConfig - the client-side
+            // precedent - parses argv the same way. The three flags read here are fixture-only, so
+            // adding them to a shipped netstandard2.1 type every engine consumes would be worse.
             var parsed = ArgsUtils.ParseLineArguments(args);
 
             if (parsed.ContainsKey("help") || parsed.ContainsKey("h"))
@@ -93,9 +98,9 @@ namespace com.IvanMurzak.McpPlugin.NullEngine
 
             var reflector = new Reflector();
 
-            var mcpPlugin = new McpPluginBuilder(version)
+            using var mcpPlugin = new McpPluginBuilder(version)
                 .WithConfigFromArgsOrEnv(args)
-                // A3: WithConfigFromArgsOrEnv sets only Host + TimeoutMs. Without ProjectRootPath the
+                // WithConfigFromArgsOrEnv sets only Host + TimeoutMs. Without ProjectRootPath the
                 // relative default SkillsPath ('SKILLS') cannot be resolved and the very first skill
                 // generation throws, which the plugin logs at Error level - the 'fail:' line this host
                 // is required to never emit. Keep this chained call.
@@ -111,8 +116,6 @@ namespace com.IvanMurzak.McpPlugin.NullEngine
                 .Build(reflector);
 
             NullEngineHost.Logger = mcpPlugin.Logger;
-            NullEngineHost.ProjectRoot = projectRoot;
-            NullEngineHost.Endpoint = endpoint;
 
             using var lifetime = new CancellationTokenSource();
             Console.CancelKeyPress += (_, eventArgs) =>
@@ -126,11 +129,18 @@ namespace com.IvanMurzak.McpPlugin.NullEngine
 
             try
             {
-                await mcpPlugin.Connect(handshakeCts.Token);
+                await mcpPlugin.Connect(handshakeCts.Token).ConfigureAwait(false);
             }
-            catch (OperationCanceledException)
+            catch (Exception ex)
             {
-                // Fall through to the deadline check below so the exit code has one source.
+                // Deliberately broad. The deadline check below is the SINGLE source of the exit code,
+                // and how a transport reports an unreachable endpoint - cancelling versus throwing -
+                // is exactly the kind of thing that differs across the three operating systems this
+                // host is required to run on. Narrowing this to OperationCanceledException lets such a
+                // throw escape Main, replacing the documented exit 3 (and the HANDSHAKE-FAILED line a
+                // consumer keys off) with an unhandled-exception exit code and no diagnostic at all.
+                // Reported on stderr so nothing is swallowed silently.
+                Console.Error.WriteLine($"NULL-ENGINE CONNECT-FAILED {ex.GetType().Name}: {ex.Message}");
             }
 
             var ready = false;
@@ -150,7 +160,6 @@ namespace com.IvanMurzak.McpPlugin.NullEngine
                 Console.Error.WriteLine(
                     $"NULL-ENGINE HANDSHAKE-FAILED endpoint={endpoint} timeout-ms={timeoutMs}");
                 Console.Error.Flush();
-                mcpPlugin.Dispose();
                 return ExitHandshakeFailed;
             }
 
@@ -162,8 +171,7 @@ namespace com.IvanMurzak.McpPlugin.NullEngine
             var resourceCount = mcpPlugin.McpManager.ResourceManager?.GetAllResources().Count() ?? 0;
             var pluginVersion = ResolvePluginInformationalVersion();
 
-            NullEngineHost.SetToolNames(toolNames);
-            NullEngineHost.SetCounts(toolNames.Length, promptCount, resourceCount, pluginVersion);
+            NullEngineHost.SetCatalog(toolNames, promptCount, resourceCount, pluginVersion, endpoint, projectRoot);
 
             Console.Out.WriteLine(
                 $"{ReadyLinePrefix} tools={toolNames.Length} prompts={promptCount} resources={resourceCount} plugin={pluginVersion}");
@@ -184,7 +192,6 @@ namespace com.IvanMurzak.McpPlugin.NullEngine
                 // Requested shutdown - the only way out of the idle wait.
             }
 
-            mcpPlugin.Dispose();
             return ExitOk;
         }
 
@@ -210,9 +217,7 @@ namespace com.IvanMurzak.McpPlugin.NullEngine
 
             var temp = readyFile + ".tmp";
             File.WriteAllText(temp, payload.ToJsonString(), new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
-            if (File.Exists(readyFile))
-                File.Delete(readyFile);
-            File.Move(temp, readyFile);
+            File.Move(temp, readyFile, overwrite: true);
         }
 
         static void Cancel(CancellationTokenSource source)

--- a/McpPlugin.NullEngine/src/Program.cs
+++ b/McpPlugin.NullEngine/src/Program.cs
@@ -1,0 +1,289 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.Common;
+using com.IvanMurzak.McpPlugin.Common.Utils;
+using com.IvanMurzak.McpPlugin.NullEngine.Tools;
+using com.IvanMurzak.ReflectorNet;
+using Microsoft.Extensions.Logging;
+using Version = com.IvanMurzak.McpPlugin.Common.Version;
+
+namespace com.IvanMurzak.McpPlugin.NullEngine
+{
+    /// <summary>
+    /// The "null engine" host: a REAL headless McpPlugin process - real
+    /// <see cref="McpPluginBuilder"/>, real SignalR transport, real attribute-scanned
+    /// tool / prompt / resource registration - with no editor behind it.
+    ///
+    /// <para>It exists so that a test (or an out-of-repo consumer) has ONE deterministic,
+    /// scriptable engine process to point an MCP server at. Every tool response is a pure
+    /// function of its arguments, so two runs of the same call sequence are byte-comparable.</para>
+    ///
+    /// <para>The seed this replaces (<c>DemoConsoleApp</c>) connects but logs
+    /// <c>fail: ... Cannot resolve relative SkillsPath 'SKILLS' ... ProjectRootPath is not set</c>
+    /// because it never tells the plugin where the host project lives
+    /// (<c>McpPlugin.ResolveSkillsPath</c>). This host always sets
+    /// <see cref="ConnectionConfig.ProjectRootPath"/> - to <c>--project-root</c>, or to a fresh
+    /// temp directory - which is why a clean run emits no <c>fail:</c> line at all. That
+    /// assignment is load-bearing, not defensive: removing it brings the message straight back.
+    /// Console logging deliberately stays at <see cref="LogLevel.Trace"/> so the
+    /// <c>fail:</c> prefix remains observable.</para>
+    ///
+    /// <para>CLI contract, exit codes and the tool table live in <c>README.md</c> beside this file.</para>
+    /// </summary>
+    public static class Program
+    {
+        /// <summary>Prefix of the single line printed to stdout once the handshake succeeded.</summary>
+        public const string ReadyLinePrefix = "NULL-ENGINE READY";
+
+        /// <summary>Clean shutdown (Ctrl-C, <c>--exit-after-ms</c>, or <c>--help</c>).</summary>
+        public const int ExitOk = 0;
+
+        /// <summary>The version handshake did not complete inside the plugin timeout.</summary>
+        public const int ExitHandshakeFailed = 3;
+
+        public static async Task<int> Main(string[] args)
+        {
+            args ??= Array.Empty<string>();
+            var parsed = ArgsUtils.ParseLineArguments(args);
+
+            if (parsed.ContainsKey("help") || parsed.ContainsKey("h"))
+            {
+                Console.Out.Write(Usage());
+                Console.Out.Flush();
+                return ExitOk;
+            }
+
+            var projectRoot = ResolveProjectRoot(parsed);
+            Directory.CreateDirectory(projectRoot);
+
+            var readyFile = parsed.TryGetValue("ready-file", out var readyFileValue) && !string.IsNullOrWhiteSpace(readyFileValue)
+                ? Path.GetFullPath(readyFileValue)
+                : null;
+
+            var exitAfterMs = ParseInt(parsed, "exit-after-ms", 0);
+            var timeoutMs = ConnectionConfig.GetTimeoutFromArgsOrEnv(args);
+            if (timeoutMs <= 0)
+                timeoutMs = Consts.Hub.DefaultTimeoutMs;
+
+            var endpoint = ConnectionConfig.GetEndpointFromArgsOrEnv(args);
+
+            var version = new Version
+            {
+                Api = Consts.ApiVersion,
+                Plugin = Consts.PluginVersion,
+                Environment = "McpPlugin.NullEngine"
+            };
+
+            var reflector = new Reflector();
+
+            var mcpPlugin = new McpPluginBuilder(version)
+                .WithConfigFromArgsOrEnv(args)
+                // A3: WithConfigFromArgsOrEnv sets only Host + TimeoutMs. Without ProjectRootPath the
+                // relative default SkillsPath ('SKILLS') cannot be resolved and the very first skill
+                // generation throws, which the plugin logs at Error level - the 'fail:' line this host
+                // is required to never emit. Keep this chained call.
+                .WithConfig(config => config.ProjectRootPath = projectRoot)
+                .AddLogging(logging =>
+                {
+                    logging.AddConsole();
+                    logging.SetMinimumLevel(LogLevel.Trace);
+                })
+                .WithToolsFromAssembly(typeof(NullEngineTools).Assembly)
+                .WithPromptsFromAssembly(typeof(NullEngineTools).Assembly)
+                .WithResourcesFromAssembly(typeof(NullEngineTools).Assembly)
+                .Build(reflector);
+
+            NullEngineHost.Logger = mcpPlugin.Logger;
+            NullEngineHost.ProjectRoot = projectRoot;
+            NullEngineHost.Endpoint = endpoint;
+
+            using var lifetime = new CancellationTokenSource();
+            Console.CancelKeyPress += (_, eventArgs) =>
+            {
+                eventArgs.Cancel = true;
+                Cancel(lifetime);
+            };
+
+            var handshakeDeadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+            using var handshakeCts = new CancellationTokenSource(timeoutMs);
+
+            try
+            {
+                await mcpPlugin.Connect(handshakeCts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                // Fall through to the deadline check below so the exit code has one source.
+            }
+
+            var ready = false;
+            while (DateTime.UtcNow < handshakeDeadline)
+            {
+                var handshake = mcpPlugin.VersionHandshakeStatus;
+                if (handshake != null && handshake.Compatible)
+                {
+                    ready = true;
+                    break;
+                }
+                await Task.Delay(50).ConfigureAwait(false);
+            }
+
+            if (!ready)
+            {
+                Console.Error.WriteLine(
+                    $"NULL-ENGINE HANDSHAKE-FAILED endpoint={endpoint} timeout-ms={timeoutMs}");
+                Console.Error.Flush();
+                mcpPlugin.Dispose();
+                return ExitHandshakeFailed;
+            }
+
+            var toolNames = (mcpPlugin.McpManager.ToolManager?.GetAllTools() ?? Enumerable.Empty<IRunTool>())
+                .Select(tool => tool.Name)
+                .OrderBy(name => name, StringComparer.Ordinal)
+                .ToArray();
+            var promptCount = mcpPlugin.McpManager.PromptManager?.GetAllPrompts().Count() ?? 0;
+            var resourceCount = mcpPlugin.McpManager.ResourceManager?.GetAllResources().Count() ?? 0;
+            var pluginVersion = ResolvePluginInformationalVersion();
+
+            NullEngineHost.SetToolNames(toolNames);
+            NullEngineHost.SetCounts(toolNames.Length, promptCount, resourceCount, pluginVersion);
+
+            Console.Out.WriteLine(
+                $"{ReadyLinePrefix} tools={toolNames.Length} prompts={promptCount} resources={resourceCount} plugin={pluginVersion}");
+            Console.Out.Flush();
+
+            if (readyFile != null)
+                WriteReadyFile(readyFile, toolNames.Length, promptCount, resourceCount, pluginVersion);
+
+            if (exitAfterMs > 0)
+                lifetime.CancelAfter(exitAfterMs);
+
+            try
+            {
+                await Task.Delay(Timeout.Infinite, lifetime.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                // Requested shutdown - the only way out of the idle wait.
+            }
+
+            mcpPlugin.Dispose();
+            return ExitOk;
+        }
+
+        /// <summary>
+        /// Writes the ready file through a temp file + rename so a reader can never observe a
+        /// half-written document: the test waits on this file's EXISTENCE, so a partial write
+        /// would surface as an opaque JSON parse error rather than as a slow start.
+        /// </summary>
+        static void WriteReadyFile(string readyFile, int tools, int prompts, int resources, string pluginVersion)
+        {
+            var directory = Path.GetDirectoryName(readyFile);
+            if (!string.IsNullOrEmpty(directory))
+                Directory.CreateDirectory(directory!);
+
+            var payload = new JsonObject
+            {
+                ["pid"] = Environment.ProcessId,
+                ["tools"] = tools,
+                ["prompts"] = prompts,
+                ["resources"] = resources,
+                ["plugin_version"] = pluginVersion
+            };
+
+            var temp = readyFile + ".tmp";
+            File.WriteAllText(temp, payload.ToJsonString(), new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            if (File.Exists(readyFile))
+                File.Delete(readyFile);
+            File.Move(temp, readyFile);
+        }
+
+        static void Cancel(CancellationTokenSource source)
+        {
+            try
+            {
+                source.Cancel();
+            }
+            catch (ObjectDisposedException)
+            {
+                // Already shutting down.
+            }
+        }
+
+        static string ResolveProjectRoot(IDictionary<string, string> parsed)
+        {
+            if (parsed.TryGetValue("project-root", out var value) && !string.IsNullOrWhiteSpace(value))
+                return Path.GetFullPath(value);
+
+            return Path.Combine(Path.GetTempPath(), "mcp-null-engine-" + Guid.NewGuid().ToString("N"));
+        }
+
+        static int ParseInt(IDictionary<string, string> parsed, string key, int fallback)
+            => parsed.TryGetValue(key, out var value) && int.TryParse(value, out var parsedValue)
+                ? parsedValue
+                : fallback;
+
+        /// <summary>
+        /// The McpPlugin ASSEMBLY's informational version, read at runtime - NOT
+        /// <c>Consts.PluginVersion</c>, a compile-time constant that cannot tell a locally built
+        /// assembly from a released one, and therefore cannot discriminate at all.
+        /// </summary>
+        static string ResolvePluginInformationalVersion()
+        {
+            var assembly = typeof(global::com.IvanMurzak.McpPlugin.McpPlugin).Assembly;
+            var informational = assembly
+                .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+
+            if (!string.IsNullOrEmpty(informational))
+                return informational!;
+
+            return assembly.GetName().Version?.ToString() ?? "unknown";
+        }
+
+        static string Usage()
+        {
+            var builder = new StringBuilder();
+            builder.AppendLine("McpPlugin.NullEngine - a real headless McpPlugin host (no editor).");
+            builder.AppendLine();
+            builder.AppendLine("Usage:");
+            builder.AppendLine("  dotnet McpPlugin.NullEngine.dll --mcp-server-endpoint=<url> [options]");
+            builder.AppendLine();
+            builder.AppendLine("Options:");
+            builder.AppendLine("  --mcp-server-endpoint=<url>  MCP server base URL. Env: MCP_SERVER_ENDPOINT.");
+            builder.AppendLine($"                               Default: {Consts.Hub.DefaultHost}");
+            builder.AppendLine("  --project-root=<dir>         Host project root; anchors the relative SkillsPath.");
+            builder.AppendLine("                               Default: a fresh temp directory.");
+            builder.AppendLine("  --ready-file=<path>          Write {pid, tools, prompts, resources, plugin_version}");
+            builder.AppendLine("                               as JSON once the handshake succeeded.");
+            builder.AppendLine("  --exit-after-ms=<n>          Exit 0 after n milliseconds of being ready.");
+            builder.AppendLine("  --mcp-server-timeout=<ms>    Handshake timeout. Env: MCP_SERVER_TIMEOUT.");
+            builder.AppendLine($"                               Default: {Consts.Hub.DefaultTimeoutMs}");
+            builder.AppendLine("  --help                       Print this text and exit 0 without connecting.");
+            builder.AppendLine();
+            builder.AppendLine("Ready line (stdout, exactly once):");
+            builder.AppendLine($"  {ReadyLinePrefix} tools=<n> prompts=<n> resources=<n> plugin=<informational version>");
+            builder.AppendLine();
+            builder.AppendLine("Exit codes:");
+            builder.AppendLine($"  {ExitOk}  clean shutdown (Ctrl-C, --exit-after-ms, --help)");
+            builder.AppendLine($"  {ExitHandshakeFailed}  the version handshake did not complete inside the timeout");
+            return builder.ToString();
+        }
+    }
+}

--- a/McpPlugin.NullEngine/src/Prompts/NullEnginePrompts.cs
+++ b/McpPlugin.NullEngine/src/Prompts/NullEnginePrompts.cs
@@ -1,0 +1,39 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System.ComponentModel;
+
+namespace com.IvanMurzak.McpPlugin.NullEngine.Prompts
+{
+    /// <summary>
+    /// The null engine's prompt surface: one prompt that takes an argument and one that does not,
+    /// so a consumer can exercise both shapes of <c>prompts/get</c>. Both are pure functions of
+    /// their arguments, like every tool in this host.
+    /// </summary>
+    [AiPromptType]
+    public static class NullEnginePrompts
+    {
+        public const string GreetingName = "null-engine/greeting";
+        public const string StaticName = "null-engine/static";
+
+        /// <summary>The exact body <see cref="Static"/> returns. Fixed so a consumer can assert on it.</summary>
+        public const string StaticBody = "null-engine: a fixed prompt body with no arguments.";
+
+        [AiPrompt(Name = GreetingName)]
+        [Description("Greets the supplied name. Exercises a prompt WITH an argument.")]
+        public static string Greeting(
+            [Description("Who to greet. Defaults to 'world'.")] string name = "world")
+            => "null-engine: hello, " + name + ".";
+
+        [AiPrompt(Name = StaticName)]
+        [Description("Returns a fixed body. Exercises a prompt with NO arguments.")]
+        public static string Static() => StaticBody;
+    }
+}

--- a/McpPlugin.NullEngine/src/Resources/NullEngineResources.cs
+++ b/McpPlugin.NullEngine/src/Resources/NullEngineResources.cs
@@ -1,0 +1,49 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System.ComponentModel;
+using com.IvanMurzak.McpPlugin.Common.Model;
+
+namespace com.IvanMurzak.McpPlugin.NullEngine.Resources
+{
+    /// <summary>
+    /// The null engine's single resource: the host's own resolved configuration, so a consumer can
+    /// read back the endpoint / project root / catalog sizes it is talking to without parsing the
+    /// ready line.
+    /// </summary>
+    [AiResourceType]
+    public static class NullEngineResources
+    {
+        public const string ConfigUri = "null-engine://config";
+        public const string ConfigName = "null-engine-config";
+        public const string ConfigMimeType = "application/json";
+        public const string ConfigDescription = "The resolved null-engine host configuration, as JSON.";
+
+        /// <param name="uri">
+        /// Supplied by the resource router from the matched route. The route carries no template
+        /// parameters, so this is always <see cref="ConfigUri"/>; it is declared because the router
+        /// invokes the method with the matched uri in its named-parameter set.
+        /// </param>
+        [AiResource(Route = ConfigUri, Name = ConfigName, MimeType = ConfigMimeType, ListResources = nameof(ListConfig))]
+        [Description(ConfigDescription)]
+        public static ResponseResourceContent[] GetConfig(string uri)
+            => new[] { ResponseResourceContent.CreateText(uri, NullEngineHost.ConfigJson, ConfigMimeType) };
+
+        public static ResponseListResource[] ListConfig()
+            => new[]
+            {
+                new ResponseListResource(
+                    uri: ConfigUri,
+                    name: ConfigName,
+                    mimeType: ConfigMimeType,
+                    description: ConfigDescription)
+            };
+    }
+}

--- a/McpPlugin.NullEngine/src/Tools/NullEngineTools.cs
+++ b/McpPlugin.NullEngine/src/Tools/NullEngineTools.cs
@@ -1,0 +1,226 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.ComponentModel;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.Common.Model;
+using Microsoft.Extensions.Logging;
+
+namespace com.IvanMurzak.McpPlugin.NullEngine.Tools
+{
+    /// <summary>
+    /// The representative tool surface of the null engine. Every response is a pure function of the
+    /// call's arguments - no clock, no randomness, no ambient state - so the same call sequence
+    /// replayed later produces byte-identical results, which is what makes this host usable as a
+    /// diff fixture.
+    ///
+    /// <para>Two of these tools are DELIBERATELY failing (<c>fail</c>, <c>throw</c>). They exist so
+    /// a consumer can prove it distinguishes a tool-level error from a transport error, and so this
+    /// repo can prove that an exception inside a tool does NOT take the host process down.</para>
+    /// </summary>
+    [AiToolType]
+    public static class NullEngineTools
+    {
+        /// <summary>Every tool name is prefixed with this, so a consumer can filter the catalog.</summary>
+        public const string Prefix = "null-engine/";
+
+        /// <summary>The exact text <c>null-engine/fail</c> returns. Fixed so a consumer can assert on it.</summary>
+        public const string FailMessage = "null-engine: deliberate tool failure (fixed message).";
+
+        /// <summary>The exact text <c>null-engine/throw</c> throws. Fixed so a consumer can assert on it.</summary>
+        public const string ThrowMessage = "null-engine: deliberate unhandled exception (fixed message).";
+
+        /// <summary>
+        /// Default payload of <c>null-engine/unicode</c> when no text is supplied: CJK, Latin-1
+        /// accents, an em dash and an astral-plane emoji (a surrogate pair). Written as escapes on
+        /// purpose - a raw glyph in a C# literal depends on the file's encoding surviving every tool
+        /// that ever rewrites this file, and the escaped form is byte-identical everywhere.
+        /// </summary>
+        public const string UnicodeSample = "\u4F60\u597D \u00E9\u00E8\u00EA \u00DF \u2014 \uD83D\uDE80";
+
+        /// <summary>Upper bound on <c>null-engine/large-payload</c>, so a typo cannot allocate a gigabyte.</summary>
+        public const int MaxPayloadKb = 1024;
+
+        /// <summary>Upper bound on <c>null-engine/slow</c>, so a typo cannot park the host for an hour.</summary>
+        public const int MaxSleepMs = 10000;
+
+        /// <summary>Upper bound on <c>null-engine/progress</c>.</summary>
+        public const int MaxProgressSteps = 100;
+
+        /// <summary>Serialization used for every structured response this class builds itself.</summary>
+        static readonly JsonSerializerOptions _json = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = null,
+            WriteIndented = false
+        };
+
+        [AiTool(Prefix + "ping", "Ping")]
+        [Description("Takes no arguments and always answers 'pong'. The liveness probe.")]
+        public static string Ping() => "pong";
+
+        [AiTool(Prefix + "echo", "Echo")]
+        [Description("Returns the supplied payload unchanged - the structured round-trip probe.")]
+        public static ResponseCallTool Echo(
+            [Description("The object to return unchanged.")] EchoPayload? payload)
+            => ResponseCallTool.SuccessStructured(
+                JsonSerializer.SerializeToNode(payload ?? new EchoPayload(), _json));
+
+        [AiTool(Prefix + "large-payload", "Large payload")]
+        [Description("Returns exactly the requested number of kibibytes of the character 'x'.")]
+        public static ResponseCallTool LargePayload(
+            [Description("How many kibibytes to return (0..1024).")] int kb = 1)
+        {
+            if (kb < 0 || kb > MaxPayloadKb)
+                return ResponseCallTool.Error($"kb must be between 0 and {MaxPayloadKb}, got {kb}.", ResponseErrorKind.BadRequest);
+
+            return ResponseCallTool.SuccessStructured(new JsonObject
+            {
+                ["kb"] = kb,
+                ["length"] = kb * 1024,
+                ["payload"] = new string('x', kb * 1024)
+            });
+        }
+
+        [AiTool(Prefix + "fail", "Fail")]
+        [Description("Always returns a tool-level error with a fixed message. Never throws.")]
+        public static ResponseCallTool Fail()
+            => ResponseCallTool.Error(FailMessage, ResponseErrorKind.Internal);
+
+        [AiTool(Prefix + "throw", "Throw")]
+        [Description("Always throws. The host must surface an error and STAY ALIVE.")]
+        public static string Throw()
+            => throw new InvalidOperationException(ThrowMessage);
+
+        [AiTool(Prefix + "slow", "Slow")]
+        [Description("Awaits the requested number of milliseconds, then answers 'slept'.")]
+        public static async Task<ResponseCallTool> Slow(
+            [Description("How long to await, in milliseconds (0..10000).")] int ms = 0)
+        {
+            if (ms < 0 || ms > MaxSleepMs)
+                return ResponseCallTool.Error($"ms must be between 0 and {MaxSleepMs}, got {ms}.", ResponseErrorKind.BadRequest);
+
+            await Task.Delay(ms).ConfigureAwait(false);
+
+            return ResponseCallTool.SuccessStructured(new JsonObject
+            {
+                ["slept_ms"] = ms,
+                ["status"] = "slept"
+            });
+        }
+
+        [AiTool(Prefix + "progress", "Progress")]
+        [Description("Emits the requested number of progress log lines, then reports how many it emitted.")]
+        public static ResponseCallTool Progress(
+            [Description("How many progress notices to emit (0..100).")] int steps = 3)
+        {
+            if (steps < 0 || steps > MaxProgressSteps)
+                return ResponseCallTool.Error($"steps must be between 0 and {MaxProgressSteps}, got {steps}.", ResponseErrorKind.BadRequest);
+
+            // The plugin has no progress-notification API on the tool seam today, so the fallback the
+            // contract allows is taken: one log line per step, through the plugin's own logger rather
+            // than Console (which would interleave with the ready line on stdout).
+            for (var step = 1; step <= steps; step++)
+                NullEngineHost.Logger?.LogInformation("null-engine progress {step}/{steps}", step, steps);
+
+            return ResponseCallTool.SuccessStructured(new JsonObject
+            {
+                ["emitted"] = steps
+            });
+        }
+
+        [AiTool(Prefix + "unicode", "Unicode")]
+        [Description("Returns the supplied text unchanged - the non-ASCII round-trip probe.")]
+        public static ResponseCallTool Unicode(
+            [Description("Text to echo back. Defaults to a mixed non-ASCII sample.")] string? text = null)
+            => ResponseCallTool.SuccessStructured(new JsonObject
+            {
+                ["text"] = string.IsNullOrEmpty(text) ? UnicodeSample : text
+            });
+
+        [AiTool(Prefix + "nested", "Nested")]
+        [Description("Returns a five-level-deep JSON document.")]
+        public static ResponseCallTool Nested()
+        {
+            JsonNode? child = null;
+            for (var level = 5; level >= 1; level--)
+            {
+                child = new JsonObject
+                {
+                    ["level"] = level,
+                    ["label"] = "level-" + level.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                    ["child"] = child
+                };
+            }
+
+            return ResponseCallTool.SuccessStructured(child);
+        }
+
+        [AiTool(Prefix + "enum-arg", "Enum argument")]
+        [Description("Accepts one of red / green / blue and rejects anything else.")]
+        public static ResponseCallTool EnumArg(
+            [Description("One of: Red, Green, Blue.")] NullEngineColor color = NullEngineColor.Red)
+        {
+            // Explicit rather than relying on the binder: an undefined value can still reach an enum
+            // parameter (Enum.ToObject accepts any integer), so the rejection this tool advertises has
+            // to be its own check to be a rejection at all.
+            if (!Enum.IsDefined(typeof(NullEngineColor), color))
+                return ResponseCallTool.Error($"color must be one of Red, Green, Blue; got '{color}'.", ResponseErrorKind.BadRequest);
+
+            return ResponseCallTool.SuccessStructured(new JsonObject
+            {
+                ["color"] = color.ToString()
+            });
+        }
+
+        [AiTool(Prefix + "optional-args", "Optional arguments")]
+        [Description("Reports the values it was invoked with, so omitted arguments show their defaults.")]
+        public static ResponseCallTool OptionalArgs(
+            [Description("Any name. Defaults to 'world'.")] string name = "world",
+            [Description("Any count. Defaults to 1.")] int count = 1)
+            => ResponseCallTool.SuccessStructured(new JsonObject
+            {
+                ["name"] = name,
+                ["count"] = count
+            });
+
+        [AiTool(Prefix + "list-self", "List self")]
+        [Description("Returns the tool names this plugin actually registered, ordered ordinally.")]
+        public static ResponseCallTool ListSelf()
+        {
+            var names = new JsonArray();
+            foreach (var name in NullEngineHost.ToolNames)
+                names.Add(name);
+
+            return ResponseCallTool.SuccessStructured(new JsonObject
+            {
+                ["tools"] = names
+            });
+        }
+    }
+
+    /// <summary>The structured argument (and result) of <c>null-engine/echo</c>.</summary>
+    public sealed class EchoPayload
+    {
+        public string Text { get; set; } = string.Empty;
+        public int Number { get; set; }
+        public bool Flag { get; set; }
+    }
+
+    /// <summary>The validated enum of <c>null-engine/enum-arg</c>.</summary>
+    public enum NullEngineColor
+    {
+        Red,
+        Green,
+        Blue
+    }
+}

--- a/McpPlugin.Server.Tests/Infrastructure/NoneAuthMcpHost.cs
+++ b/McpPlugin.Server.Tests/Infrastructure/NoneAuthMcpHost.cs
@@ -52,6 +52,16 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests.Infrastructure
         }
 
         /// <summary>
+        /// The loopback base URL Kestrel actually bound, e.g. <c>http://127.0.0.1:54321</c>.
+        ///
+        /// <para>Exposed because a test that drives this host from OUTSIDE the test process - by
+        /// spawning a real plugin subprocess and pointing it at the SignalR hub
+        /// (<c>NullEngineRealTransportTests</c>) - has no other way to learn the OS-assigned port.
+        /// In-process callers do not need it; they go through <see cref="PostAsync"/>.</para>
+        /// </summary>
+        public string BaseUrl => _baseUrl;
+
+        /// <summary>
         /// Starts the host. <paramref name="registerFakes"/> runs AFTER the production wiring, so a
         /// singleton it registers is the one the routers resolve (same pattern as
         /// <c>AmbientSessionIdOverHttpTests</c>' <c>FakeJwksKeyProvider</c>).
@@ -183,8 +193,13 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests.Infrastructure
         /// response, or a multi-line data payload — comes back as two documents run together and
         /// fails to parse. Every caller today sends one request and reads one response. A caller that
         /// needs more should split the frames here rather than work around the concatenation.</para>
+        ///
+        /// <para>Public because <see cref="CallAsync"/> only sends PARAMETERLESS requests: a caller
+        /// that needs <c>params</c> (a <c>tools/call</c>, a <c>resources/read</c>) posts through
+        /// <see cref="PostAsync"/> and needs the same unwrapping. Duplicating it in the caller would
+        /// fork the "one JSON document per reply" assumption documented above.</para>
         /// </summary>
-        static string Unwrap(string body)
+        public static string Unwrap(string body)
         {
             if (!body.Contains("data:", StringComparison.Ordinal))
                 return body;

--- a/McpPlugin.Server.Tests/NullEngineRealTransportTests.cs
+++ b/McpPlugin.Server.Tests/NullEngineRealTransportTests.cs
@@ -11,6 +11,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -34,21 +35,24 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
     /// library and the server together.
     ///
     /// <para><b>Why a subprocess, and why a derived path rather than a ProjectReference.</b> The
-    /// separate OS process is the POINT, not an isolation trick: T1 is "a real headless host process
-    /// reached over a real transport", which an in-process reference could not be. It is NOT about
-    /// keeping the client assembly out of this process — this csproj already references
-    /// <c>McpPlugin</c> (for <c>ProjectIdentity</c>), so the client library is loaded here anyway.
-    /// The engine is LOCATED by a path derived from this assembly's own bin directory (env override
-    /// <c>MCPPLUGIN_NULLENGINE_DLL</c>), relying on solution build order — the task spec's declared
-    /// default. <c>ProjectReference ReferenceOutputAssembly="false"</c> is the documented
+    /// separate OS process is the POINT, not an isolation trick: a real headless host process
+    /// reached over a real transport is exactly what this class exists to cover, and an in-process
+    /// reference could not be one. It is NOT about keeping the client assembly out of this process
+    /// — this csproj already references <c>McpPlugin</c> (for <c>ProjectIdentity</c>), so the
+    /// client library is loaded here anyway. The engine is LOCATED by a path derived from this
+    /// assembly's own bin directory (env override <c>MCPPLUGIN_NULLENGINE_DLL</c>), relying on
+    /// solution build order. <c>ProjectReference ReferenceOutputAssembly="false"</c> is the
     /// alternative if derivation ever proves brittle; it would add a build-order coupling and copy
     /// the engine's outputs beside this test's, which derivation does not.</para>
     ///
     /// <para><b>Why one plugin at a time.</b> <c>NoAuthMcpStrategy.OnPluginConnected</c> enforces a
     /// single plugin connection, and the client registry it uses (<c>ClientUtils</c>) is keyed by hub
     /// TYPE and therefore process-global. A second engine connecting anywhere in this process would
-    /// evict the first. Both tests below start and stop their own engine, and the class carries
-    /// <c>[Collection]</c> so it never runs beside another collection-marked class.</para>
+    /// evict the first. Both tests below start and stop their own engine, and the class joins the
+    /// <c>McpPlugin.Server</c> collection, which serialises it against every OTHER class in that
+    /// SAME collection. That is the available protection, not a whole-assembly guarantee: xUnit
+    /// still runs classes carrying NO <c>[Collection]</c> in parallel with this one, so the
+    /// registry could in principle be disturbed from there.</para>
     /// </summary>
     [Collection("McpPlugin.Server")]
     public sealed class NullEngineRealTransportTests
@@ -57,6 +61,11 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
         /// The exact catalog the engine must publish. Duplicated from the engine's own source rather
         /// than referenced, because this project deliberately does not reference that assembly (see
         /// the class remarks). A rename on either side must break this list - that is the point.
+        ///
+        /// <para>That reasoning governs EVERY engine-derived literal in this region, not just this
+        /// array: replacing any of them with a reference to the engine's own constant would make a
+        /// coordinated rename on both sides keep the test green, which is exactly the failure these
+        /// assertions exist to catch.</para>
         /// </summary>
         static readonly string[] ExpectedToolNames =
         {
@@ -82,6 +91,9 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
 
         const string ConfigResourceUri = "null-engine://config";
 
+        /// <summary>Duplicated from the engine's <c>Program.ReadyLinePrefix</c> - see the catalog remark above.</summary>
+        const string ReadyLinePrefix = "NULL-ENGINE READY";
+
         /// <summary>Duplicated from <c>NullEngineTools.FailMessage</c> - see the catalog remark above.</summary>
         const string FailMessage = "null-engine: deliberate tool failure (fixed message).";
 
@@ -98,7 +110,13 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
         const string EchoText = "round-trip";
         const int EchoNumber = 7;
 
-        /// <summary>CJK + Latin-1 + em dash + an astral-plane emoji, written as escapes on purpose.</summary>
+        /// <summary>
+        /// CJK + Latin-1 + em dash + an astral-plane emoji, written as escapes on purpose.
+        ///
+        /// <para>Deliberately NOT the engine's own default sample - this one omits a character that
+        /// one carries. A test that sent the engine its own default back could not tell an echo from
+        /// a tool that ignored the argument and returned the default.</para>
+        /// </summary>
         const string UnicodeText = "\u4F60\u597D \u00E9\u00E8\u00EA \u2014 \uD83D\uDE80";
 
         /// <summary>The prefixes the Microsoft.Extensions.Logging console formatter writes.</summary>
@@ -123,7 +141,10 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
             using var engine = NullEngineProcess.Start(host.BaseUrl);
             using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(60) };
 
-            var ready = engine.WaitForReady(TimeSpan.FromSeconds(30));
+            // Strictly LONGER than the engine's own 30s handshake deadline (NullEngineProcess.Start's
+            // default), so a slow handshake surfaces as the engine's own HANDSHAKE-FAILED diagnostic
+            // rather than racing this wait to a less informative timeout.
+            var ready = engine.WaitForReady(TimeSpan.FromSeconds(45));
 
             // ---- the ready contract -------------------------------------------------------------
             ready.GetProperty("pid").GetInt32().ShouldBe(engine.Id,
@@ -138,22 +159,41 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
             // read at runtime — NEVER the Consts.PluginVersion compile-time constant. A presence
             // check ("not null or whitespace") cannot tell those two apart, so this asserts the exact
             // value against the same attribute read from the copy of McpPlugin.dll loaded here.
-            // What makes it able to fail: plant P13 swaps the host's runtime read for
-            // Consts.PluginVersion, and the two differ whenever the informational version carries
-            // source-revision metadata — which every build from a git checkout produces (measured on
-            // this tree: "8.3.0+de71a72…" vs "8.3.0").
-            McpPluginInformationalVersion.ShouldNotBeNullOrWhiteSpace(
-                "the reference value must exist, else the equality below could not discriminate");
+            // What makes it able to fail: swapping the host's runtime read for Consts.PluginVersion
+            // reds this, because the two differ whenever the informational version carries
+            // source-revision metadata — which every build from a git checkout produces
+            // (measured on this tree: "8.3.0+de71a72…" vs "8.3.0").
+            // NOT a null/blank check: the engine's resolver falls back to "unknown", so its reported
+            // value is never blank and a blank-check here would be ENTAILED by the equality below
+            // (zero halves, unfalsifiable). The condition that actually destroys discrimination is
+            // the informational version collapsing ONTO the constant, which happens in any build
+            // where no source-revision suffix is stamped (a source archive, a .git-less container
+            // context). Assert THAT, so the day it happens this fails loudly instead of quietly
+            // certifying a constant the ruling forbids.
+            McpPluginInformationalVersion.ShouldNotBe(
+                global::com.IvanMurzak.McpPlugin.Common.Consts.PluginVersion,
+                "the McpPlugin assembly carries no source-revision suffix, so its runtime informational " +
+                "version is byte-identical to Consts.PluginVersion and the equality below can no longer " +
+                "tell the runtime read from the compile-time constant");
             ready.GetProperty("plugin_version").GetString().ShouldBe(McpPluginInformationalVersion,
                 "the ready file must report the McpPlugin assembly's informational version, read at runtime");
 
-            var readyLine = engine.StdoutLines.FirstOrDefault(line => line.StartsWith("NULL-ENGINE READY", StringComparison.Ordinal));
-            readyLine.ShouldNotBeNull("the engine must print exactly one ready line to stdout");
-            readyLine!.ShouldContain($"tools={ExpectedToolNames.Length}", Case.Sensitive);
-            readyLine.ShouldContain($"prompts={ExpectedPromptNames.Length}", Case.Sensitive);
-            readyLine.ShouldContain("resources=1", Case.Sensitive);
-            readyLine.ShouldContain("plugin=" + McpPluginInformationalVersion, Case.Sensitive,
-                "the ready LINE carries the same identity as the ready FILE");
+            // A bounded WAIT, not an instant read. WaitForReady returns on the ready FILE's
+            // existence, while the ready LINE reaches the capture through an asynchronous
+            // OutputDataReceived callback, so sampling the list here races the capture thread on a
+            // loaded runner. Same reasoning as the liveness window further down.
+            var readyLine = engine.WaitForStdoutLine(ReadyLinePrefix, TimeSpan.FromSeconds(10));
+            readyLine.ShouldNotBeNull("the engine must print a ready line to stdout. " + engine.Describe());
+            engine.StdoutLines.Count(line => line.StartsWith(ReadyLinePrefix, StringComparison.Ordinal))
+                .ShouldBe(1, "the engine must print EXACTLY one ready line, which is what the contract " +
+                    "promises - an at-least-one check would pass on a host that printed it twice");
+            // ONE exact equality rather than four substring checks: the ready line is a contract an
+            // out-of-process consumer parses, and ShouldContain("resources=1") is satisfied by
+            // "resources=10". Equality also gives the whole line a single plantable claim.
+            readyLine.ShouldBe(
+                $"{ReadyLinePrefix} tools={ExpectedToolNames.Length} prompts={ExpectedPromptNames.Length} " +
+                $"resources=1 plugin={McpPluginInformationalVersion}",
+                "the ready line is a contract, not a bag of substrings. " + engine.Describe());
 
             var sessionId = await host.HandshakeAsync(client, "null-engine-real-transport");
 
@@ -273,9 +313,14 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
 
             // ---- every 'fail:' block after that is one of the two deliberate error tools ---------
             var failBlocks = engine.FailBlocks();
-            failBlocks.Count.ShouldBeGreaterThanOrEqualTo(2,
-                "this test called fail AND throw, so at least two error blocks must exist - " +
-                "an empty set would satisfy the attribution check below for free");
+            // One floor PER deliberate tool, not a combined count of two: this test called fail AND
+            // throw, and a bare 'at least two' is satisfied by two blocks from the SAME tool, which
+            // would hide a regression that silenced the other one. Both floors together also rule
+            // out the empty set that would satisfy the attribution loop below for free.
+            failBlocks.Count(block => block.Contains(FailMessage, StringComparison.Ordinal))
+                .ShouldBeGreaterThan(0, "null-engine/fail must log the error block it advertises. " + engine.Describe());
+            failBlocks.Count(block => block.Contains(ThrowMessage, StringComparison.Ordinal))
+                .ShouldBeGreaterThan(0, "null-engine/throw's exception must reach the engine's own error log. " + engine.Describe());
             foreach (var block in failBlocks)
             {
                 (block.Contains(FailMessage, StringComparison.Ordinal) || block.Contains(ThrowMessage, StringComparison.Ordinal))
@@ -285,7 +330,7 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
             // ---- teardown: the engine is killed, leaving no orphan --------------------------------
             // Asserted HERE, on the engine that actually connected and served this whole session —
             // that is the shape a leaked process would come from, and it is still ALIVE at this point
-            // (the liveness assertion above proved so). Plant P12 removes the Kill call and reds this,
+            // (the liveness assertion above proved so). Removing the Kill() call below reds this,
             // which is what makes the assertion a claim about killing rather than about a process that
             // had already died on its own.
             engine.Kill();
@@ -294,10 +339,10 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
         }
 
         /// <summary>
-        /// The other half of the CLI contract the upper layers (<c>p1-null-engine-node</c>,
-        /// <c>p1-t1-app</c>, <c>p1-t1-cloud</c>) key off: an engine that cannot complete the version
-        /// handshake inside <c>--mcp-server-timeout</c> exits <b>3</b> and says so on stderr — it does
-        /// not hang, and it does not exit 0. Port 1 is used because nothing can be listening there.
+        /// The other half of the CLI contract every out-of-process consumer of this engine keys off:
+        /// an engine that cannot complete the version handshake inside <c>--mcp-server-timeout</c>
+        /// exits <b>3</b> and says so on stderr — it does not hang, and it does not exit 0.
+        /// Port 1 is used because nothing can be listening there.
         /// </summary>
         [Fact]
         public void HandshakeFailure_ExitsWithCode3_AndLeavesNoOrphan()
@@ -405,12 +450,22 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
                     RedirectStandardError = true,
                     WorkingDirectory = AppContext.BaseDirectory,
                 };
+                // The child inherits this process's environment, and ConnectionConfig reads
+                // MCP_SKILLS_FOLDER / MCP_SERVER_ENDPOINT / MCP_SERVER_TIMEOUT from it. The first
+                // feeds the SkillsPath resolution whose failure IS the `fail:` line the startup-window
+                // assertion polices, so an ambient value could red this test for a purely
+                // environmental reason. Every one of them is passed explicitly below; drop the
+                // inherited copies so the arguments are the only input.
+                startInfo.Environment.Remove("MCP_SKILLS_FOLDER");
+                startInfo.Environment.Remove("MCP_SERVER_ENDPOINT");
+                startInfo.Environment.Remove("MCP_SERVER_TIMEOUT");
+
                 startInfo.ArgumentList.Add(engineDll);
                 startInfo.ArgumentList.Add("--mcp-server-endpoint=" + endpoint);
                 startInfo.ArgumentList.Add("--project-root=" + Path.Combine(workDirectory, "project"));
                 startInfo.ArgumentList.Add("--ready-file=" + readyFile);
                 startInfo.ArgumentList.Add(
-                    "--mcp-server-timeout=" + timeoutMs.ToString(System.Globalization.CultureInfo.InvariantCulture));
+                    "--mcp-server-timeout=" + timeoutMs.ToString(CultureInfo.InvariantCulture));
 
                 return new NullEngineProcess(startInfo, workDirectory, readyFile);
             }
@@ -419,8 +474,10 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
             /// <c>AppContext.BaseDirectory</c> is
             /// <c>&lt;repo&gt;/McpPlugin.Server.Tests/bin/&lt;Configuration&gt;/&lt;tfm&gt;/</c>, so the
             /// engine built for the SAME configuration and the SAME target framework as this test leg
-            /// sits four directories up. Deriving the path (rather than adding a ProjectReference)
-            /// keeps the v8 client graph out of this v10 process.
+            /// sits four directories up. Deriving the path rather than adding a ProjectReference is
+            /// NOT about assembly isolation — this csproj already references <c>McpPlugin</c>, so
+            /// that graph is loaded here regardless (see the class remarks). It avoids a build-order
+            /// coupling and keeps the engine's outputs from being copied beside this test's.
             /// </summary>
             static string ResolveEngineDll()
             {
@@ -456,9 +513,43 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
             /// <summary>
             /// True when the process exits within <paramref name="window"/>, false when it is still
             /// running at the end of it.
+            ///
+            /// <para>The parameterless <c>WaitForExit()</c> after a positive result is load-bearing,
+            /// not belt-and-braces: the timed overload returns as soon as the process object reports
+            /// exit, WITHOUT waiting for the asynchronous stdout/stderr handlers to drain. A caller
+            /// that asserts on captured output right afterwards - as the handshake-failure test does
+            /// with the stderr line the engine writes microseconds before exiting - would otherwise
+            /// read a list the capture thread has not finished filling.</para>
             /// </summary>
             public bool ExitedWithin(TimeSpan window)
-                => _process.WaitForExit((int)window.TotalMilliseconds);
+            {
+                if (!_process.WaitForExit((int)window.TotalMilliseconds))
+                    return false;
+
+                _process.WaitForExit();
+                return true;
+            }
+
+            /// <summary>
+            /// Waits up to <paramref name="timeout"/> for a captured stdout line starting with
+            /// <paramref name="prefix"/>, or null if none arrives. Needed because the capture is
+            /// asynchronous, so a line the engine has already written may not be in the list yet.
+            /// </summary>
+            public string? WaitForStdoutLine(string prefix, TimeSpan timeout)
+            {
+                var deadlineUtc = DateTime.UtcNow + timeout;
+                while (true)
+                {
+                    var hit = StdoutLines.FirstOrDefault(line => line.StartsWith(prefix, StringComparison.Ordinal));
+                    if (hit != null)
+                        return hit;
+
+                    if (DateTime.UtcNow >= deadlineUtc)
+                        return null;
+
+                    Thread.Sleep(25);
+                }
+            }
 
             public IReadOnlyList<string> StdoutLines
             {
@@ -478,10 +569,15 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
                 var lines = StdoutLines;
                 for (var i = 0; i < lines.Count; i++)
                 {
-                    if (lines[i].StartsWith("NULL-ENGINE READY", StringComparison.Ordinal))
+                    if (lines[i].StartsWith(ReadyLinePrefix, StringComparison.Ordinal))
                         return lines.Take(i).ToArray();
                 }
-                return lines;
+
+                // No ready line captured means there IS no startup window to return. Falling back to
+                // the whole capture would fold the deliberate fail/throw blocks into it and red the
+                // startup assertion with a message blaming the engine for an error it never logged.
+                throw new Xunit.Sdk.XunitException(
+                    "no ready line was captured, so the startup window is undefined. " + Describe());
             }
 
             /// <summary>
@@ -536,25 +632,41 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
                 _process.WaitForExit(15000);
             }
 
+            /// <summary>
+            /// Built from the snapshot accessors rather than under <c>_gate</c>: that is the same lock
+            /// the output callbacks take to append lines, and every assertion message here is built
+            /// EAGERLY (Shouldly 4.x has no lazy message overload), including on the passing path.
+            /// Holding it across two joins of a Trace-level capture would briefly stall stdout
+            /// draining for the very process the assertion is about - and the liveness check calls
+            /// this while the engine is still running.
+            /// </summary>
             public string Describe()
             {
-                lock (_gate)
-                {
-                    return "exited=" + (_process.HasExited ? _process.ExitCode.ToString() : "no") +
-                        "\nstdout:\n" + string.Join("\n", _stdout) +
-                        "\nstderr:\n" + string.Join("\n", _stderr);
-                }
+                var exited = _process.HasExited
+                    ? _process.ExitCode.ToString(CultureInfo.InvariantCulture)
+                    : "no";
+
+                return "exited=" + exited +
+                    "\nstdout:\n" + string.Join("\n", StdoutLines) +
+                    "\nstderr:\n" + string.Join("\n", StderrLines);
             }
 
             public void Dispose()
             {
+                // Both catches are deliberately broad. This runs while a `using` may be unwinding an
+                // assertion failure, and an exception thrown out of Dispose REPLACES that failure -
+                // turning a precise red into an unrelated teardown stack trace, which is the worst
+                // outcome on a CI-only failure. Kill(entireProcessTree) is documented to throw
+                // AggregateException when a child races it, and Directory.Delete throws
+                // UnauthorizedAccessException (NOT an IOException) when a just-killed process still
+                // holds a handle. Neither is worth losing the real failure over.
                 try
                 {
                     Kill();
                 }
-                catch (InvalidOperationException)
+                catch (Exception)
                 {
-                    // Already gone.
+                    // Already gone, or the OS refused - teardown is best effort.
                 }
                 finally
                 {
@@ -563,7 +675,7 @@ namespace com.IvanMurzak.McpPlugin.Server.Tests
                     {
                         Directory.Delete(_workDirectory, recursive: true);
                     }
-                    catch (IOException)
+                    catch (Exception)
                     {
                         // Best effort - the OS temp directory is swept anyway.
                     }

--- a/McpPlugin.Server.Tests/NullEngineRealTransportTests.cs
+++ b/McpPlugin.Server.Tests/NullEngineRealTransportTests.cs
@@ -1,0 +1,574 @@
+/*
+┌────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                   │
+│  Repository: GitHub (https://github.com/IvanMurzak/MCP-Plugin-dotnet)  │
+│  Copyright (c) 2025 Ivan Murzak                                        │
+│  Licensed under the Apache License, Version 2.0.                       │
+│  See the LICENSE file in the project root for more information.        │
+└────────────────────────────────────────────────────────────────────────┘
+*/
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.Server.Tests.Infrastructure;
+using Shouldly;
+using Xunit;
+
+namespace com.IvanMurzak.McpPlugin.Server.Tests
+{
+    /// <summary>
+    /// The first test in this repository that drives a REAL plugin against the REAL server host over
+    /// the REAL transport: <see cref="NoneAuthMcpHost"/> (Kestrel, auth=none, Streamable HTTP) with
+    /// the <c>McpPlugin.NullEngine</c> executable spawned as an actual OS process and connected over
+    /// SignalR. Every other server suite either builds strategy / identity objects directly or
+    /// registers a fake <c>IClientToolHub</c>, so before this class nothing exercised the client
+    /// library and the server together.
+    ///
+    /// <para><b>Why a subprocess, and why a derived path rather than a ProjectReference.</b> The
+    /// separate OS process is the POINT, not an isolation trick: T1 is "a real headless host process
+    /// reached over a real transport", which an in-process reference could not be. It is NOT about
+    /// keeping the client assembly out of this process — this csproj already references
+    /// <c>McpPlugin</c> (for <c>ProjectIdentity</c>), so the client library is loaded here anyway.
+    /// The engine is LOCATED by a path derived from this assembly's own bin directory (env override
+    /// <c>MCPPLUGIN_NULLENGINE_DLL</c>), relying on solution build order — the task spec's declared
+    /// default. <c>ProjectReference ReferenceOutputAssembly="false"</c> is the documented
+    /// alternative if derivation ever proves brittle; it would add a build-order coupling and copy
+    /// the engine's outputs beside this test's, which derivation does not.</para>
+    ///
+    /// <para><b>Why one plugin at a time.</b> <c>NoAuthMcpStrategy.OnPluginConnected</c> enforces a
+    /// single plugin connection, and the client registry it uses (<c>ClientUtils</c>) is keyed by hub
+    /// TYPE and therefore process-global. A second engine connecting anywhere in this process would
+    /// evict the first. Both tests below start and stop their own engine, and the class carries
+    /// <c>[Collection]</c> so it never runs beside another collection-marked class.</para>
+    /// </summary>
+    [Collection("McpPlugin.Server")]
+    public sealed class NullEngineRealTransportTests
+    {
+        /// <summary>
+        /// The exact catalog the engine must publish. Duplicated from the engine's own source rather
+        /// than referenced, because this project deliberately does not reference that assembly (see
+        /// the class remarks). A rename on either side must break this list - that is the point.
+        /// </summary>
+        static readonly string[] ExpectedToolNames =
+        {
+            "null-engine/echo",
+            "null-engine/enum-arg",
+            "null-engine/fail",
+            "null-engine/large-payload",
+            "null-engine/list-self",
+            "null-engine/nested",
+            "null-engine/optional-args",
+            "null-engine/ping",
+            "null-engine/progress",
+            "null-engine/slow",
+            "null-engine/throw",
+            "null-engine/unicode",
+        };
+
+        static readonly string[] ExpectedPromptNames =
+        {
+            "null-engine/greeting",
+            "null-engine/static",
+        };
+
+        const string ConfigResourceUri = "null-engine://config";
+
+        /// <summary>Duplicated from <c>NullEngineTools.FailMessage</c> - see the catalog remark above.</summary>
+        const string FailMessage = "null-engine: deliberate tool failure (fixed message).";
+
+        /// <summary>Duplicated from <c>NullEngineTools.ThrowMessage</c>.</summary>
+        const string ThrowMessage = "null-engine: deliberate unhandled exception (fixed message).";
+
+        /// <summary>
+        /// The exact wire text <c>null-engine/echo</c> answers for the payload below. The engine
+        /// serializes its own response with an explicit, naming-policy-free serializer, so this is a
+        /// byte-for-byte contract rather than a shape check.
+        /// </summary>
+        const string EchoExpectedText = "{\"result\":{\"Text\":\"round-trip\",\"Number\":7,\"Flag\":true}}";
+
+        const string EchoText = "round-trip";
+        const int EchoNumber = 7;
+
+        /// <summary>CJK + Latin-1 + em dash + an astral-plane emoji, written as escapes on purpose.</summary>
+        const string UnicodeText = "\u4F60\u597D \u00E9\u00E8\u00EA \u2014 \uD83D\uDE80";
+
+        /// <summary>The prefixes the Microsoft.Extensions.Logging console formatter writes.</summary>
+        static readonly string[] LogLevelPrefixes = { "trce:", "dbug:", "info:", "warn:", "fail:", "crit:" };
+
+        /// <summary>
+        /// The <c>AssemblyInformationalVersion</c> of the McpPlugin assembly THIS test process
+        /// loaded. The engine loads its own copy of the same build output, so the two must agree —
+        /// and that agreement is what the ready line's <c>plugin=</c> field is required to report.
+        /// Read through the ProjectReference this csproj already carries, so no file-format parsing
+        /// (and no platform-specific <c>FileVersionInfo</c> behaviour) enters the assertion.
+        /// </summary>
+        static readonly string McpPluginInformationalVersion =
+            typeof(global::com.IvanMurzak.McpPlugin.McpPlugin).Assembly
+                .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+            ?? string.Empty;
+
+        [Fact]
+        public async Task RealPluginOverSignalR_ServesItsCatalog_AndSurvivesAToolThatThrows()
+        {
+            await using var host = await NoneAuthMcpHost.StartAsync();
+            using var engine = NullEngineProcess.Start(host.BaseUrl);
+            using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(60) };
+
+            var ready = engine.WaitForReady(TimeSpan.FromSeconds(30));
+
+            // ---- the ready contract -------------------------------------------------------------
+            ready.GetProperty("pid").GetInt32().ShouldBe(engine.Id,
+                "the ready file must describe the process this test spawned");
+            ready.GetProperty("tools").GetInt32().ShouldBe(ExpectedToolNames.Length,
+                "the ready file must report the engine's tool count");
+            ready.GetProperty("prompts").GetInt32().ShouldBe(ExpectedPromptNames.Length,
+                "the ready file must report the engine's prompt count");
+            ready.GetProperty("resources").GetInt32().ShouldBe(1,
+                "the ready file must report the engine's resource count");
+            // TD ruling 2026-09-03: plugin= is the McpPlugin ASSEMBLY's AssemblyInformationalVersion
+            // read at runtime — NEVER the Consts.PluginVersion compile-time constant. A presence
+            // check ("not null or whitespace") cannot tell those two apart, so this asserts the exact
+            // value against the same attribute read from the copy of McpPlugin.dll loaded here.
+            // What makes it able to fail: plant P13 swaps the host's runtime read for
+            // Consts.PluginVersion, and the two differ whenever the informational version carries
+            // source-revision metadata — which every build from a git checkout produces (measured on
+            // this tree: "8.3.0+de71a72…" vs "8.3.0").
+            McpPluginInformationalVersion.ShouldNotBeNullOrWhiteSpace(
+                "the reference value must exist, else the equality below could not discriminate");
+            ready.GetProperty("plugin_version").GetString().ShouldBe(McpPluginInformationalVersion,
+                "the ready file must report the McpPlugin assembly's informational version, read at runtime");
+
+            var readyLine = engine.StdoutLines.FirstOrDefault(line => line.StartsWith("NULL-ENGINE READY", StringComparison.Ordinal));
+            readyLine.ShouldNotBeNull("the engine must print exactly one ready line to stdout");
+            readyLine!.ShouldContain($"tools={ExpectedToolNames.Length}", Case.Sensitive);
+            readyLine.ShouldContain($"prompts={ExpectedPromptNames.Length}", Case.Sensitive);
+            readyLine.ShouldContain("resources=1", Case.Sensitive);
+            readyLine.ShouldContain("plugin=" + McpPluginInformationalVersion, Case.Sensitive,
+                "the ready LINE carries the same identity as the ready FILE");
+
+            var sessionId = await host.HandshakeAsync(client, "null-engine-real-transport");
+
+            // ---- tools/list: the EXACT set, not a superset ---------------------------------------
+            var toolsBody = await host.CallAsync(client, sessionId, "tools/list", id: 2);
+            using (var tools = JsonDocument.Parse(toolsBody))
+            {
+                var served = tools.RootElement
+                    .GetProperty("result").GetProperty("tools")
+                    .EnumerateArray()
+                    .Select(tool => tool.GetProperty("name").GetString()!)
+                    .OrderBy(name => name, StringComparer.Ordinal)
+                    .ToArray();
+
+                served.ShouldBe(ExpectedToolNames,
+                    "tools/list must serve exactly the engine's catalog: got [" + string.Join(", ", served) + "]");
+            }
+
+            // ---- tools/call echo: byte-for-byte round trip ---------------------------------------
+            var echo = await CallToolAsync(host, client, sessionId, 3, "null-engine/echo", new
+            {
+                payload = new { text = EchoText, number = EchoNumber, flag = true }
+            });
+            echo.IsError.ShouldBeFalse("echo is a success path; got: " + echo.Text);
+            echo.Text.ShouldBe(EchoExpectedText,
+                "echo must round-trip the payload byte-for-byte");
+
+            // ---- tools/call fail: a tool-level error, NOT a transport error ----------------------
+            var failed = await CallToolAsync(host, client, sessionId, 4, "null-engine/fail", new { });
+            failed.IsError.ShouldBeTrue("the fail tool must surface as isError:true");
+            failed.Text.ShouldBe(FailMessage,
+                "the fail tool's fixed message must reach the caller verbatim");
+
+            // ---- tools/call throw: surfaced as an error, and the HOST STAYS ALIVE ----------------
+            var threw = await CallToolAsync(host, client, sessionId, 5, "null-engine/throw", new { });
+            threw.IsError.ShouldBeTrue("an exception inside a tool must surface as isError:true");
+            threw.Text.ShouldContain(ThrowMessage, Case.Sensitive,
+                "the surfaced error must carry the thrown message, not a generic transport failure");
+
+            // A WINDOW, not an instant. Reading HasExited immediately after the reply cannot tell
+            // "the engine survived" from "the engine has not finished dying yet": the error reply is
+            // built and sent before any teardown the tool set off could complete, so an instant check
+            // races the process it is about. Waiting bounds the claim instead of sampling it.
+            engine.ExitedWithin(TimeSpan.FromSeconds(2)).ShouldBeFalse(
+                "an exception inside a tool must NOT take the engine process down. " + engine.Describe());
+
+            var pingAfterThrow = await CallToolAsync(host, client, sessionId, 6, "null-engine/ping", new { });
+            pingAfterThrow.IsError.ShouldBeFalse("the session must still work after a throwing tool: " + pingAfterThrow.Text);
+            pingAfterThrow.Text.ShouldBe("{\"result\":\"pong\"}",
+                "ping must still answer normally after a throwing tool");
+
+            // ---- tools/call unicode: non-ASCII survives the whole round trip ---------------------
+            var unicode = await CallToolAsync(host, client, sessionId, 7, "null-engine/unicode", new { text = UnicodeText });
+            unicode.IsError.ShouldBeFalse("unicode is a success path; got: " + unicode.Text);
+            using (var parsed = JsonDocument.Parse(unicode.Text))
+            {
+                parsed.RootElement.GetProperty("result").GetProperty("text").GetString()
+                    .ShouldBe(UnicodeText, "the non-ASCII payload must survive plugin -> hub -> server -> client");
+            }
+
+            // ---- prompts/list --------------------------------------------------------------------
+            var promptsBody = await host.CallAsync(client, sessionId, "prompts/list", id: 8);
+            using (var prompts = JsonDocument.Parse(promptsBody))
+            {
+                var served = prompts.RootElement
+                    .GetProperty("result").GetProperty("prompts")
+                    .EnumerateArray()
+                    .Select(prompt => prompt.GetProperty("name").GetString()!)
+                    .OrderBy(name => name, StringComparer.Ordinal)
+                    .ToArray();
+
+                served.ShouldBe(ExpectedPromptNames,
+                    "prompts/list must serve exactly the engine's prompts: got [" + string.Join(", ", served) + "]");
+            }
+
+            // ---- resources/read: the config document parses AND describes this run ---------------
+            var (readBody, _) = await host.PostAsync(client, sessionId, new
+            {
+                jsonrpc = "2.0",
+                id = 9,
+                method = "resources/read",
+                @params = new { uri = ConfigResourceUri }
+            });
+            using (var read = JsonDocument.Parse(NoneAuthMcpHost.Unwrap(readBody)))
+            {
+                var contents = read.RootElement.GetProperty("result").GetProperty("contents");
+                contents.GetArrayLength().ShouldBe(1, "the config resource returns exactly one content block");
+
+                var text = contents[0].GetProperty("text").GetString();
+                text.ShouldNotBeNullOrWhiteSpace();
+
+                using var config = JsonDocument.Parse(text!);
+                config.RootElement.GetProperty("tools").GetInt32().ShouldBe(ExpectedToolNames.Length,
+                    "the config resource must report the engine's tool count");
+                config.RootElement.GetProperty("prompts").GetInt32().ShouldBe(ExpectedPromptNames.Length,
+                    "the config resource must report the engine's prompt count");
+                config.RootElement.GetProperty("resources").GetInt32().ShouldBe(1,
+                    "the config resource must report the engine's resource count");
+                config.RootElement.GetProperty("endpoint").GetString().ShouldBe(host.BaseUrl,
+                    "the engine must report the endpoint this test actually pointed it at");
+            }
+
+            // ---- no 'fail:' line over the startup window ----------------------------------------
+            // The seed this host replaces logs "Cannot resolve relative SkillsPath 'SKILLS' ...
+            // ProjectRootPath is not set" at Error level during construction, which the console
+            // formatter writes as a 'fail:' line BEFORE the ready line. The window is bounded at the
+            // ready line rather than at the end of the run because two tools in the catalog
+            // (fail / throw) are REQUIRED to produce errors, so an unbounded "zero fail: lines"
+            // assertion could not hold for any run that calls them.
+            var startupWindow = engine.StdoutLinesBeforeReady();
+            startupWindow.Count.ShouldBeGreaterThan(0,
+                "console logging must be captured at all, else the fail: assertion below is vacuous");
+            startupWindow.Any(HasLogLevelPrefix).ShouldBeTrue(
+                "the engine must log at Trace to stdout, else a fail: line could not appear even if it happened");
+            startupWindow.Where(line => line.StartsWith("fail:", StringComparison.Ordinal)).ShouldBeEmpty(
+                "the engine must reach ready without logging a single error. " + engine.Describe());
+
+            // ---- every 'fail:' block after that is one of the two deliberate error tools ---------
+            var failBlocks = engine.FailBlocks();
+            failBlocks.Count.ShouldBeGreaterThanOrEqualTo(2,
+                "this test called fail AND throw, so at least two error blocks must exist - " +
+                "an empty set would satisfy the attribution check below for free");
+            foreach (var block in failBlocks)
+            {
+                (block.Contains(FailMessage, StringComparison.Ordinal) || block.Contains(ThrowMessage, StringComparison.Ordinal))
+                    .ShouldBeTrue("unexpected error logged by the engine:\n" + block);
+            }
+
+            // ---- teardown: the engine is killed, leaving no orphan --------------------------------
+            // Asserted HERE, on the engine that actually connected and served this whole session —
+            // that is the shape a leaked process would come from, and it is still ALIVE at this point
+            // (the liveness assertion above proved so). Plant P12 removes the Kill call and reds this,
+            // which is what makes the assertion a claim about killing rather than about a process that
+            // had already died on its own.
+            engine.Kill();
+            engine.HasExited.ShouldBeTrue(
+                "teardown must leave no orphan engine process behind. " + engine.Describe());
+        }
+
+        /// <summary>
+        /// The other half of the CLI contract the upper layers (<c>p1-null-engine-node</c>,
+        /// <c>p1-t1-app</c>, <c>p1-t1-cloud</c>) key off: an engine that cannot complete the version
+        /// handshake inside <c>--mcp-server-timeout</c> exits <b>3</b> and says so on stderr — it does
+        /// not hang, and it does not exit 0. Port 1 is used because nothing can be listening there.
+        /// </summary>
+        [Fact]
+        public void HandshakeFailure_ExitsWithCode3_AndLeavesNoOrphan()
+        {
+            using var engine = NullEngineProcess.Start("http://127.0.0.1:1", timeoutMs: 2000);
+
+            engine.ExitedWithin(TimeSpan.FromSeconds(60)).ShouldBeTrue(
+                "an unreachable endpoint must END the process, not hang it. " + engine.Describe());
+            engine.ExitCode.ShouldBe(3,
+                "a failed handshake must exit 3, not 0. " + engine.Describe());
+            engine.StderrLines.Any(line => line.StartsWith("NULL-ENGINE HANDSHAKE-FAILED", StringComparison.Ordinal))
+                .ShouldBeTrue("the failure must be reported on stderr. " + engine.Describe());
+        }
+
+        // ───────────────────────────── helpers ─────────────────────────────
+
+        static bool HasLogLevelPrefix(string line)
+            => LogLevelPrefixes.Any(prefix => line.StartsWith(prefix, StringComparison.Ordinal));
+
+        static async Task<(bool IsError, string Text)> CallToolAsync(
+            NoneAuthMcpHost host, HttpClient client, string sessionId, int id, string name, object arguments)
+        {
+            var (body, _) = await host.PostAsync(client, sessionId, new
+            {
+                jsonrpc = "2.0",
+                id,
+                method = "tools/call",
+                @params = new { name, arguments }
+            });
+
+            using var document = JsonDocument.Parse(NoneAuthMcpHost.Unwrap(body));
+            var result = document.RootElement.GetProperty("result");
+
+            var isError = result.TryGetProperty("isError", out var isErrorElement) && isErrorElement.GetBoolean();
+            var text = string.Empty;
+            if (result.TryGetProperty("content", out var content))
+            {
+                foreach (var block in content.EnumerateArray())
+                {
+                    if (block.TryGetProperty("type", out var type) && type.GetString() == "text")
+                    {
+                        text = block.GetProperty("text").GetString() ?? string.Empty;
+                        break;
+                    }
+                }
+            }
+
+            return (isError, text);
+        }
+
+        /// <summary>
+        /// A running <c>dotnet McpPlugin.NullEngine.dll ...</c> subprocess with line-buffered output
+        /// capture, following the <c>McpPlugin.Tests.LockHarness</c> precedent.
+        /// </summary>
+        sealed class NullEngineProcess : IDisposable
+        {
+            readonly Process _process;
+            readonly List<string> _stdout = new();
+            readonly List<string> _stderr = new();
+            readonly object _gate = new();
+            readonly string _workDirectory;
+            readonly string _readyFile;
+
+            NullEngineProcess(ProcessStartInfo startInfo, string workDirectory, string readyFile)
+            {
+                _workDirectory = workDirectory;
+                _readyFile = readyFile;
+                _process = new Process { StartInfo = startInfo };
+                _process.OutputDataReceived += (_, e) =>
+                {
+                    if (e.Data == null)
+                        return;
+                    lock (_gate)
+                        _stdout.Add(e.Data);
+                };
+                _process.ErrorDataReceived += (_, e) =>
+                {
+                    if (e.Data == null)
+                        return;
+                    lock (_gate)
+                        _stderr.Add(e.Data);
+                };
+                _process.Start();
+                _process.BeginOutputReadLine();
+                _process.BeginErrorReadLine();
+            }
+
+            public static NullEngineProcess Start(string endpoint, int timeoutMs = 30000)
+            {
+                var engineDll = ResolveEngineDll();
+                File.Exists(engineDll).ShouldBeTrue(
+                    "the null engine was not found at " + engineDll +
+                    " - McpPlugin.NullEngine must be part of McpPlugin.sln so a solution build produces it, " +
+                    "or set MCPPLUGIN_NULLENGINE_DLL to an explicit path");
+
+                var workDirectory = Path.Combine(Path.GetTempPath(), "null-engine-test-" + Guid.NewGuid().ToString("N"));
+                Directory.CreateDirectory(workDirectory);
+                var readyFile = Path.Combine(workDirectory, "ready.json");
+
+                var startInfo = new ProcessStartInfo
+                {
+                    FileName = "dotnet",
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    WorkingDirectory = AppContext.BaseDirectory,
+                };
+                startInfo.ArgumentList.Add(engineDll);
+                startInfo.ArgumentList.Add("--mcp-server-endpoint=" + endpoint);
+                startInfo.ArgumentList.Add("--project-root=" + Path.Combine(workDirectory, "project"));
+                startInfo.ArgumentList.Add("--ready-file=" + readyFile);
+                startInfo.ArgumentList.Add(
+                    "--mcp-server-timeout=" + timeoutMs.ToString(System.Globalization.CultureInfo.InvariantCulture));
+
+                return new NullEngineProcess(startInfo, workDirectory, readyFile);
+            }
+
+            /// <summary>
+            /// <c>AppContext.BaseDirectory</c> is
+            /// <c>&lt;repo&gt;/McpPlugin.Server.Tests/bin/&lt;Configuration&gt;/&lt;tfm&gt;/</c>, so the
+            /// engine built for the SAME configuration and the SAME target framework as this test leg
+            /// sits four directories up. Deriving the path (rather than adding a ProjectReference)
+            /// keeps the v8 client graph out of this v10 process.
+            /// </summary>
+            static string ResolveEngineDll()
+            {
+                var explicitPath = Environment.GetEnvironmentVariable("MCPPLUGIN_NULLENGINE_DLL");
+                if (!string.IsNullOrWhiteSpace(explicitPath))
+                    return Path.GetFullPath(explicitPath!);
+
+                var testBin = new DirectoryInfo(AppContext.BaseDirectory.TrimEnd(
+                    Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+
+                var targetFramework = testBin.Name;
+                var configuration = testBin.Parent?.Name ?? "Release";
+                var repositoryRoot = testBin.Parent?.Parent?.Parent?.Parent?.FullName
+                    ?? Directory.GetCurrentDirectory();
+
+                return Path.Combine(repositoryRoot, "McpPlugin.NullEngine", "bin", configuration, targetFramework,
+                    "McpPlugin.NullEngine.dll");
+            }
+
+            public int Id => _process.Id;
+            public bool HasExited => _process.HasExited;
+            public int ExitCode => _process.ExitCode;
+
+            public IReadOnlyList<string> StderrLines
+            {
+                get
+                {
+                    lock (_gate)
+                        return _stderr.ToArray();
+                }
+            }
+
+            /// <summary>
+            /// True when the process exits within <paramref name="window"/>, false when it is still
+            /// running at the end of it.
+            /// </summary>
+            public bool ExitedWithin(TimeSpan window)
+                => _process.WaitForExit((int)window.TotalMilliseconds);
+
+            public IReadOnlyList<string> StdoutLines
+            {
+                get
+                {
+                    lock (_gate)
+                        return _stdout.ToArray();
+                }
+            }
+
+            /// <summary>
+            /// The stdout captured BEFORE the ready line - the engine's whole startup window, which
+            /// is where a skill-path / configuration error would be logged.
+            /// </summary>
+            public IReadOnlyList<string> StdoutLinesBeforeReady()
+            {
+                var lines = StdoutLines;
+                for (var i = 0; i < lines.Count; i++)
+                {
+                    if (lines[i].StartsWith("NULL-ENGINE READY", StringComparison.Ordinal))
+                        return lines.Take(i).ToArray();
+                }
+                return lines;
+            }
+
+            /// <summary>
+            /// Every <c>fail:</c> line plus the indented continuation lines the console formatter
+            /// writes under it, which is where the message itself lives.
+            /// </summary>
+            public IReadOnlyList<string> FailBlocks()
+            {
+                var lines = StdoutLines;
+                var blocks = new List<string>();
+                for (var i = 0; i < lines.Count; i++)
+                {
+                    if (!lines[i].StartsWith("fail:", StringComparison.Ordinal))
+                        continue;
+
+                    var block = new StringBuilder(lines[i]);
+                    for (var j = i + 1; j < lines.Count && !HasLogLevelPrefix(lines[j]); j++)
+                        block.Append('\n').Append(lines[j]);
+
+                    blocks.Add(block.ToString());
+                }
+                return blocks;
+            }
+
+            public JsonElement WaitForReady(TimeSpan timeout)
+            {
+                var deadlineUtc = DateTime.UtcNow + timeout;
+                while (DateTime.UtcNow < deadlineUtc)
+                {
+                    if (File.Exists(_readyFile))
+                    {
+                        using var document = JsonDocument.Parse(File.ReadAllText(_readyFile));
+                        return document.RootElement.Clone();
+                    }
+
+                    if (_process.HasExited)
+                        break;
+
+                    Thread.Sleep(100);
+                }
+
+                throw new Xunit.Sdk.XunitException(
+                    "the null engine never became ready within " + timeout + ". " + Describe());
+            }
+
+            public void Kill()
+            {
+                if (_process.HasExited)
+                    return;
+
+                _process.Kill(entireProcessTree: true);
+                _process.WaitForExit(15000);
+            }
+
+            public string Describe()
+            {
+                lock (_gate)
+                {
+                    return "exited=" + (_process.HasExited ? _process.ExitCode.ToString() : "no") +
+                        "\nstdout:\n" + string.Join("\n", _stdout) +
+                        "\nstderr:\n" + string.Join("\n", _stderr);
+                }
+            }
+
+            public void Dispose()
+            {
+                try
+                {
+                    Kill();
+                }
+                catch (InvalidOperationException)
+                {
+                    // Already gone.
+                }
+                finally
+                {
+                    _process.Dispose();
+                    try
+                    {
+                        Directory.Delete(_workDirectory, recursive: true);
+                    }
+                    catch (IOException)
+                    {
+                        // Best effort - the OS temp directory is swept anyway.
+                    }
+                }
+            }
+        }
+    }
+}

--- a/McpPlugin.sln
+++ b/McpPlugin.sln
@@ -21,6 +21,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "McpPlugin.Tests.LockHarness
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "McpPlugin.Tests.RefreshHarness", "McpPlugin.Tests.RefreshHarness\McpPlugin.Tests.RefreshHarness.csproj", "{FAD5619B-90A6-4EC9-8ADF-8FF91572B459}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "McpPlugin.NullEngine", "McpPlugin.NullEngine\McpPlugin.NullEngine.csproj", "{DA8FDADD-5EB0-4A09-92E7-71BA175B3C36}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -139,6 +141,18 @@ Global
 		{FAD5619B-90A6-4EC9-8ADF-8FF91572B459}.Release|x64.Build.0 = Release|Any CPU
 		{FAD5619B-90A6-4EC9-8ADF-8FF91572B459}.Release|x86.ActiveCfg = Release|Any CPU
 		{FAD5619B-90A6-4EC9-8ADF-8FF91572B459}.Release|x86.Build.0 = Release|Any CPU
+		{DA8FDADD-5EB0-4A09-92E7-71BA175B3C36}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DA8FDADD-5EB0-4A09-92E7-71BA175B3C36}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DA8FDADD-5EB0-4A09-92E7-71BA175B3C36}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{DA8FDADD-5EB0-4A09-92E7-71BA175B3C36}.Debug|x64.Build.0 = Debug|Any CPU
+		{DA8FDADD-5EB0-4A09-92E7-71BA175B3C36}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{DA8FDADD-5EB0-4A09-92E7-71BA175B3C36}.Debug|x86.Build.0 = Debug|Any CPU
+		{DA8FDADD-5EB0-4A09-92E7-71BA175B3C36}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DA8FDADD-5EB0-4A09-92E7-71BA175B3C36}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DA8FDADD-5EB0-4A09-92E7-71BA175B3C36}.Release|x64.ActiveCfg = Release|Any CPU
+		{DA8FDADD-5EB0-4A09-92E7-71BA175B3C36}.Release|x64.Build.0 = Release|Any CPU
+		{DA8FDADD-5EB0-4A09-92E7-71BA175B3C36}.Release|x86.ActiveCfg = Release|Any CPU
+		{DA8FDADD-5EB0-4A09-92E7-71BA175B3C36}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary

- Adds `McpPlugin.NullEngine/` — a **real headless `McpPlugin` host** (real `McpPluginBuilder`, real
  SignalR transport, real attribute-scanned registration, no editor) with a 12-tool / 2-prompt /
  1-resource representative catalog, all names prefixed `null-engine/`. Every tool response is a pure
  function of its arguments, so a replayed call sequence is byte-comparable. `IsPackable=false`;
  nothing packs or publishes it, and `deploy.yml` / `release.yml` are untouched.
- Adds `McpPlugin.Server.Tests/NullEngineRealTransportTests.cs` — the **first test in this repo that
  connects a real plugin to the real server host over the real transport**. Before this,
  `grep -rl "HubConnectionBuilder\|McpPluginBuilder" McpPlugin.Server.Tests` returned 0 source hits.
  It starts `NoneAuthMcpHost` (real Kestrel, `auth=none`), spawns the engine as a real OS subprocess,
  waits on its ready file, and drives `tools/list` / `tools/call` / `prompts/list` / `resources/read`
  through the host's own JSON-RPC plumbing.
- Fixes the seed's defect (review finding **A3**): `DemoConsoleApp` logs
  `fail: … Cannot resolve relative SkillsPath 'SKILLS' … ProjectRootPath is not set` because
  `WithConfigFromArgsOrEnv` sets only `Host` + `TimeoutMs`. The host chains
  `.WithConfig(c => c.ProjectRootPath = …)`, so a clean startup emits **no `fail:` line at all** —
  and that is asserted, not just claimed.
- `McpPlugin.sln` gains the project, so the existing root `dotnet restore/build/test` in
  `test-pull-request.yml` compiles and runs it on all 3 OS for free. `NoneAuthMcpHost` gains a public
  `BaseUrl` (an out-of-process plugin has no other way to learn the OS-assigned port) and `Unwrap`
  becomes public (`CallAsync` only sends parameterless requests; a `tools/call` needs `PostAsync`
  plus the same SSE unwrapping).

## Design decision the spec asked to be recorded

**The engine is located by a derived path, not by a `ProjectReference`** — the spec's declared
default. `AppContext.BaseDirectory` of the test leg is `…/McpPlugin.Server.Tests/bin/<Config>/<tfm>/`,
so the engine built for the SAME configuration and the SAME TFM is four directories up
(`MCPPLUGIN_NULLENGINE_DLL` overrides). This relies on solution build order and adds no build-order
coupling, and it does not copy the engine's outputs beside the test's.
`ProjectReference ReferenceOutputAssembly="false"` remains the documented fallback.

One correction to the spec's stated rationale, verified in-tree: the hazard as written ("a
`ProjectReference` would merge the v8 client graph into the v10 test process") does not describe this
repo — `McpPlugin.Server.Tests.csproj` **already** references `../McpPlugin/McpPlugin.csproj` (for
`ProjectIdentity` in the routing tests), so the client library is loaded here regardless. The
subprocess is not an isolation trick: a separate OS process **is** what T1 is, and an in-process
reference could not be one.

## DoD 2 — live run (three outputs)

Run against **`DemoWebApp`**, not `gamedev-mcp-server`. This target profile provisions only
`shared/MCP-Plugin-dotnet`; the profile's own `test.md` § 2b names `DemoWebApp` as the sanctioned
in-repo stand-in (it hosts the same `McpPlugin.Server` library and, in `none` mode, the same
Streamable-HTTP endpoint). Launch:
`dotnet DemoWebApp/bin/Release/net9.0/DemoWebApp.dll port=5744 client-transport=streamableHttp auth=none plugin-timeout=10000`,
`GET /help` → 200.

**1. The host's ready line (stdout):**

```
NULL-ENGINE READY tools=12 prompts=2 resources=1 plugin=8.3.0+de71a7203020e2f59cf904852b2289752952abd0
```

ready file: `{"pid":13900,"tools":12,"prompts":2,"resources":1,"plugin_version":"8.3.0+de71a72…"}`

**2. The server's handshake log:**

```
PerformVersionHandshake. 8f80ef6b-f580-4ca5-868b-24df2345a598. PluginVersion: 8.3.0, ApiVersion: 2.0.0, Environment: McpPlugin.NullEngine
Version handshake successful. Plugin: 8.3.0, API: 2.0.0, Environment: McpPlugin.NullEngine
```

**3. The stdlib Streamable-HTTP probe** (initialize → notifications/initialized → tools/list → tools/call):

```
initialize -> HTTP 200  session=L6bw9bj9TTrjL72vssGqHg
  serverInfo={"name": "DemoWebApp", "version": "1.0.0.0"}
notifications/initialized -> HTTP 202
tools/list -> HTTP 200  count=12
  null-engine/echo          null-engine/enum-arg      null-engine/fail
  null-engine/large-payload null-engine/list-self     null-engine/nested
  null-engine/optional-args null-engine/ping          null-engine/progress
  null-engine/slow          null-engine/throw         null-engine/unicode
tools/call null-engine/ping  -> HTTP 200  isError=False  text={"result":"pong"}
tools/call null-engine/echo  -> HTTP 200  isError=False  text={"result":{"Text":"round-trip","Number":7,"Flag":true}}
tools/call null-engine/fail  -> HTTP 200  isError=True   text=null-engine: deliberate tool failure (fixed message).
```

## DoD 3 — the `^fail:` assertion, and why it is scoped

Measured over that whole run: **0** `^fail:` lines in the startup window (process start → the ready
line; 248 lines, 124 log records across `trce:`/`dbug:`/`info:`, so logging was demonstrably
captured), and **1** over the whole run — the deliberate `null-engine/fail` tool, whose block carries
its fixed message verbatim.

The spec's literal "zero `^fail:` lines over the whole DoD 2 run" is not satisfiable as written and
the contradiction is internal to the spec, not to this change: the same spec mandates a `fail` tool
and a `throw` tool, DoD 2 and DoD 4 both require CALLING them, `McpToolManager` logs a tool-level
error through `LogError` (`McpToolManager.cs:163` → `ResponseCallToolExtensions.Log`), and the same
spec mandates console logging at `Trace` — so a `fail:` line is the guaranteed consequence of the
mandated behaviour. Satisfying it literally would require dropping a mandated tool, lowering a
mandated log level, or editing `McpPlugin/` which the spec lists under NEVER TOUCH.

What ships instead covers the whole output with two assertions rather than one:

1. the startup window carries **no** `^fail:` line (this is where the `SkillsPath` message the DoD
   names actually appears, and it is what the DoD-3 plant reddens), guarded against vacuity by
   asserting the window is non-empty AND carries level prefixes — a capture that recorded nothing
   would otherwise satisfy an absence assertion for free; and
2. **every** `fail:` block in the entire capture is attributable to `null-engine/fail` or
   `null-engine/throw`, with at least two such blocks required, so the attribution loop cannot pass
   on an empty set.

## DoD 5 — plants (19, each RED attributed from its own per-plant log)

`SUMMARY 19/19 matched their expect | 19 RED | 0 GREEN | restore-failures 0`, harness exit 0 (re-run and extended from 14 to 19 by the refine pass — see below). Every
per-plant log carries `Failed! - Failed: 1, Passed: 1, Total: 2` on **both** TFMs — a non-zero total
and an unchanged collected count, so no RED came from a build or import break. The three the spec
names are P1 / P2 / P3; the other eleven exist because the unit of verification is a CLAIM, and this
test asserts more independently-breakable claims than three.

| # | mutation | reddens |
|---|---|---|
| P1 | rename `nested` → `nested-renamed` | exact `tools/list` set |
| P2 | `throw` also kills the process | liveness after a throwing tool |
| P3 | drop the `ProjectRootPath` assignment | no `fail:` in the startup window |
| P4 | console level `Trace` → `Critical` | the anti-vacuity guard on P3's own assertion |
| P5 | `PropertyNamingPolicy` → CamelCase | byte-for-byte `echo` round trip |
| P6 | `fail` returns `Success` | `isError:true` |
| P7 | ASCII-mangle the unicode payload | non-ASCII round trip |
| P8 | rename the `static` prompt | exact `prompts/list` set |
| P9 | blank the config resource's `endpoint` | `resources/read` reports this run |
| P10 | ready file `pid` → 0 | ready file identifies the spawned process |
| P11 | ready file tool count off by one | ready file reports the real catalog size |
| P12 | drop the teardown `Kill()` | no orphan subprocess left behind |
| P13 | report `Consts.PluginVersion` instead of the runtime read | TD ruling on `plugin=` identity |
| P14 | `ExitHandshakeFailed` 3 → 0 | handshake failure exits 3 |
| N1 | swap two fields of the ready-LINE format string | the ready line's exact contract |
| N2 | print the ready line twice | "EXACTLY one ready line" |
| N3 | make `FailBlocks()` match nothing | the `null-engine/fail` error-block floor |
| N4 | make `FailBlocks()` keep only `fail` blocks | the `null-engine/throw` error-block floor |
| N5 | collapse the test's reference read onto `Consts.PluginVersion` | the plugin-identity guard |

N1-N5 were authored by the refine pass, one per claim it added (see below). Every per-plant
log carries `Failed!` with a non-zero `Total:` on **both** TFMs, so no RED came from a build
break, and N3 and N4 fail with **different** assertion text — the degenerate
`{fail, fail}` set is genuinely distinguishable from the empty one.

P13 is why the `plugin=` check is an equality against the McpPlugin assembly's
`AssemblyInformationalVersion` and not a presence check: `ShouldNotBeNullOrWhiteSpace` is satisfied by
`Consts.PluginVersion` too, so it could not enforce the TD ruling at all. The two differ whenever the
informational version carries source-revision metadata, which every build from a git checkout
produces (`8.3.0+de71a72…` vs `8.3.0`).

## Test plan

- [x] `dotnet build McpPlugin.sln -c Release` — 0 errors, and 0 warnings from the projects
      this PR touches. (A full solution build does emit 8 pre-existing `CS8604` warnings from
      `McpPlugin.Tests/Network/Connection/Credentials/`, a project this PR never touches.)
- [x] `dotnet run --project McpPlugin.NullEngine -f net9.0 -c Release -- --help` → exit 0, prints the
      contract, does not connect. (`-f` is required: the project multi-targets `net8.0;net9.0`, which
      `McpPlugin.Server.Tests` running on both TFMs depends on. `dotnet run` refuses a multi-targeted
      project without it, so the spec's bare DoD-1 form cannot be satisfied as written.)
- [x] `dotnet test McpPlugin.Server.Tests --filter FullyQualifiedName~NullEngineRealTransport -c Release`
      → exit 0, `Passed! Failed: 0, Passed: 2, Total: 2` on net8.0 AND net9.0 (exit status captured
      directly, never through a pipe).
- [x] Suite 1, the full solution run (`dotnet test --no-build -c Release`) across both projects × both TFMs.
- [x] 19/19 plant round, each RED attributed (table above; 14 from the implement pass, extended to 19 by refine).
- [x] CI `test` + `golden-vector-parity` green on ubuntu / windows / macos (DoD 6) — run `33807989781`,
      https://github.com/IvanMurzak/MCP-Plugin-dotnet/actions/runs/33807989781
      conclusion `success`, 5/5 checks SUCCESS, on `headSha a847b9aaed64cb37f851d19e4829d60c357d4cee`
      — i.e. the run is tied to THIS PR's head, not to an earlier push.

## Refine pass

A review pass over the whole range plus the working tree (four report-only helpers: correctness,
test-vacuity, conventions/altitude, cleanup). Every prescription was ground-truthed against the
source before being applied; several were declined on that basis. What changed:

**Assertions that could not fail, or could fail for the wrong reason**

- The ready-file identity guard was `ShouldNotBeNullOrWhiteSpace`, which is **entailed** by the
  equality on the next line — the engine's resolver falls back to `"unknown"`, so its reported
  value is never blank, and any world where the guard fails is one where the equality fails too.
  It also guarded the wrong condition: what actually destroys discrimination is the informational
  version collapsing **onto** `Consts.PluginVersion`, which happens in any build with no
  source-revision suffix (a source archive, a `.git`-less container context) — and the old guard
  is green in exactly that world. Now asserted directly, and planted (N5).
- The ready LINE was four `ShouldContain` calls, one of which (`"resources=1"`) is satisfied by
  `"resources=10"`. Replaced by one exact equality against the documented contract, plus an
  EXACTLY-one count — the old message claimed "exactly one" while proving "at least one".
  Neither had a plant; both do now (N1, N2).
- The `fail:`-block floor was a combined `>= 2`, which the set `{fail, fail}` satisfies while a
  regression silencing `throw`'s error log goes unseen. Split into one floor per deliberate tool
  (N3, N4).

**Races that would have surfaced as CI-only flakes**

- `ExitedWithin` used only `WaitForExit(int)`, which does not wait for the asynchronous output
  handlers to drain — and the handshake-failure test asserts on stderr immediately afterwards,
  on a line the engine writes microseconds before exiting.
- The ready line was read instantaneously from a list filled by an async callback, while
  `WaitForReady` returns on the ready FILE. Now a bounded wait. Related:
  `StdoutLinesBeforeReady()` silently fell back to the WHOLE capture when no ready line was
  found, which would fold the deliberate `fail`/`throw` blocks into the "startup window" and red
  the startup assertion with a message blaming the engine for an error it never logged.
- The subprocess inherited `MCP_SKILLS_FOLDER`, which feeds the very `SkillsPath` resolution
  whose failure **is** the `fail:` line this test polices, so an ambient value could red the test
  for a purely environmental reason.
- `Dispose` caught too narrow a set around `Kill(entireProcessTree)` and `Directory.Delete`; an
  exception out of `Dispose` while a `using` unwinds **replaces** the assertion failure the test
  exists to report.

**Engine**

- Only `OperationCanceledException` was caught around `Connect`, so a transport that reports an
  unreachable endpoint by throwing would escape `Main` and replace the documented exit 3 (and the
  `HANDSHAKE-FAILED` line consumers key off) with an unhandled-exception code and no diagnostic.
- `NullEngineHost`'s two setters became one `SetCatalog(...)` taking the endpoint and project root
  as arguments. `SetCounts` read them back off mutable properties, so publishing the catalog
  before assigning them shipped `"endpoint": ""` in the config resource — silently, with every
  count still correct. The tool count is now derived from the names array rather than passed
  beside it, so the two cannot disagree.
- `WriteReadyFile`'s `Exists`+`Delete`+`Move` opened a window in which neither path existed,
  undercutting its own doc comment; `File.Move(overwrite: true)` is atomic.

**Documentation**

- Removed pipeline-internal identifiers that resolve nowhere for a reader holding only this
  repository, and one doc comment whose stated rationale was **false** and contradicted its own
  file's class remarks: locating the engine by derived path is not about keeping a client
  assembly out of this process, because `McpPlugin.Server.Tests.csproj` already references
  `McpPlugin`. (That csproj reference is also the correction this PR already records against the
  spec's rationale — re-verified at `McpPlugin.Server.Tests.csproj:26`.)
- Narrowed the `[Collection]` claim: it serialises against the same collection, not the whole
  assembly (24 of 73 Fact-bearing classes carry no `[Collection]` and still run in parallel).

**Declined, with reasons** — moving `NullEngineProcess` into `Infrastructure/` (two helpers
proposed it; the stated justification, that the nesting is what forced the `BaseUrl`/`Unwrap`
widenings, is false — both are called from the test class, not from inside that helper — and
there is one consumer today); widening `NoneAuthMcpHost.CallAsync` for a single caller;
brace-style edits (the repo runs 840 braceless single-statement `if`s to 394 braced, so the
written convention is out of step and "fixing" the new files would be the outlier).

**Gates on the refine commit** — Suite 1 (full solution, both projects x both TFMs): 4
`Test Run Successful.`, 0 failed, 812 + 1004 tests, exit 0. Plant round re-run against the final
tree: 19/19 RED, 0 GREEN, 0 restore failures. Targeted suite green UNPLANTED on both TFMs.
Pipeline-identifier scan: 0 hits, controls 104/104.

**DoD 6 — CI on the final head.** Run `33807989781` (https://github.com/IvanMurzak/MCP-Plugin-dotnet/actions/runs/33807989781) reported `conclusion: success`, with all 5
checks SUCCESS — `golden-vector-parity`, `test (ubuntu-latest)`, `test (windows-latest)`,
`test (macos-latest)`, `Test Results` — on `headSha a847b9aaed64cb37f851d19e4829d60c357d4cee`, which is this PR's current head.

Recorded by PR-body edit only, with no new commit: a commit would move the head and thereby
invalidate the very run that is the evidence.

Closes #221


